### PR TITLE
chore: replace git deps with crates.io versions, fix biome/schedule issues

### DIFF
--- a/.github/workflows/cloud-client-tests.yml
+++ b/.github/workflows/cloud-client-tests.yml
@@ -24,8 +24,6 @@ on:
       - 'crates/alien-core/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-cloud.yml.soon
+++ b/.github/workflows/e2e-cloud.yml.soon
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
   merge_group:
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch:
 
 permissions:
@@ -15,7 +13,6 @@ jobs:
   e2e-cloud:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ','), 'run-cloud-e2e'))
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-error",
  "chrono",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-error",
  "chrono",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.0.2"
+version = "1.0.4"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ alien-local = { path = "crates/alien-local", version = "1.0.5" }
 alien-manager = { path = "crates/alien-manager", version = "1.0.5" }
 alien-manager-api = { path = "client-sdks/manager/rust", version = "1.0.5", default-features = false, features = ["rustls"] }
 alien-platform-api = { path = "client-sdks/platform/rust", version = "1.0.5", default-features = false, features = ["rustls"] }
-horizon-client-sdk = { git = "https://github.com/alienplatform/horizon", tag = "horizon-client-sdk-v0.1.0" }
-deepstore-client = { git = "https://github.com/alienplatform/deepstore", tag = "deepstore-client-v0.1.0" }
+horizon-client-sdk = { version = "1.0.0" }
+deepstore-client = { version = "1.0.0" }
 
 # External dependencies
 anyhow = "1.0"

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -16,12 +16,7 @@
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write"
   },
-  "keywords": [
-    "alien",
-    "bindings",
-    "grpc",
-    "sdk"
-  ],
+  "keywords": ["alien", "bindings", "grpc", "sdk"],
   "author": "",
   "license": "ISC",
   "description": "TypeScript SDK for Alien bindings - gRPC client for Storage, KV, Queue, Vault, and more",

--- a/packages/commands-client/package.json
+++ b/packages/commands-client/package.json
@@ -13,12 +13,7 @@
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write"
   },
-  "keywords": [
-    "alien",
-    "commands",
-    "remote-command",
-    "command"
-  ],
+  "keywords": ["alien", "commands", "remote-command", "command"],
   "author": "",
   "license": "ISC",
   "description": "Lightweight client for Alien Commands protocol",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -10,9 +10,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Replace deepstore-client and horizon-client-sdk git deps with `version = "1.0.0"` (now published to crates.io)
- Fix biome formatting in package.json files (single-line arrays)
- Remove scheduled test triggers from cloud-client-tests.yml and e2e-cloud.yml.soon

🤖 Generated with [Claude Code](https://claude.com/claude-code)