### PR TITLE
fix(cli): send workspace to the manager on platform-mode calls

### DIFF
--- a/crates/alien-cli/src/auth.rs
+++ b/crates/alien-cli/src/auth.rs
@@ -131,6 +131,39 @@ pub fn client_with_header(auth_value: &str) -> Result<Client> {
         })?)
 }
 
+/// Build a Client that carries both the Authorization bearer and the
+/// caller's workspace name on every request. User OAuth tokens don't
+/// carry a workspace claim, so the manager needs this hint to know which
+/// membership to resolve when forwarding to `/v1/whoami`.
+pub fn client_with_auth_and_workspace(auth_value: &str, workspace: &str) -> Result<Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(auth_value)
+            .into_alien_error()
+            .context(ErrorData::AuthenticationFailed {
+                reason: "Invalid authorization header value".to_string(),
+            })?,
+    );
+    headers.insert(
+        "x-alien-workspace",
+        HeaderValue::from_str(workspace)
+            .into_alien_error()
+            .context(ErrorData::AuthenticationFailed {
+                reason: "Invalid workspace name (contains characters not allowed in an HTTP header)"
+                    .to_string(),
+            })?,
+    );
+    headers.insert(USER_AGENT, HeaderValue::from_static("alien-cli"));
+    Ok(Client::builder()
+        .default_headers(headers)
+        .build()
+        .into_alien_error()
+        .context(ErrorData::NetworkError {
+            message: "Failed to create HTTP client".to_string(),
+        })?)
+}
+
 /// Build an AuthHttp instance with both reqwest client and SDK client
 pub fn build_auth_http(client: Client, base_url: String, bearer_token: Option<String>) -> AuthHttp {
     let sdk_client = SdkClient::new_with_client(&base_url, client.clone());

--- a/crates/alien-cli/src/commands/release.rs
+++ b/crates/alien-cli/src/commands/release.rs
@@ -841,11 +841,12 @@ async fn build_proxy_push_settings(
     // Full repository: host/repo_name (e.g., "manager.alien.dev/alien-e2e")
     let repository = format!("{}/{}", registry_host, repo_name);
 
-    // OCI speaks Basic — the token rides in the password slot. In
-    // platform mode the workspace name goes in the username slot so the
-    // manager can resolve the caller's identity to the right workspace.
-    // Without a workspace, the username stays as the existing "token"
-    // placeholder.
+    // OCI speaks Basic — the token rides in the password slot, the
+    // workspace rides in the username slot. OCI clients can't add custom
+    // headers, and the username slot is exactly where cloud registries
+    // pass tenant/identity info (GCR uses `oauth2accesstoken`, ECR uses
+    // `AWS`). Without a workspace, the username stays as the existing
+    // "token" placeholder.
     let auth = match (&manager.auth_token, &manager.workspace) {
         (Some(token), Some(workspace)) => RegistryAuth::Basic(workspace.clone(), token.clone()),
         (Some(token), None) => RegistryAuth::Basic("token".to_string(), token.clone()),

--- a/crates/alien-cli/src/commands/release.rs
+++ b/crates/alien-cli/src/commands/release.rs
@@ -841,12 +841,15 @@ async fn build_proxy_push_settings(
     // Full repository: host/repo_name (e.g., "manager.alien.dev/alien-e2e")
     let repository = format!("{}/{}", registry_host, repo_name);
 
-    // Auth: use the caller's token as Basic auth password.
-    // The manager validates both Bearer and Basic auth — for OCI clients
-    // (which speak Basic), the password is the token.
-    let auth = match &manager.auth_token {
-        Some(token) => RegistryAuth::Basic("token".to_string(), token.clone()),
-        None => RegistryAuth::Anonymous,
+    // OCI speaks Basic — the token rides in the password slot. In
+    // platform mode the workspace name goes in the username slot so the
+    // manager can resolve the caller's identity to the right workspace.
+    // Without a workspace, the username stays as the existing "token"
+    // placeholder.
+    let auth = match (&manager.auth_token, &manager.workspace) {
+        (Some(token), Some(workspace)) => RegistryAuth::Basic(workspace.clone(), token.clone()),
+        (Some(token), None) => RegistryAuth::Basic("token".to_string(), token.clone()),
+        (None, _) => RegistryAuth::Anonymous,
     };
 
     info!("   Pushing through manager proxy at {}", repository);

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -432,31 +432,37 @@ impl ExecutionMode {
 
                 info!("Manager: {}", resolved.manager_url);
 
+                // Manager-bound client; workspace lives in default headers.
+                let auth_token = http.bearer_token.clone();
+                let manager_http_client = match &auth_token {
+                    Some(token) => crate::auth::client_with_auth_and_workspace(
+                        &format!("Bearer {}", token),
+                        &workspace,
+                    )?,
+                    None => http.client.clone(),
+                };
+
                 // Now call the manager directly to create/get the artifact registry repo.
                 // The repo logical name is the project ID.
                 let repo_name = create_or_get_artifact_repo(
-                    &http.client,
+                    &manager_http_client,
                     &resolved.manager_url,
                     &resolved.project_id,
                     platform,
-                    &workspace,
                 )
                 .await?;
 
                 info!("Repository: {}", repo_name);
 
-                // Create manager SDK client reusing the authenticated reqwest client
-                let authenticated_client = http.client.clone();
-                let auth_token = http.bearer_token.clone();
                 let manager_client = ServerSdkClient::new_with_client(
                     &resolved.manager_url,
-                    authenticated_client.clone(),
+                    manager_http_client.clone(),
                 );
 
                 Ok(ManagerContext {
                     manager_url: resolved.manager_url,
                     client: manager_client,
-                    http_client: authenticated_client,
+                    http_client: manager_http_client,
                     auth_token,
                     repository_name: Some(repo_name),
                     repository_uri: None,
@@ -568,16 +574,16 @@ struct ResolveResponse {
 
 /// Create or get an artifact registry repository on the manager.
 ///
-/// GET first (repo may exist), POST to create on 404. The `workspace`
-/// argument is sent as `x-alien-workspace` on every request — see
-/// [`ManagerContext::workspace`].
+/// GET first (repo may exist), POST to create on 404. The `client` is
+/// expected to carry the caller's workspace in its default headers (see
+/// [`crate::auth::client_with_auth_and_workspace`]); no per-call header
+/// plumbing happens here.
 #[cfg(feature = "platform")]
 async fn create_or_get_artifact_repo(
     client: &reqwest::Client,
     manager_url: &str,
     project_id: &str,
     platform: &str,
-    workspace: &str,
 ) -> crate::error::Result<String> {
     use alien_error::{Context, IntoAlienError};
 
@@ -588,7 +594,7 @@ async fn create_or_get_artifact_repo(
     );
 
     let get_resp = send_artifact_registry_request_with_retry(
-        || client.get(&get_url).header("x-alien-workspace", workspace),
+        || client.get(&get_url),
         manager_url,
         &get_url,
         "Failed to reach artifact registry on manager",
@@ -621,7 +627,6 @@ async fn create_or_get_artifact_repo(
         || {
             client
                 .post(&create_url)
-                .header("x-alien-workspace", workspace)
                 .json(&serde_json::json!({ "name": project_id }))
         },
         manager_url,
@@ -651,7 +656,7 @@ async fn create_or_get_artifact_repo(
     // Create returned non-success (409 = already exists, or other error).
     // Try GET again — the repo may have been created concurrently.
     let get_resp2 = send_artifact_registry_request_with_retry(
-        || client.get(&get_url).header("x-alien-workspace", workspace),
+        || client.get(&get_url),
         manager_url,
         &get_url,
         "Failed to get artifact repository from manager",

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -38,6 +38,10 @@ pub struct ManagerContext {
     pub repository_name: Option<String>,
     /// Repository URI for image pushing (only available via platform discovery).
     pub repository_uri: Option<String>,
+    /// Workspace the caller is acting in. The manager needs it to resolve
+    /// the user's identity — user OAuth tokens don't carry that themselves.
+    /// `None` in single-tenant modes (dev, standalone).
+    pub workspace: Option<String>,
 }
 
 /// Execution mode determines which API the command targets and carries all global flags.
@@ -323,6 +327,7 @@ impl ExecutionMode {
                     auth_token: Some(api_key.clone()),
                     repository_name: None, // Resolved at push time via manager's /v1/build-config
                     repository_uri: Some(server_url.clone()),
+                    workspace: None,
                 })
             }
             Self::Dev { port } => {
@@ -337,6 +342,7 @@ impl ExecutionMode {
                     auth_token: None,
                     repository_name: Some("artifacts/default".to_string()),
                     repository_uri: Some(manager_url),
+                    workspace: None,
                 })
             }
             #[cfg(feature = "platform")]
@@ -433,6 +439,7 @@ impl ExecutionMode {
                     &resolved.manager_url,
                     &resolved.project_id,
                     platform,
+                    &workspace,
                 )
                 .await?;
 
@@ -453,6 +460,7 @@ impl ExecutionMode {
                     auth_token,
                     repository_name: Some(repo_name),
                     repository_uri: None,
+                    workspace: Some(workspace),
                 })
             }
         }
@@ -560,13 +568,16 @@ struct ResolveResponse {
 
 /// Create or get an artifact registry repository on the manager.
 ///
-/// Tries GET first (repo may already exist), then POST to create if 404.
+/// GET first (repo may exist), POST to create on 404. The `workspace`
+/// argument is sent as `x-alien-workspace` on every request — see
+/// [`ManagerContext::workspace`].
 #[cfg(feature = "platform")]
 async fn create_or_get_artifact_repo(
     client: &reqwest::Client,
     manager_url: &str,
     project_id: &str,
     platform: &str,
+    workspace: &str,
 ) -> crate::error::Result<String> {
     use alien_error::{Context, IntoAlienError};
 
@@ -577,7 +588,7 @@ async fn create_or_get_artifact_repo(
     );
 
     let get_resp = send_artifact_registry_request_with_retry(
-        || client.get(&get_url),
+        || client.get(&get_url).header("x-alien-workspace", workspace),
         manager_url,
         &get_url,
         "Failed to reach artifact registry on manager",
@@ -610,6 +621,7 @@ async fn create_or_get_artifact_repo(
         || {
             client
                 .post(&create_url)
+                .header("x-alien-workspace", workspace)
                 .json(&serde_json::json!({ "name": project_id }))
         },
         manager_url,
@@ -639,7 +651,7 @@ async fn create_or_get_artifact_repo(
     // Create returned non-success (409 = already exists, or other error).
     // Try GET again — the repo may have been created concurrently.
     let get_resp2 = send_artifact_registry_request_with_retry(
-        || client.get(&get_url),
+        || client.get(&get_url).header("x-alien-workspace", workspace),
         manager_url,
         &get_url,
         "Failed to get artifact repository from manager",


### PR DESCRIPTION
## Summary

The CLI now sends the user's workspace name to the manager on every platform-mode call. Without it, a freshly logged-in user just got 401 from the manager. The manager forwards the OAuth token to whoami to figure out who's calling, and whoami needs `?workspace=<name>` to pick one when the user is in multiple workspaces.

Flow when you run `alien release` (or `deploy`, `destroy`, `deployments *`, `commands invoke`):

1. CLI logs in and gets an OAuth token.
2. CLI hits `/v1/resolve` to find out which manager and project to use.
3. CLI builds a workspace-aware reqwest client — `Authorization` and `x-alien-workspace` baked into default headers, so every subsequent request inherits both.  ← new
4. The manager SDK and any raw HTTP call use that client; the workspace flows through automatically.
5. CLI pushes images through the manager's OCI proxy. OCI clients can't add custom headers, so the workspace goes in the Basic-auth username slot and the OAuth token in the password slot — same shape GCR uses (`oauth2accesstoken:<token>`) and ECR uses (`AWS:<token>`).
6. CLI creates the release.

Before: `Authorization: Bearer <oauth>` and nothing else.
After: `Authorization: Bearer <oauth>` + `x-alien-workspace: <name>` on every HTTP call; `Basic base64("<workspace>:<oauth>")` on OCI push.

## What was broken

The CLI sent only the OAuth token. The manager forwarded that token to whoami, but a user can be in multiple workspaces and whoami needs `?workspace=<name>` to pick one. Without a hint it returned 401, and the release died at the first call to the manager. The same 401 hit four other commands: `alien deploy`, `destroy`, all `deployments` subcommands, `commands invoke`.

## What I did

Workspace hint travels via two shapes, picked once at client-build time:

- Normal HTTP (artifact-registry, deployments, releases, commands) — `x-alien-workspace: <name>` baked into the reqwest client's default headers via the new `client_with_auth_and_workspace` helper. The SDK uses the same client, so every SDK-generated request inherits the header.
- OCI push (`/v2/...`) — workspace as the Basic-auth username, OAuth token as the password. The convention is from cloud registries (GCR's `oauth2accesstoken`, ECR's `AWS`).

Dev and standalone modes leave `workspace` as `None` and behave exactly as before. No header, no Basic username override.

## Files touched

- `crates/alien-cli/src/auth.rs` — new `client_with_auth_and_workspace` helper. Sibling of the existing `client_with_header`; bakes the bearer and `x-alien-workspace` into the reqwest client's default headers.
- `crates/alien-cli/src/execution_context.rs` — `ManagerContext` gains a `workspace: Option<String>` field. In platform mode, `resolve_manager` builds the workspace-aware client and uses it for both the SDK (`ServerSdkClient`) and the raw HTTP path. `create_or_get_artifact_repo` no longer needs the workspace as a parameter — it's on the client.
- `crates/alien-cli/src/commands/release.rs` — OCI push uses the workspace as the Basic-auth username in platform mode. Doc comment explains the GCR/ECR precedent.

## How I tested

Local stack, locally-built CLI:

1. Fresh signup against `https://api.alien.localhost`.
2. `cargo build -p alien-cli --features platform`.
3. `alien login` → `alien init remote-worker-ts && cd my-worker && alien link`.
4. `alien release` → got back `rel_v5RkjWc2Gu20WPudka3BLcbcau54`.
5. `alien deployments ls` → 403 (not 401). Auth flows through; the 403 is a separate workspace-role concern.

The same flows returned 401 at the manager before this change.

Manual OCI check with vanilla `docker`, no `alien release` wrapping:

```
docker login manager.alien.localhost --username <workspace> --password <oauth>
docker push manager.alien.localhost/artifacts/default/<project_id>/<image>:tag
```

`Login Succeeded`; push completed end-to-end. The OCI spec accepts the workspace-as-Basic-username shape via a standard Docker client, not only our embedded `dockdash`.

Unit tests: 61 passed on `cargo test -p alien-cli --lib --features platform`. The change is an internal HTTP-client refactor; the existing tests cover the public API and SDK paths.

I also ran a security review on the diff. The CLI only sends headers, so there isn't much to attack. Things that the security review checked:

1. CR/LF in header values. The `http` crate rejects bytes below 32 except tab — `\r` and `\n` both fail. A workspace name with newlines in it errors at client construction time (`HeaderValue::from_str` returns `InvalidHeaderValue`).
2. Colon in workspace names. The API validates workspace names against `^(?!ws[-_])[a-z0-9](-?[a-z0-9])*$` at create time — lowercase letters, digits, hyphens only. No `:`, so the Basic-auth separator can't be hijacked from the username side.
3. Token leakage via redirects. The workspace-aware client uses the same default redirect policy as the existing `client_with_header`. Same behavior as before this PR.

Nothing else came up.
