### PR TITLE
[codex] add release id to Terraform registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-error",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-error",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -956,14 +956,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -94,6 +94,7 @@ pub struct TerraformRegistration {
     /// `provider_name` to form the full Terraform type, e.g.
     /// `<provider_name>_<resource_type>`.
     pub resource_type: String,
+    pub release_id: Option<String>,
     pub setup_target: String,
     pub setup_fingerprint: String,
     pub setup_fingerprint_version: u32,
@@ -320,7 +321,6 @@ pub fn generate_terraform_module(
             &stack_settings,
             imported_resources,
             &shared_locals,
-            options.registration.is_some(),
             has_remote_management,
         )?)?,
     );
@@ -811,33 +811,20 @@ fn variables_body(
 
     blocks.push(nested(resource_prefix_variable_block()));
 
-    if registration.is_some() {
-        blocks.push(nested(variable_block(
-            "deployment_name",
-            "Human-readable application name used in setup and cloud IAM review metadata.",
-            Some(Expression::String(deployment_name_default.to_string())),
-            false,
-        )));
-        blocks.push(nested(variable_block(
-            "deployment_group_token",
-            "Install token used when registering the resolved cloud resources.",
-            None,
-            true,
-        )));
-    } else {
-        blocks.push(nested(variable_block(
-            "name",
-            "Human-readable application name shown in setup and cloud IAM review metadata.",
-            None,
-            false,
-        )));
-        blocks.push(nested(variable_block(
-            "token",
-            "Install token from the application setup page. This is the same token used by the deploy CLI --token flag.",
-            None,
-            true,
-        )));
-    }
+    blocks.push(nested(variable_block(
+        "name",
+        "Human-readable application name shown in setup and cloud IAM review metadata.",
+        registration
+            .is_some()
+            .then(|| Expression::String(deployment_name_default.to_string())),
+        false,
+    )));
+    blocks.push(nested(variable_block(
+        "token",
+        "Install token from the application setup page. This is the same token used by the deploy CLI --token flag.",
+        None,
+        true,
+    )));
     blocks.push(nested(variable_block(
         "manager_url",
         "Optional manager endpoint used by pull-style runtimes.",
@@ -1435,7 +1422,6 @@ fn locals_body(
     stack_settings: &StackSettings,
     imported_resources: Vec<Expression>,
     extra: &IndexMap<String, Expression>,
-    registration: bool,
     has_remote_management: bool,
 ) -> Result<Body> {
     let mut body: Vec<Structure> = Vec::new();
@@ -1446,14 +1432,7 @@ fn locals_body(
             "var.resource_prefix == \"\" ? format(\"a%s\", random_id.resource_prefix.hex) : var.resource_prefix",
         ),
     ));
-    body.push(attr(
-        "deployment_name",
-        expr::raw(if registration {
-            "var.deployment_name"
-        } else {
-            "var.name"
-        }),
-    ));
+    body.push(attr("deployment_name", expr::raw("var.name")));
     if matches!(target.cloud_platform(), alien_core::Platform::Gcp) {
         body.push(attr(
             "gcp_custom_role_prefix",
@@ -1671,10 +1650,7 @@ fn import_body(
     });
     if let Some(registration) = registration {
         let mut body = vec![
-            attr(
-                "deployment_group_token",
-                expr::raw("var.deployment_group_token"),
-            ),
+            attr("token", expr::raw("var.token")),
             attr("name", expr::raw("local.deployment_name")),
             attr("resource_prefix", expr::raw("local.resource_prefix")),
             attr(
@@ -1707,6 +1683,9 @@ fn import_body(
             attr("stack_settings", expr::raw("local.deployment_settings")),
             attr("resources", expr::raw("local.deployment_resources")),
         ];
+        if let Some(release_id) = &registration.release_id {
+            body.push(attr("release_id", Expression::String(release_id.clone())));
+        }
         if target.is_kubernetes() {
             body.push(attr(
                 "base_platform",
@@ -1959,7 +1938,7 @@ fn readme_md(
     display_name: Option<&str>,
 ) -> String {
     let apply_args = if registration.is_some() {
-        "-var='deployment_group_token=...'".to_string()
+        "-var='token=...'".to_string()
     } else {
         format!("-var='name={}' -var='token=...'", stack.id())
     };
@@ -2009,6 +1988,7 @@ mod tests {
             provider_source: "registry.example.com/acme/example-app".to_string(),
             provider_version: "1.0.2".to_string(),
             resource_type: "deployment".to_string(),
+            release_id: Some("rel-test".to_string()),
             setup_target: "aws".to_string(),
             setup_fingerprint: "fp-test".to_string(),
             setup_fingerprint_version: 1,

--- a/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
+++ b/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
@@ -548,6 +548,7 @@ fn registered_kubernetes_module_installs_provider_rendered_helm_values() {
                 provider_source: "pkg.example.com/acme/app".to_string(),
                 provider_version: "1.0.0".to_string(),
                 resource_type: "deployment".to_string(),
+                release_id: Some("rel-test".to_string()),
                 setup_target: "kubernetes".to_string(),
                 setup_fingerprint: "test".to_string(),
                 setup_fingerprint_version: 1,
@@ -574,6 +575,12 @@ fn registered_kubernetes_module_installs_provider_rendered_helm_values() {
         .expect("registered module with helm install should include helm.tf");
     assert!(helm.contains("alien_deployment.this.helm_values"));
     assert!(!helm.contains("local.helm_values"));
+
+    let import = module
+        .get("import.tf")
+        .expect("registered module should include import.tf");
+    assert!(import.contains("release_id"));
+    assert!(import.contains("\"rel-test\""));
 
     let providers = module
         .get("providers.tf")
@@ -617,6 +624,7 @@ fn registered_gke_kubernetes_module_declares_dynamic_network_inputs() {
                 provider_source: "pkg.example.com/acme/app".to_string(),
                 provider_version: "1.0.0".to_string(),
                 resource_type: "deployment".to_string(),
+                release_id: Some("rel-test".to_string()),
                 setup_target: "kubernetes".to_string(),
                 setup_fingerprint: "test".to_string(),
                 setup_fingerprint_version: 1,


### PR DESCRIPTION
## Summary
- add release_id to Terraform registration metadata
- use consistent `name` and `token` module inputs for registered Terraform modules
- update generator tests for registered Kubernetes modules

## Validation
- Not run per instruction to skip Cargo/check commands.