### PR TITLE
refactor: thread caller through DeploymentStore + drop telemetry lookup

### DIFF
--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -597,9 +597,11 @@ async fn serve_task(args: ServeArgs) -> Result<()> {
             reason: "Failed to build alien-manager".to_string(),
         })?;
 
-    // Clean up stale deployment locks
+    // Clean up stale deployment locks. Startup hook — `Subject::system()` is
+    // the synthetic operator (single-tenant standalone mode).
     let deployment_store = server.deployment_store().clone();
-    match deployment_store.cleanup_stale_locks().await {
+    let startup_caller = alien_manager::auth::Subject::system();
+    match deployment_store.cleanup_stale_locks(&startup_caller).await {
         Ok(0) => {}
         Ok(n) => tracing::info!(count = n, "Cleaned up stale deployment locks"),
         Err(e) => tracing::warn!(error = %e, "Failed to clean up stale deployment locks"),
@@ -731,8 +733,10 @@ async fn watch_serve_deployments(
                 }
             }
             _ = interval.tick() => {
+                // Standalone CLI dev loop — single-tenant, synthetic operator.
+                let dev_caller = alien_manager::auth::Subject::system();
                 let deployments = match deployment_store
-                    .list_deployments(&DeploymentFilter::default())
+                    .list_deployments(&dev_caller, &DeploymentFilter::default())
                     .await
                 {
                     Ok(d) => d,
@@ -749,7 +753,7 @@ async fn watch_serve_deployments(
 
                 // Build group_id → group_name map for card labels
                 let group_names: std::collections::HashMap<String, String> =
-                    match deployment_store.list_deployment_groups().await {
+                    match deployment_store.list_deployment_groups(&dev_caller).await {
                         Ok(groups) => groups
                             .into_iter()
                             .map(|g| (g.id, g.name))

--- a/crates/alien-manager/src/auth/authz.rs
+++ b/crates/alien-manager/src/auth/authz.rs
@@ -58,10 +58,15 @@ pub trait Authz: Send + Sync {
     ) -> bool;
 
     // -- Telemetry ingest --------------------------------------------------
+    /// Telemetry decisions take only the deployment ID. Authorization is a
+    /// scope check on the bearer (the validator already bound `Subject` to a
+    /// workspace and a `Scope::Deployment`); loading the full record was
+    /// historically required only because policy needed `deployment.id`, which
+    /// is the same string we already have in the `Subject`.
     fn can_ingest_telemetry_for(
         &self,
         subject: &Subject,
-        deployment: &DeploymentRecord,
+        deployment_id: &str,
     ) -> bool;
 
     // -- Registry proxy ----------------------------------------------------

--- a/crates/alien-manager/src/auth/subject.rs
+++ b/crates/alien-manager/src/auth/subject.rs
@@ -102,8 +102,10 @@ impl Scope {
 impl Subject {
     /// Synthetic system subject for internal manager loops (deployment loop,
     /// sync handler, command dispatcher) that aren't tied to an incoming
-    /// request. `bearer_token` is empty; stores that need a real bearer must
-    /// fall back to their own auth path in this case.
+    /// request. `bearer_token` is empty by design — embedders that proxy
+    /// outbound calls must opt into their own service credential by checking
+    /// [`Self::is_system`], not by treating an empty bearer as a generic
+    /// fallback signal.
     pub fn system() -> Self {
         Self {
             kind: SubjectKind::ServiceAccount {
@@ -114,6 +116,20 @@ impl Subject {
             role: Role::WorkspaceAdmin,
             bearer_token: String::new(),
         }
+    }
+
+    /// True iff this `Subject` is the exact shape produced by
+    /// [`Self::system`]. Embedders use this as the **only** signal that an
+    /// outbound call may use their own service credential — any other
+    /// empty-bearer subject (a buggy validator, a partially-initialized test
+    /// helper) must fail loudly rather than silently inherit elevated
+    /// privilege.
+    pub fn is_system(&self) -> bool {
+        self.bearer_token.is_empty()
+            && self.workspace_id == "default"
+            && matches!(self.scope, Scope::Workspace)
+            && self.role == Role::WorkspaceAdmin
+            && matches!(&self.kind, SubjectKind::ServiceAccount { id } if id == "system")
     }
 
     /// True for callers who should be treated as the OSS operator: workspace-
@@ -173,6 +189,40 @@ mod tests {
             },
         );
         assert_eq!(s.scope.project_id(), Some("p1"));
+    }
+
+    #[test]
+    fn system_subject_is_recognised() {
+        assert!(Subject::system().is_system());
+    }
+
+    #[test]
+    fn empty_bearer_alone_is_not_system() {
+        // A real validator could legitimately produce a Subject with every
+        // other field set but an empty bearer (e.g. a future token type that
+        // doesn't carry a passthrough credential). That must not be treated
+        // as `Subject::system()`, which is reserved for *internal* callers
+        // with no inbound request.
+        let s = Subject {
+            kind: SubjectKind::ServiceAccount {
+                id: "tok-1".to_string(),
+            },
+            workspace_id: "default".to_string(),
+            scope: Scope::Workspace,
+            role: Role::WorkspaceAdmin,
+            bearer_token: String::new(),
+        };
+        assert!(!s.is_system(), "non-system service account must not match");
+    }
+
+    #[test]
+    fn system_with_real_bearer_is_not_system() {
+        let mut s = Subject::system();
+        s.bearer_token = "bearer".to_string();
+        assert!(
+            !s.is_system(),
+            "Subject::system() with a non-empty bearer is not system anymore"
+        );
     }
 
     #[test]

--- a/crates/alien-manager/src/bin/main.rs
+++ b/crates/alien-manager/src/bin/main.rs
@@ -125,9 +125,11 @@ async fn build_standalone_server(
         .await
         .expect("Failed to build alien-manager");
 
-    // Clean up stale deployment locks from previous runs
+    // Clean up stale deployment locks from previous runs. Startup hook —
+    // `Subject::system()` is the synthetic operator (single-tenant OSS mode).
     let deployment_store = server.deployment_store();
-    match deployment_store.cleanup_stale_locks().await {
+    let startup_caller = alien_manager::auth::Subject::system();
+    match deployment_store.cleanup_stale_locks(&startup_caller).await {
         Ok(0) => {}
         Ok(n) => tracing::info!(count = n, "Cleaned up stale deployment locks"),
         Err(e) => tracing::warn!(error = %e, "Failed to clean up stale deployment locks"),

--- a/crates/alien-manager/src/commands/default_dispatcher.rs
+++ b/crates/alien-manager/src/commands/default_dispatcher.rs
@@ -87,10 +87,14 @@ impl CommandDispatcher for DefaultCommandDispatcher {
             "DefaultCommandDispatcher: looking up deployment for push dispatch"
         );
 
-        // 1. Get deployment record
+        // 1. Get deployment record. Push dispatch runs from a `Subscriber`
+        // task with no inbound caller — `Subject::system()` is the standard
+        // synthetic subject for that case (empty bearer signals no
+        // passthrough is available).
+        let system = crate::auth::Subject::system();
         let deployment = self
             .deployment_store
-            .get_deployment(deployment_id)
+            .get_deployment(&system, deployment_id)
             .await
             .context(CmdErrorData::Other {
                 message: format!("Failed to get deployment {}", deployment_id),
@@ -122,7 +126,6 @@ impl CommandDispatcher for DefaultCommandDispatcher {
             })
         })?;
 
-        let system = crate::auth::Subject::system();
         let release = self
             .release_store
             .get_release(&system, release_id)

--- a/crates/alien-manager/src/loops/deployment.rs
+++ b/crates/alien-manager/src/loops/deployment.rs
@@ -25,6 +25,7 @@ use alien_error::{AlienError, Context, GenericError};
 use alien_infra::DefaultPlatformServiceProvider;
 use alien_local::LocalBindingsProvider;
 
+use crate::auth::Subject;
 use crate::config::ManagerConfig;
 use crate::traits::deployment_store::{DeploymentFilter, DeploymentRecord};
 use crate::traits::{CredentialResolver, DeploymentStore, ReleaseStore, ServerBindings};
@@ -139,7 +140,15 @@ impl DeploymentLoop {
             ..Default::default()
         };
 
-        match self.deployment_store.acquire(&session, &filter, 10).await {
+        // Internal loop: no inbound caller. `Subject::system()` carries an
+        // empty `bearer_token` — the documented signal to embedders that
+        // no caller passthrough is available.
+        let caller = Subject::system();
+        match self
+            .deployment_store
+            .acquire(&caller, &session, &filter, 10)
+            .await
+        {
             Ok(acquired) => {
                 if !acquired.is_empty() {
                     debug!(count = acquired.len(), session = %session, "Acquired deployments");
@@ -169,8 +178,13 @@ impl DeploymentLoop {
             );
         }
 
-        // Release lock unconditionally.
-        if let Err(e) = self.deployment_store.release(&deployment_id, session).await {
+        // Release lock unconditionally. Loop context, no inbound caller.
+        let caller = Subject::system();
+        if let Err(e) = self
+            .deployment_store
+            .release(&caller, &deployment_id, session)
+            .await
+        {
             error!(
                 deployment_id = %deployment_id,
                 error = %e,
@@ -293,10 +307,13 @@ impl DeploymentLoop {
             protocol_version: alien_core::DEPLOYMENT_PROTOCOL_VERSION,
         };
 
-        // Clear retry_requested flag before running.
+        // Clear retry_requested flag before running. Loop context — no
+        // inbound caller; `Subject::system()` is the documented synthetic
+        // operator for these calls.
         if deployment.retry_requested {
+            let caller = Subject::system();
             self.deployment_store
-                .set_retry_requested(&deployment_id)
+                .set_retry_requested(&caller, &deployment_id)
                 .await?;
             state.retry_requested = true;
         }
@@ -446,12 +463,14 @@ impl DeploymentLoop {
             }
         }
 
-        // 8. Handle deleted deployments — clean up the record.
+        // 8. Handle deleted deployments — clean up the record. Loop
+        // context — no inbound caller; pass `Subject::system()`.
         if state.status == DeploymentStatus::Deleted {
             info!(deployment_id = %deployment_id, "Deployment deleted, removing record");
+            let caller = Subject::system();
             if let Err(e) = self
                 .deployment_store
-                .delete_deployment(&deployment_id)
+                .delete_deployment(&caller, &deployment_id)
                 .await
             {
                 error!(

--- a/crates/alien-manager/src/loops/heartbeat.rs
+++ b/crates/alien-manager/src/loops/heartbeat.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use tracing::{debug, error};
 
+use crate::auth::Subject;
 use crate::config::ManagerConfig;
 use crate::traits::deployment_store::DeploymentFilter;
 use crate::traits::DeploymentStore;
@@ -45,7 +46,11 @@ impl HeartbeatLoop {
             ..Default::default()
         };
 
-        match self.deployment_store.list_deployments(&filter).await {
+        // Internal loop: no inbound caller. `Subject::system()` carries an
+        // empty `bearer_token` — the documented signal to embedders that
+        // no caller passthrough is available.
+        let caller = Subject::system();
+        match self.deployment_store.list_deployments(&caller, &filter).await {
             Ok(deployments) => {
                 if !deployments.is_empty() {
                     debug!(

--- a/crates/alien-manager/src/providers/oss_authz.rs
+++ b/crates/alien-manager/src/providers/oss_authz.rs
@@ -165,11 +165,11 @@ impl Authz for OssAuthz {
 
     // -- Telemetry ingest --------------------------------------------------
 
-    fn can_ingest_telemetry_for(&self, s: &Subject, deployment: &DeploymentRecord) -> bool {
+    fn can_ingest_telemetry_for(&self, s: &Subject, deployment_id: &str) -> bool {
         // Only the deployment itself ingests its own telemetry.
         matches!(
             &s.scope,
-            Scope::Deployment { deployment_id, .. } if deployment_id == &deployment.id
+            Scope::Deployment { deployment_id: scope_id, .. } if scope_id == deployment_id
         )
     }
 
@@ -290,8 +290,7 @@ mod tests {
 
     #[test]
     fn telemetry_ingest_is_self_only() {
-        let dep = deployment("d1", "dg-a");
-        assert!(OssAuthz.can_ingest_telemetry_for(&deployment_token("d1"), &dep));
-        assert!(!OssAuthz.can_ingest_telemetry_for(&admin(), &dep));
+        assert!(OssAuthz.can_ingest_telemetry_for(&deployment_token("d1"), "d1"));
+        assert!(!OssAuthz.can_ingest_telemetry_for(&admin(), "d1"));
     }
 }

--- a/crates/alien-manager/src/routes/commands.rs
+++ b/crates/alien-manager/src/routes/commands.rs
@@ -22,17 +22,6 @@ use super::{auth, AppState};
 
 // --- Helpers ---
 
-/// Look up the deployment_group_id for a deployment, for DG-scoped auth checks.
-async fn get_deployment_group_id(state: &AppState, deployment_id: &str) -> Result<String, Response> {
-    let deployment = state
-        .deployment_store
-        .get_deployment(deployment_id)
-        .await
-        .map_err(|e| e.into_response())?
-        .ok_or_else(|| ErrorData::not_found_deployment(deployment_id).into_response())?;
-    Ok(deployment.deployment_group_id.clone())
-}
-
 /// Look up the deployment_id that owns a command, for per-command auth checks.
 async fn get_command_owner(state: &AppState, command_id: &str) -> Result<String, Response> {
     state
@@ -57,7 +46,7 @@ async fn require_command_access(
 ) -> Result<(), Response> {
     let deployment = state
         .deployment_store
-        .get_deployment(deployment_id)
+        .get_deployment(subject, deployment_id)
         .await
         .map_err(|e| e.into_response())?
         .ok_or_else(|| ErrorData::not_found_deployment(deployment_id).into_response())?;
@@ -110,7 +99,7 @@ async fn create_command(
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
-    let deployment = match state.deployment_store.get_deployment(&request.deployment_id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &request.deployment_id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&request.deployment_id).into_response(),
         Err(e) => return e.into_response(),
@@ -172,7 +161,7 @@ async fn upload_complete(
         Err(e) => return e,
     };
 
-    let deployment = match state.deployment_store.get_deployment(&deployment_id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &deployment_id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&deployment_id).into_response(),
         Err(e) => return e.into_response(),
@@ -224,7 +213,7 @@ async fn submit_response(
             Ok(id) => id,
             Err(e) => return e,
         };
-        let deployment = match state.deployment_store.get_deployment(&deployment_id).await {
+        let deployment = match state.deployment_store.get_deployment(&subject, &deployment_id).await {
             Ok(Some(d)) => d,
             Ok(None) => return ErrorData::not_found_deployment(&deployment_id).into_response(),
             Err(e) => return e.into_response(),
@@ -379,7 +368,11 @@ async fn acquire_leases(
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
-    let deployment = match state.deployment_store.get_deployment(&lease_request.deployment_id).await {
+    let deployment = match state
+        .deployment_store
+        .get_deployment(&subject, &lease_request.deployment_id)
+        .await
+    {
         Ok(Some(d)) => d,
         Ok(None) => {
             return ErrorData::not_found_deployment(&lease_request.deployment_id).into_response()

--- a/crates/alien-manager/src/routes/credentials.rs
+++ b/crates/alien-manager/src/routes/credentials.rs
@@ -62,7 +62,7 @@ async fn resolve_credentials(
     // authorization-guidelines.md).
     let deployment = match state
         .deployment_store
-        .get_deployment(&req.deployment_id)
+        .get_deployment(&subject, &req.deployment_id)
         .await
     {
         Ok(Some(d)) => d,

--- a/crates/alien-manager/src/routes/deployment_groups.rs
+++ b/crates/alien-manager/src/routes/deployment_groups.rs
@@ -88,6 +88,11 @@ fn record_to_response(dg: &DeploymentGroupRecord) -> DeploymentGroupResponse {
 
 // --- Handlers ---
 
+/// Every handler in this file runs `auth::require_auth(&state, &headers)`
+/// and then threads `&subject` into the `DeploymentStore` calls — see the
+/// trait doc on [`DeploymentStore`] for the convention.
+///
+/// `POST /v1/deployment-groups` — Inbound: workspace bearer.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/deployment-groups",
@@ -117,10 +122,13 @@ async fn create_deployment_group(
 
     let dg = match state
         .deployment_store
-        .create_deployment_group(CreateDeploymentGroupParams {
-            name: req.name,
-            max_deployments: req.max_deployments,
-        })
+        .create_deployment_group(
+            &subject,
+            CreateDeploymentGroupParams {
+                name: req.name,
+                max_deployments: req.max_deployments,
+            },
+        )
         .await
     {
         Ok(dg) => dg,
@@ -147,7 +155,7 @@ async fn list_deployment_groups(State(state): State<AppState>, headers: HeaderMa
         Err(e) => return e.into_response(),
     };
 
-    let groups = match state.deployment_store.list_deployment_groups().await {
+    let groups = match state.deployment_store.list_deployment_groups(&subject).await {
         Ok(g) => g,
         Err(e) => return e.into_response(),
     };
@@ -193,7 +201,7 @@ async fn get_deployment_group(
         Err(e) => return e.into_response(),
     };
 
-    let dg = match state.deployment_store.get_deployment_group(&id).await {
+    let dg = match state.deployment_store.get_deployment_group(&subject, &id).await {
         Ok(Some(dg)) => dg,
         Ok(None) => return ErrorData::not_found_group(&id).into_response(),
         Err(e) => return e.into_response(),
@@ -232,7 +240,7 @@ async fn create_deployment_group_token(
     };
 
     // Verify group exists, then authorize on the loaded entity.
-    let dg = match state.deployment_store.get_deployment_group(&id).await {
+    let dg = match state.deployment_store.get_deployment_group(&subject, &id).await {
         Ok(Some(dg)) => dg,
         Ok(None) => return ErrorData::not_found_group(&id).into_response(),
         Err(e) => return e.into_response(),

--- a/crates/alien-manager/src/routes/deployments.rs
+++ b/crates/alien-manager/src/routes/deployments.rs
@@ -213,6 +213,14 @@ fn record_to_response(
 
 // --- Handlers ---
 
+/// Every handler in this file runs `auth::require_auth(&state, &headers)`
+/// and then threads `&subject` into the `DeploymentStore` calls. Embedders
+/// that proxy to an upstream API can use the subject's `bearer_token` for
+/// passthrough; single-tenant impls ignore it. See the trait doc on
+/// [`DeploymentStore`] for the full convention.
+///
+/// `POST /v1/deployments` — Inbound: workspace / project / dg bearer (or
+/// authenticated user). Deployment-scoped tokens cannot create deployments.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/deployments",
@@ -247,7 +255,7 @@ async fn create_deployment(
         crate::auth::Scope::Workspace | crate::auth::Scope::Project { .. } => {
             match &req.deployment_group_id {
                 Some(id) => id.clone(),
-                None => match state.deployment_store.list_deployment_groups().await {
+                None => match state.deployment_store.list_deployment_groups(&subject).await {
                     Ok(groups) if !groups.is_empty() => groups[0].id.clone(),
                     Ok(_) => {
                         return ErrorData::bad_request(
@@ -268,7 +276,7 @@ async fn create_deployment(
     // Verify deployment group exists
     let dg = match state
         .deployment_store
-        .get_deployment_group(&deployment_group_id)
+        .get_deployment_group(&subject, &deployment_group_id)
         .await
     {
         Ok(Some(dg)) => dg,
@@ -305,14 +313,17 @@ async fn create_deployment(
 
     let mut deployment = match state
         .deployment_store
-        .create_deployment(CreateDeploymentParams {
-            name: req.name,
-            deployment_group_id: deployment_group_id.clone(),
-            platform: req.platform,
-            stack_settings: req.stack_settings.unwrap_or_default(),
-            environment_variables: req.environment_variables,
-            deployment_token: Some(raw_token.clone()),
-        })
+        .create_deployment(
+            &subject,
+            CreateDeploymentParams {
+                name: req.name,
+                deployment_group_id: deployment_group_id.clone(),
+                platform: req.platform,
+                stack_settings: req.stack_settings.unwrap_or_default(),
+                environment_variables: req.environment_variables,
+                deployment_token: Some(raw_token.clone()),
+            },
+        )
         .await
     {
         Ok(d) => d,
@@ -340,7 +351,7 @@ async fn create_deployment(
     if let Some(ref release_id) = desired_release_id {
         if let Err(e) = state
             .deployment_store
-            .set_deployment_desired_release(&deployment.id, release_id)
+            .set_deployment_desired_release(&subject, &deployment.id, release_id)
             .await
         {
             return e.into_response();
@@ -404,7 +415,7 @@ async fn list_deployments(
         ..Default::default()
     };
 
-    let deployments = match state.deployment_store.list_deployments(&filter).await {
+    let deployments = match state.deployment_store.list_deployments(&subject, &filter).await {
         Ok(d) => d,
         Err(e) => return e.into_response(),
     };
@@ -422,7 +433,7 @@ async fn list_deployments(
             } else {
                 let minimal = match state
                     .deployment_store
-                    .get_deployment_group(&d.deployment_group_id)
+                    .get_deployment_group(&subject, &d.deployment_group_id)
                     .await
                 {
                     Ok(Some(dg)) => Some(DeploymentGroupMinimal {
@@ -471,7 +482,7 @@ async fn get_deployment(
         Err(e) => return e.into_response(),
     };
 
-    let deployment = match state.deployment_store.get_deployment(&id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&id).into_response(),
         Err(e) => return e.into_response(),
@@ -506,7 +517,7 @@ async fn get_deployment_info(
         Err(e) => return e.into_response(),
     };
 
-    let deployment = match state.deployment_store.get_deployment(&id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&id).into_response(),
         Err(e) => return e.into_response(),
@@ -578,7 +589,7 @@ async fn delete_deployment(
         Err(e) => return e.into_response(),
     };
 
-    let deployment = match state.deployment_store.get_deployment(&id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&id).into_response(),
         Err(e) => return e.into_response(),
@@ -587,11 +598,11 @@ async fn delete_deployment(
     }
 
     if query.force {
-        if let Err(e) = state.deployment_store.delete_deployment(&id).await {
+        if let Err(e) = state.deployment_store.delete_deployment(&subject, &id).await {
             return e.into_response();
         }
     } else {
-        if let Err(e) = state.deployment_store.set_delete_pending(&id).await {
+        if let Err(e) = state.deployment_store.set_delete_pending(&subject, &id).await {
             return e.into_response();
         }
     }
@@ -629,7 +640,7 @@ async fn retry_deployment(
         Err(e) => return e.into_response(),
     };
 
-    let deployment = match state.deployment_store.get_deployment(&id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&id).into_response(),
         Err(e) => return e.into_response(),
@@ -637,7 +648,7 @@ async fn retry_deployment(
         return ErrorData::forbidden("Cannot retry deployment").into_response();
     }
 
-    if let Err(e) = state.deployment_store.set_retry_requested(&id).await {
+    if let Err(e) = state.deployment_store.set_retry_requested(&subject, &id).await {
         return e.into_response();
     }
 
@@ -668,7 +679,7 @@ async fn redeploy(
         Err(e) => return e.into_response(),
     };
 
-    let deployment = match state.deployment_store.get_deployment(&id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&id).into_response(),
         Err(e) => return e.into_response(),
@@ -676,7 +687,7 @@ async fn redeploy(
         return ErrorData::forbidden("Cannot redeploy").into_response();
     }
 
-    if let Err(e) = state.deployment_store.set_redeploy(&id).await {
+    if let Err(e) = state.deployment_store.set_redeploy(&subject, &id).await {
         return e.into_response();
     }
 

--- a/crates/alien-manager/src/routes/registry_proxy.rs
+++ b/crates/alien-manager/src/routes/registry_proxy.rs
@@ -775,7 +775,7 @@ async fn validate_pull_access(
         // Cache miss — query DB.
         let deployment = state
             .deployment_store
-            .get_deployment(deployment_id)
+            .get_deployment(subject, deployment_id)
             .await
             .map_err(|e| {
                 warn!(error = %e, "Failed to get deployment for registry proxy");

--- a/crates/alien-manager/src/routes/releases.rs
+++ b/crates/alien-manager/src/routes/releases.rs
@@ -250,7 +250,7 @@ async fn create_release(
     // Set desired_release_id on eligible deployments
     if let Err(e) = state
         .deployment_store
-        .set_desired_release(&release.id, None)
+        .set_desired_release(&subject, &release.id, None)
         .await
     {
         tracing::warn!(error = %e, "Failed to set desired release on deployments");

--- a/crates/alien-manager/src/routes/sync.rs
+++ b/crates/alien-manager/src/routes/sync.rs
@@ -156,6 +156,9 @@ pub fn initialize_router() -> Router<AppState> {
 
 // --- Handlers ---
 
+/// `POST /v1/sync/acquire` — Inbound: workspace / dg / deployment bearer.
+/// `caller: &Subject` is threaded into `DeploymentStore::acquire` so
+/// embedders can authorize against the inbound caller's scope.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/sync/acquire",
@@ -184,7 +187,7 @@ async fn acquire(
     if let Some(ids) = req.deployment_ids.as_ref() {
         let mut deployments = Vec::with_capacity(ids.len());
         for id in ids {
-            match state.deployment_store.get_deployment(id).await {
+            match state.deployment_store.get_deployment(&subject, id).await {
                 Ok(Some(d)) => deployments.push(d),
                 Ok(None) => return ErrorData::not_found_deployment(id).into_response(),
                 Err(e) => return e.into_response(),
@@ -211,7 +214,7 @@ async fn acquire(
 
     let acquired = match state
         .deployment_store
-        .acquire(&req.session, &filter, req.limit)
+        .acquire(&subject, &req.session, &filter, req.limit)
         .await
     {
         Ok(a) => a,
@@ -237,6 +240,8 @@ async fn acquire(
     Json(AcquireResponse { deployments }).into_response()
 }
 
+/// `POST /v1/sync/reconcile` — Inbound: workspace / dg / deployment
+/// bearer. `caller: &Subject` is threaded into `DeploymentStore::reconcile`.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/sync/reconcile",
@@ -261,7 +266,7 @@ async fn reconcile(
 
     // Allow admin tokens (push mode) or deployment tokens (pull mode) per
     // the unified Authz policy.
-    let deployment = match state.deployment_store.get_deployment(&req.deployment_id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &req.deployment_id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&req.deployment_id).into_response(),
         Err(e) => return e.into_response(),
@@ -297,13 +302,16 @@ async fn reconcile(
     // 2. Persist the step result (including any registry access changes).
     let _result = match state
         .deployment_store
-        .reconcile(ReconcileData {
-            deployment_id: req.deployment_id.clone(),
-            session: req.session,
-            state: final_state.clone(),
-            update_heartbeat: req.update_heartbeat,
-            error: req.error,
-        })
+        .reconcile(
+            &subject,
+            ReconcileData {
+                deployment_id: req.deployment_id.clone(),
+                session: req.session,
+                state: final_state.clone(),
+                update_heartbeat: req.update_heartbeat,
+                error: req.error,
+            },
+        )
         .await
     {
         Ok(r) => r,
@@ -336,6 +344,8 @@ async fn reconcile(
     .into_response()
 }
 
+/// `POST /v1/sync/release` — Inbound: workspace / dg / deployment bearer.
+/// `caller: &Subject` is threaded into `DeploymentStore::release`.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/sync/release",
@@ -356,7 +366,7 @@ async fn release(
     let subject = match auth::require_auth(&state, &headers).await {
         Ok(s) => s,
         Err(e) => return e.into_response(),
-    };    let deployment = match state.deployment_store.get_deployment(&req.deployment_id).await {
+    };    let deployment = match state.deployment_store.get_deployment(&subject, &req.deployment_id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&req.deployment_id).into_response(),
         Err(e) => return e.into_response(),
@@ -367,7 +377,7 @@ async fn release(
 
     match state
         .deployment_store
-        .release(&req.deployment_id, &req.session)
+        .release(&subject, &req.deployment_id, &req.session)
         .await
     {
         Ok(()) => Json(serde_json::json!({ "success": true })).into_response(),
@@ -375,6 +385,9 @@ async fn release(
     }
 }
 
+/// `POST /v1/sync` — Inbound: deployment bearer. The agent-driven sync
+/// path; `caller: &Subject` is threaded into the store so embedders see
+/// the agent's own scope.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/sync",
@@ -399,7 +412,7 @@ async fn agent_sync(
 
     // Must be a deployment token matching this deployment (workspace-scoped
     // tokens are accepted by `Authz::can_sync_deployment` for system flows).
-    let deployment = match state.deployment_store.get_deployment(&req.deployment_id).await {
+    let deployment = match state.deployment_store.get_deployment(&subject, &req.deployment_id).await {
         Ok(Some(d)) => d,
         Ok(None) => return ErrorData::not_found_deployment(&req.deployment_id).into_response(),
         Err(e) => return e.into_response(),
@@ -426,13 +439,16 @@ async fn agent_sync(
 
                 if let Err(e) = state
                     .deployment_store
-                    .reconcile(ReconcileData {
-                        deployment_id: req.deployment_id.clone(),
-                        session: "agent-sync".to_string(),
-                        state: agent_state.clone(),
-                        update_heartbeat: true,
-                        error: None,
-                    })
+                    .reconcile(
+                        &subject,
+                        ReconcileData {
+                            deployment_id: req.deployment_id.clone(),
+                            session: "agent-sync".to_string(),
+                            state: agent_state.clone(),
+                            update_heartbeat: true,
+                            error: None,
+                        },
+                    )
                     .await
                 {
                     tracing::warn!(
@@ -454,7 +470,7 @@ async fn agent_sync(
 
     let deployment = match state
         .deployment_store
-        .get_deployment(&req.deployment_id)
+        .get_deployment(&subject, &req.deployment_id)
         .await
     {
         Ok(Some(d)) => d,
@@ -585,6 +601,11 @@ async fn agent_sync(
     .into_response()
 }
 
+/// `POST /v1/initialize` — Inbound: deployment-group bearer (typical),
+/// or workspace bearer for self-hosted operator workflows. New deployments
+/// are created via `DeploymentStore::create_deployment(caller, …)` so
+/// embedders that proxy to an upstream API write the row in the dg's
+/// workspace, not the manager's.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
     path = "/v1/initialize",
@@ -631,7 +652,7 @@ async fn initialize(
             // group, issue a fresh deployment token and return the existing ID.
             if let Ok(Some(existing)) = state
                 .deployment_store
-                .get_deployment_by_name(&dg_id, &name)
+                .get_deployment_by_name(&subject, &dg_id, &name)
                 .await
             {
                 let (raw_token, key_prefix, key_hash) =
@@ -673,26 +694,31 @@ async fn initialize(
 
             let deployment = match state
                 .deployment_store
-                .create_deployment(CreateDeploymentParams {
-                    name,
-                    deployment_group_id: dg_id.clone(),
-                    platform,
-                    stack_settings: settings,
-                    environment_variables: None,
-                    deployment_token: dep_token,
-                })
+                .create_deployment(
+                    &subject,
+                    CreateDeploymentParams {
+                        name,
+                        deployment_group_id: dg_id.clone(),
+                        platform,
+                        stack_settings: settings,
+                        environment_variables: None,
+                        deployment_token: dep_token,
+                    },
+                )
                 .await
             {
                 Ok(d) => d,
                 Err(e) => return e.into_response(),
             };
 
-            // Auto-assign latest release if available
-            let system = crate::auth::Subject::system();
-            if let Ok(Some(release)) = state.release_store.get_latest_release(&system).await {
+            // Auto-assign latest release if available. Initialize is the
+            // agent's own bootstrap: keep the caller's subject for both
+            // reads and writes so embedders can authorize against the
+            // agent's scope rather than a service credential.
+            if let Ok(Some(release)) = state.release_store.get_latest_release(&subject).await {
                 let _ = state
                     .deployment_store
-                    .set_deployment_desired_release(&deployment.id, &release.id)
+                    .set_deployment_desired_release(&subject, &deployment.id, &release.id)
                     .await;
             }
 
@@ -733,7 +759,7 @@ async fn initialize(
                 platforms: None,
                 limit: Some(1),
             };
-            match state.deployment_store.list_deployments(&filter).await {
+            match state.deployment_store.list_deployments(&subject, &filter).await {
                 Ok(deployments) if !deployments.is_empty() => {
                     let deployment_id = deployments[0].id.clone();
                     tracing::info!(

--- a/crates/alien-manager/src/routes/telemetry.rs
+++ b/crates/alien-manager/src/routes/telemetry.rs
@@ -23,6 +23,11 @@ pub struct TelemetryResponse {
 }
 
 /// POST /v1/logs
+///
+/// Inbound: deployment bearer — the validator must yield a
+/// `Scope::Deployment`. The handler builds [`TelemetryCaller`] from the
+/// subject's scope and never reads a deployment record; the deployment id
+/// the bearer was issued for is sufficient.
 pub async fn ingest_logs(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -32,6 +37,8 @@ pub async fn ingest_logs(
 }
 
 /// POST /v1/traces
+///
+/// Inbound: deployment bearer. See [`ingest_logs`] doc for the auth model.
 pub async fn ingest_traces(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -41,6 +48,8 @@ pub async fn ingest_traces(
 }
 
 /// POST /v1/metrics
+///
+/// Inbound: deployment bearer. See [`ingest_logs`] doc for the auth model.
 pub async fn ingest_metrics(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -55,36 +64,35 @@ async fn ingest(
     body: Bytes,
     signal: TelemetrySignal,
 ) -> Response {
-    // Extract deployment_id from auth subject and run the subject telemetry-
-    // ingest authz check. The configured `Authz::can_ingest_telemetry_for`
-    // impl decides whether this caller may ingest for this deployment.
+    // The validator already bound `Subject` to the deployment whose token
+    // we hold (`Scope::Deployment` carries `project_id` and `deployment_id`;
+    // `subject.workspace_id` comes from the issuer). Everything the
+    // telemetry forward needs is on the subject — round-tripping through
+    // `deployment_store.get_deployment` only added a redundant lookup.
     let subject = match auth::require_auth(&state, &headers).await {
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
-    let deployment_id = match &subject.scope {
-        crate::auth::Scope::Deployment { deployment_id, .. } => deployment_id.clone(),
+    let (deployment_id, project_id) = match &subject.scope {
+        crate::auth::Scope::Deployment {
+            deployment_id,
+            project_id,
+        } => (deployment_id.clone(), project_id.clone()),
         _ => {
             return ErrorData::forbidden("Telemetry ingestion requires a deployment token")
                 .into_response()
         }
     };
 
-    let deployment = match state.deployment_store.get_deployment(&deployment_id).await {
-        Ok(Some(d)) => d,
-        Ok(None) => return ErrorData::not_found_deployment(&deployment_id).into_response(),
-        Err(e) => return e.into_response(),
-    };
-
-    if !state.authz.can_ingest_telemetry_for(&subject, &deployment) {
+    if !state.authz.can_ingest_telemetry_for(&subject, &deployment_id) {
         return ErrorData::forbidden("Cannot ingest telemetry for this deployment")
             .into_response();
     }
 
     let caller = TelemetryCaller {
-        deployment_id: deployment.id.clone(),
-        project_id: Some(deployment.project_id.clone()),
-        workspace_id: Some(deployment.workspace_id.clone()),
+        deployment_id,
+        project_id: Some(project_id),
+        workspace_id: Some(subject.workspace_id.clone()),
     };
 
     match state

--- a/crates/alien-manager/src/routes/vault.rs
+++ b/crates/alien-manager/src/routes/vault.rs
@@ -43,6 +43,7 @@ pub fn router() -> Router<AppState> {
 /// Build a vault binding and load a vault instance for the given deployment and vault name.
 async fn load_vault_for_deployment(
     state: &AppState,
+    caller: &crate::auth::Subject,
     deployment_id: &str,
     vault_name: &str,
 ) -> Result<std::sync::Arc<dyn alien_bindings::traits::Vault>> {
@@ -50,7 +51,7 @@ async fn load_vault_for_deployment(
     use std::collections::HashMap;
 
     // 1. Look up the deployment.
-    let deployment = match state.deployment_store.get_deployment(deployment_id).await {
+    let deployment = match state.deployment_store.get_deployment(caller, deployment_id).await {
         Ok(Some(d)) => d,
         Ok(None) => return Err(ErrorData::not_found_deployment(deployment_id)),
         Err(e) => {
@@ -129,9 +130,10 @@ async fn set_secret(
     Path((deployment_id, vault_name, key)): Path<(String, String, String)>,
     Json(body): Json<SetSecretRequest>,
 ) -> Result<Json<serde_json::Value>> {
-    let subject = auth::require_auth(&state, &headers).await?;    let deployment = state
+    let subject = auth::require_auth(&state, &headers).await?;
+    let deployment = state
         .deployment_store
-        .get_deployment(&deployment_id)
+        .get_deployment(&subject, &deployment_id)
         .await
         .context(ErrorData::InternalError {
             message: "Failed to load deployment".to_string(),
@@ -145,7 +147,7 @@ async fn set_secret(
 
     info!(deployment_id = %deployment_id, vault_name = %vault_name, key = %key, "Setting vault secret");
 
-    let vault = load_vault_for_deployment(&state, &deployment_id, &vault_name).await?;
+    let vault = load_vault_for_deployment(&state, &subject, &deployment_id, &vault_name).await?;
 
     vault
         .set_secret(&key, &body.value)
@@ -163,9 +165,10 @@ async fn get_secret(
     headers: HeaderMap,
     Path((deployment_id, vault_name, key)): Path<(String, String, String)>,
 ) -> Result<Json<GetSecretResponse>> {
-    let subject = auth::require_auth(&state, &headers).await?;    let deployment = state
+    let subject = auth::require_auth(&state, &headers).await?;
+    let deployment = state
         .deployment_store
-        .get_deployment(&deployment_id)
+        .get_deployment(&subject, &deployment_id)
         .await
         .context(ErrorData::InternalError {
             message: "Failed to load deployment".to_string(),
@@ -179,7 +182,7 @@ async fn get_secret(
 
     info!(deployment_id = %deployment_id, vault_name = %vault_name, key = %key, "Getting vault secret");
 
-    let vault = load_vault_for_deployment(&state, &deployment_id, &vault_name).await?;
+    let vault = load_vault_for_deployment(&state, &subject, &deployment_id, &vault_name).await?;
 
     let value = vault
         .get_secret(&key)

--- a/crates/alien-manager/src/stores/sqlite/command_registry.rs
+++ b/crates/alien-manager/src/stores/sqlite/command_registry.rs
@@ -120,9 +120,11 @@ impl CommandRegistry for SqliteCommandRegistry {
 
         let state_str = serialize_enum(&initial_state);
         // Look up deployment and require it to be fully running before accepting commands.
+        // SQLite-backed (single-tenant) registry — caller is unused; use system.
+        let caller = crate::auth::Subject::system();
         let deployment = self
             .deployment_store
-            .get_deployment(deployment_id)
+            .get_deployment(&caller, deployment_id)
             .await
             .map_err(|e| {
                 alien_error::AlienError::new(CommandErrorData::Other {

--- a/crates/alien-manager/src/stores/sqlite/deployment.rs
+++ b/crates/alien-manager/src/stores/sqlite/deployment.rs
@@ -112,10 +112,11 @@ impl SqliteDeploymentStore {
 impl DeploymentStore for SqliteDeploymentStore {
     async fn create_deployment(
         &self,
+        caller: &crate::auth::Subject,
         params: CreateDeploymentParams,
     ) -> Result<DeploymentRecord, AlienError> {
         if let Some(_existing) = self
-            .get_deployment_by_name(&params.deployment_group_id, &params.name)
+            .get_deployment_by_name(caller, &params.deployment_group_id, &params.name)
             .await?
         {
             return Err(AlienError::new(ErrorData::DeploymentNameConflict {
@@ -214,7 +215,11 @@ impl DeploymentStore for SqliteDeploymentStore {
         })
     }
 
-    async fn get_deployment(&self, id: &str) -> Result<Option<DeploymentRecord>, AlienError> {
+    async fn get_deployment(
+        &self,
+        _caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<Option<DeploymentRecord>, AlienError> {
         let sql = Query::select()
             .columns(Self::DEPLOYMENT_COLUMNS)
             .from(Deployments::Table)
@@ -240,6 +245,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn get_deployment_by_name(
         &self,
+        _caller: &crate::auth::Subject,
         deployment_group_id: &str,
         name: &str,
     ) -> Result<Option<DeploymentRecord>, AlienError> {
@@ -269,6 +275,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn list_deployments(
         &self,
+        _caller: &crate::auth::Subject,
         filter: &DeploymentFilter,
     ) -> Result<Vec<DeploymentRecord>, AlienError> {
         let sql = {
@@ -313,7 +320,11 @@ impl DeploymentStore for SqliteDeploymentStore {
         Ok(results)
     }
 
-    async fn delete_deployment(&self, id: &str) -> Result<(), AlienError> {
+    async fn delete_deployment(
+        &self,
+        _caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError> {
         let sql = Query::delete()
             .from_table(Deployments::Table)
             .and_where(Expr::col(Deployments::Id).eq(id))
@@ -321,9 +332,13 @@ impl DeploymentStore for SqliteDeploymentStore {
         self.db.execute(&sql).await
     }
 
-    async fn set_delete_pending(&self, id: &str) -> Result<(), AlienError> {
+    async fn set_delete_pending(
+        &self,
+        caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError> {
         let deployment = self
-            .get_deployment(id)
+            .get_deployment(caller, id)
             .await?
             .ok_or_else(|| db_error(&format!("Deployment {} not found", id)))?;
 
@@ -344,7 +359,11 @@ impl DeploymentStore for SqliteDeploymentStore {
         self.db.execute(&sql).await
     }
 
-    async fn set_retry_requested(&self, id: &str) -> Result<(), AlienError> {
+    async fn set_retry_requested(
+        &self,
+        _caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError> {
         let sql = Query::update()
             .table(Deployments::Table)
             .value(Deployments::RetryRequested, 1i64)
@@ -353,7 +372,11 @@ impl DeploymentStore for SqliteDeploymentStore {
         self.db.execute(&sql).await
     }
 
-    async fn set_redeploy(&self, id: &str) -> Result<(), AlienError> {
+    async fn set_redeploy(
+        &self,
+        _caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError> {
         let sql = Query::update()
             .table(Deployments::Table)
             .value(Deployments::Status, "update-pending")
@@ -364,6 +387,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn set_deployment_desired_release(
         &self,
+        _caller: &crate::auth::Subject,
         deployment_id: &str,
         release_id: &str,
     ) -> Result<(), AlienError> {
@@ -377,6 +401,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn set_desired_release(
         &self,
+        _caller: &crate::auth::Subject,
         release_id: &str,
         platform: Option<Platform>,
     ) -> Result<(), AlienError> {
@@ -403,6 +428,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn acquire(
         &self,
+        _caller: &crate::auth::Subject,
         session: &str,
         filter: &DeploymentFilter,
         limit: u32,
@@ -544,7 +570,11 @@ impl DeploymentStore for SqliteDeploymentStore {
         Ok(acquired)
     }
 
-    async fn reconcile(&self, data: ReconcileData) -> Result<DeploymentRecord, AlienError> {
+    async fn reconcile(
+        &self,
+        caller: &crate::auth::Subject,
+        data: ReconcileData,
+    ) -> Result<DeploymentRecord, AlienError> {
         let now = Utc::now();
         let state = &data.state;
 
@@ -586,7 +616,7 @@ impl DeploymentStore for SqliteDeploymentStore {
             .unwrap_or_else(|_| "pending".to_string());
 
         // Check if deployment completed (current matches desired)
-        let deployment = self.get_deployment(&data.deployment_id).await?;
+        let deployment = self.get_deployment(caller, &data.deployment_id).await?;
         let deployment_completed = deployment
             .as_ref()
             .and_then(|d| d.desired_release_id.as_ref())
@@ -663,12 +693,17 @@ impl DeploymentStore for SqliteDeploymentStore {
         self.db.execute(&sql).await?;
 
         // Fetch and return the updated deployment
-        self.get_deployment(&data.deployment_id)
+        self.get_deployment(caller, &data.deployment_id)
             .await?
             .ok_or_else(|| db_error("Deployment not found after reconcile"))
     }
 
-    async fn release(&self, deployment_id: &str, session: &str) -> Result<(), AlienError> {
+    async fn release(
+        &self,
+        _caller: &crate::auth::Subject,
+        deployment_id: &str,
+        session: &str,
+    ) -> Result<(), AlienError> {
         let sql = Query::update()
             .table(Deployments::Table)
             .value(Deployments::LockedBy, Option::<String>::None)
@@ -683,6 +718,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn create_deployment_group(
         &self,
+        _caller: &crate::auth::Subject,
         params: CreateDeploymentGroupParams,
     ) -> Result<DeploymentGroupRecord, AlienError> {
         let id = alien_core::new_id(alien_core::IdType::DeploymentGroup);
@@ -721,6 +757,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn create_deployment_group_with_id(
         &self,
+        _caller: &crate::auth::Subject,
         id: &str,
         params: CreateDeploymentGroupParams,
     ) -> Result<DeploymentGroupRecord, AlienError> {
@@ -759,6 +796,7 @@ impl DeploymentStore for SqliteDeploymentStore {
 
     async fn get_deployment_group(
         &self,
+        _caller: &crate::auth::Subject,
         id: &str,
     ) -> Result<Option<DeploymentGroupRecord>, AlienError> {
         // Compute deployment_count via LEFT JOIN instead of stored column
@@ -820,7 +858,10 @@ impl DeploymentStore for SqliteDeploymentStore {
         }
     }
 
-    async fn cleanup_stale_locks(&self) -> Result<u64, AlienError> {
+    async fn cleanup_stale_locks(
+        &self,
+        _caller: &crate::auth::Subject,
+    ) -> Result<u64, AlienError> {
         let sql = Query::update()
             .table(Deployments::Table)
             .value(Deployments::LockedBy, Option::<String>::None)
@@ -837,7 +878,10 @@ impl DeploymentStore for SqliteDeploymentStore {
         Ok(rows)
     }
 
-    async fn list_deployment_groups(&self) -> Result<Vec<DeploymentGroupRecord>, AlienError> {
+    async fn list_deployment_groups(
+        &self,
+        _caller: &crate::auth::Subject,
+    ) -> Result<Vec<DeploymentGroupRecord>, AlienError> {
         // Compute deployment_count via LEFT JOIN for each group
         let sql = Query::select()
             .expr_as(

--- a/crates/alien-manager/src/traits/deployment_store.rs
+++ b/crates/alien-manager/src/traits/deployment_store.rs
@@ -142,14 +142,16 @@ pub struct ReconcileData {
 /// Persistence for deployments and deployment groups.
 ///
 /// Every method takes `caller: &Subject`. Single-tenant impls
-/// (`SqliteDeploymentStore`) ignore it. Multi-tenant embedders that
-/// proxy through an upstream API can use `caller.bearer_token` to forward
-/// the original request's authentication, so cross-tenant calls remain
-/// gated by the inbound caller's scope rather than the embedder's own
-/// service credential. Internal callers without an inbound request
-/// (background loops, startup hooks) pass `Subject::system()` — its
-/// empty `bearer_token` is the documented signal to embedders that no
-/// passthrough is available.
+/// (`SqliteDeploymentStore`) ignore it. Multi-tenant embedders that proxy
+/// through an upstream API can use `caller.bearer_token` to forward the
+/// original request's authentication, so cross-tenant calls remain gated
+/// by the inbound caller's scope rather than the embedder's own service
+/// credential. Internal callers without an inbound request (background
+/// loops, startup hooks) pass [`Subject::system`]; embedders that need to
+/// know whether to fall back to a service credential must check
+/// [`Subject::is_system`] explicitly — never use an empty `bearer_token`
+/// as an implicit fallback signal, since a buggy validator could otherwise
+/// silently escalate privilege.
 ///
 /// `caller` is metadata-about-who; the per-method `params` / IDs are
 /// data-to-act-on — never conflate the two on a single struct.

--- a/crates/alien-manager/src/traits/deployment_store.rs
+++ b/crates/alien-manager/src/traits/deployment_store.rs
@@ -10,6 +10,7 @@ use alien_error::AlienError;
 
 /// A deployment record as stored in the database.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DeploymentRecord {
     pub id: String,
     /// Workspace this deployment belongs to. Always `"default"` in OSS.
@@ -90,6 +91,7 @@ pub struct CreateDeploymentParams {
 
 /// A deployment group record.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DeploymentGroupRecord {
     pub id: String,
     /// Workspace this deployment group belongs to. Always `"default"` in OSS.
@@ -138,39 +140,76 @@ pub struct ReconcileData {
 }
 
 /// Persistence for deployments and deployment groups.
+///
+/// Every method takes `caller: &Subject`. Single-tenant impls
+/// (`SqliteDeploymentStore`) ignore it. Multi-tenant embedders that
+/// proxy through an upstream API can use `caller.bearer_token` to forward
+/// the original request's authentication, so cross-tenant calls remain
+/// gated by the inbound caller's scope rather than the embedder's own
+/// service credential. Internal callers without an inbound request
+/// (background loops, startup hooks) pass `Subject::system()` — its
+/// empty `bearer_token` is the documented signal to embedders that no
+/// passthrough is available.
+///
+/// `caller` is metadata-about-who; the per-method `params` / IDs are
+/// data-to-act-on — never conflate the two on a single struct.
 #[async_trait]
 pub trait DeploymentStore: Send + Sync {
     // --- Deployment CRUD ---
 
     async fn create_deployment(
         &self,
+        caller: &crate::auth::Subject,
         params: CreateDeploymentParams,
     ) -> Result<DeploymentRecord, AlienError>;
 
-    async fn get_deployment(&self, id: &str) -> Result<Option<DeploymentRecord>, AlienError>;
+    async fn get_deployment(
+        &self,
+        caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<Option<DeploymentRecord>, AlienError>;
 
     async fn get_deployment_by_name(
         &self,
+        caller: &crate::auth::Subject,
         deployment_group_id: &str,
         name: &str,
     ) -> Result<Option<DeploymentRecord>, AlienError>;
 
     async fn list_deployments(
         &self,
+        caller: &crate::auth::Subject,
         filter: &DeploymentFilter,
     ) -> Result<Vec<DeploymentRecord>, AlienError>;
 
-    async fn delete_deployment(&self, id: &str) -> Result<(), AlienError>;
+    async fn delete_deployment(
+        &self,
+        caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError>;
 
-    async fn set_delete_pending(&self, id: &str) -> Result<(), AlienError>;
+    async fn set_delete_pending(
+        &self,
+        caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError>;
 
-    async fn set_retry_requested(&self, id: &str) -> Result<(), AlienError>;
+    async fn set_retry_requested(
+        &self,
+        caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError>;
 
-    async fn set_redeploy(&self, id: &str) -> Result<(), AlienError>;
+    async fn set_redeploy(
+        &self,
+        caller: &crate::auth::Subject,
+        id: &str,
+    ) -> Result<(), AlienError>;
 
     /// Set desired_release_id on a specific deployment.
     async fn set_deployment_desired_release(
         &self,
+        caller: &crate::auth::Subject,
         deployment_id: &str,
         release_id: &str,
     ) -> Result<(), AlienError>;
@@ -178,6 +217,7 @@ pub trait DeploymentStore: Send + Sync {
     /// Set desired_release_id on eligible deployments when a new release is created.
     async fn set_desired_release(
         &self,
+        caller: &crate::auth::Subject,
         release_id: &str,
         platform: Option<Platform>,
     ) -> Result<(), AlienError>;
@@ -187,41 +227,62 @@ pub trait DeploymentStore: Send + Sync {
     /// Acquire deployments that need processing. Sets locked_by on matched rows.
     async fn acquire(
         &self,
+        caller: &crate::auth::Subject,
         session: &str,
         filter: &DeploymentFilter,
         limit: u32,
     ) -> Result<Vec<AcquiredDeployment>, AlienError>;
 
     /// Write new state back after processing.
-    async fn reconcile(&self, data: ReconcileData) -> Result<DeploymentRecord, AlienError>;
+    async fn reconcile(
+        &self,
+        caller: &crate::auth::Subject,
+        data: ReconcileData,
+    ) -> Result<DeploymentRecord, AlienError>;
 
     /// Release lock on a deployment.
-    async fn release(&self, deployment_id: &str, session: &str) -> Result<(), AlienError>;
+    async fn release(
+        &self,
+        caller: &crate::auth::Subject,
+        deployment_id: &str,
+        session: &str,
+    ) -> Result<(), AlienError>;
 
     // --- Deployment groups ---
 
     async fn create_deployment_group(
         &self,
+        caller: &crate::auth::Subject,
         params: CreateDeploymentGroupParams,
     ) -> Result<DeploymentGroupRecord, AlienError>;
 
     /// Create a deployment group with a specific ID (for dev mode well-known IDs).
     async fn create_deployment_group_with_id(
         &self,
+        caller: &crate::auth::Subject,
         id: &str,
         params: CreateDeploymentGroupParams,
     ) -> Result<DeploymentGroupRecord, AlienError>;
 
     async fn get_deployment_group(
         &self,
+        caller: &crate::auth::Subject,
         id: &str,
     ) -> Result<Option<DeploymentGroupRecord>, AlienError>;
 
-    async fn list_deployment_groups(&self) -> Result<Vec<DeploymentGroupRecord>, AlienError>;
+    async fn list_deployment_groups(
+        &self,
+        caller: &crate::auth::Subject,
+    ) -> Result<Vec<DeploymentGroupRecord>, AlienError>;
 
-    /// Clean up stale locks from crashed sessions. Called on startup.
-    /// Default implementation is a no-op (platform store handles this differently).
-    async fn cleanup_stale_locks(&self) -> Result<u64, AlienError> {
+    /// Clean up stale locks from crashed sessions. Called on startup with
+    /// `Subject::system()` from the standalone binary; embedders that mount
+    /// the manager's startup hook into a request context can pass the request
+    /// caller instead.
+    async fn cleanup_stale_locks(
+        &self,
+        _caller: &crate::auth::Subject,
+    ) -> Result<u64, AlienError> {
         Ok(0)
     }
 }

--- a/crates/alien-manager/src/traits/release_store.rs
+++ b/crates/alien-manager/src/traits/release_store.rs
@@ -8,6 +8,7 @@ use alien_error::AlienError;
 
 /// A release record. Contains stacks for one or more platforms.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReleaseRecord {
     pub id: String,
     /// Workspace this release belongs to. Always `"default"` in OSS.

--- a/crates/alien-manager/src/transports/manager.rs
+++ b/crates/alien-manager/src/transports/manager.rs
@@ -14,6 +14,7 @@ use alien_core::{DeploymentState, Platform};
 use alien_deployment::transport::{DeploymentLoopTransport, StepReconcileResult};
 use alien_error::AlienError;
 
+use crate::auth::Subject;
 use crate::traits::deployment_store::ReconcileData;
 use crate::traits::DeploymentStore;
 
@@ -67,14 +68,21 @@ impl DeploymentLoopTransport for ManagerTransport {
         // 2. Persist the step result (including any registry access changes).
         let error_value = step_error.map(|e| serde_json::to_value(e).unwrap_or_default());
 
+        // Driven from the deployment loop with no inbound caller — use the
+        // synthetic system subject (empty bearer signals to embedders that
+        // no caller passthrough is available).
+        let caller = Subject::system();
         self.deployment_store
-            .reconcile(ReconcileData {
-                deployment_id: deployment_id.to_string(),
-                session: self.session.clone(),
-                state: updated_state.clone(),
-                update_heartbeat,
-                error: error_value,
-            })
+            .reconcile(
+                &caller,
+                ReconcileData {
+                    deployment_id: deployment_id.to_string(),
+                    session: self.session.clone(),
+                    state: updated_state.clone(),
+                    update_heartbeat,
+                    error: error_value,
+                },
+            )
             .await?;
 
         // Only return updated state if something actually changed.

--- a/crates/alien-manager/tests/registry_proxy_cloud_test.rs
+++ b/crates/alien-manager/tests/registry_proxy_cloud_test.rs
@@ -307,25 +307,31 @@ impl CloudProxyTest {
 
         // Create deployment group + deployment
         let dg = deployment_store
-            .create_deployment_group(CreateDeploymentGroupParams {
-                name: "cloud-proxy-test".to_string(),
-                max_deployments: 100,
-            })
+            .create_deployment_group(
+                &test_subject(),
+                CreateDeploymentGroupParams {
+                    name: "cloud-proxy-test".to_string(),
+                    max_deployments: 100,
+                },
+            )
             .await
             .unwrap();
 
         let dep = deployment_store
-            .create_deployment(CreateDeploymentParams {
-                name: "cloud-proxy-deploy".to_string(),
-                deployment_group_id: dg.id.clone(),
-                platform,
-                stack_settings: StackSettings {
-                    deployment_model: DeploymentModel::Pull,
-                    ..Default::default()
+            .create_deployment(
+                &test_subject(),
+                CreateDeploymentParams {
+                    name: "cloud-proxy-deploy".to_string(),
+                    deployment_group_id: dg.id.clone(),
+                    platform,
+                    stack_settings: StackSettings {
+                        deployment_model: DeploymentModel::Pull,
+                        ..Default::default()
+                    },
+                    environment_variables: None,
+                    deployment_token: Some(deploy_raw.clone()),
                 },
-                environment_variables: None,
-                deployment_token: Some(deploy_raw.clone()),
-            })
+            )
             .await
             .unwrap();
 
@@ -403,7 +409,7 @@ impl CloudProxyTest {
 
         // Assign release to deployment
         deployment_store
-            .set_desired_release(&release.id, None)
+            .set_desired_release(&test_subject(), &release.id, None)
             .await
             .unwrap();
 
@@ -425,13 +431,16 @@ impl CloudProxyTest {
             protocol_version: 0,
         };
         deployment_store
-            .reconcile(ReconcileData {
-                deployment_id: self.deployment_id.clone(),
-                session: "cloud-proxy-test".to_string(),
-                state,
-                update_heartbeat: false,
-                error: None,
-            })
+            .reconcile(
+                &test_subject(),
+                ReconcileData {
+                    deployment_id: self.deployment_id.clone(),
+                    session: "cloud-proxy-test".to_string(),
+                    state,
+                    update_heartbeat: false,
+                    error: None,
+                },
+            )
             .await
             .unwrap();
 

--- a/crates/alien-manager/tests/registry_proxy_test.rs
+++ b/crates/alien-manager/tests/registry_proxy_test.rs
@@ -269,10 +269,13 @@ async fn setup() -> TestSetup {
 
     // Create deployment group + deployment
     let dg = deployment_store
-        .create_deployment_group(CreateDeploymentGroupParams {
-            name: "test-group".to_string(),
-            max_deployments: 100,
-        })
+        .create_deployment_group(
+            &test_subject(),
+            CreateDeploymentGroupParams {
+                name: "test-group".to_string(),
+                max_deployments: 100,
+            },
+        )
         .await
         .unwrap();
 
@@ -283,17 +286,20 @@ async fn setup() -> TestSetup {
     );
 
     let dep = deployment_store
-        .create_deployment(CreateDeploymentParams {
-            name: "test-deployment".to_string(),
-            deployment_group_id: dg.id.clone(),
-            platform: Platform::Local,
-            stack_settings: alien_core::StackSettings {
-                deployment_model: alien_core::DeploymentModel::Pull,
-                ..Default::default()
+        .create_deployment(
+            &test_subject(),
+            CreateDeploymentParams {
+                name: "test-deployment".to_string(),
+                deployment_group_id: dg.id.clone(),
+                platform: Platform::Local,
+                stack_settings: alien_core::StackSettings {
+                    deployment_model: alien_core::DeploymentModel::Pull,
+                    ..Default::default()
+                },
+                environment_variables: None,
+                deployment_token: Some(deploy_raw.clone()),
             },
-            environment_variables: None,
-            deployment_token: Some(deploy_raw.clone()),
-        })
+        )
         .await
         .unwrap();
 
@@ -317,7 +323,7 @@ async fn setup() -> TestSetup {
             protocol_version: 0,
         };
         deployment_store
-            .reconcile(alien_manager::traits::ReconcileData {
+            .reconcile(&test_subject(), alien_manager::traits::ReconcileData {
                 deployment_id: dep.id.clone(),
                 session: "test-setup".to_string(),
                 state,
@@ -330,7 +336,7 @@ async fn setup() -> TestSetup {
 
     // Also set desired_release_id (so the proxy can find the release)
     deployment_store
-        .set_desired_release(&release.id, Some(Platform::Local))
+        .set_desired_release(&test_subject(), &release.id, Some(Platform::Local))
         .await
         .unwrap();
 
@@ -782,7 +788,7 @@ async fn test_proxy_push_then_pull() {
             protocol_version: 0,
         };
         s.deployment_store
-            .reconcile(alien_manager::traits::ReconcileData {
+            .reconcile(&test_subject(), alien_manager::traits::ReconcileData {
                 deployment_id: s.deployment_id.clone(),
                 session: "push-test".to_string(),
                 state,

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -43,10 +43,13 @@ async fn fresh_db() -> Arc<SqliteDatabase> {
 /// Helper to create a deployment group and return its ID.
 async fn create_test_group(store: &SqliteDeploymentStore) -> String {
     let group = store
-        .create_deployment_group(CreateDeploymentGroupParams {
-            name: "test-group".to_string(),
-            max_deployments: 100,
-        })
+        .create_deployment_group(
+            &test_subject(),
+            CreateDeploymentGroupParams {
+                name: "test-group".to_string(),
+                max_deployments: 100,
+            },
+        )
         .await
         .unwrap();
     group.id
@@ -60,14 +63,17 @@ async fn create_test_deployment(
     platform: Platform,
 ) -> DeploymentRecord {
     store
-        .create_deployment(CreateDeploymentParams {
-            name: name.to_string(),
-            deployment_group_id: group_id.to_string(),
-            platform,
-            stack_settings: StackSettings::default(),
-            environment_variables: None,
-            deployment_token: None,
-        })
+        .create_deployment(
+            &test_subject(),
+            CreateDeploymentParams {
+                name: name.to_string(),
+                deployment_group_id: group_id.to_string(),
+                platform,
+                stack_settings: StackSettings::default(),
+                environment_variables: None,
+                deployment_token: None,
+            },
+        )
         .await
         .unwrap()
 }
@@ -97,7 +103,7 @@ async fn create_and_get_deployment() {
     assert!(created.locked_by.is_none());
 
     // Get by ID
-    let fetched = store.get_deployment(&created.id).await.unwrap().unwrap();
+    let fetched = store.get_deployment(&test_subject(), &created.id).await.unwrap().unwrap();
     assert_eq!(fetched.id, created.id);
     assert_eq!(fetched.name, "my-deploy");
     assert_eq!(fetched.platform, Platform::Aws);
@@ -117,12 +123,12 @@ async fn list_by_status() {
     // Move dep1 to "running" status via set_redeploy (which sets update-pending)
     // For a cleaner test, let's use the reconcile to set status, but that's complex.
     // Instead, use set_redeploy which sets "update-pending"
-    store.set_redeploy(&dep1.id).await.unwrap();
-    store.set_delete_pending(&dep2.id).await.unwrap();
+    store.set_redeploy(&test_subject(), &dep1.id).await.unwrap();
+    store.set_delete_pending(&test_subject(), &dep2.id).await.unwrap();
 
     // Filter by "pending" status
     let pending = store
-        .list_deployments(&DeploymentFilter {
+        .list_deployments(&test_subject(), &DeploymentFilter {
             statuses: Some(vec!["pending".to_string()]),
             ..Default::default()
         })
@@ -133,7 +139,7 @@ async fn list_by_status() {
 
     // Filter by multiple statuses
     let mixed = store
-        .list_deployments(&DeploymentFilter {
+        .list_deployments(&test_subject(), &DeploymentFilter {
             statuses: Some(vec![
                 "update-pending".to_string(),
                 "delete-pending".to_string(),
@@ -151,7 +157,7 @@ async fn list_by_deployment_group() {
     let store = SqliteDeploymentStore::new(db);
 
     let group_a = store
-        .create_deployment_group(CreateDeploymentGroupParams {
+        .create_deployment_group(&test_subject(), CreateDeploymentGroupParams {
             name: "group-a".to_string(),
             max_deployments: 10,
         })
@@ -159,7 +165,7 @@ async fn list_by_deployment_group() {
         .unwrap();
 
     let group_b = store
-        .create_deployment_group(CreateDeploymentGroupParams {
+        .create_deployment_group(&test_subject(), CreateDeploymentGroupParams {
             name: "group-b".to_string(),
             max_deployments: 10,
         })
@@ -171,7 +177,7 @@ async fn list_by_deployment_group() {
     create_test_deployment(&store, &group_b.id, "dep-b1", Platform::Gcp).await;
 
     let group_a_deps = store
-        .list_deployments(&DeploymentFilter {
+        .list_deployments(&test_subject(), &DeploymentFilter {
             deployment_group_id: Some(group_a.id.clone()),
             ..Default::default()
         })
@@ -180,7 +186,7 @@ async fn list_by_deployment_group() {
     assert_eq!(group_a_deps.len(), 2);
 
     let group_b_deps = store
-        .list_deployments(&DeploymentFilter {
+        .list_deployments(&test_subject(), &DeploymentFilter {
             deployment_group_id: Some(group_b.id.clone()),
             ..Default::default()
         })
@@ -199,26 +205,26 @@ async fn update_status() {
     let dep = create_test_deployment(&store, &group_id, "dep", Platform::Aws).await;
 
     // set_delete_pending
-    store.set_delete_pending(&dep.id).await.unwrap();
-    let fetched = store.get_deployment(&dep.id).await.unwrap().unwrap();
+    store.set_delete_pending(&test_subject(), &dep.id).await.unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep.id).await.unwrap().unwrap();
     assert_eq!(fetched.status, "delete-pending");
 
     // set_delete_pending again should fail (already delete-pending)
-    let result = store.set_delete_pending(&dep.id).await;
+    let result = store.set_delete_pending(&test_subject(), &dep.id).await;
     assert!(result.is_err());
 
     // Create another deployment for retry and redeploy
     let dep2 = create_test_deployment(&store, &group_id, "dep2", Platform::Aws).await;
 
     // set_retry_requested
-    store.set_retry_requested(&dep2.id).await.unwrap();
-    let fetched = store.get_deployment(&dep2.id).await.unwrap().unwrap();
+    store.set_retry_requested(&test_subject(), &dep2.id).await.unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep2.id).await.unwrap().unwrap();
     assert!(fetched.retry_requested);
 
     // set_redeploy
     let dep3 = create_test_deployment(&store, &group_id, "dep3", Platform::Aws).await;
-    store.set_redeploy(&dep3.id).await.unwrap();
-    let fetched = store.get_deployment(&dep3.id).await.unwrap().unwrap();
+    store.set_redeploy(&test_subject(), &dep3.id).await.unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep3.id).await.unwrap().unwrap();
     assert_eq!(fetched.status, "update-pending");
 }
 
@@ -253,11 +259,11 @@ async fn set_desired_release() {
         .unwrap();
 
     store
-        .set_deployment_desired_release(&dep.id, &release.id)
+        .set_deployment_desired_release(&test_subject(), &dep.id, &release.id)
         .await
         .unwrap();
 
-    let fetched = store.get_deployment(&dep.id).await.unwrap().unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep.id).await.unwrap().unwrap();
     assert_eq!(
         fetched.desired_release_id.as_deref(),
         Some(release.id.as_str())
@@ -275,7 +281,7 @@ async fn acquire_and_release() {
 
     // Acquire should pick it up
     let acquired = store
-        .acquire("session-1", &DeploymentFilter::default(), 10)
+        .acquire(&test_subject(), "session-1", &DeploymentFilter::default(), 10)
         .await
         .unwrap();
 
@@ -287,14 +293,14 @@ async fn acquire_and_release() {
     );
 
     // Verify lock is persisted
-    let fetched = store.get_deployment(&dep.id).await.unwrap().unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep.id).await.unwrap().unwrap();
     assert_eq!(fetched.locked_by.as_deref(), Some("session-1"));
     assert!(fetched.locked_at.is_some());
 
     // Release the lock
-    store.release(&dep.id, "session-1").await.unwrap();
+    store.release(&test_subject(), &dep.id, "session-1").await.unwrap();
 
-    let fetched = store.get_deployment(&dep.id).await.unwrap().unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep.id).await.unwrap().unwrap();
     assert!(fetched.locked_by.is_none());
     assert!(fetched.locked_at.is_none());
 }
@@ -309,14 +315,14 @@ async fn concurrent_acquire() {
 
     // First session acquires
     let acquired_1 = store
-        .acquire("session-1", &DeploymentFilter::default(), 10)
+        .acquire(&test_subject(), "session-1", &DeploymentFilter::default(), 10)
         .await
         .unwrap();
     assert_eq!(acquired_1.len(), 1);
 
     // Second session tries to acquire - should get nothing (already locked)
     let acquired_2 = store
-        .acquire("session-2", &DeploymentFilter::default(), 10)
+        .acquire(&test_subject(), "session-2", &DeploymentFilter::default(), 10)
         .await
         .unwrap();
     assert_eq!(acquired_2.len(), 0);
@@ -340,7 +346,7 @@ async fn stale_lock_broken() {
 
     // New session should be able to acquire (stale lock gets broken)
     let acquired = store
-        .acquire("new-session", &DeploymentFilter::default(), 10)
+        .acquire(&test_subject(), "new-session", &DeploymentFilter::default(), 10)
         .await
         .unwrap();
     assert_eq!(acquired.len(), 1);
@@ -364,7 +370,7 @@ async fn reconcile_succeeds_under_other_session_lock() {
 
     // Session A holds the lock.
     let acquired = store
-        .acquire("session-A", &DeploymentFilter::default(), 10)
+        .acquire(&test_subject(), "session-A", &DeploymentFilter::default(), 10)
         .await
         .unwrap();
     assert_eq!(acquired.len(), 1);
@@ -383,7 +389,7 @@ async fn reconcile_succeeds_under_other_session_lock() {
         protocol_version: alien_core::DEPLOYMENT_PROTOCOL_VERSION,
     };
     store
-        .reconcile(ReconcileData {
+        .reconcile(&test_subject(), ReconcileData {
             deployment_id: dep.id.clone(),
             session: "agent-sync".to_string(),
             state,
@@ -394,7 +400,7 @@ async fn reconcile_succeeds_under_other_session_lock() {
         .expect("reconcile must succeed even when another session holds the lock");
 
     // The UPDATE applied — status is the new value.
-    let fetched = store.get_deployment(&dep.id).await.unwrap().unwrap();
+    let fetched = store.get_deployment(&test_subject(), &dep.id).await.unwrap().unwrap();
     assert_eq!(fetched.status, "running");
     // The lock is unaffected — still held by session-A.
     assert_eq!(fetched.locked_by.as_deref(), Some("session-A"));
@@ -409,13 +415,13 @@ async fn delete_deployment() {
     let dep = create_test_deployment(&store, &group_id, "dep", Platform::Aws).await;
 
     // Verify it exists
-    assert!(store.get_deployment(&dep.id).await.unwrap().is_some());
+    assert!(store.get_deployment(&test_subject(), &dep.id).await.unwrap().is_some());
 
     // Delete it
-    store.delete_deployment(&dep.id).await.unwrap();
+    store.delete_deployment(&test_subject(), &dep.id).await.unwrap();
 
     // Verify it's gone
-    assert!(store.get_deployment(&dep.id).await.unwrap().is_none());
+    assert!(store.get_deployment(&test_subject(), &dep.id).await.unwrap().is_none());
 }
 
 #[tokio::test]
@@ -424,7 +430,7 @@ async fn group_count_computed() {
     let store = SqliteDeploymentStore::new(db);
 
     let group = store
-        .create_deployment_group(CreateDeploymentGroupParams {
+        .create_deployment_group(&test_subject(), CreateDeploymentGroupParams {
             name: "counted-group".to_string(),
             max_deployments: 100,
         })
@@ -433,7 +439,7 @@ async fn group_count_computed() {
 
     // Initially 0
     let fetched = store
-        .get_deployment_group(&group.id)
+        .get_deployment_group(&test_subject(), &group.id)
         .await
         .unwrap()
         .unwrap();
@@ -444,24 +450,24 @@ async fn group_count_computed() {
     create_test_deployment(&store, &group.id, "dep-2", Platform::Gcp).await;
 
     let fetched = store
-        .get_deployment_group(&group.id)
+        .get_deployment_group(&test_subject(), &group.id)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(fetched.deployment_count, 2);
 
     // Delete one
-    store.delete_deployment(&dep1.id).await.unwrap();
+    store.delete_deployment(&test_subject(), &dep1.id).await.unwrap();
 
     let fetched = store
-        .get_deployment_group(&group.id)
+        .get_deployment_group(&test_subject(), &group.id)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(fetched.deployment_count, 1);
 
     // Verify list_deployment_groups also computes counts
-    let groups = store.list_deployment_groups().await.unwrap();
+    let groups = store.list_deployment_groups(&test_subject()).await.unwrap();
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].deployment_count, 1);
 }
@@ -471,7 +477,7 @@ async fn deployment_not_found() {
     let db = fresh_db().await;
     let store = SqliteDeploymentStore::new(db);
 
-    let result = store.get_deployment("dep_nonexistent").await.unwrap();
+    let result = store.get_deployment(&test_subject(), "dep_nonexistent").await.unwrap();
     assert!(result.is_none());
 }
 


### PR DESCRIPTION
## Summary

- `DeploymentStore` now mirrors `ReleaseStore`: every method takes `caller: &Subject`. `SqliteDeploymentStore` accepts and ignores it; routes thread `&subject` from `auth::require_auth`; internal loops pass `Subject::system()`.
- Telemetry ingestion no longer loads a deployment record. The validator already binds `Subject` to a `Scope::Deployment` with `project_id` + `deployment_id`; the lookup was redundant. `Authz::can_ingest_telemetry_for(subject, deployment_id: &str)` is now a pure scope check.
- `DeploymentRecord`, `DeploymentGroupRecord`, and `ReleaseRecord` get `#[serde(rename_all = "camelCase")]`. Aligns with the project's documented serde convention; `alien-core` nested types already do this.

Embedders that proxy to an upstream API can now forward the caller's bearer for cross-tenant calls instead of relying on a service credential.

Linear: [ALIEN-106](https://linear.app/alienplatform/issue/ALIEN-106/thread-caller-through-deploymentstore-drop-redundant-telemetry-lookup)

## Test plan

- [x] \`cargo check --workspace --tests\` clean
- [x] \`cargo test -p alien-manager --lib\` — 37 passed
- [x] \`cargo test -p alien-manager --test sqlite_store_tests\` — 22 passed
- [ ] Reviewer: spot-check that callers pass the right \`Subject\` (route handlers use the request's; loops use \`Subject::system()\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)