### PR TITLE
chore: add context7.json for Context7 library claim

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/alienplatform/alien",
+  "public_key": "pk_2c74cZNmx2EVE9DAjR2WR"
+}


### PR DESCRIPTION
## Summary

- Add `context7.json` at the repo root to claim the `alienplatform/alien` library on [Context7](https://context7.com)
- Enables Context7's documentation indexer to verify ownership and surface up-to-date docs for the Alien SDK
- `public_key` is a public verification token (analogous to a DNS TXT challenge) shown openly in Context7's Claim Library dialog — safe to commit