### PR TITLE
fix: support Helm provider v3 config

### DIFF
--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -753,10 +753,7 @@ fn versions_body(
         ));
     }
     if include_helm_provider {
-        provider_attrs.push(attr(
-            "helm",
-            provider_decl_attr("hashicorp/helm", ">= 2.13"),
-        ));
+        provider_attrs.push(attr("helm", provider_decl_attr("hashicorp/helm", ">= 3.0")));
     }
     provider_attrs.push(attr(
         "random",
@@ -1355,13 +1352,22 @@ fn providers_body(
         structures.push(Structure::Block(Block {
             identifier: Identifier::sanitized("provider"),
             labels: vec![BlockLabel::String("helm".to_string())],
-            body: Body::from(vec![nested(block(
+            body: Body::from(vec![attr(
                 "kubernetes",
-                kubernetes_provider_body(target),
-            ))]),
+                provider_config_object(kubernetes_provider_body(target)),
+            )]),
         }));
     }
     Body::from(structures)
+}
+
+fn provider_config_object(items: Vec<Structure>) -> Expression {
+    expr::object(items.into_iter().filter_map(|item| {
+        let Structure::Attribute(attribute) = item else {
+            return None;
+        };
+        Some((attribute.key.to_string(), attribute.expr))
+    }))
 }
 
 fn kubernetes_provider_body(target: TerraformTarget) -> Vec<Structure> {

--- a/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
+++ b/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
@@ -574,6 +574,12 @@ fn registered_kubernetes_module_installs_provider_rendered_helm_values() {
         .expect("registered module with helm install should include helm.tf");
     assert!(helm.contains("alien_deployment.this.helm_values"));
     assert!(!helm.contains("local.helm_values"));
+
+    let providers = module
+        .get("providers.tf")
+        .expect("registered Kubernetes module should include providers.tf");
+    assert!(providers.contains("kubernetes = {"));
+    assert!(!providers.contains("kubernetes {"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- require Helm provider >= 3.0
- render Helm provider Kubernetes settings using provider v3 object config syntax
- cover the rendered syntax in the Kubernetes overlay test

## Validation
- cargo test -p alien-terraform registered_kubernetes_module_installs_provider_rendered_helm_values