### PR TITLE
Improve release and build diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,11 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - name: Validate npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -230,6 +235,11 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Validate npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
 
       - name: Build and publish platform API SDK
         working-directory: client-sdks/platform/typescript
@@ -850,6 +860,11 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Validate npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@v4

--- a/crates/alien-build/src/command_output.rs
+++ b/crates/alien-build/src/command_output.rs
@@ -1,0 +1,227 @@
+use crate::error::{ErrorData, Result};
+use alien_error::{AlienError, Context, IntoAlienError};
+use std::future::Future;
+use std::process::{ExitStatus, Output};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::process::Child;
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandOutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandOutputLine {
+    pub(crate) stream: CommandOutputStream,
+    pub(crate) line: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CapturedCommandOutput {
+    stdout: Vec<String>,
+    stderr: Vec<String>,
+}
+
+impl CapturedCommandOutput {
+    pub(crate) fn from_output(output: &Output) -> Self {
+        Self {
+            stdout: String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(ToString::to_string)
+                .collect(),
+            stderr: String::from_utf8_lossy(&output.stderr)
+                .lines()
+                .map(ToString::to_string)
+                .collect(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, line: CommandOutputLine) {
+        match line.stream {
+            CommandOutputStream::Stdout => self.stdout.push(line.line),
+            CommandOutputStream::Stderr => self.stderr.push(line.line),
+        }
+    }
+
+    pub(crate) fn display(&self) -> String {
+        let stdout = self.stdout.join("\n");
+        let stderr = self.stderr.join("\n");
+
+        match (stdout.trim().is_empty(), stderr.trim().is_empty()) {
+            (true, true) => String::new(),
+            (false, true) => stdout,
+            (true, false) => stderr,
+            (false, false) => format!("stdout:\n{stdout}\n\nstderr:\n{stderr}"),
+        }
+    }
+}
+
+pub(crate) async fn wait_with_captured_output<F, Fut>(
+    child: &mut Child,
+    resource_name: &str,
+    read_reason: &str,
+    wait_reason: &str,
+    mut on_line: F,
+) -> Result<(ExitStatus, CapturedCommandOutput)>
+where
+    F: FnMut(CommandOutputLine) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    if let Some(stdout) = child.stdout.take() {
+        spawn_reader(stdout, CommandOutputStream::Stdout, tx.clone());
+    }
+
+    if let Some(stderr) = child.stderr.take() {
+        spawn_reader(stderr, CommandOutputStream::Stderr, tx.clone());
+    }
+
+    drop(tx);
+
+    let mut captured = CapturedCommandOutput::default();
+    while let Some(line_result) = rx.recv().await {
+        let line = line_result
+            .into_alien_error()
+            .context(ErrorData::ImageBuildFailed {
+                resource_name: resource_name.to_string(),
+                reason: read_reason.to_string(),
+                build_output: Some(captured.display()),
+            })?;
+
+        captured.push(line.clone());
+        on_line(line).await;
+    }
+
+    let status = child
+        .wait()
+        .await
+        .into_alien_error()
+        .context(ErrorData::ImageBuildFailed {
+            resource_name: resource_name.to_string(),
+            reason: wait_reason.to_string(),
+            build_output: Some(captured.display()),
+        })?;
+
+    Ok((status, captured))
+}
+
+fn spawn_reader<R>(
+    stream: R,
+    stream_kind: CommandOutputStream,
+    tx: mpsc::UnboundedSender<std::io::Result<CommandOutputLine>>,
+) where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(stream).lines();
+        loop {
+            match reader.next_line().await {
+                Ok(Some(line)) => {
+                    if tx
+                        .send(Ok(CommandOutputLine {
+                            stream: stream_kind,
+                            line,
+                        }))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    let _ = tx.send(Err(error));
+                    break;
+                }
+            }
+        }
+    });
+}
+
+pub(crate) fn image_build_error_with_output(
+    resource_name: impl Into<String>,
+    reason: impl Into<String>,
+    output: &Output,
+) -> AlienError<ErrorData> {
+    AlienError::new(ErrorData::ImageBuildFailed {
+        resource_name: resource_name.into(),
+        reason: reason.into(),
+        build_output: Some(CapturedCommandOutput::from_output(output).display()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    #[test]
+    fn display_prefers_raw_stdout_when_only_stdout_is_present() {
+        let mut output = CapturedCommandOutput::default();
+        output.push(CommandOutputLine {
+            stream: CommandOutputStream::Stdout,
+            line: "hello".to_string(),
+        });
+
+        assert_eq!(output.display(), "hello");
+    }
+
+    #[test]
+    fn display_prefers_raw_stderr_when_only_stderr_is_present() {
+        let mut output = CapturedCommandOutput::default();
+        output.push(CommandOutputLine {
+            stream: CommandOutputStream::Stderr,
+            line: "error".to_string(),
+        });
+
+        assert_eq!(output.display(), "error");
+    }
+
+    #[test]
+    fn display_labels_streams_when_both_are_present() {
+        let mut output = CapturedCommandOutput::default();
+        output.push(CommandOutputLine {
+            stream: CommandOutputStream::Stdout,
+            line: "out".to_string(),
+        });
+        output.push(CommandOutputLine {
+            stream: CommandOutputStream::Stderr,
+            line: "err".to_string(),
+        });
+
+        assert_eq!(output.display(), "stdout:\nout\n\nstderr:\nerr");
+    }
+
+    #[test]
+    fn display_is_empty_when_no_output_was_captured() {
+        assert_eq!(CapturedCommandOutput::default().display(), "");
+    }
+
+    #[tokio::test]
+    async fn captures_stdout_and_stderr_without_waiting_for_process_exit_first() {
+        let mut child = Command::new("sh")
+            .args(["-c", "printf 'out\\n'; printf 'err\\n' >&2; exit 7"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn test process");
+
+        let (status, output) = wait_with_captured_output(
+            &mut child,
+            "test",
+            "failed to read test output",
+            "failed to wait for test process",
+            |_| async {},
+        )
+        .await
+        .expect("capture output");
+
+        assert_eq!(status.code(), Some(7));
+        let display = output.display();
+        assert!(display.contains("out"));
+        assert!(display.contains("err"));
+    }
+}

--- a/crates/alien-build/src/dependencies.rs
+++ b/crates/alien-build/src/dependencies.rs
@@ -1,3 +1,4 @@
+use crate::command_output::{image_build_error_with_output, CapturedCommandOutput};
 use crate::error::{ErrorData, Result};
 use alien_error::{AlienError, Context, IntoAlienError};
 use std::path::{Path, PathBuf};
@@ -227,17 +228,16 @@ pub async fn install_dependencies(src_dir: &Path) -> Result<()> {
         })?;
 
     if !install_output.status.success() {
-        let stderr = String::from_utf8_lossy(&install_output.stderr);
-        let stdout = String::from_utf8_lossy(&install_output.stdout);
+        let captured = CapturedCommandOutput::from_output(&install_output).display();
         debug!(
-            "Failed to install dependencies - stderr: {}, stdout: {}",
-            stderr, stdout
+            "Failed to install dependencies with {}. Build output:\n{}",
+            pm_command, captured
         );
-        return Err(AlienError::new(ErrorData::ImageBuildFailed {
-            resource_name: "dependency-install".to_string(),
-            reason: format!("{} install failed", pm_command),
-            build_output: Some(stderr.to_string()),
-        }));
+        return Err(image_build_error_with_output(
+            "dependency-install",
+            format!("{} install failed", pm_command),
+            &install_output,
+        ));
     }
 
     let install_stdout = String::from_utf8_lossy(&install_output.stdout);

--- a/crates/alien-build/src/lib.rs
+++ b/crates/alien-build/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod command_output;
 pub mod dependencies;
 pub mod error;
 pub mod settings;
@@ -9,6 +10,7 @@ use alien_core::{
 };
 use alien_error::{AlienError, Context, IntoAlienError};
 use alien_preflights::runner::PreflightRunner;
+use command_output::image_build_error_with_output;
 use dockdash::{Image as DockDashImage, Layer as DockDashLayer, PullPolicy};
 use error::{DockdashResultExt, ErrorData, Result};
 use rand::distr::Alphanumeric;
@@ -1850,12 +1852,11 @@ async fn pull_and_export_image(
             })?;
 
         if !pull_output.status.success() {
-            let stderr = String::from_utf8_lossy(&pull_output.stderr);
-            return Err(AlienError::new(ErrorData::ImageBuildFailed {
-                resource_name: container_name.to_string(),
-                reason: format!("docker pull failed for image '{}'", image),
-                build_output: Some(stderr.to_string()),
-            }));
+            return Err(image_build_error_with_output(
+                container_name,
+                format!("docker pull failed for image '{}'", image),
+                &pull_output,
+            ));
         }
 
         info!("Successfully pulled image '{}' for {}", image, platform_str);
@@ -1880,12 +1881,11 @@ async fn pull_and_export_image(
             })?;
 
         if !save_output.status.success() {
-            let stderr = String::from_utf8_lossy(&save_output.stderr);
-            return Err(AlienError::new(ErrorData::ImageBuildFailed {
-                resource_name: container_name.to_string(),
-                reason: "docker save failed".to_string(),
-                build_output: Some(stderr.to_string()),
-            }));
+            return Err(image_build_error_with_output(
+                container_name,
+                "docker save failed",
+                &save_output,
+            ));
         }
 
         info!(

--- a/crates/alien-build/src/toolchain/docker.rs
+++ b/crates/alien-build/src/toolchain/docker.rs
@@ -1,4 +1,5 @@
 use super::{Toolchain, ToolchainContext, ToolchainOutput};
+use crate::command_output::{image_build_error_with_output, wait_with_captured_output};
 use crate::error::{ErrorData, Result};
 use crate::settings::BinaryTargetExt;
 use alien_core::AlienEvent;
@@ -7,7 +8,6 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tracing::info;
 
@@ -53,31 +53,15 @@ impl DockerToolchain {
     fn humanize_buildx_failure(stderr_output: &str) -> String {
         let lower = stderr_output.to_ascii_lowercase();
 
-        let summary = if lower.contains("cannot connect to the docker daemon")
+        if lower.contains("cannot connect to the docker daemon")
             || lower.contains("is the docker daemon running")
             || lower.contains("docker.sock")
         {
             "Docker is installed but the daemon is unavailable. Start Docker or OrbStack and retry."
         } else {
             "docker buildx build failed"
-        };
-
-        let tail = stderr_output
-            .lines()
-            .rev()
-            .filter(|line| !line.trim().is_empty())
-            .take(20)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        if tail.is_empty() {
-            summary.to_string()
-        } else {
-            format!("{summary}; docker output:\n{tail}")
         }
+        .to_string()
     }
 }
 
@@ -168,48 +152,34 @@ impl Toolchain for DockerToolchain {
                     build_output: None,
                 })?;
 
-            // Read stderr for progress (docker outputs to stderr)
-            let stderr = child.stderr.take().unwrap();
-            let mut stderr_reader = BufReader::new(stderr).lines();
-            let mut stderr_lines = Vec::new();
-
-            while let Some(line) = stderr_reader.next_line().await.into_alien_error().context(
-                ErrorData::ImageBuildFailed {
-                    resource_name: "docker-build".to_string(),
-                    reason: "Failed to read docker build output".to_string(),
-                    build_output: None,
+            let (output, captured_output) = wait_with_captured_output(
+                &mut child,
+                "docker-build",
+                "Failed to read docker build output",
+                "Failed to wait for docker build completion",
+                |line| {
+                    let compilation_event = &compilation_event;
+                    async move {
+                        let trimmed_line = line.line.trim();
+                        if !trimmed_line.is_empty() {
+                            let _ = compilation_event
+                                .update(AlienEvent::CompilingCode {
+                                    language: "docker".to_string(),
+                                    progress: Some(trimmed_line.to_string()),
+                                })
+                                .await;
+                        }
+                    }
                 },
-            )? {
-                stderr_lines.push(line.clone());
-
-                let trimmed_line = line.trim();
-                if !trimmed_line.is_empty() {
-                    let _ = compilation_event
-                        .update(AlienEvent::CompilingCode {
-                            language: "docker".to_string(),
-                            progress: Some(trimmed_line.to_string()),
-                        })
-                        .await;
-                }
-            }
-
-            let output =
-                child
-                    .wait()
-                    .await
-                    .into_alien_error()
-                    .context(ErrorData::ImageBuildFailed {
-                        resource_name: "docker-build".to_string(),
-                        reason: "Failed to wait for docker build completion".to_string(),
-                        build_output: None,
-                    })?;
+            )
+            .await?;
 
             if !output.success() {
-                let stderr_output = stderr_lines.join("\n");
+                let build_output = captured_output.display();
                 return Err(AlienError::new(ErrorData::ImageBuildFailed {
                     resource_name: "docker-build".to_string(),
-                    reason: Self::humanize_buildx_failure(&stderr_output),
-                    build_output: Some(stderr_output),
+                    reason: Self::humanize_buildx_failure(&build_output),
+                    build_output: Some(build_output),
                 }));
             }
 
@@ -247,12 +217,11 @@ impl Toolchain for DockerToolchain {
             })?;
 
         if !save_output.status.success() {
-            let stderr = String::from_utf8_lossy(&save_output.stderr);
-            return Err(AlienError::new(ErrorData::ImageBuildFailed {
-                resource_name: "docker-build".to_string(),
-                reason: "docker save failed".to_string(),
-                build_output: Some(stderr.to_string()),
-            }));
+            return Err(image_build_error_with_output(
+                "docker-build",
+                "docker save failed",
+                &save_output,
+            ));
         }
 
         info!("Successfully exported Docker image to OCI tarball");

--- a/crates/alien-build/src/toolchain/rust.rs
+++ b/crates/alien-build/src/toolchain/rust.rs
@@ -1,4 +1,5 @@
 use super::{cache_utils, Toolchain, ToolchainContext, ToolchainOutput};
+use crate::command_output::{image_build_error_with_output, wait_with_captured_output};
 use crate::error::{ErrorData, Result};
 use alien_core::AlienEvent;
 use alien_error::{AlienError, Context, IntoAlienError};
@@ -7,7 +8,6 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::fs;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tracing::{error, info, warn};
 
@@ -111,12 +111,11 @@ impl RustToolchain {
             })?;
 
         if !metadata_output.status.success() {
-            let stderr = String::from_utf8_lossy(&metadata_output.stderr);
-            return Err(AlienError::new(ErrorData::ImageBuildFailed {
-                resource_name: self.binary_name.clone(),
-                reason: "cargo metadata failed".to_string(),
-                build_output: Some(stderr.to_string()),
-            }));
+            return Err(image_build_error_with_output(
+                self.binary_name.clone(),
+                "cargo metadata failed",
+                &metadata_output,
+            ));
         }
 
         let stdout = String::from_utf8_lossy(&metadata_output.stdout);
@@ -195,12 +194,11 @@ impl Toolchain for RustToolchain {
                     })?;
 
                 if !install_output.status.success() {
-                    let stderr = String::from_utf8_lossy(&install_output.stderr);
-                    return Err(AlienError::new(ErrorData::ImageBuildFailed {
-                        resource_name: self.binary_name.clone(),
-                        reason: format!("Failed to install {}", package),
-                        build_output: Some(stderr.to_string()),
-                    }));
+                    return Err(image_build_error_with_output(
+                        self.binary_name.clone(),
+                        format!("Failed to install {}", package),
+                        &install_output,
+                    ));
                 }
                 info!("Successfully installed {}", package);
             } else {
@@ -246,15 +244,14 @@ impl Toolchain for RustToolchain {
                 })?;
 
             if !install_target_output.status.success() {
-                let stderr = String::from_utf8_lossy(&install_target_output.stderr);
-                return Err(AlienError::new(ErrorData::ImageBuildFailed {
-                    resource_name: self.binary_name.clone(),
-                    reason: format!(
+                return Err(image_build_error_with_output(
+                    self.binary_name.clone(),
+                    format!(
                         "Failed to install target {}",
                         context.build_target.rust_target_triple()
                     ),
-                    build_output: Some(stderr.to_string()),
-                }));
+                    &install_target_output,
+                ));
             }
             info!(
                 "Successfully installed target {}",
@@ -356,56 +353,40 @@ impl Toolchain for RustToolchain {
                     build_output: None,
                 })?;
 
-            // Read stderr line by line for progress updates
-            let stderr = child.stderr.take().unwrap();
-            let mut stderr_reader = BufReader::new(stderr).lines();
-            let mut stderr_lines = Vec::new();
-
-            // Process stderr output line by line
-            while let Some(line) = stderr_reader.next_line().await.into_alien_error().context(
-                ErrorData::ImageBuildFailed {
-                    resource_name: self.binary_name.clone(),
-                    reason: "Failed to read cargo build output".to_string(),
-                    build_output: None,
+            let (output, captured_output) = wait_with_captured_output(
+                &mut child,
+                &self.binary_name,
+                "Failed to read cargo build output",
+                &format!("Failed to wait for {} completion", build_command),
+                |line| {
+                    let compilation_event = &compilation_event;
+                    async move {
+                        // Update the event with the latest line for progress.
+                        // Only show meaningful cargo output, filtering out decorative lines.
+                        if Self::is_meaningful_cargo_line(&line.line) {
+                            let _ = compilation_event
+                                .update(AlienEvent::CompilingCode {
+                                    language: "rust".to_string(),
+                                    progress: Some(line.line.trim().to_string()),
+                                })
+                                .await; // Ignore update errors to not fail the build
+                        }
+                    }
                 },
-            )? {
-                stderr_lines.push(line.clone());
-
-                // Update the event with the latest line for progress
-                // Only show meaningful cargo output, filtering out decorative lines
-                if Self::is_meaningful_cargo_line(&line) {
-                    let _ = compilation_event
-                        .update(AlienEvent::CompilingCode {
-                            language: "rust".to_string(),
-                            progress: Some(line.trim().to_string()),
-                        })
-                        .await; // Ignore update errors to not fail the build
-                }
-            }
-
-            // Wait for the process to complete
-            let output =
-                child
-                    .wait()
-                    .await
-                    .into_alien_error()
-                    .context(ErrorData::ImageBuildFailed {
-                        resource_name: self.binary_name.clone(),
-                        reason: format!("Failed to wait for {} completion", build_command),
-                        build_output: None,
-                    })?;
+            )
+            .await?;
 
             if !output.success() {
-                let stderr_output = stderr_lines.join("\n");
+                let build_output = captured_output.display();
                 error!(
                     binary = %self.binary_name,
                     "{} failed. Build output:\n{}",
-                    build_command, stderr_output
+                    build_command, build_output
                 );
                 return Err(AlienError::new(ErrorData::ImageBuildFailed {
                     resource_name: self.binary_name.clone(),
                     reason: format!("{} failed", build_command),
-                    build_output: Some(stderr_output),
+                    build_output: Some(build_output),
                 }));
             }
 

--- a/crates/alien-build/src/toolchain/typescript.rs
+++ b/crates/alien-build/src/toolchain/typescript.rs
@@ -1,4 +1,5 @@
 use super::{cache_utils, Toolchain, ToolchainContext, ToolchainOutput};
+use crate::command_output::wait_with_captured_output;
 use crate::dependencies::install_dependencies;
 use crate::error::{ErrorData, Result};
 use alien_core::AlienEvent;
@@ -8,7 +9,6 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::fs;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tracing::{error, info};
 
@@ -449,53 +449,39 @@ impl Toolchain for TypeScriptToolchain {
                     build_output: None,
                 })?;
 
-            // Read stderr for progress
-            let stderr = child.stderr.take().unwrap();
-            let mut stderr_reader = BufReader::new(stderr).lines();
-            let mut stderr_lines = Vec::new();
-
-            while let Some(line) = stderr_reader.next_line().await.into_alien_error().context(
-                ErrorData::ImageBuildFailed {
-                    resource_name: binary_name_clone.clone(),
-                    reason: "Failed to read bun build output".to_string(),
-                    build_output: None,
+            let (output, captured_output) = wait_with_captured_output(
+                &mut child,
+                &binary_name_clone,
+                "Failed to read bun build output",
+                "Failed to wait for bun build --compile",
+                |line| {
+                    let compilation_event = &compilation_event;
+                    async move {
+                        let trimmed_line = line.line.trim();
+                        if !trimmed_line.is_empty() {
+                            let _ = compilation_event
+                                .update(AlienEvent::CompilingCode {
+                                    language: "typescript".to_string(),
+                                    progress: Some(trimmed_line.to_string()),
+                                })
+                                .await;
+                        }
+                    }
                 },
-            )? {
-                stderr_lines.push(line.clone());
-
-                let trimmed_line = line.trim();
-                if !trimmed_line.is_empty() {
-                    let _ = compilation_event
-                        .update(AlienEvent::CompilingCode {
-                            language: "typescript".to_string(),
-                            progress: Some(trimmed_line.to_string()),
-                        })
-                        .await;
-                }
-            }
-
-            let output =
-                child
-                    .wait()
-                    .await
-                    .into_alien_error()
-                    .context(ErrorData::ImageBuildFailed {
-                        resource_name: binary_name_clone.clone(),
-                        reason: "Failed to wait for bun build --compile".to_string(),
-                        build_output: None,
-                    })?;
+            )
+            .await?;
 
             if !output.success() {
-                let stderr_output = stderr_lines.join("\n");
+                let build_output = captured_output.display();
                 error!(
                     binary = %binary_name_clone,
                     "bun build --compile failed. Build output:\n{}",
-                    stderr_output
+                    build_output
                 );
                 return Err(AlienError::new(ErrorData::ImageBuildFailed {
                     resource_name: binary_name_clone.clone(),
                     reason: "bun build --compile failed".to_string(),
-                    build_output: Some(stderr_output),
+                    build_output: Some(build_output),
                 }));
             }
 

--- a/crates/alien-cli/src/ui.rs
+++ b/crates/alien-cli/src/ui.rs
@@ -10,7 +10,7 @@ use alien_core::{
     AlienEvent, DeploymentStatus, EventBus, EventChange, EventHandler, EventState, Platform,
     PushProgress, ResourceStatus, StackResourceState,
 };
-use alien_error::{AlienError, AlienErrorData};
+use alien_error::{AlienError, AlienErrorData, GenericError};
 use async_trait::async_trait;
 use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL_CONDENSED, Attribute, Cell, Color,
@@ -18,6 +18,7 @@ use comfy_table::{
 };
 use console::{measure_text_width, style, truncate_str, Term};
 use indexmap::IndexMap;
+use serde_json::Value;
 
 // ---------------------------------------------------------------------------
 // Shared utilities
@@ -202,6 +203,13 @@ where
         }
     }
 
+    if let Some(build_output) = find_build_output(error) {
+        rendered.push('\n');
+        rendered.push_str("Build output:");
+        rendered.push('\n');
+        rendered.push_str(&build_output);
+    }
+
     if let Some(hint) = report.hint {
         rendered.push('\n');
         rendered.push_str("Next:");
@@ -210,6 +218,92 @@ where
     }
 
     rendered
+}
+
+fn find_build_output<T>(error: &AlienError<T>) -> Option<String>
+where
+    T: AlienErrorData + Clone + std::fmt::Debug + serde::Serialize,
+{
+    build_output_from_context(error.context.as_ref())
+        .or_else(|| error.source.as_deref().and_then(find_build_output_generic))
+}
+
+fn find_build_output_generic(error: &AlienError<GenericError>) -> Option<String> {
+    build_output_from_context(error.context.as_ref())
+        .or_else(|| error.source.as_deref().and_then(find_build_output_generic))
+}
+
+fn build_output_from_context(context: Option<&Value>) -> Option<String> {
+    let context = context?;
+    context
+        .get("buildOutput")
+        .or_else(|| context.get("build_output"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_error::Context;
+
+    #[test]
+    fn render_human_error_leaves_regular_errors_unchanged() {
+        let error = AlienError::new(crate::error::ErrorData::ValidationError {
+            field: "platform".to_string(),
+            message: "unknown platform".to_string(),
+        });
+
+        let rendered = render_human_error(&error);
+
+        assert_eq!(rendered, "Validation failed for platform: unknown platform");
+    }
+
+    #[test]
+    fn render_human_error_prints_build_output() {
+        let error = AlienError::new(alien_build::error::ErrorData::ImageBuildFailed {
+            resource_name: "api".to_string(),
+            reason: "cargo zigbuild failed".to_string(),
+            build_output: Some("error[E0308]: mismatched types".to_string()),
+        });
+
+        let rendered = render_human_error(&error);
+
+        assert!(rendered.contains("Failed to build container image for resource 'api'"));
+        assert!(rendered.contains("Build output:\nerror[E0308]: mismatched types"));
+    }
+
+    #[test]
+    fn render_human_error_prints_build_output_from_wrapped_source() {
+        let source = AlienError::new(alien_build::error::ErrorData::ImageBuildFailed {
+            resource_name: "api".to_string(),
+            reason: "cargo zigbuild failed".to_string(),
+            build_output: Some("compiler said no".to_string()),
+        });
+        let error = Err::<(), _>(source)
+            .context(crate::error::ErrorData::BuildFailed)
+            .unwrap_err();
+
+        let rendered = render_human_error(&error);
+
+        assert_eq!(rendered.matches("Build output:").count(), 1);
+        assert!(rendered.contains("Build output:\ncompiler said no"));
+    }
+
+    #[test]
+    fn render_human_error_skips_empty_build_output() {
+        let error = AlienError::new(alien_build::error::ErrorData::ImageBuildFailed {
+            resource_name: "api".to_string(),
+            reason: "cargo zigbuild failed".to_string(),
+            build_output: Some("   ".to_string()),
+        });
+
+        let rendered = render_human_error(&error);
+
+        assert!(!rendered.contains("Build output:"));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/alien-infra/src/network/azure.rs
+++ b/crates/alien-infra/src/network/azure.rs
@@ -740,7 +740,10 @@ impl AzureNetworkController {
             .create_or_update_subnet(&resource_group, &vnet_name, &subnet_name, &subnet)
             .await
             .context(ErrorData::InfrastructureError {
-                message: format!("Failed to create Application Gateway subnet '{}'", subnet_name),
+                message: format!(
+                    "Failed to create Application Gateway subnet '{}'",
+                    subnet_name
+                ),
                 operation: Some("create_or_update_subnet".to_string()),
                 resource_id: Some(config.id.clone()),
             })?;

--- a/crates/alien-infra/src/network/azure_import.rs
+++ b/crates/alien-infra/src/network/azure_import.rs
@@ -31,14 +31,12 @@ impl ResourceImporter for AzureNetworkImporter {
             .get(1)
             .and_then(|id| subnet_name_from_id(id))
             .map(str::to_string);
-        let application_gateway_subnet_name = data
-            .application_gateway_subnet_name
-            .or_else(|| {
-                data.application_gateway_subnet_id
-                    .as_deref()
-                    .and_then(subnet_name_from_id)
-                    .map(str::to_string)
-            });
+        let application_gateway_subnet_name = data.application_gateway_subnet_name.or_else(|| {
+            data.application_gateway_subnet_id
+                .as_deref()
+                .and_then(subnet_name_from_id)
+                .map(str::to_string)
+        });
         let _ = (data.subscription_id, data.network_security_group_id);
         let controller = AzureNetworkController {
             state: AzureNetworkState::Ready,

--- a/crates/alien-manager/src/routes/registry_proxy.rs
+++ b/crates/alien-manager/src/routes/registry_proxy.rs
@@ -704,7 +704,7 @@ async fn forward_request(
         .into_response();
 
     let upstream_host = upstream_endpoint.trim_end_matches('/');
-    let proxy_base = state.config.base_url();
+    let proxy_base = proxy_base_url(original_headers, &state.config.base_url());
     let proxy_host = proxy_base.trim_end_matches('/');
 
     for (key, value) in &resp_headers {
@@ -963,6 +963,70 @@ fn query_string(params: &HashMap<String, String>) -> String {
     }
 }
 
+fn proxy_base_url(original_headers: &HeaderMap, fallback_base_url: &str) -> String {
+    let host = first_header_value(original_headers, "x-forwarded-host")
+        .or_else(|| forwarded_header_param(original_headers, "host"))
+        .or_else(|| first_header_value(original_headers, "host"));
+
+    let Some(host) = host else {
+        return fallback_base_url.trim_end_matches('/').to_string();
+    };
+
+    let proto = first_header_value(original_headers, "x-forwarded-proto")
+        .or_else(|| forwarded_header_param(original_headers, "proto"))
+        .unwrap_or_else(|| {
+            if is_loopback_host(&host) {
+                fallback_base_url
+                    .split_once("://")
+                    .map(|(scheme, _)| scheme)
+                    .unwrap_or("http")
+                    .to_string()
+            } else {
+                "https".to_string()
+            }
+        });
+
+    format!("{}://{}", proto, host)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn first_header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn forwarded_header_param(headers: &HeaderMap, param: &str) -> Option<String> {
+    let header = headers.get("forwarded")?.to_str().ok()?;
+    header.split(',').next()?.split(';').find_map(|part| {
+        let (key, value) = part.trim().split_once('=')?;
+        if key.trim().eq_ignore_ascii_case(param) {
+            let value = value.trim().trim_matches('"');
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        } else {
+            None
+        }
+    })
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host_without_port = host
+        .strip_prefix('[')
+        .and_then(|h| h.split_once(']').map(|(h, _)| h))
+        .unwrap_or_else(|| host.split(':').next().unwrap_or(host));
+
+    matches!(host_without_port, "localhost" | "127.0.0.1" | "::1")
+}
+
 /// Load the artifact registry for a specific repository path.
 ///
 /// Uses the routing table to find the correct upstream registry based on the
@@ -1102,6 +1166,41 @@ mod tests {
         assert_eq!(
             extract_repo_name("alien-e2e/blobs/uploads/uuid-123"),
             "alien-e2e"
+        );
+    }
+
+    #[test]
+    fn proxy_base_url_prefers_forwarded_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "127.0.0.1:8080".parse().unwrap());
+        headers.insert("x-forwarded-host", "manager.example.com".parse().unwrap());
+        headers.insert("x-forwarded-proto", "https".parse().unwrap());
+
+        assert_eq!(
+            proxy_base_url(&headers, "http://localhost:8080"),
+            "https://manager.example.com"
+        );
+    }
+
+    #[test]
+    fn proxy_base_url_uses_request_host_for_public_requests() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "alien-manager.example.com".parse().unwrap());
+
+        assert_eq!(
+            proxy_base_url(&headers, "http://localhost:8080"),
+            "https://alien-manager.example.com"
+        );
+    }
+
+    #[test]
+    fn proxy_base_url_keeps_localhost_http() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "localhost:8080".parse().unwrap());
+
+        assert_eq!(
+            proxy_base_url(&headers, "http://localhost:8080"),
+            "http://localhost:8080"
         );
     }
 

--- a/scripts/build-npm-packages.sh
+++ b/scripts/build-npm-packages.sh
@@ -26,6 +26,19 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
+publish_if_missing() {
+  local package_spec="$1"
+  local tarball="$2"
+  local tag="$3"
+
+  if npm view "$package_spec" version >/dev/null 2>&1; then
+    echo "Skipping $package_spec; already published"
+    return
+  fi
+
+  npm publish "$tarball" --tag "$tag"
+}
+
 # Platform definitions: npm_suffix target_triple os cpu binary_ext
 PLATFORMS=(
   "linux-x64    x86_64-unknown-linux-musl    linux   x64   "
@@ -72,7 +85,7 @@ EOF
 
   # Pack and publish with platform-specific tag
   (cd "$pkg_dir" && npm pack)
-  npm publish "${pkg_dir}/"*.tgz --tag "${npm_suffix}" || echo "WARN: publish of ${npm_suffix} variant may have already been published"
+  publish_if_missing "@alienplatform/cli@${VERSION}-${npm_suffix}" "${pkg_dir}/"*.tgz "${npm_suffix}"
 done
 
 # ── Step 2: Build the main package ───────────────────────────────────
@@ -119,7 +132,7 @@ cat > "${main_dir}/package.json" << EOF
 EOF
 
 (cd "$main_dir" && npm pack)
-npm publish "${main_dir}/"*.tgz --tag latest || echo "WARN: main package may have already been published"
+publish_if_missing "@alienplatform/cli@${VERSION}" "${main_dir}/"*.tgz latest
 
 echo ""
 echo "==> Done! Published @alienplatform/cli@${VERSION}"


### PR DESCRIPTION
Summary:
- improve build failure output capture/rendering
- make release npm publish steps easier to diagnose/retry
- include registry proxy and Azure network fixes

Validation:
- cargo check -p alien-build --lib
- cargo check -p alien-cli --lib was started but stopped per request