### PR TITLE
feat: CLI mints scoped tokens for release; per-project scope on OCI push (ALIEN-139)

### DIFF
--- a/crates/alien-bindings/src/providers/artifact_registry/local.rs
+++ b/crates/alien-bindings/src/providers/artifact_registry/local.rs
@@ -147,11 +147,15 @@ impl ArtifactRegistry for LocalArtifactRegistry {
     }
 
     fn upstream_repository_prefix(&self) -> String {
-        // The embedded local registry accepts two-segment repo paths (e.g.,
-        // "namespace/repo"). We use "artifacts/default" as the canonical prefix
-        // — this matches what the CLI hardcodes in dev mode and what the proxy
-        // routing table uses to route pushes to this local registry.
-        "artifacts/default".to_string()
+        // The binding name is the routing prefix; the next path segment is the
+        // project namespace (`artifacts/{project_id}` in platform mode,
+        // `artifacts/default` in dev mode). Returning the bare binding name
+        // here — instead of the legacy `"artifacts/default"` — lets the proxy
+        // routing table correctly identify both modes' pushes as local and
+        // extract the right project_id for downstream authz/scope checks.
+        // Matches the per-cloud convention documented in
+        // `internal-docs/alien/02-manager/02-releases.md`.
+        self.binding_name.clone()
     }
 
     async fn create_repository(&self, repo_name: &str) -> Result<RepositoryResponse> {

--- a/crates/alien-cli/src/auth.rs
+++ b/crates/alien-cli/src/auth.rs
@@ -501,8 +501,18 @@ mod oauth_flow {
             project: &'a str,
         }
 
+        // URL-encode the path segment to match the established convention in
+        // the rest of the crate (see `execution_context.rs::resolve_url` and
+        // the gcp / aws clients). Manager IDs are ULIDs today and contain no
+        // URL-special characters, but encoding here keeps the call site
+        // correct-by-construction rather than correct-by-coincidence — a
+        // future change to the ID format won't silently mis-route the request.
         let response = client
-            .post(format!("{}/v1/managers/{}/token", base, manager_id))
+            .post(format!(
+                "{}/v1/managers/{}/token",
+                base,
+                urlencoding::encode(manager_id)
+            ))
             .query(&[("workspace", workspace)])
             .header("Authorization", format!("Bearer {}", user_jwt))
             .json(&ExchangeBody {
@@ -621,7 +631,16 @@ mod oauth_flow {
             project_id,
         )
         .await?;
-        store_manager_token(&minted)?;
+        // Cache write is best-effort. The mint succeeded, so we hold a valid
+        // token in memory and the caller can complete the operation. A failed
+        // keyring write just means we'll re-mint on the next invocation —
+        // strictly slower, never wrong. This matches the cache-failure pattern
+        // documented in `alien/CLAUDE.md` ("When `warn!` Is Appropriate").
+        if let Err(e) = store_manager_token(&minted) {
+            tracing::warn!(
+                "Failed to cache manager token in keyring (will re-mint next run): {e}"
+            );
+        }
         Ok(minted)
     }
 

--- a/crates/alien-cli/src/auth.rs
+++ b/crates/alien-cli/src/auth.rs
@@ -174,6 +174,10 @@ mod oauth_flow {
     const SERVICE: &str = "alien-cli";
     const ACCESS_USER: &str = "access_token";
     const REFRESH_USER: &str = "refresh_token";
+    /// Manager-scoped Platform JWT minted on `alien login`. Different audience
+    /// from the user OAuth access_token, so the manager can verify it locally
+    /// against its configured public key without a /v1/whoami forward.
+    const MANAGER_TOKEN_USER: &str = "manager_token";
     const DEFAULT_BASE: &str = "https://api.alien.dev";
     const CLI_CLIENT_ID: &str = "alien-cli";
 
@@ -280,6 +284,7 @@ mod oauth_flow {
     pub fn logout() {
         let _ = Entry::new(SERVICE, ACCESS_USER).and_then(|e| e.delete_password());
         let _ = Entry::new(SERVICE, REFRESH_USER).and_then(|e| e.delete_password());
+        let _ = Entry::new(SERVICE, MANAGER_TOKEN_USER).and_then(|e| e.delete_password());
         let _ = std::fs::remove_file(cfg_path());
         with_cache(|cache| cache.clear());
     }
@@ -470,6 +475,154 @@ mod oauth_flow {
         });
 
         Ok(())
+    }
+
+    /// Exchanges a user OAuth JWT for a project-scoped registry-push JWT via
+    /// `POST {base}/v1/managers/{manager_id}/token`. The result is the only
+    /// credential the manager accepts on `/v2/...` pushes (single scope tuple,
+    /// `managerId`-bound, audience `alien:manager:registry-push`).
+    pub async fn mint_registry_push_token(
+        client: &Client,
+        base: &str,
+        user_jwt: &str,
+        workspace: &str,
+        manager_id: &str,
+        project_id: &str,
+    ) -> Result<String> {
+        #[derive(serde::Deserialize)]
+        struct ExchangeResponse {
+            #[serde(rename = "accessToken")]
+            access_token: String,
+        }
+
+        #[derive(serde::Serialize)]
+        struct ExchangeBody<'a> {
+            purpose: &'a str,
+            project: &'a str,
+        }
+
+        let response = client
+            .post(format!("{}/v1/managers/{}/token", base, manager_id))
+            .query(&[("workspace", workspace)])
+            .header("Authorization", format!("Bearer {}", user_jwt))
+            .json(&ExchangeBody {
+                purpose: "registry-push",
+                project: project_id,
+            })
+            .send()
+            .await
+            .into_alien_error()
+            .context(ErrorData::AuthenticationFailed {
+                reason: "Failed to call manager-token exchange endpoint".to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(AlienError::new(ErrorData::AuthenticationFailed {
+                reason: format!(
+                    "manager-token exchange returned status {}: {}",
+                    status, body
+                ),
+            }));
+        }
+
+        let body: ExchangeResponse = response.json().await.into_alien_error().context(
+            ErrorData::AuthenticationFailed {
+                reason: "Failed to parse manager-token exchange response".to_string(),
+            },
+        )?;
+
+        Ok(body.access_token)
+    }
+
+    pub fn store_manager_token(token: &str) -> Result<()> {
+        Entry::new(SERVICE, MANAGER_TOKEN_USER)
+            .into_alien_error()
+            .context(ErrorData::AuthenticationFailed {
+                reason: "Failed to create manager token keyring entry".to_string(),
+            })?
+            .set_password(token)
+            .into_alien_error()
+            .context(ErrorData::AuthenticationFailed {
+                reason: "Failed to store manager token".to_string(),
+            })?;
+        Ok(())
+    }
+
+    pub fn load_manager_token() -> Option<String> {
+        Entry::new(SERVICE, MANAGER_TOKEN_USER)
+            .ok()?
+            .get_password()
+            .ok()
+    }
+
+    /// Checks `managerId` equality and that at least one `scopes` entry ends
+    /// with `/{project_id}`. Project IDs are globally-unique `prj_*` ULIDs, so
+    /// the suffix check is equivalent to an exact match on the project segment
+    /// without needing `workspace_id` (the CLI doesn't have it locally).
+    /// Returns false on any decode failure — caller re-mints, avoiding a
+    /// guaranteed 401 on the wire.
+    fn token_matches_target(jwt: &str, manager_id: &str, project_id: &str) -> bool {
+        let Some(payload_b64) = jwt.split('.').nth(1) else {
+            return false;
+        };
+        let Ok(payload_bytes) = URL_SAFE_NO_PAD.decode(payload_b64) else {
+            return false;
+        };
+        let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&payload_bytes) else {
+            return false;
+        };
+        let mid_ok = claims
+            .get("managerId")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m == manager_id);
+        let suffix = format!("/{}", project_id);
+        let scope_ok = claims
+            .get("scopes")
+            .and_then(|v| v.as_array())
+            .is_some_and(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str())
+                    .any(|s| s.ends_with(&suffix))
+            });
+        mid_ok && scope_ok
+    }
+
+    /// Returns a valid registry-push JWT for the (manager, project) target.
+    /// Reuses the keyring-cached JWT when it matches; common re-mint case is
+    /// the user switching projects between `alien release` invocations.
+    pub async fn get_or_mint_registry_push_token(
+        http: &AuthHttp,
+        workspace: &str,
+        manager_id: &str,
+        project_id: &str,
+    ) -> Result<String> {
+        if let Some(existing) = load_manager_token() {
+            if !token_expired(&existing, 30)
+                && token_matches_target(&existing, manager_id, project_id)
+            {
+                return Ok(existing);
+            }
+        }
+
+        let user_jwt = http.bearer_token.as_deref().ok_or_else(|| {
+            AlienError::new(ErrorData::AuthenticationFailed {
+                reason: "No user OAuth JWT available to exchange for manager token".to_string(),
+            })
+        })?;
+
+        let minted = mint_registry_push_token(
+            &http.client,
+            &http.base_url,
+            user_jwt,
+            workspace,
+            manager_id,
+            project_id,
+        )
+        .await?;
+        store_manager_token(&minted)?;
+        Ok(minted)
     }
 
     async fn refresh_token(base: &str, refresh: &str) -> Result<TokenResponse> {
@@ -872,4 +1025,7 @@ mod oauth_flow {
 
 // Re-export platform-only functions
 #[cfg(feature = "platform")]
-pub use oauth_flow::{force_login, get_auth_http, logout, store_tokens, try_bearer_client};
+pub use oauth_flow::{
+    force_login, get_auth_http, get_or_mint_registry_push_token, logout, store_tokens,
+    try_bearer_client,
+};

--- a/crates/alien-cli/src/auth.rs
+++ b/crates/alien-cli/src/auth.rs
@@ -1021,6 +1021,100 @@ mod oauth_flow {
             }
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        //! Tests for cache-reuse logic. `token_matches_target` decides whether
+        //! a cached manager-scoped JWT can be reused for a given (manager,
+        //! project) target without re-minting. Failure modes:
+        //!
+        //!   * A token minted for a *different* manager being reused (would
+        //!     cause a managerId-binding rejection at the manager's verifier
+        //!     and an avoidable round-trip — but more importantly, would
+        //!     surface as a confusing 401 rather than triggering a fresh mint).
+        //!   * A token minted for a *different* project being reused (would
+        //!     fail at the scope check on the OCI push path).
+        //!   * A malformed JWT being treated as "matches" (would skip the
+        //!     re-mint and definitely 401 at the manager).
+        //!
+        //! All failure cases must return `false` so the caller re-mints.
+        use super::*;
+
+        const MANAGER_ID: &str = "mgr_xaji0y6dpbhsahxthv3a3zmf8mdd";
+        const OTHER_MANAGER_ID: &str = "mgr_other";
+        const PROJECT_ID: &str = "prj_nisyo047zb0ourgk7wguij040q1x";
+        const OTHER_PROJECT_ID: &str = "prj_other";
+
+        /// Build a fake JWT (header.payload.sig) where the payload is the
+        /// given JSON object base64-url-encoded without padding. The header
+        /// and signature segments are placeholders — `token_matches_target`
+        /// only ever decodes the payload, so this is enough to exercise the
+        /// matching logic.
+        fn fake_jwt(payload: &str) -> String {
+            format!(
+                "header.{}.sig",
+                URL_SAFE_NO_PAD.encode(payload.as_bytes())
+            )
+        }
+
+        #[test]
+        fn matches_when_manager_id_and_project_scope_align() {
+            let jwt = fake_jwt(&format!(
+                r#"{{"managerId":"{MANAGER_ID}","scopes":["ws_abc/{PROJECT_ID}"]}}"#
+            ));
+            assert!(token_matches_target(&jwt, MANAGER_ID, PROJECT_ID));
+        }
+
+        #[test]
+        fn rejects_when_manager_id_mismatches() {
+            let jwt = fake_jwt(&format!(
+                r#"{{"managerId":"{OTHER_MANAGER_ID}","scopes":["ws_abc/{PROJECT_ID}"]}}"#
+            ));
+            assert!(!token_matches_target(&jwt, MANAGER_ID, PROJECT_ID));
+        }
+
+        #[test]
+        fn rejects_when_project_scope_mismatches() {
+            let jwt = fake_jwt(&format!(
+                r#"{{"managerId":"{MANAGER_ID}","scopes":["ws_abc/{OTHER_PROJECT_ID}"]}}"#
+            ));
+            assert!(!token_matches_target(&jwt, MANAGER_ID, PROJECT_ID));
+        }
+
+        #[test]
+        fn rejects_when_scopes_claim_is_missing() {
+            // Defense in depth: even if managerId matches, a token with no
+            // scope can't push to the target project, so don't reuse it.
+            let jwt = fake_jwt(&format!(r#"{{"managerId":"{MANAGER_ID}"}}"#));
+            assert!(!token_matches_target(&jwt, MANAGER_ID, PROJECT_ID));
+        }
+
+        #[test]
+        fn rejects_when_manager_id_claim_is_missing() {
+            let jwt = fake_jwt(&format!(
+                r#"{{"scopes":["ws_abc/{PROJECT_ID}"]}}"#
+            ));
+            assert!(!token_matches_target(&jwt, MANAGER_ID, PROJECT_ID));
+        }
+
+        #[test]
+        fn rejects_malformed_jwt() {
+            // Must NOT panic on garbage — re-minting is the safe response.
+            assert!(!token_matches_target("not.a.jwt", MANAGER_ID, PROJECT_ID));
+            assert!(!token_matches_target("only-one-segment", MANAGER_ID, PROJECT_ID));
+            assert!(!token_matches_target("", MANAGER_ID, PROJECT_ID));
+        }
+
+        #[test]
+        fn rejects_jwt_with_non_array_scopes() {
+            // A buggy producer that serialized `scopes` as a string instead
+            // of an array must not be treated as a valid cached token.
+            let jwt = fake_jwt(&format!(
+                r#"{{"managerId":"{MANAGER_ID}","scopes":"ws_abc/{PROJECT_ID}"}}"#
+            ));
+            assert!(!token_matches_target(&jwt, MANAGER_ID, PROJECT_ID));
+        }
+    }
 }
 
 // Re-export platform-only functions

--- a/crates/alien-cli/src/commands/commands.rs
+++ b/crates/alien-cli/src/commands/commands.rs
@@ -64,8 +64,44 @@ pub enum CommandsAction {
 
 /// Execute commands task — works in all execution modes.
 pub async fn commands_task(args: CommandsArgs, ctx: ExecutionMode) -> Result<()> {
-    let manager = ctx.server_sdk_client()?;
-    let manager_url = ctx.manager_url();
+    // `server_sdk_client()` errors in Platform mode because the manager
+    // URL + auth aren't known until the project is resolved. For Platform
+    // mode we resolve the manager (which mints the per-project JWT and
+    // builds an authenticated client) before doing anything else. For
+    // Standalone/Dev the existing code path is unchanged — those modes
+    // already carry the manager URL + API key statically on ExecutionMode.
+    let (manager, manager_url, auth_token) = {
+        #[cfg(feature = "platform")]
+        if matches!(&ctx, ExecutionMode::Platform { .. }) {
+            // Platform mode: resolve the project (from --project override or
+            // local config), then ask the platform API for the manager that
+            // hosts it. `resolve_manager` returns a ManagerContext whose
+            // `client` is already authenticated with the minted manager JWT
+            // and whose `auth_token` carries that same JWT for the separate
+            // CommandsClient HTTP call below.
+            let (_, project_link) = ctx.resolve_project(None, true).await?;
+            let mgr_ctx = ctx
+                .resolve_manager(&project_link.project_id, "aws")
+                .await?;
+            (
+                mgr_ctx.client,
+                mgr_ctx.manager_url,
+                mgr_ctx.auth_token.unwrap_or_default(),
+            )
+        } else {
+            (
+                ctx.server_sdk_client()?,
+                ctx.manager_url(),
+                ctx.auth_token().unwrap_or_default().to_string(),
+            )
+        }
+        #[cfg(not(feature = "platform"))]
+        (
+            ctx.server_sdk_client()?,
+            ctx.manager_url(),
+            ctx.auth_token().unwrap_or_default().to_string(),
+        )
+    };
 
     match args.action {
         CommandsAction::Invoke {
@@ -75,7 +111,6 @@ pub async fn commands_task(args: CommandsArgs, ctx: ExecutionMode) -> Result<()>
             timeout,
         } => {
             let is_dev = ctx.is_dev();
-            let auth_token = ctx.auth_token().unwrap_or_default().to_string();
             invoke_command(
                 &manager,
                 &manager_url,

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -617,10 +617,26 @@ async fn create_or_get_artifact_repo(
     let get_body = get_resp.text().await.unwrap_or_default();
 
     if get_status.is_success() {
-        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&get_body) {
-            if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
-                return Ok(name.to_string());
-            }
+        // Fail loud on parse error (matches the canonical pattern at
+        // `execution_context.rs:378-381` and `auth.rs:541`). A reverse-proxy
+        // or WAF responding with an HTML 200 would otherwise silently fall
+        // through to CREATE, and the user would see a confusing
+        // "Failed to create artifact repository" instead of the real
+        // problem. Valid-JSON-without-`name` still falls through — that's
+        // the manager's "no such repo" shape and the CREATE below is the
+        // correct next step.
+        let body: serde_json::Value =
+            serde_json::from_str(&get_body)
+                .into_alien_error()
+                .context(ErrorData::ApiRequestFailed {
+                    message: format!(
+                        "GET artifact registry returned HTTP {} but the response body wasn't parseable JSON",
+                        get_status
+                    ),
+                    url: Some(get_url.clone()),
+                })?;
+        if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
+            return Ok(name.to_string());
         }
     }
 
@@ -647,10 +663,21 @@ async fn create_or_get_artifact_repo(
     let create_body = create_resp.text().await.unwrap_or_default();
 
     if create_status.is_success() {
-        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&create_body) {
-            if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
-                return Ok(name.to_string());
-            }
+        // Same fail-loud rationale as the GET above — a CREATE that returned
+        // 2xx with an unparseable body is the kind of upstream weirdness an
+        // operator needs to see, not have silently masked by the retry-GET.
+        let body: serde_json::Value =
+            serde_json::from_str(&create_body)
+                .into_alien_error()
+                .context(ErrorData::ApiRequestFailed {
+                    message: format!(
+                        "POST artifact registry returned HTTP {} but the response body wasn't parseable JSON",
+                        create_status
+                    ),
+                    url: Some(create_url.clone()),
+                })?;
+        if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
+            return Ok(name.to_string());
         }
     }
 
@@ -672,10 +699,22 @@ async fn create_or_get_artifact_repo(
     let get_resp2_body = get_resp2.text().await.unwrap_or_default();
 
     if get_resp2_status.is_success() {
-        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&get_resp2_body) {
-            if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
-                return Ok(name.to_string());
-            }
+        // Final GET in the retry chain — if this returns 2xx with an
+        // unparseable body, the final "Failed to create artifact repository"
+        // error below would otherwise swallow the diagnostic that the
+        // retry-GET response itself was malformed. Surface it.
+        let body: serde_json::Value =
+            serde_json::from_str(&get_resp2_body)
+                .into_alien_error()
+                .context(ErrorData::ApiRequestFailed {
+                    message: format!(
+                        "GET artifact registry (retry after CREATE) returned HTTP {} but the response body wasn't parseable JSON",
+                        get_resp2_status
+                    ),
+                    url: Some(get_url.clone()),
+                })?;
+        if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
+            return Ok(name.to_string());
         }
     }
 

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -426,10 +426,31 @@ impl ExecutionMode {
 
                 info!("Manager: {}", resolved.manager_url);
 
+                // The manager rejects the user OAuth JWT directly; exchange it
+                // for a manager-scoped Platform JWT (audience registry-push,
+                // managerId-bound) before talking to any manager endpoint.
+                //
+                // Today this single token covers BOTH `/v1/artifact-registry/*`
+                // repo-setup AND the `/v2/...` OCI push — both legs of the
+                // release flow share an audience because they're prereqs of
+                // the same user-facing operation. When other platform-mode
+                // commands (e.g. `alien commands invoke`) come online they
+                // must mint their OWN audience instead of reusing this one,
+                // so the audience name keeps reflecting the actual scope.
+                let manager_jwt = crate::auth::get_or_mint_registry_push_token(
+                    &http,
+                    &workspace,
+                    &resolved.manager_id,
+                    &resolved.project_id,
+                )
+                .await?;
+                let manager_http_client =
+                    crate::auth::client_with_header(&format!("Bearer {}", manager_jwt))?;
+
                 // Now call the manager directly to create/get the artifact registry repo.
                 // The repo logical name is the project ID.
                 let repo_name = create_or_get_artifact_repo(
-                    &http.client,
+                    &manager_http_client,
                     &resolved.manager_url,
                     &resolved.project_id,
                     platform,
@@ -438,19 +459,16 @@ impl ExecutionMode {
 
                 info!("Repository: {}", repo_name);
 
-                // Create manager SDK client reusing the authenticated reqwest client
-                let authenticated_client = http.client.clone();
-                let auth_token = http.bearer_token.clone();
                 let manager_client = ServerSdkClient::new_with_client(
                     &resolved.manager_url,
-                    authenticated_client.clone(),
+                    manager_http_client.clone(),
                 );
 
                 Ok(ManagerContext {
                     manager_url: resolved.manager_url,
                     client: manager_client,
-                    http_client: authenticated_client,
-                    auth_token,
+                    http_client: manager_http_client,
+                    auth_token: Some(manager_jwt),
                     repository_name: Some(repo_name),
                     repository_uri: None,
                 })
@@ -554,6 +572,7 @@ async fn check_server_health(port: u16) -> bool {
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResolveResponse {
+    manager_id: String,
     manager_url: String,
     project_id: String,
 }

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -595,6 +595,12 @@ async fn create_or_get_artifact_repo(
         manager_url, project_id, platform
     );
 
+    // Each response below has the same shape: capture status + body once
+    // (the body has to be read even on non-success — without it, the manager's
+    // structured error (e.g. "Platform JWT not bound to this manager") gets
+    // dropped and the user sees only the HTTP status. Pattern matches
+    // `auth.rs::mint_registry_push_token` for the same reason.
+
     let get_resp = client
         .get(&get_url)
         .send()
@@ -607,20 +613,14 @@ async fn create_or_get_artifact_repo(
             ),
             url: Some(get_url.clone()),
         })?;
+    let get_status = get_resp.status();
+    let get_body = get_resp.text().await.unwrap_or_default();
 
-    if get_resp.status().is_success() {
-        let body: serde_json::Value =
-            get_resp
-                .json()
-                .await
-                .into_alien_error()
-                .context(ErrorData::ApiRequestFailed {
-                    message: "Failed to parse artifact repository response".to_string(),
-                    url: Some(get_url.clone()),
-                })?;
-
-        if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
-            return Ok(name.to_string());
+    if get_status.is_success() {
+        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&get_body) {
+            if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
+                return Ok(name.to_string());
+            }
         }
     }
 
@@ -643,22 +643,14 @@ async fn create_or_get_artifact_repo(
             ),
             url: Some(create_url.clone()),
         })?;
-
     let create_status = create_resp.status();
+    let create_body = create_resp.text().await.unwrap_or_default();
 
     if create_status.is_success() {
-        let body: serde_json::Value =
-            create_resp
-                .json()
-                .await
-                .into_alien_error()
-                .context(ErrorData::ApiRequestFailed {
-                    message: "Failed to parse artifact repository response".to_string(),
-                    url: Some(create_url.clone()),
-                })?;
-
-        if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
-            return Ok(name.to_string());
+        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&create_body) {
+            if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
+                return Ok(name.to_string());
+            }
         }
     }
 
@@ -676,28 +668,27 @@ async fn create_or_get_artifact_repo(
             ),
             url: Some(get_url.clone()),
         })?;
+    let get_resp2_status = get_resp2.status();
+    let get_resp2_body = get_resp2.text().await.unwrap_or_default();
 
-    if get_resp2.status().is_success() {
-        let body: serde_json::Value =
-            get_resp2
-                .json()
-                .await
-                .into_alien_error()
-                .context(ErrorData::ApiRequestFailed {
-                    message: "Failed to parse artifact repository response".to_string(),
-                    url: Some(get_url.clone()),
-                })?;
-
-        if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
-            return Ok(name.to_string());
+    if get_resp2_status.is_success() {
+        if let Ok(body) = serde_json::from_str::<serde_json::Value>(&get_resp2_body) {
+            if let Some(name) = body.get("name").and_then(|v| v.as_str()) {
+                return Ok(name.to_string());
+            }
         }
     }
 
-    // Both create and get failed — report the create error
+    // Both create and get failed — report the create error WITH the manager's
+    // response body so the user sees the actual reason (auth failure, bad
+    // payload, scope mismatch, etc.) instead of just an HTTP status.
     Err(AlienError::new(ErrorData::ApiRequestFailed {
         message: format!(
-            "Failed to create artifact repository '{}' for platform '{}' on manager (HTTP {})",
-            project_id, platform, create_status
+            "Failed to create artifact repository '{}' for platform '{}' on manager (HTTP {}): {}",
+            project_id,
+            platform,
+            create_status,
+            create_body.trim()
         ),
         url: Some(create_url),
     }))

--- a/crates/alien-manager/src/auth/subject.rs
+++ b/crates/alien-manager/src/auth/subject.rs
@@ -25,6 +25,11 @@ pub struct Subject {
     pub workspace_id: String,
     pub scope: Scope,
     pub role: Role,
+    /// Per-project scopes from the credential. Format: `"${workspace_id}/${project_id}"`.
+    /// Empty means no narrowing — OSS validators (`TokenDbValidator`,
+    /// `PermissiveAuthValidator`) leave this empty and `require_push_auth`
+    /// falls back to the role/scope check, preserving OSS standalone behavior.
+    pub scopes: Vec<String>,
     /// The raw bearer token the caller presented.
     ///
     /// Lifecycle: request-scoped only. Constructed by the AuthValidator from
@@ -47,6 +52,7 @@ impl fmt::Debug for Subject {
             .field("workspace_id", &self.workspace_id)
             .field("scope", &self.scope)
             .field("role", &self.role)
+            .field("scopes", &self.scopes)
             .field("bearer_token", &"[redacted]")
             .finish()
     }
@@ -114,6 +120,7 @@ impl Subject {
             workspace_id: "default".to_string(),
             scope: Scope::Workspace,
             role: Role::WorkspaceAdmin,
+            scopes: Vec::new(),
             bearer_token: String::new(),
         }
     }
@@ -168,6 +175,7 @@ mod tests {
             workspace_id: "default".to_string(),
             scope,
             role,
+            scopes: Vec::new(),
             bearer_token: "bearer".to_string(),
         }
     }
@@ -210,6 +218,7 @@ mod tests {
             workspace_id: "default".to_string(),
             scope: Scope::Workspace,
             role: Role::WorkspaceAdmin,
+            scopes: Vec::new(),
             bearer_token: String::new(),
         };
         assert!(!s.is_system(), "non-system service account must not match");

--- a/crates/alien-manager/src/providers/oss_authz.rs
+++ b/crates/alien-manager/src/providers/oss_authz.rs
@@ -210,6 +210,7 @@ mod tests {
             workspace_id: "default".to_string(),
             scope: Scope::Workspace,
             role: Role::WorkspaceAdmin,
+            scopes: Vec::new(),
             bearer_token: "bearer".to_string(),
         }
     }
@@ -225,6 +226,7 @@ mod tests {
                 deployment_group_id: dg_id.to_string(),
             },
             role: Role::DeploymentGroupDeployer,
+            scopes: Vec::new(),
             bearer_token: "bearer".to_string(),
         }
     }
@@ -240,6 +242,7 @@ mod tests {
                 deployment_id: deployment_id.to_string(),
             },
             role: Role::DeploymentManager,
+            scopes: Vec::new(),
             bearer_token: "bearer".to_string(),
         }
     }

--- a/crates/alien-manager/src/providers/permissive_auth.rs
+++ b/crates/alien-manager/src/providers/permissive_auth.rs
@@ -31,6 +31,7 @@ impl AuthValidator for PermissiveAuthValidator {
             workspace_id: "default".to_string(),
             scope: Scope::Workspace,
             role: Role::WorkspaceAdmin,
+            scopes: Vec::new(),
             bearer_token: bearer,
         }))
     }

--- a/crates/alien-manager/src/providers/token_db_validator.rs
+++ b/crates/alien-manager/src/providers/token_db_validator.rs
@@ -146,6 +146,7 @@ fn record_to_subject(record: &crate::traits::token_store::TokenRecord, bearer: S
         workspace_id: "default".to_string(),
         scope,
         role,
+        scopes: Vec::new(),
         bearer_token: bearer,
     }
 }

--- a/crates/alien-manager/src/routes/registry_proxy.rs
+++ b/crates/alien-manager/src/routes/registry_proxy.rs
@@ -737,23 +737,37 @@ fn require_push_auth(state: &AppState, subject: &Subject, repo_name: &str) -> Re
         ));
     }
 
-    // Require at least one JWT scope to cover this project. Suffix-match on
-    // `/{project_id}` (not the full tuple) because system-manager-minted JWTs
-    // carry the manager's workspace_id in `subject.workspace_id` but the
-    // caller's workspace in the scope; project IDs are globally unique so the
-    // suffix is sufficient. OSS validators leave scopes empty → fall through.
-    if !subject.scopes.is_empty() {
-        let suffix = format!("/{}", project_id);
-        if !subject.scopes.iter().any(|s| s.ends_with(&suffix)) {
-            return Err(oci_error(
-                StatusCode::FORBIDDEN,
-                "DENIED",
-                "Caller's token scope does not cover this project.",
-            ));
-        }
+    if !scopes_cover_project(&subject.scopes, project_id) {
+        return Err(oci_error(
+            StatusCode::FORBIDDEN,
+            "DENIED",
+            "Caller's token scope does not cover this project.",
+        ));
     }
 
     Ok(())
+}
+
+/// Per-project scope check for the OCI push path.
+///
+/// Returns `true` when the caller's token scopes cover `project_id`. An empty
+/// `scopes` slice means "no scope claim was attached to this credential" — OSS
+/// validators leave it empty, so the check falls through and the role-based
+/// gate above is the only authorization required. When scopes ARE present,
+/// at least one must end with `/<project_id>`.
+///
+/// Suffix-match on `/{project_id}` (not the full `workspace_id/project_id`
+/// tuple) because system-manager-minted JWTs carry the manager's workspace_id
+/// in `subject.workspace_id` but the caller's workspace_id in the scope.
+/// Project IDs are globally-unique ULIDs so the suffix is unambiguous, and
+/// the leading slash prevents a `project_id` that's a substring suffix of
+/// another (e.g. `prj_abc` accidentally matching `prj_abcd`).
+fn scopes_cover_project(scopes: &[String], project_id: &str) -> bool {
+    if scopes.is_empty() {
+        return true;
+    }
+    let suffix = format!("/{}", project_id);
+    scopes.iter().any(|s| s.ends_with(&suffix))
 }
 
 /// Validate that a deployment token can access the requested repo.
@@ -1172,5 +1186,56 @@ mod tests {
             project_id_after_prefix("unknown/path/prj_xxx", "alien-artifacts"),
             None
         );
+    }
+
+    // -- scopes_cover_project ---------------------------------------------
+    //
+    // Coverage of the OCI push path's per-project scope check. The full
+    // path (`require_push_auth`) needs `&AppState` which has ~17 fields,
+    // so the security-critical predicate is extracted into a pure helper
+    // and tested directly. Failure modes:
+    //   * suffix-substring confusion (e.g. `prj_abc` matching `prj_abcd`)
+    //   * empty-scopes semantics flipped (would block OSS standalone)
+    //   * cross-project scope accepted
+
+    #[test]
+    fn scopes_cover_project_empty_scopes_pass_through_for_oss_validators() {
+        // OSS validators (`TokenDbValidator`, `PermissiveAuthValidator`)
+        // leave `Subject::scopes` empty. The push handler must not reject
+        // those subjects on the scope axis — the role check above is the
+        // only gate for OSS standalone deployments.
+        assert!(scopes_cover_project(&[], "prj_anything"));
+    }
+
+    #[test]
+    fn scopes_cover_project_matching_scope_passes() {
+        let scopes = vec!["ws_main/prj_abc".to_string()];
+        assert!(scopes_cover_project(&scopes, "prj_abc"));
+    }
+
+    #[test]
+    fn scopes_cover_project_different_project_is_rejected() {
+        let scopes = vec!["ws_main/prj_other".to_string()];
+        assert!(!scopes_cover_project(&scopes, "prj_abc"));
+    }
+
+    #[test]
+    fn scopes_cover_project_matches_when_any_of_multiple_scopes_covers() {
+        let scopes = vec![
+            "ws_main/prj_other".to_string(),
+            "ws_main/prj_abc".to_string(),
+            "ws_main/prj_third".to_string(),
+        ];
+        assert!(scopes_cover_project(&scopes, "prj_abc"));
+    }
+
+    #[test]
+    fn scopes_cover_project_requires_leading_slash_not_just_substring_suffix() {
+        // Without the leading slash in the suffix this would incorrectly
+        // pass — `"prj_abcd"` ends with `"prj_abc"` as a substring. The
+        // `/`-prefix is what makes the suffix a project-segment match
+        // and not a string-suffix match.
+        let scopes = vec!["ws_main/prj_abcd".to_string()];
+        assert!(!scopes_cover_project(&scopes, "prj_abc"));
     }
 }

--- a/crates/alien-manager/src/routes/registry_proxy.rs
+++ b/crates/alien-manager/src/routes/registry_proxy.rs
@@ -729,15 +729,31 @@ fn require_push_auth(state: &AppState, subject: &Subject, repo_name: &str) -> Re
         .registry_routing_table
         .project_id_for_repo(repo_name)
         .unwrap_or("default");
-    if state.authz.can_push_image(subject, project_id, repo_name) {
-        Ok(())
-    } else {
-        Err(oci_error(
+    if !state.authz.can_push_image(subject, project_id, repo_name) {
+        return Err(oci_error(
             StatusCode::FORBIDDEN,
             "DENIED",
             "Caller cannot push images to this project.",
-        ))
+        ));
     }
+
+    // Require at least one JWT scope to cover this project. Suffix-match on
+    // `/{project_id}` (not the full tuple) because system-manager-minted JWTs
+    // carry the manager's workspace_id in `subject.workspace_id` but the
+    // caller's workspace in the scope; project IDs are globally unique so the
+    // suffix is sufficient. OSS validators leave scopes empty → fall through.
+    if !subject.scopes.is_empty() {
+        let suffix = format!("/{}", project_id);
+        if !subject.scopes.iter().any(|s| s.ends_with(&suffix)) {
+            return Err(oci_error(
+                StatusCode::FORBIDDEN,
+                "DENIED",
+                "Caller's token scope does not cover this project.",
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Validate that a deployment token can access the requested repo.

--- a/crates/alien-manager/tests/registry_proxy_cloud_test.rs
+++ b/crates/alien-manager/tests/registry_proxy_cloud_test.rs
@@ -48,6 +48,7 @@ fn test_subject() -> Subject {
         workspace_id: "default".to_string(),
         scope: Scope::Workspace,
         role: Role::WorkspaceAdmin,
+        scopes: Vec::new(),
         bearer_token: String::new(),
     }
 }

--- a/crates/alien-manager/tests/registry_proxy_test.rs
+++ b/crates/alien-manager/tests/registry_proxy_test.rs
@@ -49,6 +49,7 @@ fn test_subject() -> Subject {
         workspace_id: "default".to_string(),
         scope: Scope::Workspace,
         role: Role::WorkspaceAdmin,
+        scopes: Vec::new(),
         bearer_token: String::new(),
     }
 }

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -26,6 +26,7 @@ fn test_subject() -> Subject {
         workspace_id: "default".to_string(),
         scope: Scope::Workspace,
         role: Role::WorkspaceAdmin,
+        scopes: Vec::new(),
         bearer_token: String::new(),
     }
 }


### PR DESCRIPTION
## Summary

Two OSS-side changes that together let `alien release` work against a manager when the caller is authenticated with an OAuth bearer, plus follow-up CLI hardening:

1. **CLI** exchanges the user OAuth JWT for a short-lived, project-and-manager-scoped token before talking to any manager endpoint, and uses that token for the artifact-registry setup + OCI push.
2. **alien-manager** gains a per-project `scopes` field on `Subject` and enforces it on the OCI push path — a token whose scopes don't cover the target project's ID is rejected at `/v2/.../blobs/uploads/`.
3. **CLI follow-ups** (a) surface the manager's response body in error messages so the user sees the actual reason (auth failure, scope mismatch, etc.) instead of just an HTTP status, and (b) unblock `alien commands invoke` in platform mode (previously errored out before reaching the manager).

OSS standalone behaviour is preserved bit-for-bit: validators that don't populate `scopes` leave it empty, and the new scope check no-ops on empty scopes — so existing single-tenant deployments still work without any token-format changes.

## Commits

| | |
|---|---|
| `feat(manager): per-project scope on Subject, enforced on OCI push` | `Subject.scopes: Vec<String>` field; `require_push_auth` suffix-matches `/<project_id>` against the JWT's scope list when non-empty. Also fixes `LocalArtifactRegistry::upstream_repository_prefix()` which was returning a hardcoded `"artifacts/default"` instead of the binding name — that was masked before because no per-project authz extracted the real project_id from the routing table. |
| `feat(cli): exchange OAuth JWT for manager-scoped token on release` | `mint_registry_push_token` + `get_or_mint_registry_push_token` in `crates/alien-cli/src/auth.rs`. Cached in keyring under `MANAGER_TOKEN_USER` (separate slot from the OAuth tokens so `logout` cleans both). `execution_context.rs` mints once at the top of the platform-mode release flow and reuses the token for `/v1/artifact-registry/*` repo setup + `/v2/...` OCI push. |
| `test: cover the per-project scope check on the OCI push path` | Extracts `scopes_cover_project` from `require_push_auth` so the security-critical predicate is unit-testable without standing up a 17-field `AppState`. 5 tests cover empty/matching/non-matching/multi-scope/leading-slash-substring-guard cases, plus 7 tests for `token_matches_target` covering match, manager mismatch, project mismatch, missing claim, malformed JWT, etc. |
| `refactor(cli): match codebase conventions on URL encoding and cache writes` | (1) `urlencoding::encode(manager_id)` in the mint URL — matches the established pattern in `execution_context.rs::resolve_url` and the gcp/aws clients. (2) `store_manager_token` is now best-effort (`warn!` on keyring write failure instead of aborting the release) — matches the worked example in `alien/CLAUDE.md` under "When `warn!` Is Appropriate". |
| `fix(cli): surface manager response body and unblock commands invoke in platform mode` ✨ NEW | (1) `create_or_get_artifact_repo` reads each response's body once via `.text().unwrap_or_default()`; surfaces the manager's structured error in the final `Failed to create artifact repository` message instead of dropping it. (2) `commands_task` branches: in platform mode, resolves the project + manager to get an authenticated client + bearer (previously `server_sdk_client()`'s platform arm errored out, blocking step 5 of onboarding); standalone/dev keep the existing path. |

## Verification

- `cargo test -p alien-manager` — **108 tests passing** across 6 binaries (was 103 before the scope-check predicate tests landed)
- `cargo test -p alien-manager --test registry_proxy_test` — 7 tests including push-auth, all green
- `cargo test -p alien-cli --features platform --lib oauth_flow::tests` — 7 tests for `token_matches_target`, all green
- `cargo build -p alien-cli --features platform` — clean
- Live end-to-end: `alien release --experimental` from a worker-template project succeeds and produces a release ID

## Backward compatibility

- OSS standalone managers run unchanged. Validators that don't set `Subject.scopes` leave it empty, and the new scope check is gated on `!subject.scopes.is_empty()`.
- The CLI's token-mint flow only activates in `#[cfg(feature = "platform")]` `ExecutionMode::Platform`. Standalone CLI use (`ALIEN_MANAGER_URL=...`) is unchanged.
- The platform-mode branch in `commands_task` is gated under `#[cfg(feature = "platform")]`; non-platform builds still go through `server_sdk_client()` directly.

## Out of scope (separate tickets)

- `Subject.scopes: Vec<String>` is loosely typed — format `"<workspace_id>/<project_id>"` enforced only by doc comment. A typed `permits_project_push(project_id)` helper on `Subject` would kill the open-coded `ends_with` matching at call sites.
- The platform-mode `alien commands invoke` flow currently re-uses the registry-push token. A separate, more-specific audience would match the operation's intent better — track in a follow-up using the documentation skill on the platform side.

## Test plan

- [ ] Reviewer runs `cargo test -p alien-manager` and confirms 108/108.
- [ ] Reviewer runs `cargo build -p alien-cli --features platform` and confirms clean.
- [ ] Reviewer confirms `Subject.scopes` default-empty behaviour preserves OSS standalone: grep for `Subject {` literals in OSS validators shows `scopes: Vec::new()` everywhere.
