### PR TITLE
refactor: clean up ArtifactRegistry trait, remove dead methods, add explicit auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ Or [try it with Claude Code, Codex, or Cursor](https://www.alien.dev#prompt).
 - **[Observability](https://alien.dev/docs/how-alien-works)** — Logs, metrics, and traces from every deployment. Full visibility without touching customer infrastructure.
 - **[Least-privilege Permissions](https://alien.dev/docs/permissions)** — Alien derives the exact IAM permissions required to deploy and manage your app.
 
-## What you can build
-
-- **AI Worker** — Agent harness in your cloud, tool execution in theirs. Read files, run commands, query data — all local. ([example](examples/remote-worker-ts))
-- **Data Connector** — Query Snowflake, Postgres, or any private database. No shared credentials, no exposed services. ([example](examples/data-connector-ts))
-- **Browser Automation** — Headless browser inside their network. Navigate Jira, SAP, GitLab, on-prem wikis. Only results leave.
-- **Security Outpost** — Scan IAM policies, storage, network configs from inside the perimeter. On a schedule or on-demand.
-- **Cloud Actions** — API inside their network. Restart services, rotate credentials, react to infrastructure changes. ([example](examples/webhook-api-ts))
-
 ## How deployment works
 
 ### Push model
@@ -111,16 +103,6 @@ docker run ghcr.io/alienplatform/alien-agent \
 
 Both models give you the same capabilities: updates, telemetry, remote commands. See [Deployment Models](https://alien.dev/docs/deploying/deployment-models).
 
-## Releases
-
-Push a release and every environment updates automatically.
-
-```bash
-alien release
-```
-
-Builds your code, pushes artifacts, and creates a release. Every active deployment picks up the new version.
-
 ## One codebase, every cloud
 
 Ship to AWS, GCP, and Azure customers without maintaining separate integrations. Alien maps your stack to each cloud's native services at deploy time.
@@ -160,6 +142,25 @@ At deploy time, each resource maps to the cloud's native service:
 The same applies to queues, vaults, and KV stores. One codebase, all clouds. Drop to native SDKs whenever you need to.
 
 Each resource documents its [guarantees, limits, and platform-specific behavior](https://alien.dev/docs/infrastructure) so you know exactly what to expect across clouds.
+
+## Releases
+
+Push a release and every environment updates automatically.
+
+```bash
+alien release
+```
+
+Builds your code, pushes artifacts, and creates a release. Every active deployment picks up the new version.
+
+## What you can build
+
+- **AI Worker** — Agent harness in your cloud, tool execution in theirs. Read files, run commands, query data — all local. ([example](examples/remote-worker-ts))
+- **Data Connector** — Query Snowflake, Postgres, or any private database. No shared credentials, no exposed services. ([example](examples/data-connector-ts))
+- **Browser Automation** — Headless browser inside their network. Navigate Jira, SAP, GitLab, on-prem wikis. 
+- **Security Outpost** — Scan IAM policies, storage, network configs from inside the perimeter. On a schedule or on-demand.
+- **Cloud Actions** — API inside their network. Restart services, rotate credentials, react to infrastructure changes. ([example](examples/webhook-api-ts))
+
 
 ## Remote commands
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,16 @@
 # Alien
 
-[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/alien)](https://x.com/alien)
-[![GitHub Release](https://img.shields.io/github/v/release/alienplatform/alien)](https://github.com/alienplatform/alien/releases)
-[![Discord](https://img.shields.io/discord/1490401456124199224?label=Discord&logo=discord&logoColor=white)](https://alien.dev/discord)
+Alien provides infrastructure to deploy and operate software inside your users' environments, while retaining centralized control over updates, monitoring, and lifecycle management.
 
-*"My data is sensitive. Can you deploy into my cloud?"* — Every enterprise customer, **ever**.
+## Why Alien?
 
-Alien provides infrastructure for deploying into your customers' cloud accounts and keeping it fully managed. AWS, GCP, or Azure.
+Self-hosting works - *until someone starts paying for your software*.
 
-Your code needs to run inside the customer's environment when:
+Customers run it in their own environment, but they don’t actually know how to operate it. They might change something small like Postgres version, environment variables, IAM, firewall rules, and things start failing. From their perspective, your product is broken. And even if the root cause is on their side, it doesn't matter... the customer is always right, you're still the one expected to fix it.
 
-- Sensitive data can't leave their environment
-- You need to access internal services that aren't reachable from the internet (databases behind a VPC, GitHub Enterprise, etc)
-- Their security or compliance team requires it
+But you can't. You don't have access to their environment. You don't have real visibility. You can't run anything yourself. So you're stuck debugging a system you don’t control, through screenshots and copy-pasted logs on a Zoom call. You end up responsible for something you don't control.
 
-The usual answer is sending a Docker image or a Helm chart. But while self-hosting is great, many enterprises want you to manage everything for them. And when something breaks, you're on a 2am Zoom call debugging blind because you have no direct access. No auto-updates, no logs, every customer on a different version.
-
-Alien gives you a different option. Deploy into their cloud and keep full control — push updates, collect non-sensitive logs and metrics, roll back. The customer doesn't operate anything. Their data never leaves.
+Alien provides a better model: **managed self-hosting**.
 
 ## Quickstart
 
@@ -39,6 +33,7 @@ Or [try it with Claude Code, Codex, or Cursor](https://www.alien.dev#prompt).
 
 ## Features
 
+- **[AWS, GCP, and Azure support](https://www.alien.dev/docs/how-alien-works)** - Deploy to all major clouds. 
 - **[TypeScript & Rust](https://alien.dev/docs/infrastructure/function/toolchains)** — First-class support for both. Python and arbitrary containers coming soon.
 - **[Real-time Heartbeat](https://alien.dev/docs/how-alien-works)** — Know the instant a deployment goes down. 
 - **[Auto Updates & Rollbacks](https://alien.dev/docs/releases)** — Push a release and every remote environment picks it up automatically. 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Alien provides infrastructure to deploy and operate software inside your users' 
 
 Self-hosting works - *until someone starts paying for your software*.
 
-Customers run it in their own environment, but they don’t actually know how to operate it. They might change something small like Postgres version, environment variables, IAM, firewall rules, and things start failing. From their perspective, your product is broken. And even if the root cause is on their side, it doesn't matter... the customer is always right, you're still the one expected to fix it.
+Customers run it in their own environment, but they don't actually know how to operate it. They might change something small like Postgres version, environment variables, IAM, firewall rules, and things start failing. From their perspective, your product is broken. And even if the root cause is on their side, it doesn't matter... the customer is always right, you're still the one expected to fix it.
 
-But you can't. You don't have access to their environment. You don't have real visibility. You can't run anything yourself. So you're stuck debugging a system you don’t control, through screenshots and copy-pasted logs on a Zoom call. You end up responsible for something you don't control.
+But you can't. You don't have access to their environment. You don't have real visibility. You can't run anything yourself. So you're stuck debugging a system you don't control, through screenshots and copy-pasted logs on a Zoom call. You end up responsible for something you don't control.
 
 Alien provides a better model: **managed self-hosting**.
 

--- a/crates/alien-bindings/proto/artifact_registry.proto
+++ b/crates/alien-bindings/proto/artifact_registry.proto
@@ -186,6 +186,12 @@ message RepositoryResult {
     optional string created_at = 3;
 }
 
+// How the registry expects credentials to be presented
+enum AuthMethod {
+    AUTH_METHOD_BASIC = 0;
+    AUTH_METHOD_BEARER = 1;
+}
+
 // Credentials for accessing a repository
 message Credentials {
     // Username for authentication
@@ -194,4 +200,6 @@ message Credentials {
     string password = 2;
     // Optional expiration time in ISO8601 format
     optional string expires_at = 3;
-} 
+    // How to present these credentials to the registry
+    AuthMethod auth_method = 4;
+}

--- a/crates/alien-bindings/src/grpc/artifact_registry_service.rs
+++ b/crates/alien-bindings/src/grpc/artifact_registry_service.rs
@@ -309,10 +309,15 @@ impl ArtifactRegistryService for ArtifactRegistryGrpcServer {
             .await
             .map_err(alien_error_to_status)?;
 
+        use crate::traits::RegistryAuthMethod;
         let proto_credentials = ProtoCredentials {
             username: credentials.username,
             password: credentials.password,
             expires_at: credentials.expires_at,
+            auth_method: match credentials.auth_method {
+                RegistryAuthMethod::Basic => 0,
+                RegistryAuthMethod::Bearer => 1,
+            },
         };
 
         Ok(Response::new(GenerateCredentialsResponse {

--- a/crates/alien-bindings/src/grpc/artifact_registry_service.rs
+++ b/crates/alien-bindings/src/grpc/artifact_registry_service.rs
@@ -310,13 +310,14 @@ impl ArtifactRegistryService for ArtifactRegistryGrpcServer {
             .map_err(alien_error_to_status)?;
 
         use crate::traits::RegistryAuthMethod;
+        use alien_bindings::artifact_registry::AuthMethod as ProtoAuthMethod;
         let proto_credentials = ProtoCredentials {
             username: credentials.username,
             password: credentials.password,
             expires_at: credentials.expires_at,
             auth_method: match credentials.auth_method {
-                RegistryAuthMethod::Basic => 0,
-                RegistryAuthMethod::Bearer => 1,
+                RegistryAuthMethod::Basic => ProtoAuthMethod::Basic as i32,
+                RegistryAuthMethod::Bearer => ProtoAuthMethod::Bearer as i32,
             },
         };
 

--- a/crates/alien-bindings/src/lib.rs
+++ b/crates/alien-bindings/src/lib.rs
@@ -6,7 +6,7 @@ pub use alien_core::{BindingsMode, Platform};
 pub use error::{ErrorData, Result};
 pub use provider::BindingsProvider;
 pub use traits::{
-    ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions,
+    ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, RegistryAuthMethod,
     AwsServiceAccountInfo, AzureServiceAccountInfo, Binding, BindingsProviderApi, Build, Container,
     Function, GcpServiceAccountInfo, ImpersonationRequest, Kv, Queue, RepositoryResponse,
     ServiceAccount, ServiceAccountInfo, Storage, Vault,

--- a/crates/alien-bindings/src/providers/artifact_registry/acr.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/acr.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{map_cloud_client_error, ErrorData, Result},
     traits::{
-        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, Binding,
+        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, Binding, RegistryAuthMethod,
         CrossAccountAccess, CrossAccountPermissions, RepositoryResponse,
     },
 };
@@ -459,58 +459,22 @@ impl ArtifactRegistry for AcrArtifactRegistry {
             "ACR access token generated"
         );
 
-        // Return the access token with empty username to signal Bearer auth.
-        // The proxy checks: if username is empty, use Bearer instead of Basic.
+        // ACR OAuth2 access tokens expire in ~5 minutes
+        let expires_at = Some(
+            (chrono::Utc::now() + chrono::Duration::seconds(300)).to_rfc3339(),
+        );
+
         Ok(ArtifactRegistryCredentials {
+            auth_method: RegistryAuthMethod::Bearer,
             username: String::new(),
             password: access_token,
-            expires_at: None,
+            expires_at,
         })
     }
 
-    async fn cleanup_credentials(&self, repo_id: &str) -> Result<()> {
-        // Same namespaced parsing as generate_credentials
-        let (naming_key, repo_name) = if let Some((_prefix, repo)) = repo_id.split_once("--") {
-            (repo_id, repo)
-        } else {
-            (repo_id, repo_id)
-        };
-
-        let scope_map_name = self.make_azure_resource_name(naming_key, "pull-scope");
-        let token_name = self.make_azure_resource_name(naming_key, "pull-token");
-
-        info!(
-            repo_name = %repo_name,
-            scope_map = %scope_map_name,
-            token = %token_name,
-            registry_name = %self.registry_name,
-            "Cleaning up Azure ACR credentials: deleting token and scope map"
-        );
-
-        // Delete token first (it references the scope map)
-        if let Err(e) = self
-            .acr_client
-            .delete_token(&self.resource_group_name, &self.registry_name, &token_name)
-            .await
-        {
-            warn!(token = %token_name, error = %e, "Failed to delete ACR token (may not exist)");
-        }
-
-        // Delete scope map
-        if let Err(e) = self
-            .acr_client
-            .delete_scope_map(
-                &self.resource_group_name,
-                &self.registry_name,
-                &scope_map_name,
-            )
-            .await
-        {
-            warn!(scope_map = %scope_map_name, error = %e, "Failed to delete ACR scope map (may not exist)");
-        }
-
-        Ok(())
-    }
+    // No-op: generate_credentials() uses the stateless AAD → refresh → access token
+    // OAuth2 flow. No persistent resources (scope maps, tokens) are created, so
+    // there is nothing to clean up.
 
     async fn delete_repository(&self, repo_id: &str) -> Result<()> {
         let repo_name = repo_id;
@@ -537,29 +501,6 @@ impl ArtifactRegistry for AcrArtifactRegistry {
                     repo_name = %repo_name,
                     "Azure Container Registry repository scope map deleted successfully"
                 );
-
-                // Also clean up credentials-related resources (from generate_credentials)
-                let pull_scope_name = self.make_azure_resource_name(repo_name, "pull-scope");
-                let pull_token_name = self.make_azure_resource_name(repo_name, "pull-token");
-
-                // Delete token first (it references the scope map)
-                let _ = self
-                    .acr_client
-                    .delete_token(
-                        &self.resource_group_name,
-                        &self.registry_name,
-                        &pull_token_name,
-                    )
-                    .await;
-
-                let _ = self
-                    .acr_client
-                    .delete_scope_map(
-                        &self.resource_group_name,
-                        &self.registry_name,
-                        &pull_scope_name,
-                    )
-                    .await;
 
                 Ok(())
             }

--- a/crates/alien-bindings/src/providers/artifact_registry/acr.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/acr.rs
@@ -5,8 +5,7 @@ use crate::{
         CrossAccountAccess, CrossAccountPermissions, RepositoryResponse,
     },
 };
-use alien_azure_clients::long_running_operation::{LongRunningOperationClient, OperationResult};
-use alien_azure_clients::models::containerregistry::ScopeMapProperties;
+use alien_azure_clients::long_running_operation::LongRunningOperationClient;
 use alien_azure_clients::{
     containerregistry::{AzureContainerRegistryClient, ContainerRegistryApi},
     AzureClientConfig, AzureTokenCache,
@@ -157,133 +156,25 @@ impl ArtifactRegistry for AcrArtifactRegistry {
     }
 
     async fn create_repository(&self, repo_name: &str) -> Result<RepositoryResponse> {
-        info!(
-            repo_name = %repo_name,
-            registry_name = %self.registry_name,
-            "Creating Azure Container Registry repository (via scope map)"
-        );
-
-        // In ACR, repositories are created implicitly on first push
-        // However, we can create a scope map to control access to the repository
-        let scope_map_name = self.make_azure_resource_name(repo_name, "scope");
-        let actions = vec![
-            format!("repositories/{}/content/read", repo_name),
-            format!("repositories/{}/content/write", repo_name),
-        ];
-
-        let scope_map_properties = ScopeMapProperties {
-            description: Some(format!("Scope map for repository {}", repo_name)),
-            actions,
-            creation_date: None,
-            provisioning_state: None,
-            type_: None,
-        };
-
-        match self
-            .acr_client
-            .create_scope_map(
-                &self.resource_group_name,
-                &self.registry_name,
-                &scope_map_name,
-                &scope_map_properties,
-            )
-            .await
-        {
-            Ok(operation_result) => {
-                match operation_result {
-                    OperationResult::Completed(_) => {
-                        info!(
-                            repo_name = %repo_name,
-                            "Azure Container Registry repository scope map created successfully"
-                        );
-
-                        // Construct the repository URI for Azure Container Registry
-                        let repository_uri = format!("{}/{}", self.registry_endpoint, repo_name);
-
-                        Ok(RepositoryResponse {
-                            name: repo_name.to_string(),
-                            uri: Some(repository_uri),
-                            created_at: None, // ACR doesn't provide creation time in this response
-                        })
-                    }
-                    OperationResult::LongRunning(_) => {
-                        info!(
-                            repo_name = %repo_name,
-                            "Azure Container Registry repository scope map creation is in progress"
-                        );
-
-                        Ok(RepositoryResponse {
-                            name: repo_name.to_string(),
-                            uri: None, // Will be available once creation completes
-                            created_at: None,
-                        })
-                    }
-                }
-            }
-            Err(e) => {
-                warn!(
-                    repo_name = %repo_name,
-                    error = %e,
-                    "Failed to create Azure Container Registry repository scope map"
-                );
-
-                Err(map_cloud_client_error(
-                    e,
-                    format!(
-                        "Failed to create Azure Container Registry repository '{}'",
-                        repo_name
-                    ),
-                    Some(repo_name.to_string()),
-                ))
-            }
-        }
-    }
-
-    async fn get_repository(&self, repo_id: &str) -> Result<RepositoryResponse> {
-        let repo_name = repo_id;
-        let scope_map_name = self.make_azure_resource_name(repo_name, "scope");
-
-        info!(
-            repo_name = %repo_name,
-            registry_name = %self.registry_name,
-            "Getting Azure Container Registry repository details"
-        );
-
-        let scope_map = self
-            .acr_client
-            .get_scope_map(
-                &self.resource_group_name,
-                &self.registry_name,
-                &scope_map_name,
-            )
-            .await
-            .map_err(|_e| {
-                warn!(
-                    repo_name = %repo_name,
-                    "Azure Container Registry repository not found"
-                );
-
-                AlienError::new(ErrorData::ResourceNotFound {
-                    resource_id: repo_name.to_string(),
-                })
-            })?;
-
-        // Construct the repository URI for Azure Container Registry
+        // ACR repositories are created implicitly on first push.
+        // The ACR resource itself is provisioned by alien-infra.
         let repository_uri = format!("{}/{}", self.registry_endpoint, repo_name);
-
-        // Azure scope maps don't directly provide creation time
-        let created_at = scope_map.properties.and_then(|props| props.creation_date);
-
-        info!(
-            repo_name = %repo_name,
-            repo_uri = %repository_uri,
-            "Azure Container Registry repository details retrieved"
-        );
 
         Ok(RepositoryResponse {
             name: repo_name.to_string(),
             uri: Some(repository_uri),
-            created_at,
+            created_at: None,
+        })
+    }
+
+    async fn get_repository(&self, repo_id: &str) -> Result<RepositoryResponse> {
+        // ACR repositories are implicit — return the routable name and URI.
+        let repository_uri = format!("{}/{}", self.registry_endpoint, repo_id);
+
+        Ok(RepositoryResponse {
+            name: repo_id.to_string(),
+            uri: Some(repository_uri),
+            created_at: None,
         })
     }
 
@@ -476,50 +367,8 @@ impl ArtifactRegistry for AcrArtifactRegistry {
     // OAuth2 flow. No persistent resources (scope maps, tokens) are created, so
     // there is nothing to clean up.
 
-    async fn delete_repository(&self, repo_id: &str) -> Result<()> {
-        let repo_name = repo_id;
-        let scope_map_name = self.make_azure_resource_name(repo_name, "scope");
-
-        info!(
-            repo_name = %repo_name,
-            registry_name = %self.registry_name,
-            "Deleting Azure Container Registry repository scope map"
-        );
-
-        // Delete the scope map associated with the repository
-        match self
-            .acr_client
-            .delete_scope_map(
-                &self.resource_group_name,
-                &self.registry_name,
-                &scope_map_name,
-            )
-            .await
-        {
-            Ok(_) => {
-                info!(
-                    repo_name = %repo_name,
-                    "Azure Container Registry repository scope map deleted successfully"
-                );
-
-                Ok(())
-            }
-            Err(e) => {
-                warn!(
-                    repo_name = %repo_name,
-                    error = %e,
-                    "Failed to delete Azure Container Registry repository scope map"
-                );
-
-                Err(map_cloud_client_error(
-                    e,
-                    format!(
-                        "Failed to delete Azure Container Registry repository '{}'",
-                        repo_name
-                    ),
-                    Some(repo_name.to_string()),
-                ))
-            }
-        }
+    async fn delete_repository(&self, _repo_id: &str) -> Result<()> {
+        // ACR repositories are implicit (created on push). Nothing to delete.
+        Ok(())
     }
 }

--- a/crates/alien-bindings/src/providers/artifact_registry/ecr.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/ecr.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{map_cloud_client_error, Error, ErrorData, Result},
     traits::{
-        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions,
+        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, RegistryAuthMethod,
         AwsCrossAccountAccess, Binding, ComputeServiceType, CrossAccountAccess,
         CrossAccountPermissions, RepositoryResponse,
     },
@@ -9,7 +9,7 @@ use crate::{
 use alien_aws_clients::{
     ecr::{
         CreateRepositoryRequest, DescribeRepositoriesRequest, EcrApi, EcrClient,
-        GetAuthorizationTokenRequest, GetDownloadUrlForLayerRequest, GetRepositoryPolicyRequest,
+        GetAuthorizationTokenRequest, GetRepositoryPolicyRequest,
         SetRepositoryPolicyRequest,
     },
     sts::{AssumeRoleRequest, StsApi, StsClient},
@@ -105,6 +105,7 @@ impl EcrArtifactRegistry {
 
     /// Constructs the full repository name for ECR using the repository prefix.
     /// If `repo_name` is empty, returns just the prefix (shared-repo pattern).
+    /// Uses `-` separator to match IAM policy wildcards (e.g., `alien-artifacts-prj_xxx`).
     fn make_full_repo_name(&self, repo_name: &str) -> String {
         if repo_name.is_empty() {
             self.repository_prefix.clone()
@@ -337,7 +338,7 @@ impl ArtifactRegistry for EcrArtifactRegistry {
         };
 
         Ok(RepositoryResponse {
-            name: repo_name.to_string(),
+            name: full_repo_name,
             uri: Some(repository.repository_uri.clone()),
             created_at,
         })
@@ -867,6 +868,7 @@ impl ArtifactRegistry for EcrArtifactRegistry {
                 );
 
                 Ok(ArtifactRegistryCredentials {
+                    auth_method: RegistryAuthMethod::Basic,
                     username: username.to_string(),
                     password: password.to_string(),
                     expires_at,
@@ -950,34 +952,4 @@ impl ArtifactRegistry for EcrArtifactRegistry {
         Ok(())
     }
 
-    async fn generate_blob_download_url(
-        &self,
-        repo_name: &str,
-        digest: &str,
-        _ttl_seconds: u32,
-    ) -> Result<Option<String>> {
-        let full_repo_name = self.make_full_repo_name(repo_name);
-
-        let request = GetDownloadUrlForLayerRequest::builder()
-            .repository_name(full_repo_name.clone())
-            .layer_digest(digest.to_string())
-            .build();
-
-        let response = self
-            .ecr_client
-            .get_download_url_for_layer(request)
-            .await
-            .map_err(|e| {
-                map_cloud_client_error(
-                    e,
-                    format!(
-                        "Failed to get download URL for layer '{}' in repository '{}'",
-                        digest, full_repo_name
-                    ),
-                    Some(repo_name.to_string()),
-                )
-            })?;
-
-        Ok(Some(response.download_url))
-    }
 }

--- a/crates/alien-bindings/src/providers/artifact_registry/gar.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/gar.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{map_cloud_client_error, ErrorData, Result},
     traits::{
-        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, Binding,
+        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, Binding, RegistryAuthMethod,
         ComputeServiceType, CrossAccountAccess, CrossAccountPermissions, GcpCrossAccountAccess,
         RepositoryResponse,
     },
@@ -107,22 +107,15 @@ impl GarArtifactRegistry {
         })
     }
 
-    /// Converts a repository name to a full repository ID for GCP operations
-    fn make_repo_id(&self, repo_name: &str) -> String {
-        format!(
-            "projects/{}/locations/{}/repositories/{}",
-            self.project_id, self.location, repo_name
-        )
-    }
-
-    /// Extracts repository name from a repository ID.
-    /// If `repo_id` is empty, returns the binding's configured `repository_name`.
+    /// Extracts a name segment from a repo ID or routable name.
+    /// If `repo_id` is empty, returns the binding's configured `repository_name`
+    /// (the GAR repository resource, used for IAM operations).
     fn extract_repo_name(&self, repo_id: &str) -> Result<String> {
         if repo_id.is_empty() {
             return Ok(self.repository_name.clone());
         }
-        if let Some(repo_name) = repo_id.split('/').last() {
-            Ok(repo_name.to_string())
+        if let Some(name) = repo_id.split('/').last() {
+            Ok(name.to_string())
         } else {
             Err(AlienError::new(ErrorData::BindingConfigInvalid {
                 binding_name: self.binding_name.clone(),
@@ -228,95 +221,32 @@ impl ArtifactRegistry for GarArtifactRegistry {
     }
 
     async fn create_repository(&self, repo_name: &str) -> Result<RepositoryResponse> {
-        info!(
-            repo_name = %repo_name,
-            project_id = %self.project_id,
-            location = %self.location,
-            "Creating GCP Artifact Registry repository"
-        );
-
-        let repository = Repository::builder()
-            .format(RepositoryFormat::Docker)
-            .build();
-
-        let _operation = self
-            .client
-            .create_repository(
-                self.project_id.clone(),
-                self.location.clone(),
-                repo_name.to_string(),
-                repository,
-            )
-            .await
-            .map_err(|e| {
-                map_cloud_client_error(
-                    e,
-                    format!(
-                        "Failed to create GCP Artifact Registry repository '{}'",
-                        repo_name
-                    ),
-                    Some(repo_name.to_string()),
-                )
-            })?;
-
-        info!(
-            repo_name = %repo_name,
-            "GCP Artifact Registry repository creation started"
-        );
-
-        // GCP repository creation is async, so URI is None until ready
+        // In GAR, the binding's GAR repository (e.g., "alien-artifacts") IS the registry.
+        // Image paths within it (e.g., "prj_abc123") are created automatically on first push.
+        // No GAR API call needed — the GAR repository is created by alien-infra at provisioning time.
+        // Underscores are valid in image paths (OCI distribution spec allows [a-z0-9._-/]).
+        let routable_name = format!("{}/{}", self.upstream_repository_prefix(), repo_name);
         Ok(RepositoryResponse {
-            name: repo_name.to_string(),
-            uri: None,        // Will be available once repository is ready
-            created_at: None, // Creation time not available until completion
+            name: routable_name,
+            uri: None,
+            created_at: None,
         })
     }
 
     async fn get_repository(&self, repo_id: &str) -> Result<RepositoryResponse> {
-        let repo_name = self.extract_repo_name(repo_id)?;
-
-        info!(
-            repo_name = %repo_name,
-            project_id = %self.project_id,
-            location = %self.location,
-            "Getting GCP Artifact Registry repository details"
-        );
-
-        let repository = self
-            .client
-            .get_repository(
-                self.project_id.clone(),
-                self.location.clone(),
-                repo_name.clone(),
-            )
-            .await
-            .map_err(|_e| {
-                warn!(
-                    repo_name = %repo_name,
-                    "GCP Artifact Registry repository not found"
-                );
-
-                AlienError::new(ErrorData::ResourceNotFound {
-                    resource_id: repo_name.clone(),
-                })
-            })?;
-
-        // Construct the repository URI for GCP Artifact Registry
+        // Image paths within a GAR repository are implicit — no GAR API call needed.
+        // Just return the routable name, same as create_repository.
+        let image_path = self.extract_repo_name(repo_id)?;
+        let routable_name = format!("{}/{}", self.upstream_repository_prefix(), image_path);
         let repository_uri = format!(
             "{}-docker.pkg.dev/{}/{}",
-            self.location, self.project_id, repo_name
-        );
-
-        info!(
-            repo_name = %repo_name,
-            repo_uri = %repository_uri,
-            "GCP Artifact Registry repository details retrieved"
+            self.location, self.project_id, image_path
         );
 
         Ok(RepositoryResponse {
-            name: repo_name,
+            name: routable_name,
             uri: Some(repository_uri),
-            created_at: repository.create_time,
+            created_at: None,
         })
     }
 
@@ -668,6 +598,7 @@ impl ArtifactRegistry for GarArtifactRegistry {
 
         // For GCP Artifact Registry, the username is 'oauth2accesstoken' and password is the OAuth token
         Ok(ArtifactRegistryCredentials {
+            auth_method: RegistryAuthMethod::Basic,
             username: "oauth2accesstoken".to_string(),
             password: access_token,
             expires_at,

--- a/crates/alien-bindings/src/providers/artifact_registry/grpc.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/grpc.rs
@@ -334,9 +334,10 @@ impl ArtifactRegistry for GrpcArtifactRegistry {
             })
         })?;
 
+        use crate::grpc::artifact_registry_service::alien_bindings::artifact_registry::AuthMethod as ProtoAuthMethod;
         Ok(ArtifactRegistryCredentials {
-            auth_method: match credentials.auth_method {
-                1 => crate::traits::RegistryAuthMethod::Bearer,
+            auth_method: match ProtoAuthMethod::try_from(credentials.auth_method) {
+                Ok(ProtoAuthMethod::Bearer) => crate::traits::RegistryAuthMethod::Bearer,
                 _ => crate::traits::RegistryAuthMethod::Basic,
             },
             username: credentials.username,

--- a/crates/alien-bindings/src/providers/artifact_registry/grpc.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/grpc.rs
@@ -335,6 +335,10 @@ impl ArtifactRegistry for GrpcArtifactRegistry {
         })?;
 
         Ok(ArtifactRegistryCredentials {
+            auth_method: match credentials.auth_method {
+                1 => crate::traits::RegistryAuthMethod::Bearer,
+                _ => crate::traits::RegistryAuthMethod::Basic,
+            },
             username: credentials.username,
             password: credentials.password,
             expires_at: credentials.expires_at,

--- a/crates/alien-bindings/src/providers/artifact_registry/local.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/local.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{ErrorData, Result},
     traits::{
-        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, Binding,
+        ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions, Binding, RegistryAuthMethod,
         CrossAccountAccess, CrossAccountPermissions, RepositoryResponse,
     },
 };
@@ -240,8 +240,15 @@ impl ArtifactRegistry for LocalArtifactRegistry {
             "Local Docker repository created successfully"
         );
 
+        // Return the full routable name (prefix + repo) so the manager proxy can match it.
+        let routable_name = if repo_name.is_empty() {
+            self.upstream_repository_prefix()
+        } else {
+            format!("{}/{}", self.upstream_repository_prefix(), repo_name)
+        };
+
         Ok(RepositoryResponse {
-            name: repo_name.to_string(),
+            name: routable_name,
             uri: Some(repository_uri),
             created_at: None,
         })
@@ -282,8 +289,14 @@ impl ArtifactRegistry for LocalArtifactRegistry {
                     "Local repository exists"
                 );
 
+                let routable_name = if repo_id.is_empty() {
+                    self.upstream_repository_prefix()
+                } else {
+                    format!("{}/{}", self.upstream_repository_prefix(), repo_id)
+                };
+
                 Ok(RepositoryResponse {
-                    name: repo_id.to_string(),
+                    name: routable_name,
                     uri: Some(repository_uri),
                     created_at: None,
                 })
@@ -406,122 +419,11 @@ impl ArtifactRegistry for LocalArtifactRegistry {
         // Local registry runs on localhost without auth.
         // Return empty credentials — callers should use anonymous access.
         Ok(ArtifactRegistryCredentials {
+            auth_method: RegistryAuthMethod::Basic,
             username: String::new(),
             password: String::new(),
             expires_at: None,
         })
-    }
-
-    async fn get_manifest(&self, repo_name: &str, reference: &str) -> Result<(Vec<u8>, String)> {
-        // Fetch raw manifest bytes via HTTP to preserve exact byte content.
-        // Re-serializing through oci-client would change whitespace and break
-        // digest verification by OCI clients.
-        let url = format!(
-            "http://{}/v2/{}/manifests/{}",
-            self.registry_endpoint, repo_name, reference
-        );
-
-        let http_client = reqwest::Client::new();
-        let resp = http_client
-            .get(&url)
-            .header("accept", "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json")
-            .send()
-            .await
-            .into_alien_error()
-            .context(ErrorData::Other {
-                message: format!("Failed to fetch manifest for {}:{}", repo_name, reference),
-            })?;
-
-        if !resp.status().is_success() {
-            return Err(AlienError::new(ErrorData::Other {
-                message: format!(
-                    "Upstream registry returned {} for manifest {}:{}",
-                    resp.status(),
-                    repo_name,
-                    reference
-                ),
-            }));
-        }
-
-        let content_type = resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/vnd.oci.image.manifest.v1+json")
-            .to_string();
-
-        let body = resp
-            .bytes()
-            .await
-            .into_alien_error()
-            .context(ErrorData::Other {
-                message: "Failed to read manifest body".to_string(),
-            })?;
-
-        Ok((body.to_vec(), content_type))
-    }
-
-    async fn head_manifest(
-        &self,
-        repo_name: &str,
-        reference: &str,
-    ) -> Result<Option<(String, String)>> {
-        // HEAD request via HTTP to get the digest without pulling the full manifest.
-        let url = format!(
-            "http://{}/v2/{}/manifests/{}",
-            self.registry_endpoint, repo_name, reference
-        );
-
-        let http_client = reqwest::Client::new();
-        match http_client
-            .head(&url)
-            .header("accept", "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json")
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                let content_type = resp
-                    .headers()
-                    .get("content-type")
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("application/vnd.oci.image.manifest.v1+json")
-                    .to_string();
-                let digest = resp
-                    .headers()
-                    .get("docker-content-digest")
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("")
-                    .to_string();
-                if digest.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some((content_type, digest)))
-                }
-            }
-            _ => Ok(None),
-        }
-    }
-
-    async fn head_blob(&self, repo_name: &str, digest: &str) -> Result<Option<u64>> {
-        // HEAD request to the OCI blob endpoint
-        let url = format!(
-            "http://{}/v2/{}/blobs/{}",
-            self.registry_endpoint, repo_name, digest
-        );
-
-        let http_client = reqwest::Client::new();
-        match http_client.head(&url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                let content_length = resp
-                    .headers()
-                    .get("content-length")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(0);
-                Ok(Some(content_length))
-            }
-            _ => Ok(None),
-        }
     }
 
     async fn delete_repository(&self, repo_id: &str) -> Result<()> {

--- a/crates/alien-bindings/src/traits.rs
+++ b/crates/alien-bindings/src/traits.rs
@@ -163,12 +163,25 @@ pub enum ArtifactRegistryPermissions {
     PushPull,
 }
 
+/// How the registry expects credentials to be presented.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum RegistryAuthMethod {
+    /// HTTP Basic auth (username:password). Used by ECR, GAR, Local.
+    Basic,
+    /// HTTP Bearer token. Used by ACR (Azure).
+    Bearer,
+}
+
 /// Credentials for accessing a repository.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ArtifactRegistryCredentials {
-    /// Username for authentication.
+    /// How to present these credentials to the registry.
+    pub auth_method: RegistryAuthMethod,
+    /// Username for authentication (empty for Bearer auth).
     pub username: String,
     /// Password or token for authentication.
     pub password: String,
@@ -312,83 +325,8 @@ pub trait ArtifactRegistry: Binding {
         ttl_seconds: Option<u32>,
     ) -> Result<ArtifactRegistryCredentials>;
 
-    /// Cleans up resources created by `generate_credentials` (scope maps, tokens).
-    /// On Azure: deletes the scope map and token for the given repo ID.
-    /// Default: no-op (other providers use short-lived or IAM-based credentials).
-    async fn cleanup_credentials(&self, _repo_id: &str) -> Result<()> {
-        Ok(())
-    }
-
     /// Deletes a repository and all contained images.
     async fn delete_repository(&self, repo_id: &str) -> Result<()>;
-
-    /// Generates a pre-signed download URL for a blob (layer) in the registry.
-    ///
-    /// Used by the registry proxy to return 307 redirects instead of streaming
-    /// blob bytes through the manager. Returns `None` if the provider doesn't
-    /// support pre-signed URLs (the proxy will stream the blob directly instead).
-    ///
-    /// - ECR: Calls `GetDownloadUrlForLayer` (returns pre-signed S3 URL).
-    /// - GAR: Returns `None` (GAR uses OCI distribution API with bearer auth).
-    /// - ACR: Returns `None` (ACR uses OCI distribution API with bearer auth).
-    /// - Local: Returns `None` (local registry is co-located, streaming is fine).
-    async fn generate_blob_download_url(
-        &self,
-        _repo_name: &str,
-        _digest: &str,
-        _ttl_seconds: u32,
-    ) -> Result<Option<String>> {
-        Ok(None)
-    }
-
-    /// Fetches a manifest from the upstream registry by reference (tag or digest).
-    ///
-    /// Used by the registry proxy to serve manifest requests. Returns the
-    /// manifest bytes and the content type (e.g., `application/vnd.oci.image.manifest.v1+json`).
-    ///
-    /// Default implementation returns `OperationNotSupported`. Providers that
-    /// support the registry proxy should implement this.
-    async fn get_manifest(&self, _repo_name: &str, _reference: &str) -> Result<(Vec<u8>, String)> {
-        Err(alien_error::AlienError::new(
-            crate::error::ErrorData::OperationNotSupported {
-                operation: "get_manifest".to_string(),
-                reason: "This artifact registry provider does not support manifest fetching"
-                    .to_string(),
-            },
-        ))
-    }
-
-    /// Checks if a manifest exists in the upstream registry.
-    ///
-    /// Returns the content type and digest if the manifest exists.
-    /// Default implementation returns `OperationNotSupported`.
-    async fn head_manifest(
-        &self,
-        _repo_name: &str,
-        _reference: &str,
-    ) -> Result<Option<(String, String)>> {
-        Err(alien_error::AlienError::new(
-            crate::error::ErrorData::OperationNotSupported {
-                operation: "head_manifest".to_string(),
-                reason: "This artifact registry provider does not support manifest checking"
-                    .to_string(),
-            },
-        ))
-    }
-
-    /// Checks if a blob exists in the upstream registry.
-    ///
-    /// Returns the content length if the blob exists.
-    /// Default implementation returns `OperationNotSupported`.
-    async fn head_blob(&self, _repo_name: &str, _digest: &str) -> Result<Option<u64>> {
-        Err(alien_error::AlienError::new(
-            crate::error::ErrorData::OperationNotSupported {
-                operation: "head_blob".to_string(),
-                reason: "This artifact registry provider does not support blob checking"
-                    .to_string(),
-            },
-        ))
-    }
 }
 
 /// A trait for vault bindings that provide secure secret management.

--- a/crates/alien-manager/src/registry_access.rs
+++ b/crates/alien-manager/src/registry_access.rs
@@ -144,31 +144,7 @@ pub async fn reconcile_registry_access(
         // Passing the prefix here would double it (e.g. "alien-quickstart-alien-quickstart").
         let repo_id = "";
 
-        // Azure ACR: clean up scope map + token.
-        if matches!(environment_info, EnvironmentInfo::Azure(_)) {
-            if let Some(repo_name) = extract_acr_image_repo(state.stack_state.as_ref()) {
-                use std::collections::hash_map::DefaultHasher;
-                use std::hash::{Hash, Hasher};
-                let mut hasher = DefaultHasher::new();
-                deployment_id.hash(&mut hasher);
-                let prefix = format!("d{:x}", hasher.finish());
-                let namespaced_repo = format!("{}--{}", prefix, repo_name);
-
-                if let Err(e) = artifact_registry
-                    .cleanup_credentials(&namespaced_repo)
-                    .await
-                {
-                    warn!(
-                        deployment_id = %deployment_id,
-                        namespaced_repo = %namespaced_repo,
-                        error = %e,
-                        "Failed to clean up Azure ACR credentials"
-                    );
-                }
-            }
-        }
-
-        // AWS/GCP: revoke IAM-based cross-account access.
+        // Revoke cross-account access (AWS/GCP only; Azure/Local are no-ops).
         revoke_registry_access(
             artifact_registry.as_ref(),
             &repo_id,
@@ -244,38 +220,6 @@ fn needs_registry_access(status: &DeploymentStatus) -> bool {
             | DeploymentStatus::Updating
             | DeploymentStatus::UpdateFailed
     )
-}
-
-/// Extract the ACR image repo name from the stack state's function resources.
-///
-/// Downcasts function configs to `Function` to read the image URI,
-/// then extracts the repo path from ACR URIs like
-/// `registry.azurecr.io/http-server:tag` → `http-server`.
-fn extract_acr_image_repo(stack_state: Option<&StackState>) -> Option<String> {
-    use alien_core::{Function, FunctionCode};
-
-    let stack_state = stack_state?;
-    for (_id, resource) in &stack_state.resources {
-        let image_uri = if let Some(func) = resource.config.downcast_ref::<Function>() {
-            match &func.code {
-                FunctionCode::Image { image } => Some(image.as_str()),
-                FunctionCode::Source { .. } => None,
-            }
-        } else {
-            None
-        };
-
-        if let Some(image) = image_uri {
-            if image.contains(".azurecr.io/") {
-                let after_host = image.split(".azurecr.io/").nth(1)?;
-                let repo_path = after_host.split(':').next()?;
-                if !repo_path.is_empty() {
-                    return Some(repo_path.to_string());
-                }
-            }
-        }
-    }
-    None
 }
 
 /// Extract RSM access configuration from stack state to include in cross-account access.

--- a/crates/alien-manager/src/routes/registry_proxy.rs
+++ b/crates/alien-manager/src/routes/registry_proxy.rs
@@ -582,12 +582,16 @@ async fn forward_request(
     }
 
     // Inject upstream auth.
-    // Empty username = Bearer auth (ACR access tokens).
-    // Non-empty username = Basic auth (ECR, GAR, local).
-    if creds.username.is_empty() && !creds.password.is_empty() {
-        req = req.bearer_auth(&creds.password);
-    } else if !creds.username.is_empty() || !creds.password.is_empty() {
-        req = req.basic_auth(&creds.username, Some(&creds.password));
+    use alien_bindings::traits::RegistryAuthMethod;
+    match creds.auth_method {
+        RegistryAuthMethod::Bearer => {
+            req = req.bearer_auth(&creds.password);
+        }
+        RegistryAuthMethod::Basic => {
+            if !creds.username.is_empty() || !creds.password.is_empty() {
+                req = req.basic_auth(&creds.username, Some(&creds.password));
+            }
+        }
     }
 
     // Stream body to upstream (push operations).

--- a/packages/sdk/src/bindings/artifact-registry.ts
+++ b/packages/sdk/src/bindings/artifact-registry.ts
@@ -223,6 +223,7 @@ export class ArtifactRegistry {
 
   private fromProtoCredentials(proto: Credentials): ArtifactRegistryCredentials {
     return {
+      authMethod: proto.authMethod === 1 ? "bearer" : "basic",
       username: proto.username,
       password: proto.password,
       expiresAt: proto.expiresAt ? new Date(proto.expiresAt) : undefined,

--- a/packages/sdk/src/generated/artifact_registry.ts
+++ b/packages/sdk/src/generated/artifact_registry.ts
@@ -75,6 +75,40 @@ export function computeServiceTypeToJSON(object: ComputeServiceType): string {
   }
 }
 
+/** How the registry expects credentials to be presented */
+export enum AuthMethod {
+  AUTH_METHOD_BASIC = 0,
+  AUTH_METHOD_BEARER = 1,
+  UNRECOGNIZED = -1,
+}
+
+export function authMethodFromJSON(object: any): AuthMethod {
+  switch (object) {
+    case 0:
+    case "AUTH_METHOD_BASIC":
+      return AuthMethod.AUTH_METHOD_BASIC;
+    case 1:
+    case "AUTH_METHOD_BEARER":
+      return AuthMethod.AUTH_METHOD_BEARER;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return AuthMethod.UNRECOGNIZED;
+  }
+}
+
+export function authMethodToJSON(object: AuthMethod): string {
+  switch (object) {
+    case AuthMethod.AUTH_METHOD_BASIC:
+      return "AUTH_METHOD_BASIC";
+    case AuthMethod.AUTH_METHOD_BEARER:
+      return "AUTH_METHOD_BEARER";
+    case AuthMethod.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
 /** Messages for CreateRepository */
 export interface CreateRepositoryRequest {
   /** Name of the artifact registry binding to use */
@@ -232,7 +266,11 @@ export interface Credentials {
   /** Password or token for authentication */
   password: string;
   /** Optional expiration time in ISO8601 format */
-  expiresAt?: string | undefined;
+  expiresAt?:
+    | string
+    | undefined;
+  /** How to present these credentials to the registry */
+  authMethod: AuthMethod;
 }
 
 function createBaseCreateRepositoryRequest(): CreateRepositoryRequest {
@@ -1691,7 +1729,7 @@ export const RepositoryResult: MessageFns<RepositoryResult> = {
 };
 
 function createBaseCredentials(): Credentials {
-  return { username: "", password: "", expiresAt: undefined };
+  return { username: "", password: "", expiresAt: undefined, authMethod: 0 };
 }
 
 export const Credentials: MessageFns<Credentials> = {
@@ -1704,6 +1742,9 @@ export const Credentials: MessageFns<Credentials> = {
     }
     if (message.expiresAt !== undefined) {
       writer.uint32(26).string(message.expiresAt);
+    }
+    if (message.authMethod !== 0) {
+      writer.uint32(32).int32(message.authMethod);
     }
     return writer;
   },
@@ -1739,6 +1780,14 @@ export const Credentials: MessageFns<Credentials> = {
           message.expiresAt = reader.string();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.authMethod = reader.int32() as any;
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1753,6 +1802,7 @@ export const Credentials: MessageFns<Credentials> = {
       username: isSet(object.username) ? globalThis.String(object.username) : "",
       password: isSet(object.password) ? globalThis.String(object.password) : "",
       expiresAt: isSet(object.expiresAt) ? globalThis.String(object.expiresAt) : undefined,
+      authMethod: isSet(object.authMethod) ? authMethodFromJSON(object.authMethod) : 0,
     };
   },
 
@@ -1767,6 +1817,9 @@ export const Credentials: MessageFns<Credentials> = {
     if (message.expiresAt !== undefined) {
       obj.expiresAt = message.expiresAt;
     }
+    if (message.authMethod !== 0) {
+      obj.authMethod = authMethodToJSON(message.authMethod);
+    }
     return obj;
   },
 
@@ -1778,6 +1831,7 @@ export const Credentials: MessageFns<Credentials> = {
     message.username = object.username ?? "";
     message.password = object.password ?? "";
     message.expiresAt = object.expiresAt ?? undefined;
+    message.authMethod = object.authMethod ?? 0;
     return message;
   },
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -99,6 +99,7 @@ export type {
   ArtifactRegistryPermissions,
   RepositoryInfo,
   ArtifactRegistryCredentials,
+  RegistryAuthMethod,
   ComputeServiceType,
   AwsCrossAccountAccess,
   GcpCrossAccountAccess,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -206,9 +206,18 @@ export interface RepositoryInfo {
 }
 
 /**
+ * How the registry expects credentials to be presented.
+ * - "basic": HTTP Basic auth (ECR, GAR, Local)
+ * - "bearer": HTTP Bearer token (ACR)
+ */
+export type RegistryAuthMethod = "basic" | "bearer"
+
+/**
  * Credentials for repository access.
  */
 export interface ArtifactRegistryCredentials {
+  /** How to present these credentials to the registry */
+  authMethod: RegistryAuthMethod
   /** Username for authentication */
   username: string
   /** Password/token for authentication */


### PR DESCRIPTION
## Summary

- Remove 5 unused trait methods (`cleanup_credentials`, `generate_blob_download_url`, `get_manifest`, `head_manifest`, `head_blob`) and dead Azure scope-map cleanup from the deployment loop
- Add `RegistryAuthMethod` enum (`Basic` | `Bearer`) to replace the implicit "empty username = Bearer" convention in the proxy
- Fix ACR `expires_at` to return computed 300s expiry instead of `None`
- GAR `create_repository` / `get_repository` are now no-ops — image paths are created implicitly on push. Removed underscore-to-hyphen sanitization (OCI spec allows underscores in image paths)

Net: **+110 / -450 lines** across 14 files.

## Test plan

- [ ] `cargo check -p alien-bindings -p alien-manager` compiles clean
- [ ] `alien release --platforms local,aws` pushes through proxy successfully
- [ ] Proxy correctly uses Bearer auth for ACR, Basic auth for ECR/GAR/Local
- [ ] Cross-account access still works for AWS (ECR policies) and GCP (IAM bindings)

Resolves [ALIEN-32](https://linear.app/alienplatform/issue/ALIEN-32/artifactregistry-semantic-consistency-and-dead-code-cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)