### PR TITLE
[codex] wire multicloud runtime credentials

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
@@ -16,8 +16,8 @@ use crate::{
     template::{CfExpression, CfResource},
 };
 use alien_core::{
-    import::EmitContext, ErrorData, PermissionProfile, PermissionSetReference,
-    RemoteStackManagement, Result,
+    import::EmitContext, DeploymentModel, ErrorData, KubernetesCluster, PermissionProfile,
+    PermissionSetReference, RemoteStackManagement, Result,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
 use alien_permissions::{generators::AwsCloudFormationPermissionsGenerator, BindingTarget};
@@ -36,10 +36,23 @@ impl CfEmitter for AwsRemoteStackManagementEmitter {
             "RoleName".to_string(),
             CfExpression::sub("${AWS::StackName}-management"),
         );
-        role.properties.insert(
-            "AssumeRolePolicyDocument".to_string(),
-            remote_management_trust_policy(),
-        );
+        if let Some(irsa) = eks_pull_irsa_context(ctx) {
+            role.properties.insert(
+                "AssumeRolePolicyDocument".to_string(),
+                irsa_trust_policy(
+                    &irsa.oidc_provider_id,
+                    &irsa.cluster_id,
+                    &irsa.namespace,
+                    &irsa.service_account_name,
+                ),
+            );
+            role.depends_on.push(irsa.oidc_provider_id);
+        } else {
+            role.properties.insert(
+                "AssumeRolePolicyDocument".to_string(),
+                remote_management_trust_policy(),
+            );
+        }
         role.properties.insert("Tags".to_string(), tags(ctx));
 
         let policy_documents = remote_management_policy_documents(ctx)?;
@@ -95,6 +108,79 @@ fn remote_management_trust_policy() -> CfExpression {
             ])]),
         ),
     ])
+}
+
+struct EksPullIrsaContext {
+    oidc_provider_id: String,
+    cluster_id: String,
+    namespace: String,
+    service_account_name: String,
+}
+
+fn eks_pull_irsa_context(ctx: &EmitContext<'_>) -> Option<EksPullIrsaContext> {
+    if ctx.stack_settings.deployment_model != DeploymentModel::Pull {
+        return None;
+    }
+
+    ctx.stack.resources().find_map(|(resource_id, entry)| {
+        let cluster = entry.config.downcast_ref::<KubernetesCluster>()?;
+        let prefix = ctx.name_for(resource_id)?;
+        Some(EksPullIrsaContext {
+            oidc_provider_id: format!("{prefix}OidcProvider"),
+            cluster_id: format!("{prefix}Cluster"),
+            namespace: cluster.namespace.clone(),
+            service_account_name: "${AWS::StackName}-manager-sa".to_string(),
+        })
+    })
+}
+
+fn irsa_trust_policy(
+    oidc_provider_id: &str,
+    cluster_id: &str,
+    namespace: &str,
+    service_account_name: &str,
+) -> CfExpression {
+    CfExpression::object([(
+        "Fn::Sub",
+        CfExpression::list([
+            CfExpression::from(format!(
+                r#"{{
+  "Version": "2012-10-17",
+  "Statement": [{{
+    "Effect": "Allow",
+    "Principal": {{"Federated": "${{OidcProviderArn}}"}},
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {{
+      "StringEquals": {{
+        "${{OidcIssuerHostPath}}:aud": "sts.amazonaws.com",
+        "${{OidcIssuerHostPath}}:sub": "system:serviceaccount:{namespace}:{service_account_name}"
+      }}
+    }}
+  }}]
+}}"#
+            )),
+            CfExpression::object([
+                ("OidcProviderArn", CfExpression::ref_(oidc_provider_id)),
+                ("OidcIssuerHostPath", oidc_issuer_host_path(cluster_id)),
+            ]),
+        ]),
+    )])
+}
+
+fn oidc_issuer_host_path(cluster_id: &str) -> CfExpression {
+    CfExpression::object([(
+        "Fn::Select",
+        CfExpression::list([
+            CfExpression::from(1u8),
+            CfExpression::object([(
+                "Fn::Split",
+                CfExpression::list([
+                    CfExpression::from("https://"),
+                    CfExpression::get_att(cluster_id, "OpenIdConnectIssuerUrl"),
+                ]),
+            )]),
+        ]),
+    )])
 }
 
 fn remote_management_policy_documents(ctx: &EmitContext<'_>) -> Result<Vec<CfExpression>> {

--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -621,7 +621,7 @@ fn add_standard_parameters(template: &mut CfTemplate, settings: &StackSettings) 
         PARAM_MANAGING_ROLE_ARN.to_string(),
         string_parameter(
             "Manager IAM role ARN allowed to assume generated management roles.",
-            None,
+            Some(String::new()),
             None,
             false,
         ),
@@ -1116,7 +1116,7 @@ fn add_outputs(
         OUTPUT_MANAGEMENT_CONFIG.to_string(),
         output(
             "Manager import ManagementConfig JSON.",
-            CfExpression::to_json_string(management_config),
+            json_output_value(management_config),
         ),
     );
     template.outputs.insert(
@@ -1128,6 +1128,13 @@ fn add_outputs(
     );
     add_resource_outputs(template, resources)?;
     Ok(())
+}
+
+fn json_output_value(value: CfExpression) -> CfExpression {
+    match value {
+        CfExpression::Null => CfExpression::from("null"),
+        value => CfExpression::to_json_string(value),
+    }
 }
 
 fn add_resource_outputs(template: &mut CfTemplate, resources: CfExpression) -> Result<()> {
@@ -1483,7 +1490,11 @@ fn domains_expression() -> CfExpression {
     )
 }
 
-fn management_config_expression(_target: CloudFormationTarget) -> CfExpression {
+fn management_config_expression(target: CloudFormationTarget) -> CfExpression {
+    if target.is_kubernetes() {
+        return CfExpression::Null;
+    }
+
     CfExpression::object([
         ("platform", CfExpression::from("aws")),
         (

--- a/crates/alien-cloudformation/tests/generator/kubernetes_cluster_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/kubernetes_cluster_tests.rs
@@ -3,7 +3,7 @@
 use super::helpers::render_built_ins_target;
 use alien_cloudformation::{CloudFormationTarget, RegistrationMode};
 use alien_core::{
-    KubernetesCertificateMode, KubernetesCluster, KubernetesClusterOwnership,
+    DeploymentModel, KubernetesCertificateMode, KubernetesCluster, KubernetesClusterOwnership,
     KubernetesClusterProvider, KubernetesExposureSettings, KubernetesHeartbeatMode,
     KubernetesIngressRouteProfile, KubernetesRouteProfile, KubernetesRouteProviderOptions,
     KubernetesSettings, PermissionProfile, RemoteStackManagement, ResourceLifecycle,
@@ -63,6 +63,44 @@ fn eks_target_renders_managed_cluster_and_kubernetes_import_payload() {
     assert!(yaml.contains("NodePools:"));
     assert!(yaml.contains("- system"));
     assert!(!yaml.contains("general-purpose"));
+}
+
+#[test]
+fn eks_target_remote_management_uses_manager_service_account_irsa_for_pull() {
+    let stack = Stack::new("kubernetes".to_string())
+        .add(
+            KubernetesCluster::new("kubernetes".to_string())
+                .provider(KubernetesClusterProvider::Eks)
+                .ownership(KubernetesClusterOwnership::Managed)
+                .namespace("alien".to_string())
+                .heartbeat_mode(KubernetesHeartbeatMode::KubernetesApiAndCloudMetadata)
+                .build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            RemoteStackManagement::new("remote-stack-management".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+    let settings = StackSettings {
+        deployment_model: DeploymentModel::Pull,
+        ..StackSettings::default()
+    };
+
+    let yaml = render_built_ins_target(
+        &stack,
+        settings,
+        RegistrationMode::OutputsFallback,
+        CloudFormationTarget::Eks,
+        "kubernetes",
+        "eks remote management irsa",
+    );
+
+    assert!(yaml.contains("DeploymentManagementConfig:"));
+    assert!(yaml.contains("Value: 'null'") || yaml.contains("Value: null"));
+    assert!(yaml.contains("RemoteStackManagementRole:"));
+    assert!(yaml.contains("sts:AssumeRoleWithWebIdentity"));
+    assert!(yaml.contains("system:serviceaccount:alien:${AWS::StackName}-manager-sa"));
 }
 
 #[test]

--- a/crates/alien-core/src/client_config.rs
+++ b/crates/alien-core/src/client_config.rs
@@ -148,6 +148,20 @@ pub enum GcpCredentials {
         service_account_email: String,
     },
 
+    /// Use an external account credential configuration.
+    ExternalAccount {
+        /// Workload identity audience.
+        audience: String,
+        /// Subject token type for STS token exchange.
+        subject_token_type: String,
+        /// STS token exchange URL.
+        token_url: String,
+        /// Path to the subject token file.
+        credential_source_file: String,
+        /// Optional service account impersonation URL.
+        service_account_impersonation_url: Option<String>,
+    },
+
     /// Use gcloud Application Default Credentials (authorized_user).
     /// Exchanges refresh_token for an access_token via Google's OAuth2 endpoint.
     AuthorizedUser {
@@ -179,6 +193,23 @@ impl std::fmt::Debug for GcpCredentials {
                 .debug_struct("GcpCredentials::ProjectedServiceAccount")
                 .field("token_file", token_file)
                 .field("service_account_email", service_account_email)
+                .finish(),
+            GcpCredentials::ExternalAccount {
+                audience,
+                subject_token_type,
+                token_url,
+                credential_source_file,
+                service_account_impersonation_url,
+            } => f
+                .debug_struct("GcpCredentials::ExternalAccount")
+                .field("audience", audience)
+                .field("subject_token_type", subject_token_type)
+                .field("token_url", token_url)
+                .field("credential_source_file", credential_source_file)
+                .field(
+                    "service_account_impersonation_url",
+                    service_account_impersonation_url,
+                )
                 .finish(),
             GcpCredentials::AuthorizedUser { client_id, .. } => f
                 .debug_struct("GcpCredentials::AuthorizedUser")

--- a/crates/alien-gcp-clients/src/gcp/mod.rs
+++ b/crates/alien-gcp-clients/src/gcp/mod.rs
@@ -77,6 +77,15 @@ pub trait GcpClientConfigExt {
         refresh_token: &str,
     ) -> Result<String>;
 
+    /// Exchange an external account subject token for a Google access token.
+    async fn exchange_external_account_token(
+        audience: &str,
+        subject_token_type: &str,
+        token_url: &str,
+        credential_source_file: &str,
+        service_account_impersonation_url: Option<&str>,
+    ) -> Result<String>;
+
     /// Parse a credentials JSON value and return (credentials, project_id, region)
     async fn parse_credentials_json(
         credential_data: &serde_json::Value,
@@ -304,6 +313,22 @@ impl GcpClientConfigExt for GcpClientConfig {
             GcpCredentials::ServiceMetadata => self.fetch_metadata_token().await,
             GcpCredentials::ProjectedServiceAccount { token_file, .. } => {
                 self.get_projected_token(token_file).await
+            }
+            GcpCredentials::ExternalAccount {
+                audience,
+                subject_token_type,
+                token_url,
+                credential_source_file,
+                service_account_impersonation_url,
+            } => {
+                Self::exchange_external_account_token(
+                    audience,
+                    subject_token_type,
+                    token_url,
+                    credential_source_file,
+                    service_account_impersonation_url.as_deref(),
+                )
+                .await
             }
             GcpCredentials::AuthorizedUser {
                 client_id,
@@ -730,8 +755,139 @@ impl GcpClientConfigExt for GcpClientConfig {
         Ok(token_response.access_token)
     }
 
+    /// Exchanges an external account subject token through Google's Security Token Service.
+    async fn exchange_external_account_token(
+        audience: &str,
+        subject_token_type: &str,
+        token_url: &str,
+        credential_source_file: &str,
+        service_account_impersonation_url: Option<&str>,
+    ) -> Result<String> {
+        #[derive(Deserialize)]
+        struct StsTokenResponse {
+            access_token: String,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ImpersonationTokenResponse {
+            access_token: String,
+        }
+
+        let subject_token = std::fs::read_to_string(credential_source_file)
+            .into_alien_error()
+            .context(ErrorData::InvalidClientConfig {
+                message: format!(
+                    "Failed to read external account subject token from: {}",
+                    credential_source_file
+                ),
+                errors: None,
+            })?
+            .trim()
+            .to_string();
+
+        let scope = "https://www.googleapis.com/auth/cloud-platform";
+        let client = Client::new();
+        let response = client
+            .post(token_url)
+            .form(&[
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:token-exchange",
+                ),
+                ("audience", audience),
+                (
+                    "requested_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
+                ("subject_token_type", subject_token_type),
+                ("subject_token", &subject_token),
+                ("scope", scope),
+            ])
+            .send()
+            .await
+            .into_alien_error()
+            .context(ErrorData::HttpRequestFailed {
+                message: "Failed to exchange external account token".to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(AlienError::new(ErrorData::HttpResponseError {
+                message: format!(
+                    "External account token exchange failed with status {}: {}",
+                    status, error_text
+                ),
+                url: token_url.to_string(),
+                http_status: status.as_u16(),
+                http_request_text: None,
+                http_response_text: Some(error_text),
+            }));
+        }
+
+        let sts_token: StsTokenResponse =
+            response
+                .json()
+                .await
+                .into_alien_error()
+                .context(ErrorData::SerializationError {
+                    message: "Failed to parse external account token exchange response".to_string(),
+                })?;
+
+        let Some(impersonation_url) = service_account_impersonation_url else {
+            return Ok(sts_token.access_token);
+        };
+
+        let response = client
+            .post(impersonation_url)
+            .bearer_auth(&sts_token.access_token)
+            .json(&serde_json::json!({
+                "scope": [scope],
+                "lifetime": "3600s",
+            }))
+            .send()
+            .await
+            .into_alien_error()
+            .context(ErrorData::HttpRequestFailed {
+                message: "Failed to impersonate external account service account".to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(AlienError::new(ErrorData::HttpResponseError {
+                message: format!(
+                    "External account service account impersonation failed with status {}: {}",
+                    status, error_text
+                ),
+                url: impersonation_url.to_string(),
+                http_status: status.as_u16(),
+                http_request_text: None,
+                http_response_text: Some(error_text),
+            }));
+        }
+
+        let token_response: ImpersonationTokenResponse =
+            response
+                .json()
+                .await
+                .into_alien_error()
+                .context(ErrorData::SerializationError {
+                    message: "Failed to parse service account impersonation response".to_string(),
+                })?;
+
+        Ok(token_response.access_token)
+    }
+
     /// Parse a credentials JSON value and return (credentials, project_id, region).
-    /// Supports both `service_account` and `authorized_user` credential types.
+    /// Supports `service_account`, `authorized_user`, and `external_account` credential types.
     async fn parse_credentials_json(
         credential_data: &serde_json::Value,
         raw_json: &str,
@@ -741,7 +897,83 @@ impl GcpClientConfigExt for GcpClientConfig {
             .as_str()
             .unwrap_or("service_account");
 
-        if cred_type == "authorized_user" {
+        if cred_type == "external_account" {
+            let audience = credential_data["audience"]
+                .as_str()
+                .ok_or_else(|| {
+                    AlienError::new(ErrorData::InvalidClientConfig {
+                        message: "audience not found in external_account credentials".to_string(),
+                        errors: None,
+                    })
+                })?
+                .to_string();
+
+            let subject_token_type = credential_data["subject_token_type"]
+                .as_str()
+                .unwrap_or("urn:ietf:params:oauth:token-type:jwt")
+                .to_string();
+
+            let token_url = credential_data["token_url"]
+                .as_str()
+                .unwrap_or("https://sts.googleapis.com/v1/token")
+                .to_string();
+
+            let credential_source_file = credential_data["credential_source"]["file"]
+                .as_str()
+                .ok_or_else(|| {
+                    AlienError::new(ErrorData::InvalidClientConfig {
+                        message: "credential_source.file not found in external_account credentials"
+                            .to_string(),
+                        errors: None,
+                    })
+                })?
+                .to_string();
+
+            let service_account_impersonation_url = credential_data
+                ["service_account_impersonation_url"]
+                .as_str()
+                .map(|value| value.to_string());
+
+            let project_id = environment_variables
+                .get("GCP_PROJECT_ID")
+                .or_else(|| environment_variables.get("GOOGLE_CLOUD_PROJECT"))
+                .cloned()
+                .or_else(|| {
+                    credential_data["quota_project_id"]
+                        .as_str()
+                        .map(|value| value.to_string())
+                })
+                .ok_or_else(|| {
+                    AlienError::new(ErrorData::InvalidClientConfig {
+                        message: "Missing GCP_PROJECT_ID or GOOGLE_CLOUD_PROJECT environment variable for external_account credentials".to_string(),
+                        errors: None,
+                    })
+                })?;
+
+            let region = environment_variables
+                .get("GCP_REGION")
+                .ok_or_else(|| {
+                    AlienError::new(ErrorData::InvalidClientConfig {
+                        message:
+                            "Missing GCP_REGION environment variable for external_account credentials"
+                                .to_string(),
+                        errors: None,
+                    })
+                })?
+                .clone();
+
+            Ok((
+                GcpCredentials::ExternalAccount {
+                    audience,
+                    subject_token_type,
+                    token_url,
+                    credential_source_file,
+                    service_account_impersonation_url,
+                },
+                project_id,
+                region,
+            ))
+        } else if cred_type == "authorized_user" {
             let client_id = credential_data["client_id"]
                 .as_str()
                 .ok_or_else(|| {

--- a/crates/alien-helm/src/generator.rs
+++ b/crates/alien-helm/src/generator.rs
@@ -11,8 +11,10 @@ use crate::{
 };
 use alien_core::{
     import::EmitContext, AzureResourceGroupOutputs, Container, ContainerCode, Daemon, DaemonCode,
-    ErrorData, ExposeProtocol, Ingress, Platform, RemoteStackManagementOutputs, ResourceLifecycle,
-    Result, ServiceAccount, ServiceAccountOutputs, Stack, StackSettings, Worker, WorkerCode,
+    ErrorData, ExposeProtocol, Ingress, KubernetesCluster, KubernetesClusterOutputs,
+    KubernetesClusterOwnership, KubernetesClusterProvider, Platform, RemoteStackManagementOutputs,
+    ResourceLifecycle, Result, ServiceAccount, ServiceAccountOutputs, Stack, StackSettings, Worker,
+    WorkerCode,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
 use indexmap::IndexMap;
@@ -41,6 +43,7 @@ pub struct ManagerFetchHelmValuesOptions<'a> {
     pub deployment_name: &'a str,
     pub manager_url: &'a str,
     pub deployment_token: &'a str,
+    pub runtime_encryption_key: &'a str,
     pub stack: &'a Stack,
     pub stack_state: &'a alien_core::StackState,
     pub stack_settings: &'a StackSettings,
@@ -144,6 +147,8 @@ pub fn generate_helm_chart(stack: &Stack, options: HelmOptions<'_>) -> Result<He
 
 /// Render one complete manager-fetch values file from imported deployment state.
 pub fn render_manager_fetch_values(options: ManagerFetchHelmValuesOptions<'_>) -> Result<String> {
+    validate_runtime_encryption_key(options.runtime_encryption_key)?;
+
     let registry = HelmRegistry::built_in();
     let analysis = ChartAnalysis::from_stack(options.stack, &registry)?;
     let mut yaml = String::new();
@@ -173,6 +178,13 @@ pub fn render_manager_fetch_values(options: ManagerFetchHelmValuesOptions<'_>) -
     yaml.push_str(&format!(
         "  healthChecks: {}\n\n",
         yaml_string(heartbeats_mode_value(options.stack_settings.heartbeats))
+    ));
+
+    yaml.push_str("runtime:\n");
+    yaml.push_str("  encryption:\n");
+    yaml.push_str(&format!(
+        "    key: {}\n\n",
+        yaml_string(options.runtime_encryption_key)
     ));
 
     append_stack_settings(&mut yaml, options.stack_settings)?;
@@ -229,11 +241,26 @@ pub fn render_manager_fetch_values(options: ManagerFetchHelmValuesOptions<'_>) -
         options.base_platform,
     );
     append_runtime_cloud_identity(&mut yaml, options.base_platform);
-    append_cluster_bootstrap(&mut yaml, options.stack_state, options.base_platform);
+    append_cluster_bootstrap(
+        &mut yaml,
+        options.stack,
+        options.stack_state,
+        options.base_platform,
+    );
     append_services(&mut yaml, &analysis);
     yaml.push_str("\npublicUrls: {}\n");
 
     Ok(yaml)
+}
+
+fn validate_runtime_encryption_key(key: &str) -> Result<()> {
+    if key.len() == 64 && key.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Ok(());
+    }
+
+    Err(AlienError::new(ErrorData::GenericError {
+        message: "runtime encryption key must be exactly 64 hex characters".to_string(),
+    }))
 }
 
 /// Result of dispatching every stack resource through the
@@ -633,7 +660,12 @@ fn append_manager_service_account(
         }
         None => yaml.push_str("  annotations: {}\n"),
     }
-    yaml.push_str("  labels: {}\n");
+    if base_platform == Some(Platform::Azure) {
+        yaml.push_str("  labels:\n");
+        yaml.push_str("    azure.workload.identity/use: 'true'\n");
+    } else {
+        yaml.push_str("  labels: {}\n");
+    }
     Ok(())
 }
 
@@ -708,20 +740,12 @@ fn azure_subscription_id_from_resource_id(resource_id: &str) -> Option<String> {
 
 fn append_cluster_bootstrap(
     yaml: &mut String,
+    stack: &Stack,
     stack_state: &alien_core::StackState,
     base_platform: Option<Platform>,
 ) {
-    let eks_managed = base_platform == Some(Platform::Aws)
-        && stack_state.resources.values().any(|resource| {
-            resource
-                .outputs
-                .as_ref()
-                .and_then(|outputs| outputs.downcast_ref::<alien_core::KubernetesClusterOutputs>())
-                .is_some_and(|outputs| {
-                    outputs.provider == alien_core::KubernetesClusterProvider::Eks
-                        && outputs.ownership == alien_core::KubernetesClusterOwnership::Managed
-                })
-        });
+    let eks_managed =
+        base_platform == Some(Platform::Aws) && managed_eks_cluster_present(stack, stack_state);
 
     yaml.push_str("clusterBootstrap:\n");
     yaml.push_str("  metricsServer:\n");
@@ -784,6 +808,35 @@ fn append_cluster_bootstrap(
     yaml.push_str("        limits:\n");
     yaml.push_str("          cpu: \"1000\"\n");
     yaml.push_str("          memory: 1000Gi\n");
+}
+
+fn managed_eks_cluster_present(stack: &Stack, stack_state: &alien_core::StackState) -> bool {
+    stack_state.resources.values().any(|resource| {
+        resource
+            .outputs
+            .as_ref()
+            .and_then(|outputs| outputs.downcast_ref::<KubernetesClusterOutputs>())
+            .is_some_and(is_managed_eks_cluster_outputs)
+            || resource
+                .config
+                .downcast_ref::<KubernetesCluster>()
+                .is_some_and(is_managed_eks_cluster_config)
+    }) || stack.resources().any(|(_, entry)| {
+        entry
+            .config
+            .downcast_ref::<KubernetesCluster>()
+            .is_some_and(is_managed_eks_cluster_config)
+    })
+}
+
+fn is_managed_eks_cluster_outputs(outputs: &KubernetesClusterOutputs) -> bool {
+    outputs.provider == KubernetesClusterProvider::Eks
+        && outputs.ownership == KubernetesClusterOwnership::Managed
+}
+
+fn is_managed_eks_cluster_config(cluster: &KubernetesCluster) -> bool {
+    cluster.provider == KubernetesClusterProvider::Eks
+        && cluster.ownership == KubernetesClusterOwnership::Managed
 }
 
 fn azure_application_gateway_for_containers_bootstrap(
@@ -2421,6 +2474,9 @@ mod tests {
         ResourceOutputs, ResourceStatus, StackResourceState, Storage, WorkerCode, WorkerTrigger,
     };
 
+    const TEST_RUNTIME_ENCRYPTION_KEY: &str =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
     fn sample_stack() -> Stack {
         let storage = Storage::new("assets".to_string()).versioning(true).build();
         let queue = Queue::new("jobs".to_string()).build();
@@ -2467,6 +2523,104 @@ mod tests {
     }
 
     #[test]
+    fn manager_fetch_values_include_runtime_encryption_key() {
+        let stack_state =
+            alien_core::StackState::with_resource_prefix(Platform::Kubernetes, "e2e123".into());
+
+        let values = render_manager_fetch_values(ManagerFetchHelmValuesOptions {
+            deployment_id: "dep_123",
+            deployment_name: "deployment",
+            manager_url: "https://manager.example.com",
+            deployment_token: "token",
+            runtime_encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
+            stack: &sample_stack(),
+            stack_state: &stack_state,
+            stack_settings: &StackSettings::default(),
+            base_platform: Some(Platform::Aws),
+            region: Some("us-east-1"),
+            gcp_project_id: None,
+            azure_location: None,
+        })
+        .expect("manager-fetch values should render");
+
+        assert!(values.contains("runtime:\n  encryption:\n"));
+        assert!(values.contains(&format!("    key: '{}'", TEST_RUNTIME_ENCRYPTION_KEY)));
+    }
+
+    #[test]
+    fn manager_fetch_values_reject_invalid_runtime_encryption_key() {
+        let stack_state =
+            alien_core::StackState::with_resource_prefix(Platform::Kubernetes, "e2e123".into());
+
+        let error = render_manager_fetch_values(ManagerFetchHelmValuesOptions {
+            deployment_id: "dep_123",
+            deployment_name: "deployment",
+            manager_url: "https://manager.example.com",
+            deployment_token: "token",
+            runtime_encryption_key: "replace-me-with-a-stable-64-character-encryption-secret",
+            stack: &sample_stack(),
+            stack_state: &stack_state,
+            stack_settings: &StackSettings::default(),
+            base_platform: Some(Platform::Aws),
+            region: Some("us-east-1"),
+            gcp_project_id: None,
+            azure_location: None,
+        })
+        .expect_err("invalid runtime encryption key should fail");
+
+        assert!(error
+            .to_string()
+            .contains("runtime encryption key must be exactly 64 hex characters"));
+    }
+
+    #[test]
+    fn manager_fetch_values_enable_eks_cluster_bootstrap_from_imported_config() {
+        let cluster = KubernetesCluster::new("kubernetes".to_string())
+            .provider(KubernetesClusterProvider::Eks)
+            .ownership(KubernetesClusterOwnership::Managed)
+            .namespace("alien-test".to_string())
+            .heartbeat_mode(alien_core::KubernetesHeartbeatMode::KubernetesApiAndCloudMetadata)
+            .build();
+        let stack = Stack::new("sample-stack".to_string())
+            .add(cluster.clone(), ResourceLifecycle::Frozen)
+            .build();
+        let mut stack_state =
+            alien_core::StackState::with_resource_prefix(Platform::Kubernetes, "e2e123".into());
+        stack_state.resources.insert(
+            "kubernetes".to_string(),
+            StackResourceState::new_pending(
+                KubernetesCluster::RESOURCE_TYPE.to_string(),
+                Resource::new(cluster),
+                Some(ResourceLifecycle::Frozen),
+                Vec::new(),
+            ),
+        );
+
+        let values = render_manager_fetch_values(ManagerFetchHelmValuesOptions {
+            deployment_id: "dep_123",
+            deployment_name: "deployment",
+            manager_url: "https://manager.example.com",
+            deployment_token: "token",
+            runtime_encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
+            stack: &stack,
+            stack_state: &stack_state,
+            stack_settings: &StackSettings::default(),
+            base_platform: Some(Platform::Aws),
+            region: Some("us-east-1"),
+            gcp_project_id: None,
+            azure_location: None,
+        })
+        .expect("manager-fetch values should render");
+
+        assert!(values.contains("clusterBootstrap:"));
+        assert!(values
+            .contains("storageClass:\n    default:\n      enabled: true\n      name: \"gp3\""));
+        assert!(values.contains("ingress:\n    eksAutoMode:\n      enabled: true\n      name: alb"));
+        assert!(values
+            .contains("compute:\n    eksAutoMode:\n      arm64NodePool:\n        enabled: true"));
+    }
+
+    #[test]
     fn manager_fetch_values_use_azure_workload_identity_client_id() {
         let mut stack_state =
             alien_core::StackState::with_resource_prefix(Platform::Kubernetes, "e2e123".into());
@@ -2497,6 +2651,7 @@ mod tests {
             deployment_name: "deployment",
             manager_url: "https://manager.example.com",
             deployment_token: "token",
+            runtime_encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
             stack: &sample_stack(),
             stack_state: &stack_state,
             stack_settings: &StackSettings::default(),
@@ -2565,6 +2720,7 @@ mod tests {
             deployment_name: "deployment",
             manager_url: "https://manager.example.com",
             deployment_token: "token",
+            runtime_encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
             stack: &sample_stack(),
             stack_state: &stack_state,
             stack_settings: &StackSettings::default(),

--- a/crates/alien-helm/tests/generator/snapshots/generator__generator__helpers__data_layer.snap.new
+++ b/crates/alien-helm/tests/generator/snapshots/generator__generator__helpers__data_layer.snap.new
@@ -1,0 +1,1620 @@
+---
+source: crates/alien-helm/tests/generator/helpers.rs
+assertion_line: 37
+expression: buf
+---
+=== Chart.yaml ===
+apiVersion: v2
+name: data-chart
+description: Deployment chart for data-chart
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+=== values.yaml ===
+management:
+  token: ""
+  existingSecret:
+    name: ""
+    tokenKey: sync-token
+  name: ""
+  url: ""
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+runtime:
+  image:
+    repository: ghcr.io/alienplatform/alien-agent
+    tag: latest
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podLabels: {}
+  podAnnotations: {}
+  automountServiceAccountToken: true
+  encryption:
+    # Set this explicitly, or reference an existing Secret below.
+    key: "replace-me-with-a-stable-64-character-encryption-secret"
+    existingSecret:
+      name: ""
+      key: encryption-key
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  api:
+    enabled: false
+    bindHost: 0.0.0.0
+    port: 8080
+    service:
+      type: ClusterIP
+  probes:
+    liveness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 3
+  security:
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroup: 10001
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+  tmp:
+    enabled: true
+    sizeLimit: 256Mi
+  data:
+    mountPath: /var/lib/alien-agent
+    persistence:
+      enabled: false
+      existingClaim: ""
+      storageClassName: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+  scheduling:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    topologySpreadConstraints: []
+    priorityClassName: ""
+    runtimeClassName: ""
+  pdb:
+    enabled: false
+    minAvailable: 1
+  networkPolicy:
+    enabled: false
+    ingress:
+      enabled: true
+    egress:
+      enabled: true
+
+heartbeat:
+  collection:
+    nodes:
+      enabled: true
+
+clusterBootstrap:
+  metricsServer:
+    enabled: false
+    image: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+  storageClass:
+    default:
+      enabled: false
+      name: ""
+      provisioner: ""
+      parameters: {}
+  ingress:
+    eksAutoMode:
+      enabled: false
+      name: alb
+      controller: eks.amazonaws.com/alb
+      scheme: internet-facing
+      subnetIds: []
+    azureApplicationGatewayForContainers:
+      enabled: false
+      applicationLoadBalancer:
+        name: ""
+        namespace: ""
+        associationSubnetId: ""
+  compute:
+    eksAutoMode:
+      arm64NodePool:
+        enabled: false
+        name: general-purpose-arm64
+        nodeClassName: default
+        capacityType: on-demand
+        instanceCategories:
+          - c
+          - m
+          - r
+        minInstanceGeneration: "5"
+        limits:
+          cpu: "1000"
+          memory: 1000Gi
+
+serviceAccounts:
+  {}
+
+stackSettings: null
+
+infrastructure: null
+
+basePlatform: null
+basePlatformConfig:
+  gcp:
+    projectId: ""
+    region: ""
+  aws:
+    region: ""
+  azure:
+    location: ""
+    subscriptionId: ""
+    tenantId: ""
+serviceAccountPrefix: ""
+managerServiceAccount:
+  annotations: {}
+  labels: {}
+
+services:
+  {}
+
+publicUrls: {}
+
+persistentStorage:
+  storageClassName: ""
+
+ephemeralStorage:
+  nodeSelector: {}
+
+=== values.schema.json ===
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "management": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token", "updates", "telemetry", "healthChecks"],
+      "properties": {
+        "token": { "type": "string" },
+        "existingSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "tokenKey": { "type": "string", "minLength": 1 }
+          }
+        },
+        "name": { "type": "string" },
+        "url": { "type": "string" },
+        "deploymentId": { "type": ["string", "null"] },
+        "updates": { "type": "string", "enum": ["auto", "approval-required"] },
+        "telemetry": { "type": "string", "enum": ["auto", "approval-required", "off"] },
+        "healthChecks": { "type": "string", "enum": ["on", "off"] }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string", "minLength": 1 },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": { "name": { "type": "string", "minLength": 1 } }
+          }
+        },
+        "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "automountServiceAccountToken": { "type": "boolean" },
+        "encryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key": { "type": "string" },
+            "existingSecret": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": { "type": "string" },
+                "key": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "resources": { "type": "object" },
+        "api": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "bindHost": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] }
+              }
+            }
+          }
+        },
+        "probes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "liveness": { "$ref": "#/definitions/httpProbe" },
+            "readiness": { "$ref": "#/definitions/httpProbe" }
+          }
+        },
+        "security": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "podSecurityContext": { "type": "object" },
+            "containerSecurityContext": { "type": "object" }
+          }
+        },
+        "tmp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "sizeLimit": { "type": "string" }
+          }
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mountPath": { "type": "string", "minLength": 1 },
+            "persistence": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "existingClaim": { "type": "string" },
+                "storageClassName": { "type": "string" },
+                "accessModes": { "type": "array", "items": { "type": "string" } },
+                "size": { "type": "string" }
+              }
+            }
+          }
+        },
+        "scheduling": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" },
+            "topologySpreadConstraints": { "type": "array" },
+            "priorityClassName": { "type": "string" },
+            "runtimeClassName": { "type": "string" }
+          }
+        },
+        "pdb": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minAvailable": { "type": ["integer", "string"] },
+            "maxUnavailable": { "type": ["integer", "string"] }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ingress": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": { "enabled": { "type": "boolean" } }
+            },
+            "egress": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": { "enabled": { "type": "boolean" } }
+            }
+          }
+        }
+      }
+    },
+    "managerServiceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+    "serviceAccounts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+          "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+      }
+    },
+    "stackSettings": {
+      "type": ["object", "null"],
+      "properties": {
+        "deploymentModel": { "type": "string", "enum": ["pull", "Pull"] },
+        "updates": { "type": "string" },
+        "telemetry": { "type": "string" },
+        "heartbeats": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "infrastructure": { "type": ["object", "null"] },
+    "basePlatform": { "type": ["string", "null"], "enum": ["aws", "gcp", "azure", null] },
+    "basePlatformConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "gcp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "projectId": { "type": "string" },
+            "region": { "type": "string" }
+          }
+        },
+        "aws": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "region": { "type": "string" }
+          }
+        },
+        "azure": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "location": { "type": "string" },
+            "subscriptionId": { "type": "string" },
+            "tenantId": { "type": "string" }
+          }
+        }
+      }
+    },
+    "heartbeat": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "nodes": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "clusterBootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "metricsServer": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "type": "string" }
+          }
+        },
+        "storageClass": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "name": { "type": "string" },
+                "provisioner": { "type": "string" },
+                "parameters": { "type": "object", "additionalProperties": { "type": "string" } }
+              }
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eksAutoMode": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "name": { "type": "string" },
+                "controller": { "type": "string" },
+                "scheme": { "type": "string" },
+                "subnetIds": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            },
+            "azureApplicationGatewayForContainers": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "applicationLoadBalancer": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": { "type": "string" },
+                    "namespace": { "type": "string" },
+                    "associationSubnetId": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "compute": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eksAutoMode": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "arm64NodePool": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "name": { "type": "string" },
+                    "nodeClassName": { "type": "string" },
+                    "capacityType": { "type": "string" },
+                    "instanceCategories": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "minInstanceGeneration": { "type": "string" },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "cpu": { "type": "string" },
+                        "memory": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "serviceAccountPrefix": { "type": "string" },
+    "services": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": { "type": "string", "enum": ["clusterIp", "loadBalancer"] },
+          "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "component": { "type": "string" }
+        }
+      }
+    },
+    "publicUrls": { "type": "object", "additionalProperties": { "type": "string" } },
+    "persistentStorage": { "type": "object" },
+    "ephemeralStorage": { "type": "object" }
+  },
+  "definitions": {
+    "httpProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "path": { "type": "string", "minLength": 1 },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "title": "manager-fetch path",
+      "required": ["management"],
+      "properties": {
+        "management": {
+          "required": ["token", "deploymentId"],
+          "properties": {
+            "deploymentId": { "type": "string", "minLength": 1 }
+          }
+        },
+        "infrastructure": { "type": "null" }
+      }
+    },
+    {
+      "title": "external-bindings initialize path",
+      "required": ["management", "infrastructure"],
+      "properties": {
+        "management": {
+          "properties": {
+            "deploymentId": { "type": "null" }
+          }
+        },
+        "stackSettings": { "type": ["object", "null"] },
+        "infrastructure": { "type": "object" }
+      }
+    }
+  ]
+}
+
+=== templates/_helpers.tpl ===
+{{- define "alien.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "alien.labels" -}}
+app.kubernetes.io/name: {{ include "alien.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- define "alien.managerServiceAccountName" -}}
+{{- $prefix := default (include "alien.fullname" .) .Values.serviceAccountPrefix -}}
+{{- $raw := printf "%s-manager-sa" $prefix | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $raw "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.serviceAccountName" -}}
+{{- $prefix := default (include "alien.fullname" .root) .root.Values.serviceAccountPrefix -}}
+{{- $raw := printf "%s-%s-sa" $prefix .name | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $raw "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.resourceName" -}}
+{{- $raw := .name | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $raw "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.managementSecretName" -}}
+{{- default (include "alien.fullname" .) .Values.management.existingSecret.name -}}
+{{- end -}}
+
+{{- define "alien.managementSecretTokenKey" -}}
+{{- default "sync-token" .Values.management.existingSecret.tokenKey -}}
+{{- end -}}
+
+{{- define "alien.encryptionSecretName" -}}
+{{- default (include "alien.fullname" .) .Values.runtime.encryption.existingSecret.name -}}
+{{- end -}}
+
+{{- define "alien.encryptionSecretKey" -}}
+{{- default "encryption-key" .Values.runtime.encryption.existingSecret.key -}}
+{{- end -}}
+
+{{- define "alien.heartbeatNodeClusterRoleName" -}}
+{{- printf "%s-heartbeat-nodes" (include "alien.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+=== templates/serviceaccount.yaml ===
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alien.managerServiceAccountName" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+    {{- with .Values.managerServiceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.managerServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- range $name, $account := .Values.serviceAccounts }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alien.serviceAccountName" (dict "root" $ "name" $name) }}
+  labels:
+    {{- include "alien.labels" $ | nindent 4 }}
+    {{- with $account.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $account.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+
+=== templates/role.yaml ===
+{{- $stackSettings := default dict .Values.stackSettings -}}
+{{- $exposure := dig "kubernetes" "exposure" dict $stackSettings -}}
+{{- $exposureMode := dig "mode" "" $exposure -}}
+{{- $route := dig "route" dict $exposure -}}
+{{- $routeApi := dig "routeApi" "" $route -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/log", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- if and (ne $exposureMode "disabled") (eq $routeApi "ingress") }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
+  {{- if and (ne $exposureMode "disabled") (eq $routeApi "gateway") }}
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.gke.io"]
+    resources: ["healthcheckpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["alb.networking.azure.io"]
+    resources: ["healthcheckpolicy"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
+
+=== templates/rolebinding.yaml ===
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "alien.managerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "alien.fullname" . }}
+
+=== templates/clusterrole.yaml ===
+{{- $nodeCollectionEnabled := dig "collection" "nodes" "enabled" true (default dict .Values.heartbeat) -}}
+{{- if $nodeCollectionEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "alien.heartbeatNodeClusterRoleName" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+{{- end }}
+
+=== templates/clusterrolebinding.yaml ===
+{{- $nodeCollectionEnabled := dig "collection" "nodes" "enabled" true (default dict .Values.heartbeat) -}}
+{{- if $nodeCollectionEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "alien.heartbeatNodeClusterRoleName" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "alien.managerServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "alien.heartbeatNodeClusterRoleName" . }}
+{{- end }}
+
+=== templates/secret.yaml ===
+{{- $createManagementSecret := not .Values.management.existingSecret.name -}}
+{{- $createEncryptionSecret := not .Values.runtime.encryption.existingSecret.name -}}
+{{- if or $createManagementSecret $createEncryptionSecret .Values.infrastructure }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if $createManagementSecret }}
+  sync-token: {{ .Values.management.token | quote }}
+  {{- end }}
+  {{- if $createEncryptionSecret }}
+  encryption-key: {{ required "runtime.encryption.key or runtime.encryption.existingSecret.name is required" .Values.runtime.encryption.key | quote }}
+  {{- end }}
+  {{- if .Values.infrastructure }}
+  external-bindings.json: {{ toJson .Values.infrastructure | quote }}
+  {{- end }}
+{{- end }}
+
+=== templates/configmap.yaml ===
+{{- $defaultStackSettings := dict "deploymentModel" "pull" "updates" .Values.management.updates "telemetry" .Values.management.telemetry "heartbeats" .Values.management.healthChecks -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+data:
+  stack.json: |-
+{{ .Files.Get "files/stack.json" | indent 4 }}
+  stack-settings.json: {{ toJson (default $defaultStackSettings .Values.stackSettings) | quote }}
+  services.json: {{ toJson .Values.services | quote }}
+  public-urls.json: {{ toJson (default dict .Values.publicUrls) | quote }}
+
+=== templates/deployment.yaml ===
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.runtime.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "alien.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "alien.labels" . | nindent 8 }}
+        {{- with .Values.runtime.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.runtime.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "alien.managerServiceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.runtime.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.runtime.security.podSecurityContext | nindent 8 }}
+      {{- with .Values.runtime.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.runtime.scheduling.priorityClassName }}
+      priorityClassName: {{ .Values.runtime.scheduling.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.runtime.scheduling.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtime.scheduling.runtimeClassName | quote }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: "{{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag }}"
+          imagePullPolicy: {{ .Values.runtime.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.runtime.security.containerSecurityContext | nindent 12 }}
+          env:
+            - name: PLATFORM
+              value: kubernetes
+            {{- if .Values.basePlatform }}
+            - name: BASE_PLATFORM
+              value: {{ .Values.basePlatform | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "gcp") .Values.basePlatformConfig.gcp.projectId }}
+            - name: GCP_PROJECT_ID
+              value: {{ .Values.basePlatformConfig.gcp.projectId | quote }}
+            - name: GOOGLE_CLOUD_PROJECT
+              value: {{ .Values.basePlatformConfig.gcp.projectId | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "gcp") .Values.basePlatformConfig.gcp.region }}
+            - name: GCP_REGION
+              value: {{ .Values.basePlatformConfig.gcp.region | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "azure") .Values.basePlatformConfig.azure.subscriptionId }}
+            - name: AZURE_SUBSCRIPTION_ID
+              value: {{ .Values.basePlatformConfig.azure.subscriptionId | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "azure") .Values.basePlatformConfig.azure.tenantId }}
+            - name: AZURE_TENANT_ID
+              value: {{ .Values.basePlatformConfig.azure.tenantId | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "azure") .Values.basePlatformConfig.azure.location }}
+            - name: AZURE_REGION
+              value: {{ .Values.basePlatformConfig.azure.location | quote }}
+            {{- end }}
+            - name: SYNC_URL
+              value: {{ .Values.management.url | quote }}
+            - name: AGENT_NAME
+              value: {{ .Values.management.name | quote }}
+            {{- if .Values.management.deploymentId }}
+            - name: DEPLOYMENT_ID
+              value: {{ .Values.management.deploymentId | quote }}
+            {{- end }}
+            - name: KUBERNETES_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: SYNC_TOKEN_FILE
+              value: /etc/alien/secrets/sync-token
+            - name: AGENT_ENCRYPTION_KEY_FILE
+              value: /etc/alien/secrets/encryption-key
+            - name: STACK_SETTINGS_FILE
+              value: /etc/alien/config/stack-settings.json
+            - name: PUBLIC_URLS_FILE
+              value: /etc/alien/config/public-urls.json
+            {{- if .Values.infrastructure }}
+            - name: EXTERNAL_BINDINGS_FILE
+              value: /etc/alien/secrets/external-bindings.json
+            {{- end }}
+            - name: SYNC_INTERVAL
+              value: "30"
+            - name: OTLP_PORT
+              value: {{ .Values.runtime.api.port | quote }}
+            - name: OTLP_HOST
+              value: {{ .Values.runtime.api.bindHost | quote }}
+          ports:
+            - name: otlp
+              containerPort: {{ .Values.runtime.api.port }}
+          {{- if .Values.runtime.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.runtime.probes.liveness.path | quote }}
+              port: otlp
+            initialDelaySeconds: {{ .Values.runtime.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.runtime.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.runtime.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.runtime.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.runtime.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.runtime.probes.readiness.path | quote }}
+              port: otlp
+            initialDelaySeconds: {{ .Values.runtime.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.runtime.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.runtime.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.runtime.probes.readiness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alien/config
+              readOnly: true
+            - name: management-token
+              mountPath: /etc/alien/secrets/sync-token
+              subPath: sync-token
+              readOnly: true
+            - name: encryption-key
+              mountPath: /etc/alien/secrets/encryption-key
+              subPath: {{ include "alien.encryptionSecretKey" . }}
+              readOnly: true
+            {{- if .Values.infrastructure }}
+            - name: external-bindings
+              mountPath: /etc/alien/secrets/external-bindings.json
+              subPath: external-bindings.json
+              readOnly: true
+            {{- end }}
+            {{- if .Values.runtime.tmp.enabled }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
+            - name: runtime-data
+              mountPath: {{ .Values.runtime.data.mountPath | quote }}
+          resources:
+            {{- toYaml .Values.runtime.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "alien.fullname" . }}
+        - name: management-token
+          secret:
+            secretName: {{ include "alien.managementSecretName" . }}
+            items:
+              - key: {{ include "alien.managementSecretTokenKey" . }}
+                path: sync-token
+            defaultMode: 384
+        - name: encryption-key
+          secret:
+            secretName: {{ include "alien.encryptionSecretName" . }}
+            defaultMode: 384
+        {{- if .Values.infrastructure }}
+        - name: external-bindings
+          secret:
+            secretName: {{ include "alien.fullname" . }}
+            items:
+              - key: external-bindings.json
+                path: external-bindings.json
+            defaultMode: 384
+        {{- end }}
+        {{- if .Values.runtime.tmp.enabled }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.runtime.tmp.sizeLimit | quote }}
+        {{- end }}
+        - name: runtime-data
+          {{- if .Values.runtime.data.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-runtime-data" (include "alien.fullname" .)) .Values.runtime.data.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
+=== templates/pvc.yaml ===
+{{- if and .Values.runtime.data.persistence.enabled (not .Values.runtime.data.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-runtime-data" (include "alien.fullname" .) }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.runtime.data.persistence.accessModes | nindent 4 }}
+  {{- if .Values.runtime.data.persistence.storageClassName }}
+  storageClassName: {{ .Values.runtime.data.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.runtime.data.persistence.size | quote }}
+{{- end }}
+
+=== templates/service.yaml ===
+{{- if .Values.runtime.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.runtime.api.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "alien.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.runtime.api.port }}
+      targetPort: otlp
+{{- end }}
+
+=== templates/app-service.yaml ===
+{{- range $id, $service := .Values.services }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alien.resourceName" (dict "root" $ "name" $id) }}
+  labels:
+    {{- include "alien.labels" $ | nindent 4 }}
+    alien.dev/resource-id: {{ $id | quote }}
+spec:
+  type: {{ if eq $service.type "loadBalancer" }}LoadBalancer{{ else }}ClusterIP{{ end }}
+  selector:
+    app: {{ include "alien.resourceName" (dict "root" $ "name" $id) }}
+    managed-by: alien
+    component: {{ $service.component | quote }}
+  ports:
+    - name: http
+      port: {{ default 80 $service.port }}
+      targetPort: {{ default 8080 $service.targetPort }}
+---
+{{- end }}
+
+=== templates/cluster-bootstrap.yaml ===
+{{- $bootstrap := default dict .Values.clusterBootstrap -}}
+{{- $storage := dig "storageClass" "default" dict $bootstrap -}}
+{{- if dig "enabled" false $storage }}
+{{- $storageName := required "clusterBootstrap.storageClass.default.name is required when enabled" $storage.name -}}
+{{- $provisioner := required "clusterBootstrap.storageClass.default.provisioner is required when enabled" $storage.provisioner -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $storageName | quote }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+provisioner: {{ $provisioner | quote }}
+{{ with $storage.parameters }}
+parameters:
+  {{ range $key, $value := . }}
+  {{ $key }}: {{ $value | quote }}
+  {{ end }}
+{{ end }}
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{ end }}
+{{- $eksAlb := dig "ingress" "eksAutoMode" dict $bootstrap -}}
+{{- if dig "enabled" false $eksAlb }}
+{{- $ingressClassName := required "clusterBootstrap.ingress.eksAutoMode.name is required when enabled" $eksAlb.name -}}
+{{- $controller := required "clusterBootstrap.ingress.eksAutoMode.controller is required when enabled" $eksAlb.controller -}}
+---
+apiVersion: eks.amazonaws.com/v1
+kind: IngressClassParams
+metadata:
+  name: {{ $ingressClassName | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  scheme: {{ default "internet-facing" $eksAlb.scheme | quote }}
+  {{ with $eksAlb.subnetIds }}
+  subnets:
+    ids:
+      {{ range . }}
+      - {{ . | quote }}
+      {{ end }}
+  {{ end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ $ingressClassName | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  controller: {{ $controller | quote }}
+  parameters:
+    apiGroup: eks.amazonaws.com
+    kind: IngressClassParams
+    name: {{ $ingressClassName | quote }}
+{{ end }}
+{{- $azureAgc := dig "ingress" "azureApplicationGatewayForContainers" dict $bootstrap -}}
+{{- if dig "enabled" false $azureAgc }}
+{{- $azureAlb := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer is required when enabled" $azureAgc.applicationLoadBalancer -}}
+{{- $azureAlbName := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer.name is required when enabled" $azureAlb.name -}}
+{{- $azureAlbNamespace := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer.namespace is required when enabled" $azureAlb.namespace -}}
+{{- $azureAssociationSubnetId := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer.associationSubnetId is required when enabled" $azureAlb.associationSubnetId -}}
+---
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: {{ $azureAlbName | quote }}
+  namespace: {{ $azureAlbNamespace | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  associations:
+    - {{ $azureAssociationSubnetId | quote }}
+{{ end }}
+{{- $eksArm64NodePool := dig "compute" "eksAutoMode" "arm64NodePool" dict $bootstrap -}}
+{{- if dig "enabled" false $eksArm64NodePool }}
+{{- $nodePoolName := required "clusterBootstrap.compute.eksAutoMode.arm64NodePool.name is required when enabled" $eksArm64NodePool.name -}}
+{{- $nodeClassName := required "clusterBootstrap.compute.eksAutoMode.arm64NodePool.nodeClassName is required when enabled" $eksArm64NodePool.nodeClassName -}}
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: {{ $nodePoolName | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: {{ $nodeClassName | quote }}
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+            - {{ default "on-demand" $eksArm64NodePool.capacityType | quote }}
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+            - "arm64"
+        - key: eks.amazonaws.com/instance-category
+          operator: In
+          values:
+            {{ range (default (list "c" "m" "r") $eksArm64NodePool.instanceCategories) }}
+            - {{ . | quote }}
+            {{ end }}
+        - key: eks.amazonaws.com/instance-generation
+          operator: Gt
+          values:
+            - {{ default "5" $eksArm64NodePool.minInstanceGeneration | quote }}
+  {{ with $eksArm64NodePool.limits }}
+  limits:
+    {{ with .cpu }}
+    cpu: {{ . | quote }}
+    {{ end }}
+    {{ with .memory }}
+    memory: {{ . | quote }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{- $metrics := dig "metricsServer" dict $bootstrap -}}
+{{- if dig "enabled" false $metrics }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes/metrics"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      containers:
+        - name: metrics-server
+          image: {{ default "registry.k8s.io/metrics-server/metrics-server:v0.8.1" $metrics.image | quote }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --cert-dir=/tmp
+            - --secure-port=10250
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+          ports:
+            - name: https
+              containerPort: 10250
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end }}
+
+=== templates/poddisruptionbudget.yaml ===
+{{- if .Values.runtime.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  {{- if hasKey .Values.runtime.pdb "maxUnavailable" }}
+  maxUnavailable: {{ .Values.runtime.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.runtime.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "alien.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+=== templates/networkpolicy.yaml ===
+{{- if .Values.runtime.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "alien.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    {{- if .Values.runtime.networkPolicy.ingress.enabled }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.runtime.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  {{- if .Values.runtime.networkPolicy.ingress.enabled }}
+  ingress:
+    - {}
+  {{- end }}
+  {{- if .Values.runtime.networkPolicy.egress.enabled }}
+  egress:
+    - {}
+  {{- end }}
+{{- end }}
+
+=== examples/eks.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+serviceAccounts:
+  {}
+
+services:
+  {}
+
+=== examples/gke.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+serviceAccounts:
+  {}
+
+services:
+  {}
+
+=== examples/aks.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+serviceAccounts:
+  {}
+
+services:
+  {}
+
+=== examples/onprem.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: null
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+stackSettings:
+  deploymentModel: pull
+  network: null
+  domains: null
+  updates: auto
+  telemetry: auto
+  heartbeats: "on"
+
+serviceAccounts:
+  {}
+
+infrastructure:
+  assets:
+    type: storage
+    service: s3
+    bucketName: 'your-assets-bucket'
+  jobs:
+    type: queue
+    service: sqs
+    queueUrl: 'https://sqs.us-east-1.amazonaws.com/123456789012/jobs'
+  metadata:
+    type: kv
+    service: redis
+    connectionUrl: 'redis://metadata.internal:6379'
+  secrets:
+    type: vault
+    service: kubernetes-secret
+    namespace: 'default'
+    vaultPrefix: 'secrets'
+  registry:
+    type: artifact_registry
+    service: local
+    registryUrl: 'registry.example.com'
+    dataDir: null
+
+services:
+  {}
+
+=== README.md ===
+# data-chart
+
+Install this chart into an existing Kubernetes cluster:
+
+```bash
+helm install data-chart ./data-chart --namespace production --create-namespace --values values.yaml
+```
+
+The generated `values.yaml` contains placeholders for management, service-account identity annotations, agent-local infrastructure bindings, and the Kubernetes exposure profile. The chart no longer renders per-app public `Ingress` objects from `services.*.host` or hostless ingress values; public endpoints are runtime-owned through `stackSettings.kubernetes.exposure`.
+
+See `examples/<target>.yaml` for ready-to-use values matching EKS / GKE / AKS / on-prem.
+
+=== files/stack.json ===
+{
+  "id": "data-chart",
+  "resources": {
+    "assets": {
+      "config": {
+        "id": "assets",
+        "lifecycleRules": [],
+        "publicRead": false,
+        "type": "storage",
+        "versioning": false
+      },
+      "lifecycle": "frozen",
+      "dependencies": [],
+      "remoteAccess": false
+    },
+    "jobs": {
+      "config": {
+        "id": "jobs",
+        "type": "queue"
+      },
+      "lifecycle": "frozen",
+      "dependencies": [],
+      "remoteAccess": false
+    },
+    "metadata": {
+      "config": {
+        "id": "metadata",
+        "type": "kv"
+      },
+      "lifecycle": "frozen",
+      "dependencies": [],
+      "remoteAccess": false
+    },
+    "secrets": {
+      "config": {
+        "id": "secrets",
+        "type": "vault"
+      },
+      "lifecycle": "frozen",
+      "dependencies": [],
+      "remoteAccess": false
+    },
+    "registry": {
+      "config": {
+        "id": "registry",
+        "type": "artifact-registry"
+      },
+      "lifecycle": "frozen",
+      "dependencies": [],
+      "remoteAccess": false
+    }
+  },
+  "permissions": {
+    "profiles": {},
+    "management": "auto"
+  }
+}
+
+=== files/stack-settings.json ===
+{}

--- a/crates/alien-helm/tests/generator/snapshots/generator__generator__helpers__manager_only_pure_worker.snap.new
+++ b/crates/alien-helm/tests/generator/snapshots/generator__generator__helpers__manager_only_pure_worker.snap.new
@@ -1,0 +1,1613 @@
+---
+source: crates/alien-helm/tests/generator/helpers.rs
+assertion_line: 37
+expression: buf
+---
+=== Chart.yaml ===
+apiVersion: v2
+name: pure-fn
+description: Deployment chart for pure-fn
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+=== values.yaml ===
+management:
+  token: ""
+  existingSecret:
+    name: ""
+    tokenKey: sync-token
+  name: ""
+  url: ""
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+runtime:
+  image:
+    repository: ghcr.io/alienplatform/alien-agent
+    tag: latest
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  podLabels: {}
+  podAnnotations: {}
+  automountServiceAccountToken: true
+  encryption:
+    # Set this explicitly, or reference an existing Secret below.
+    key: "replace-me-with-a-stable-64-character-encryption-secret"
+    existingSecret:
+      name: ""
+      key: encryption-key
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  api:
+    enabled: false
+    bindHost: 0.0.0.0
+    port: 8080
+    service:
+      type: ClusterIP
+  probes:
+    liveness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 2
+      failureThreshold: 3
+  security:
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroup: 10001
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+  tmp:
+    enabled: true
+    sizeLimit: 256Mi
+  data:
+    mountPath: /var/lib/alien-agent
+    persistence:
+      enabled: false
+      existingClaim: ""
+      storageClassName: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+  scheduling:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    topologySpreadConstraints: []
+    priorityClassName: ""
+    runtimeClassName: ""
+  pdb:
+    enabled: false
+    minAvailable: 1
+  networkPolicy:
+    enabled: false
+    ingress:
+      enabled: true
+    egress:
+      enabled: true
+
+heartbeat:
+  collection:
+    nodes:
+      enabled: true
+
+clusterBootstrap:
+  metricsServer:
+    enabled: false
+    image: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+  storageClass:
+    default:
+      enabled: false
+      name: ""
+      provisioner: ""
+      parameters: {}
+  ingress:
+    eksAutoMode:
+      enabled: false
+      name: alb
+      controller: eks.amazonaws.com/alb
+      scheme: internet-facing
+      subnetIds: []
+    azureApplicationGatewayForContainers:
+      enabled: false
+      applicationLoadBalancer:
+        name: ""
+        namespace: ""
+        associationSubnetId: ""
+  compute:
+    eksAutoMode:
+      arm64NodePool:
+        enabled: false
+        name: general-purpose-arm64
+        nodeClassName: default
+        capacityType: on-demand
+        instanceCategories:
+          - c
+          - m
+          - r
+        minInstanceGeneration: "5"
+        limits:
+          cpu: "1000"
+          memory: 1000Gi
+
+serviceAccounts:
+  runtime:
+    annotations: {}
+    labels: {}
+
+stackSettings: null
+
+infrastructure: null
+
+basePlatform: null
+basePlatformConfig:
+  gcp:
+    projectId: ""
+    region: ""
+  aws:
+    region: ""
+  azure:
+    location: ""
+    subscriptionId: ""
+    tenantId: ""
+serviceAccountPrefix: ""
+managerServiceAccount:
+  annotations: {}
+  labels: {}
+
+services:
+  api:
+    type: clusterIp
+    port: 80
+    targetPort: 8080
+    component: 'worker'
+
+publicUrls: {}
+
+persistentStorage:
+  storageClassName: ""
+
+ephemeralStorage:
+  nodeSelector: {}
+
+=== values.schema.json ===
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "management": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token", "updates", "telemetry", "healthChecks"],
+      "properties": {
+        "token": { "type": "string" },
+        "existingSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "tokenKey": { "type": "string", "minLength": 1 }
+          }
+        },
+        "name": { "type": "string" },
+        "url": { "type": "string" },
+        "deploymentId": { "type": ["string", "null"] },
+        "updates": { "type": "string", "enum": ["auto", "approval-required"] },
+        "telemetry": { "type": "string", "enum": ["auto", "approval-required", "off"] },
+        "healthChecks": { "type": "string", "enum": ["on", "off"] }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string", "minLength": 1 },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": { "name": { "type": "string", "minLength": 1 } }
+          }
+        },
+        "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "automountServiceAccountToken": { "type": "boolean" },
+        "encryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key": { "type": "string" },
+            "existingSecret": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": { "type": "string" },
+                "key": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        },
+        "replicas": { "type": "integer", "minimum": 1 },
+        "resources": { "type": "object" },
+        "api": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "bindHost": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] }
+              }
+            }
+          }
+        },
+        "probes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "liveness": { "$ref": "#/definitions/httpProbe" },
+            "readiness": { "$ref": "#/definitions/httpProbe" }
+          }
+        },
+        "security": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "podSecurityContext": { "type": "object" },
+            "containerSecurityContext": { "type": "object" }
+          }
+        },
+        "tmp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "sizeLimit": { "type": "string" }
+          }
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mountPath": { "type": "string", "minLength": 1 },
+            "persistence": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "existingClaim": { "type": "string" },
+                "storageClassName": { "type": "string" },
+                "accessModes": { "type": "array", "items": { "type": "string" } },
+                "size": { "type": "string" }
+              }
+            }
+          }
+        },
+        "scheduling": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+            "tolerations": { "type": "array" },
+            "affinity": { "type": "object" },
+            "topologySpreadConstraints": { "type": "array" },
+            "priorityClassName": { "type": "string" },
+            "runtimeClassName": { "type": "string" }
+          }
+        },
+        "pdb": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "minAvailable": { "type": ["integer", "string"] },
+            "maxUnavailable": { "type": ["integer", "string"] }
+          }
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "ingress": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": { "enabled": { "type": "boolean" } }
+            },
+            "egress": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": { "enabled": { "type": "boolean" } }
+            }
+          }
+        }
+      }
+    },
+    "managerServiceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+    "serviceAccounts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+          "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+      }
+    },
+    "stackSettings": {
+      "type": ["object", "null"],
+      "properties": {
+        "deploymentModel": { "type": "string", "enum": ["pull", "Pull"] },
+        "updates": { "type": "string" },
+        "telemetry": { "type": "string" },
+        "heartbeats": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "infrastructure": { "type": ["object", "null"] },
+    "basePlatform": { "type": ["string", "null"], "enum": ["aws", "gcp", "azure", null] },
+    "basePlatformConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "gcp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "projectId": { "type": "string" },
+            "region": { "type": "string" }
+          }
+        },
+        "aws": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "region": { "type": "string" }
+          }
+        },
+        "azure": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "location": { "type": "string" },
+            "subscriptionId": { "type": "string" },
+            "tenantId": { "type": "string" }
+          }
+        }
+      }
+    },
+    "heartbeat": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "nodes": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "clusterBootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "metricsServer": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "type": "string" }
+          }
+        },
+        "storageClass": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "name": { "type": "string" },
+                "provisioner": { "type": "string" },
+                "parameters": { "type": "object", "additionalProperties": { "type": "string" } }
+              }
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eksAutoMode": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "name": { "type": "string" },
+                "controller": { "type": "string" },
+                "scheme": { "type": "string" },
+                "subnetIds": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            },
+            "azureApplicationGatewayForContainers": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "applicationLoadBalancer": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": { "type": "string" },
+                    "namespace": { "type": "string" },
+                    "associationSubnetId": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "compute": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "eksAutoMode": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "arm64NodePool": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "name": { "type": "string" },
+                    "nodeClassName": { "type": "string" },
+                    "capacityType": { "type": "string" },
+                    "instanceCategories": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "minInstanceGeneration": { "type": "string" },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "cpu": { "type": "string" },
+                        "memory": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "serviceAccountPrefix": { "type": "string" },
+    "services": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": { "type": "string", "enum": ["clusterIp", "loadBalancer"] },
+          "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "component": { "type": "string" }
+        }
+      }
+    },
+    "publicUrls": { "type": "object", "additionalProperties": { "type": "string" } },
+    "persistentStorage": { "type": "object" },
+    "ephemeralStorage": { "type": "object" }
+  },
+  "definitions": {
+    "httpProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "path": { "type": "string", "minLength": 1 },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "title": "manager-fetch path",
+      "required": ["management"],
+      "properties": {
+        "management": {
+          "required": ["token", "deploymentId"],
+          "properties": {
+            "deploymentId": { "type": "string", "minLength": 1 }
+          }
+        },
+        "infrastructure": { "type": "null" }
+      }
+    },
+    {
+      "title": "external-bindings initialize path",
+      "required": ["management", "infrastructure"],
+      "properties": {
+        "management": {
+          "properties": {
+            "deploymentId": { "type": "null" }
+          }
+        },
+        "stackSettings": { "type": ["object", "null"] },
+        "infrastructure": { "type": "object" }
+      }
+    }
+  ]
+}
+
+=== templates/_helpers.tpl ===
+{{- define "alien.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "alien.labels" -}}
+app.kubernetes.io/name: {{ include "alien.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- define "alien.managerServiceAccountName" -}}
+{{- $prefix := default (include "alien.fullname" .) .Values.serviceAccountPrefix -}}
+{{- $raw := printf "%s-manager-sa" $prefix | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $raw "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.serviceAccountName" -}}
+{{- $prefix := default (include "alien.fullname" .root) .root.Values.serviceAccountPrefix -}}
+{{- $raw := printf "%s-%s-sa" $prefix .name | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $raw "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.resourceName" -}}
+{{- $raw := .name | lower -}}
+{{- regexReplaceAll "[^a-z0-9-]" $raw "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "alien.managementSecretName" -}}
+{{- default (include "alien.fullname" .) .Values.management.existingSecret.name -}}
+{{- end -}}
+
+{{- define "alien.managementSecretTokenKey" -}}
+{{- default "sync-token" .Values.management.existingSecret.tokenKey -}}
+{{- end -}}
+
+{{- define "alien.encryptionSecretName" -}}
+{{- default (include "alien.fullname" .) .Values.runtime.encryption.existingSecret.name -}}
+{{- end -}}
+
+{{- define "alien.encryptionSecretKey" -}}
+{{- default "encryption-key" .Values.runtime.encryption.existingSecret.key -}}
+{{- end -}}
+
+{{- define "alien.heartbeatNodeClusterRoleName" -}}
+{{- printf "%s-heartbeat-nodes" (include "alien.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+=== templates/serviceaccount.yaml ===
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alien.managerServiceAccountName" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+    {{- with .Values.managerServiceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.managerServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- range $name, $account := .Values.serviceAccounts }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alien.serviceAccountName" (dict "root" $ "name" $name) }}
+  labels:
+    {{- include "alien.labels" $ | nindent 4 }}
+    {{- with $account.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $account.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+
+=== templates/role.yaml ===
+{{- $stackSettings := default dict .Values.stackSettings -}}
+{{- $exposure := dig "kubernetes" "exposure" dict $stackSettings -}}
+{{- $exposureMode := dig "mode" "" $exposure -}}
+{{- $route := dig "route" dict $exposure -}}
+{{- $routeApi := dig "routeApi" "" $route -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/log", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- if and (ne $exposureMode "disabled") (eq $routeApi "ingress") }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
+  {{- if and (ne $exposureMode "disabled") (eq $routeApi "gateway") }}
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.gke.io"]
+    resources: ["healthcheckpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["alb.networking.azure.io"]
+    resources: ["healthcheckpolicy"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
+
+=== templates/rolebinding.yaml ===
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "alien.managerServiceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "alien.fullname" . }}
+
+=== templates/clusterrole.yaml ===
+{{- $nodeCollectionEnabled := dig "collection" "nodes" "enabled" true (default dict .Values.heartbeat) -}}
+{{- if $nodeCollectionEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "alien.heartbeatNodeClusterRoleName" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+{{- end }}
+
+=== templates/clusterrolebinding.yaml ===
+{{- $nodeCollectionEnabled := dig "collection" "nodes" "enabled" true (default dict .Values.heartbeat) -}}
+{{- if $nodeCollectionEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "alien.heartbeatNodeClusterRoleName" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "alien.managerServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "alien.heartbeatNodeClusterRoleName" . }}
+{{- end }}
+
+=== templates/secret.yaml ===
+{{- $createManagementSecret := not .Values.management.existingSecret.name -}}
+{{- $createEncryptionSecret := not .Values.runtime.encryption.existingSecret.name -}}
+{{- if or $createManagementSecret $createEncryptionSecret .Values.infrastructure }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if $createManagementSecret }}
+  sync-token: {{ .Values.management.token | quote }}
+  {{- end }}
+  {{- if $createEncryptionSecret }}
+  encryption-key: {{ required "runtime.encryption.key or runtime.encryption.existingSecret.name is required" .Values.runtime.encryption.key | quote }}
+  {{- end }}
+  {{- if .Values.infrastructure }}
+  external-bindings.json: {{ toJson .Values.infrastructure | quote }}
+  {{- end }}
+{{- end }}
+
+=== templates/configmap.yaml ===
+{{- $defaultStackSettings := dict "deploymentModel" "pull" "updates" .Values.management.updates "telemetry" .Values.management.telemetry "heartbeats" .Values.management.healthChecks -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+data:
+  stack.json: |-
+{{ .Files.Get "files/stack.json" | indent 4 }}
+  stack-settings.json: {{ toJson (default $defaultStackSettings .Values.stackSettings) | quote }}
+  services.json: {{ toJson .Values.services | quote }}
+  public-urls.json: {{ toJson (default dict .Values.publicUrls) | quote }}
+
+=== templates/deployment.yaml ===
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.runtime.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "alien.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "alien.labels" . | nindent 8 }}
+        {{- with .Values.runtime.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.runtime.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "alien.managerServiceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.runtime.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.runtime.security.podSecurityContext | nindent 8 }}
+      {{- with .Values.runtime.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runtime.scheduling.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.runtime.scheduling.priorityClassName }}
+      priorityClassName: {{ .Values.runtime.scheduling.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.runtime.scheduling.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtime.scheduling.runtimeClassName | quote }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: "{{ .Values.runtime.image.repository }}:{{ .Values.runtime.image.tag }}"
+          imagePullPolicy: {{ .Values.runtime.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.runtime.security.containerSecurityContext | nindent 12 }}
+          env:
+            - name: PLATFORM
+              value: kubernetes
+            {{- if .Values.basePlatform }}
+            - name: BASE_PLATFORM
+              value: {{ .Values.basePlatform | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "gcp") .Values.basePlatformConfig.gcp.projectId }}
+            - name: GCP_PROJECT_ID
+              value: {{ .Values.basePlatformConfig.gcp.projectId | quote }}
+            - name: GOOGLE_CLOUD_PROJECT
+              value: {{ .Values.basePlatformConfig.gcp.projectId | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "gcp") .Values.basePlatformConfig.gcp.region }}
+            - name: GCP_REGION
+              value: {{ .Values.basePlatformConfig.gcp.region | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "azure") .Values.basePlatformConfig.azure.subscriptionId }}
+            - name: AZURE_SUBSCRIPTION_ID
+              value: {{ .Values.basePlatformConfig.azure.subscriptionId | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "azure") .Values.basePlatformConfig.azure.tenantId }}
+            - name: AZURE_TENANT_ID
+              value: {{ .Values.basePlatformConfig.azure.tenantId | quote }}
+            {{- end }}
+            {{- if and (eq .Values.basePlatform "azure") .Values.basePlatformConfig.azure.location }}
+            - name: AZURE_REGION
+              value: {{ .Values.basePlatformConfig.azure.location | quote }}
+            {{- end }}
+            - name: SYNC_URL
+              value: {{ .Values.management.url | quote }}
+            - name: AGENT_NAME
+              value: {{ .Values.management.name | quote }}
+            {{- if .Values.management.deploymentId }}
+            - name: DEPLOYMENT_ID
+              value: {{ .Values.management.deploymentId | quote }}
+            {{- end }}
+            - name: KUBERNETES_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: SYNC_TOKEN_FILE
+              value: /etc/alien/secrets/sync-token
+            - name: AGENT_ENCRYPTION_KEY_FILE
+              value: /etc/alien/secrets/encryption-key
+            - name: STACK_SETTINGS_FILE
+              value: /etc/alien/config/stack-settings.json
+            - name: PUBLIC_URLS_FILE
+              value: /etc/alien/config/public-urls.json
+            {{- if .Values.infrastructure }}
+            - name: EXTERNAL_BINDINGS_FILE
+              value: /etc/alien/secrets/external-bindings.json
+            {{- end }}
+            - name: SYNC_INTERVAL
+              value: "30"
+            - name: OTLP_PORT
+              value: {{ .Values.runtime.api.port | quote }}
+            - name: OTLP_HOST
+              value: {{ .Values.runtime.api.bindHost | quote }}
+          ports:
+            - name: otlp
+              containerPort: {{ .Values.runtime.api.port }}
+          {{- if .Values.runtime.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.runtime.probes.liveness.path | quote }}
+              port: otlp
+            initialDelaySeconds: {{ .Values.runtime.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.runtime.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.runtime.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.runtime.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.runtime.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.runtime.probes.readiness.path | quote }}
+              port: otlp
+            initialDelaySeconds: {{ .Values.runtime.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.runtime.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.runtime.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.runtime.probes.readiness.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alien/config
+              readOnly: true
+            - name: management-token
+              mountPath: /etc/alien/secrets/sync-token
+              subPath: sync-token
+              readOnly: true
+            - name: encryption-key
+              mountPath: /etc/alien/secrets/encryption-key
+              subPath: {{ include "alien.encryptionSecretKey" . }}
+              readOnly: true
+            {{- if .Values.infrastructure }}
+            - name: external-bindings
+              mountPath: /etc/alien/secrets/external-bindings.json
+              subPath: external-bindings.json
+              readOnly: true
+            {{- end }}
+            {{- if .Values.runtime.tmp.enabled }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
+            - name: runtime-data
+              mountPath: {{ .Values.runtime.data.mountPath | quote }}
+          resources:
+            {{- toYaml .Values.runtime.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "alien.fullname" . }}
+        - name: management-token
+          secret:
+            secretName: {{ include "alien.managementSecretName" . }}
+            items:
+              - key: {{ include "alien.managementSecretTokenKey" . }}
+                path: sync-token
+            defaultMode: 384
+        - name: encryption-key
+          secret:
+            secretName: {{ include "alien.encryptionSecretName" . }}
+            defaultMode: 384
+        {{- if .Values.infrastructure }}
+        - name: external-bindings
+          secret:
+            secretName: {{ include "alien.fullname" . }}
+            items:
+              - key: external-bindings.json
+                path: external-bindings.json
+            defaultMode: 384
+        {{- end }}
+        {{- if .Values.runtime.tmp.enabled }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.runtime.tmp.sizeLimit | quote }}
+        {{- end }}
+        - name: runtime-data
+          {{- if .Values.runtime.data.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-runtime-data" (include "alien.fullname" .)) .Values.runtime.data.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
+=== templates/pvc.yaml ===
+{{- if and .Values.runtime.data.persistence.enabled (not .Values.runtime.data.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-runtime-data" (include "alien.fullname" .) }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.runtime.data.persistence.accessModes | nindent 4 }}
+  {{- if .Values.runtime.data.persistence.storageClassName }}
+  storageClassName: {{ .Values.runtime.data.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.runtime.data.persistence.size | quote }}
+{{- end }}
+
+=== templates/service.yaml ===
+{{- if .Values.runtime.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.runtime.api.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "alien.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.runtime.api.port }}
+      targetPort: otlp
+{{- end }}
+
+=== templates/app-service.yaml ===
+{{- range $id, $service := .Values.services }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alien.resourceName" (dict "root" $ "name" $id) }}
+  labels:
+    {{- include "alien.labels" $ | nindent 4 }}
+    alien.dev/resource-id: {{ $id | quote }}
+spec:
+  type: {{ if eq $service.type "loadBalancer" }}LoadBalancer{{ else }}ClusterIP{{ end }}
+  selector:
+    app: {{ include "alien.resourceName" (dict "root" $ "name" $id) }}
+    managed-by: alien
+    component: {{ $service.component | quote }}
+  ports:
+    - name: http
+      port: {{ default 80 $service.port }}
+      targetPort: {{ default 8080 $service.targetPort }}
+---
+{{- end }}
+
+=== templates/cluster-bootstrap.yaml ===
+{{- $bootstrap := default dict .Values.clusterBootstrap -}}
+{{- $storage := dig "storageClass" "default" dict $bootstrap -}}
+{{- if dig "enabled" false $storage }}
+{{- $storageName := required "clusterBootstrap.storageClass.default.name is required when enabled" $storage.name -}}
+{{- $provisioner := required "clusterBootstrap.storageClass.default.provisioner is required when enabled" $storage.provisioner -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $storageName | quote }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+provisioner: {{ $provisioner | quote }}
+{{ with $storage.parameters }}
+parameters:
+  {{ range $key, $value := . }}
+  {{ $key }}: {{ $value | quote }}
+  {{ end }}
+{{ end }}
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{ end }}
+{{- $eksAlb := dig "ingress" "eksAutoMode" dict $bootstrap -}}
+{{- if dig "enabled" false $eksAlb }}
+{{- $ingressClassName := required "clusterBootstrap.ingress.eksAutoMode.name is required when enabled" $eksAlb.name -}}
+{{- $controller := required "clusterBootstrap.ingress.eksAutoMode.controller is required when enabled" $eksAlb.controller -}}
+---
+apiVersion: eks.amazonaws.com/v1
+kind: IngressClassParams
+metadata:
+  name: {{ $ingressClassName | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  scheme: {{ default "internet-facing" $eksAlb.scheme | quote }}
+  {{ with $eksAlb.subnetIds }}
+  subnets:
+    ids:
+      {{ range . }}
+      - {{ . | quote }}
+      {{ end }}
+  {{ end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ $ingressClassName | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  controller: {{ $controller | quote }}
+  parameters:
+    apiGroup: eks.amazonaws.com
+    kind: IngressClassParams
+    name: {{ $ingressClassName | quote }}
+{{ end }}
+{{- $azureAgc := dig "ingress" "azureApplicationGatewayForContainers" dict $bootstrap -}}
+{{- if dig "enabled" false $azureAgc }}
+{{- $azureAlb := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer is required when enabled" $azureAgc.applicationLoadBalancer -}}
+{{- $azureAlbName := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer.name is required when enabled" $azureAlb.name -}}
+{{- $azureAlbNamespace := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer.namespace is required when enabled" $azureAlb.namespace -}}
+{{- $azureAssociationSubnetId := required "clusterBootstrap.ingress.azureApplicationGatewayForContainers.applicationLoadBalancer.associationSubnetId is required when enabled" $azureAlb.associationSubnetId -}}
+---
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: {{ $azureAlbName | quote }}
+  namespace: {{ $azureAlbNamespace | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  associations:
+    - {{ $azureAssociationSubnetId | quote }}
+{{ end }}
+{{- $eksArm64NodePool := dig "compute" "eksAutoMode" "arm64NodePool" dict $bootstrap -}}
+{{- if dig "enabled" false $eksArm64NodePool }}
+{{- $nodePoolName := required "clusterBootstrap.compute.eksAutoMode.arm64NodePool.name is required when enabled" $eksArm64NodePool.name -}}
+{{- $nodeClassName := required "clusterBootstrap.compute.eksAutoMode.arm64NodePool.nodeClassName is required when enabled" $eksArm64NodePool.nodeClassName -}}
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: {{ $nodePoolName | quote }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: {{ $nodeClassName | quote }}
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+            - {{ default "on-demand" $eksArm64NodePool.capacityType | quote }}
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+            - "arm64"
+        - key: eks.amazonaws.com/instance-category
+          operator: In
+          values:
+            {{ range (default (list "c" "m" "r") $eksArm64NodePool.instanceCategories) }}
+            - {{ . | quote }}
+            {{ end }}
+        - key: eks.amazonaws.com/instance-generation
+          operator: Gt
+          values:
+            - {{ default "5" $eksArm64NodePool.minInstanceGeneration | quote }}
+  {{ with $eksArm64NodePool.limits }}
+  limits:
+    {{ with .cpu }}
+    cpu: {{ . | quote }}
+    {{ end }}
+    {{ with .memory }}
+    memory: {{ . | quote }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{- $metrics := dig "metricsServer" dict $bootstrap -}}
+{{- if dig "enabled" false $metrics }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes/metrics"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      containers:
+        - name: metrics-server
+          image: {{ default "registry.k8s.io/metrics-server/metrics-server:v0.8.1" $metrics.image | quote }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --cert-dir=/tmp
+            - --secure-port=10250
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+          ports:
+            - name: https
+              containerPort: 10250
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+  labels:
+    k8s-app: metrics-server
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end }}
+
+=== templates/poddisruptionbudget.yaml ===
+{{- if .Values.runtime.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  {{- if hasKey .Values.runtime.pdb "maxUnavailable" }}
+  maxUnavailable: {{ .Values.runtime.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.runtime.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "alien.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+=== templates/networkpolicy.yaml ===
+{{- if .Values.runtime.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "alien.fullname" . }}
+  labels:
+    {{- include "alien.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "alien.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    {{- if .Values.runtime.networkPolicy.ingress.enabled }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.runtime.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  {{- if .Values.runtime.networkPolicy.ingress.enabled }}
+  ingress:
+    - {}
+  {{- end }}
+  {{- if .Values.runtime.networkPolicy.egress.enabled }}
+  egress:
+    - {}
+  {{- end }}
+{{- end }}
+
+=== examples/eks.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+serviceAccounts:
+  runtime:
+    annotations:
+      'eks.amazonaws.com/role-arn': 'arn:aws:iam::123456789012:role/deployment-runtime'
+    labels: {}
+
+services:
+  api:
+    type: clusterIp
+    port: 80
+    targetPort: 8080
+    component: 'worker'
+
+=== examples/gke.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+serviceAccounts:
+  runtime:
+    annotations:
+      'iam.gke.io/gcp-service-account': 'deployment@project.iam.gserviceaccount.com'
+    labels: {}
+
+services:
+  api:
+    type: clusterIp
+    port: 80
+    targetPort: 8080
+    component: 'worker'
+
+=== examples/aks.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: "dep_replace_me"
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+serviceAccounts:
+  runtime:
+    annotations:
+      'azure.workload.identity/client-id': '00000000-0000-0000-0000-000000000000'
+    labels: {}
+
+services:
+  api:
+    type: clusterIp
+    port: 80
+    targetPort: 8080
+    component: 'worker'
+
+=== examples/onprem.yaml ===
+management:
+  token: "dg_replace_me"
+  name: "production"
+  url: "https://manager.example.com"
+  deploymentId: null
+  updates: auto
+  telemetry: auto
+  healthChecks: "on"
+
+stackSettings:
+  deploymentModel: pull
+  network: null
+  domains: null
+  updates: auto
+  telemetry: auto
+  heartbeats: "on"
+
+serviceAccounts:
+  runtime:
+    annotations: {}
+    labels: {}
+
+infrastructure:
+  {}
+
+services:
+  api:
+    type: clusterIp
+    port: 80
+    targetPort: 8080
+    component: 'worker'
+
+=== README.md ===
+# pure-fn
+
+Install this chart into an existing Kubernetes cluster:
+
+```bash
+helm install pure-fn ./pure-fn --namespace production --create-namespace --values values.yaml
+```
+
+The generated `values.yaml` contains placeholders for management, service-account identity annotations, agent-local infrastructure bindings, and the Kubernetes exposure profile. The chart no longer renders per-app public `Ingress` objects from `services.*.host` or hostless ingress values; public endpoints are runtime-owned through `stackSettings.kubernetes.exposure`.
+
+See `examples/<target>.yaml` for ready-to-use values matching EKS / GKE / AKS / on-prem.
+
+=== files/stack.json ===
+{
+  "id": "pure-fn",
+  "resources": {
+    "api": {
+      "config": {
+        "code": {
+          "image": "registry.example.com/api:1",
+          "type": "image"
+        },
+        "commandsEnabled": false,
+        "concurrencyLimit": null,
+        "environment": {},
+        "id": "api",
+        "ingress": "public",
+        "links": [],
+        "memoryMb": 256,
+        "permissions": "runtime",
+        "readinessProbe": null,
+        "timeoutSeconds": 180,
+        "triggers": [],
+        "type": "worker"
+      },
+      "lifecycle": "live",
+      "dependencies": [],
+      "remoteAccess": false
+    }
+  },
+  "permissions": {
+    "profiles": {
+      "runtime": {
+        "*": [
+          "worker/management"
+        ]
+      }
+    },
+    "management": "auto"
+  }
+}
+
+=== files/stack-settings.json ===
+{}

--- a/crates/alien-infra/src/container/kubernetes.rs
+++ b/crates/alien-infra/src/container/kubernetes.rs
@@ -48,58 +48,14 @@ async fn create_registry_pull_secret(
     proxy_host: &str,
     deployment_token: &str,
 ) -> Result<()> {
-    use base64::engine::{general_purpose::STANDARD as BASE64, Engine as _};
-
-    let auth = BASE64.encode(format!("deployment:{deployment_token}"));
-    let docker_config = serde_json::json!({
-        "auths": {
-            proxy_host: {
-                "username": "deployment",
-                "password": deployment_token,
-                "auth": auth,
-            }
-        }
-    });
-
-    let docker_config_bytes = serde_json::to_vec(&docker_config)
-        .into_alien_error()
-        .context(ErrorData::CloudPlatformError {
-            message: "Failed to serialize Docker config".to_string(),
-            resource_id: None,
-        })?;
-
-    let secret = Secret {
-        metadata: ObjectMeta {
-            name: Some(secret_name.to_string()),
-            namespace: Some(namespace.to_string()),
-            ..Default::default()
-        },
-        type_: Some("kubernetes.io/dockerconfigjson".to_string()),
-        data: Some({
-            let mut data = BTreeMap::new();
-            data.insert(
-                ".dockerconfigjson".to_string(),
-                k8s_openapi::ByteString(docker_config_bytes),
-            );
-            data
-        }),
-        ..Default::default()
-    };
-
-    match secrets_client.create_secret(namespace, &secret).await {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            let err = format!("{e}");
-            if err.contains("AlreadyExists") || err.contains("409") {
-                Ok(())
-            } else {
-                Err(e.context(ErrorData::CloudPlatformError {
-                    message: format!("Failed to create registry pull secret '{secret_name}'"),
-                    resource_id: None,
-                }))
-            }
-        }
-    }
+    crate::kubernetes_registry::ensure_registry_pull_secret(
+        secrets_client,
+        namespace,
+        secret_name,
+        proxy_host,
+        deployment_token,
+    )
+    .await
 }
 
 #[derive(Debug, Clone)]

--- a/crates/alien-infra/src/daemon/kubernetes.rs
+++ b/crates/alien-infra/src/daemon/kubernetes.rs
@@ -15,11 +15,11 @@ use alien_core::{
     kubernetes_resource_name, kubernetes_service_account_name, Daemon, DaemonCode, DaemonOutputs,
     ResourceOutputs, ResourceStatus,
 };
-use alien_error::{AlienError, Context, ContextError, IntoAlienError};
+use alien_error::{AlienError, Context, ContextError};
 use alien_macros::controller;
 use k8s_openapi::api::apps::v1::{DaemonSet, DaemonSetSpec};
 use k8s_openapi::api::core::v1::{
-    Container, EnvVar, LocalObjectReference, PodSpec, PodTemplateSpec, Secret,
+    Container, EnvVar, LocalObjectReference, PodSpec, PodTemplateSpec,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 
@@ -629,57 +629,12 @@ async fn create_registry_pull_secret(
     proxy_host: &str,
     deployment_token: &str,
 ) -> Result<()> {
-    use base64::engine::{general_purpose::STANDARD as BASE64, Engine as _};
-
-    let auth = BASE64.encode(format!("deployment:{}", deployment_token));
-    let mut auths = serde_json::Map::new();
-    auths.insert(
-        proxy_host.to_string(),
-        serde_json::json!({
-            "username": "deployment",
-            "password": deployment_token,
-            "auth": auth,
-        }),
-    );
-    let docker_config = serde_json::json!({ "auths": auths });
-
-    let docker_config_bytes = serde_json::to_vec(&docker_config)
-        .into_alien_error()
-        .context(ErrorData::CloudPlatformError {
-            message: "Failed to serialize Docker config".to_string(),
-            resource_id: None,
-        })?;
-
-    let secret = Secret {
-        metadata: ObjectMeta {
-            name: Some(secret_name.to_string()),
-            namespace: Some(namespace.to_string()),
-            ..Default::default()
-        },
-        type_: Some("kubernetes.io/dockerconfigjson".to_string()),
-        data: Some({
-            let mut data = BTreeMap::new();
-            data.insert(
-                ".dockerconfigjson".to_string(),
-                k8s_openapi::ByteString(docker_config_bytes),
-            );
-            data
-        }),
-        ..Default::default()
-    };
-
-    match secrets_client.create_secret(namespace, &secret).await {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            let err_str = format!("{}", e);
-            if err_str.contains("AlreadyExists") || err_str.contains("409") {
-                Ok(())
-            } else {
-                Err(e.context(ErrorData::CloudPlatformError {
-                    message: format!("Failed to create registry pull secret '{}'", secret_name),
-                    resource_id: None,
-                }))
-            }
-        }
-    }
+    crate::kubernetes_registry::ensure_registry_pull_secret(
+        secrets_client,
+        namespace,
+        secret_name,
+        proxy_host,
+        deployment_token,
+    )
+    .await
 }

--- a/crates/alien-infra/src/kubernetes_registry.rs
+++ b/crates/alien-infra/src/kubernetes_registry.rs
@@ -1,0 +1,105 @@
+use std::collections::BTreeMap;
+
+use crate::error::{ErrorData, Result};
+use alien_error::{Context, ContextError, IntoAlienError};
+use k8s_openapi::api::core::v1::Secret;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+pub(crate) async fn ensure_registry_pull_secret(
+    secrets_client: &std::sync::Arc<dyn alien_k8s_clients::SecretsApi>,
+    namespace: &str,
+    secret_name: &str,
+    proxy_url: &str,
+    deployment_token: &str,
+) -> Result<()> {
+    use base64::engine::{general_purpose::STANDARD as BASE64, Engine as _};
+
+    let registry_host = registry_auth_host(proxy_url);
+    let auth = BASE64.encode(format!("deployment:{deployment_token}"));
+    let docker_config = serde_json::json!({
+        "auths": {
+            registry_host: {
+                "username": "deployment",
+                "password": deployment_token,
+                "auth": auth,
+            }
+        }
+    });
+
+    let docker_config_bytes = serde_json::to_vec(&docker_config)
+        .into_alien_error()
+        .context(ErrorData::CloudPlatformError {
+            message: "Failed to serialize Docker config".to_string(),
+            resource_id: None,
+        })?;
+
+    let secret = Secret {
+        metadata: ObjectMeta {
+            name: Some(secret_name.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        type_: Some("kubernetes.io/dockerconfigjson".to_string()),
+        data: Some(BTreeMap::from([(
+            ".dockerconfigjson".to_string(),
+            k8s_openapi::ByteString(docker_config_bytes),
+        )])),
+        ..Default::default()
+    };
+
+    match secrets_client.create_secret(namespace, &secret).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let err = format!("{e}");
+            if err.contains("AlreadyExists") || err.contains("409") {
+                secrets_client
+                    .update_secret(namespace, secret_name, &secret)
+                    .await
+                    .map(|_| ())
+                    .context(ErrorData::CloudPlatformError {
+                        message: format!("Failed to update registry pull secret '{secret_name}'"),
+                        resource_id: None,
+                    })
+            } else {
+                Err(e.context(ErrorData::CloudPlatformError {
+                    message: format!("Failed to create registry pull secret '{secret_name}'"),
+                    resource_id: None,
+                }))
+            }
+        }
+    }
+}
+
+fn registry_auth_host(proxy_url: &str) -> String {
+    let without_scheme = proxy_url
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    without_scheme
+        .split('/')
+        .next()
+        .unwrap_or(without_scheme)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::registry_auth_host;
+
+    #[test]
+    fn registry_auth_host_strips_scheme_and_path() {
+        assert_eq!(
+            registry_auth_host("https://alien-manager.example.com/v1"),
+            "alien-manager.example.com"
+        );
+        assert_eq!(
+            registry_auth_host("http://localhost:8080/registry"),
+            "localhost:8080"
+        );
+        assert_eq!(
+            registry_auth_host("registry.example.com"),
+            "registry.example.com"
+        );
+    }
+}

--- a/crates/alien-infra/src/lib.rs
+++ b/crates/alien-infra/src/lib.rs
@@ -46,6 +46,8 @@ mod kubernetes_cluster_heartbeat;
 #[cfg(feature = "kubernetes")]
 mod kubernetes_public_endpoint;
 #[cfg(feature = "kubernetes")]
+mod kubernetes_registry;
+#[cfg(feature = "kubernetes")]
 mod kubernetes_workload_heartbeat;
 
 mod container;

--- a/crates/alien-infra/src/worker/kubernetes.rs
+++ b/crates/alien-infra/src/worker/kubernetes.rs
@@ -24,7 +24,7 @@ use alien_macros::controller;
 
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
 use k8s_openapi::api::core::v1::{
-    Container, ContainerPort, EnvVar, LocalObjectReference, PodSpec, PodTemplateSpec, Secret,
+    Container, ContainerPort, EnvVar, LocalObjectReference, PodSpec, PodTemplateSpec,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 
@@ -1121,74 +1121,12 @@ async fn create_registry_pull_secret(
     proxy_host: &str,
     deployment_token: &str,
 ) -> Result<()> {
-    use base64::engine::{general_purpose::STANDARD as BASE64, Engine as _};
-
-    let registry_url = proxy_host;
-    let username = "deployment";
-    let password = deployment_token;
-
-    let auth = BASE64.encode(format!("{}:{}", username, password));
-    let docker_config = serde_json::json!({
-        "auths": {
-            registry_url: {
-                "username": username,
-                "password": password,
-                "auth": auth,
-            }
-        }
-    });
-
-    let docker_config_bytes = serde_json::to_vec(&docker_config)
-        .into_alien_error()
-        .context(ErrorData::CloudPlatformError {
-            message: "Failed to serialize Docker config".to_string(),
-            resource_id: None,
-        })?;
-
-    let secret = Secret {
-        metadata: ObjectMeta {
-            name: Some(secret_name.to_string()),
-            namespace: Some(namespace.to_string()),
-            ..Default::default()
-        },
-        type_: Some("kubernetes.io/dockerconfigjson".to_string()),
-        data: Some({
-            let mut data = BTreeMap::new();
-            data.insert(
-                ".dockerconfigjson".to_string(),
-                k8s_openapi::ByteString(docker_config_bytes),
-            );
-            data
-        }),
-        ..Default::default()
-    };
-
-    // Try to create; if it already exists, update it
-    match secrets_client.create_secret(namespace, &secret).await {
-        Ok(_) => {
-            info!(
-                secret_name = %secret_name,
-                namespace = %namespace,
-                "Created registry pull secret for proxy"
-            );
-        }
-        Err(e) => {
-            // If already exists (409 Conflict), that's fine — it was created
-            // on a previous deployment attempt. Update it.
-            let err_str = format!("{}", e);
-            if err_str.contains("AlreadyExists") || err_str.contains("409") {
-                debug!(
-                    secret_name = %secret_name,
-                    "Registry pull secret already exists, skipping"
-                );
-            } else {
-                return Err(e.context(ErrorData::CloudPlatformError {
-                    message: format!("Failed to create registry pull secret '{}'", secret_name),
-                    resource_id: None,
-                }));
-            }
-        }
-    }
-
-    Ok(())
+    crate::kubernetes_registry::ensure_registry_pull_secret(
+        secrets_client,
+        namespace,
+        secret_name,
+        proxy_host,
+        deployment_token,
+    )
+    .await
 }

--- a/crates/alien-preflights/src/mutations/remote_stack_management.rs
+++ b/crates/alien-preflights/src/mutations/remote_stack_management.rs
@@ -3,8 +3,8 @@
 use crate::error::Result;
 use crate::StackMutation;
 use alien_core::{
-    DeploymentConfig, Platform, RemoteStackManagement, ResourceEntry, ResourceLifecycle, Stack,
-    StackState,
+    DeploymentConfig, DeploymentModel, Platform, RemoteStackManagement, ResourceEntry,
+    ResourceLifecycle, Stack, StackState,
 };
 use async_trait::async_trait;
 use tracing::{debug, info};
@@ -47,8 +47,17 @@ impl StackMutation for RemoteStackManagementMutation {
             return false;
         }
 
-        // Only add if management is configured in deployment config
-        if config.management_config.is_none() {
+        let cloud_backed_kubernetes_pull = platform == Platform::Kubernetes
+            && matches!(
+                base_platform,
+                Platform::Aws | Platform::Gcp | Platform::Azure
+            )
+            && config.stack_settings.deployment_model == DeploymentModel::Pull;
+
+        // Push-mode cloud stacks need an external manager management config.
+        // Cloud-backed Kubernetes pull stacks still need this setup-owned
+        // identity, but the agent uses it from inside the cluster.
+        if config.management_config.is_none() && !cloud_backed_kubernetes_pull {
             return false;
         }
 
@@ -90,5 +99,62 @@ impl StackMutation for RemoteStackManagementMutation {
         debug!("Added RemoteStackManagement resource '{}'", remote_mgmt_id);
 
         Ok(stack)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_core::{EnvironmentVariablesSnapshot, ExternalBindings, StackSettings};
+
+    fn empty_stack() -> Stack {
+        Stack::new("test".to_string()).build()
+    }
+
+    fn config(
+        base_platform: Option<Platform>,
+        deployment_model: DeploymentModel,
+    ) -> DeploymentConfig {
+        DeploymentConfig {
+            deployment_name: None,
+            stack_settings: StackSettings {
+                deployment_model,
+                ..StackSettings::default()
+            },
+            management_config: None,
+            environment_variables: EnvironmentVariablesSnapshot {
+                variables: Vec::new(),
+                hash: "empty".to_string(),
+                created_at: "1970-01-01T00:00:00Z".to_string(),
+            },
+            allow_frozen_changes: false,
+            compute_backend: None,
+            external_bindings: ExternalBindings::default(),
+            base_platform,
+            public_urls: None,
+            domain_metadata: None,
+            monitoring: None,
+            manager_url: None,
+            deployment_token: None,
+            native_image_host: None,
+        }
+    }
+
+    #[test]
+    fn cloud_backed_kubernetes_pull_runs_without_external_management_config() {
+        let mutation = RemoteStackManagementMutation;
+        let stack = empty_stack();
+        let config = config(Some(Platform::Aws), DeploymentModel::Pull);
+
+        assert!(mutation.should_run(&stack, &StackState::new(Platform::Kubernetes), &config));
+    }
+
+    #[test]
+    fn cloud_backed_kubernetes_push_still_requires_external_management_config() {
+        let mutation = RemoteStackManagementMutation;
+        let stack = empty_stack();
+        let config = config(Some(Platform::Aws), DeploymentModel::Push);
+
+        assert!(!mutation.should_run(&stack, &StackState::new(Platform::Kubernetes), &config));
     }
 }

--- a/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
@@ -82,6 +82,12 @@ impl TfEmitter for AzureRemoteStackManagementEmitter {
             &format!("{label}_fic"),
             [
                 attr(
+                    "count",
+                    expr::raw(
+                        "var.azure_oidc_issuer != \"\" && var.azure_oidc_subject != \"\" ? 1 : 0",
+                    ),
+                ),
+                attr(
                     "name",
                     expr::template("${local.resource_prefix}-federated-credential".to_string()),
                 ),

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -24,8 +24,8 @@ use crate::{
 };
 use alien_core::{
     import::{EmitContext, CURRENT_SETUP_IMPORT_FORMAT_VERSION},
-    ownership_policy_for_resource_type, ErrorData, Network, NetworkSettings, RemoteStackManagement,
-    Result, Stack, StackSettings,
+    ownership_policy_for_resource_type, DeploymentModel, ErrorData, Network, NetworkSettings,
+    RemoteStackManagement, Result, Stack, StackSettings,
 };
 use alien_error::{AlienError, IntoAlienError};
 use hcl::{
@@ -268,7 +268,8 @@ pub fn generate_terraform_module(
         || has_resource_type(&per_resource, "azapi_resource_action");
     let has_remote_management =
         stack_has_resource_type(stack, RemoteStackManagement::RESOURCE_TYPE);
-    let needs_azure_management_inputs = has_remote_management || target == TerraformTarget::Aks;
+    let needs_azure_management_inputs =
+        matches!(target.cloud_platform(), alien_core::Platform::Azure) && has_remote_management;
     let deployment_name_default = options
         .display_name
         .as_deref()
@@ -994,19 +995,19 @@ fn variables_body(
             blocks.push(nested(variable_block(
                 "azure_managing_tenant_id",
                 "Azure tenant ID the manager uses for cross-tenant access.",
-                None,
+                Some(Expression::String(String::new())),
                 false,
             )));
             blocks.push(nested(variable_block(
                 "azure_oidc_issuer",
                 "OIDC issuer URL for Azure Federated Identity Credential.",
-                None,
+                Some(Expression::String(String::new())),
                 false,
             )));
             blocks.push(nested(variable_block(
                 "azure_oidc_subject",
                 "OIDC subject claim for Azure Federated Identity Credential.",
-                None,
+                Some(Expression::String(String::new())),
                 false,
             )));
         }
@@ -1458,7 +1459,7 @@ fn locals_body(
     body.push(attr("deployment_region", region_expression(target)));
     body.push(attr(
         "deployment_management_config",
-        if has_remote_management {
+        if has_remote_management && stack_settings.deployment_model == DeploymentModel::Push {
             management_config_expression(target)
         } else {
             expr::raw("null")

--- a/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
+++ b/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
@@ -424,6 +424,12 @@ fn eks_managed_cluster_with_remote_management_irsa_is_valid() {
     };
 
     let module = render(&stack, TerraformTarget::Eks, settings);
+    let locals = module.get("locals.tf").expect("locals should render");
+    let management_config_line = locals
+        .lines()
+        .find(|line| line.contains("deployment_management_config"))
+        .expect("locals should include deployment_management_config");
+    assert!(management_config_line.ends_with("= null"));
     snapshot_module("eks_managed_cluster_remote_management_irsa", &module);
     assert_terraform_valid(&module, "eks_managed_cluster_remote_management_irsa");
 }

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_managed_cluster_remote_management_irsa.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_managed_cluster_remote_management_irsa.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/alien-terraform/tests/generator/helpers.rs
+assertion_line: 61
 expression: buf
 ---
 === versions.tf ===
@@ -152,16 +153,13 @@ resource "random_id" "resource_prefix" {
 
 === locals.tf ===
 locals {
-  resource_prefix          = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
-  deployment_name          = var.name
-  deployment_platform      = "kubernetes"
-  deployment_base_platform = "aws"
-  deployment_target        = "eks"
-  deployment_region        = data.aws_region.current.region
-  deployment_management_config = {
-    platform        = "aws"
-    managingRoleArn = var.managing_role_arn
-  }
+  resource_prefix                = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
+  deployment_name                = var.name
+  deployment_platform            = "kubernetes"
+  deployment_base_platform       = "aws"
+  deployment_target              = "eks"
+  deployment_region              = data.aws_region.current.region
+  deployment_management_config   = null
   deployment_kubernetes_settings = merge(try(jsondecode(var.stack_settings_json).kubernetes, {}), { exposure = jsondecode(try(jsondecode(var.stack_settings_json).kubernetes.exposure, null) == null ? jsonencode(local.kubernetes_exposure) : jsonencode(jsondecode(var.stack_settings_json).kubernetes.exposure)) })
   deployment_settings            = merge(jsondecode(var.stack_settings_json), { network = jsondecode(var.network_mode == "create-new" ? jsonencode({ type = "create", cidr = var.vpc_cidr == "" ? null : var.vpc_cidr, availabilityZones = var.availability_zones }) : var.network_mode == "use-existing" ? jsonencode({ type = "byo-vpc-aws", vpcId = var.vpc_id, publicSubnetIds = var.public_subnet_ids, privateSubnetIds = var.private_subnet_ids, securityGroupIds = var.security_group_ids }) : jsonencode({ type = "use-default" })), kubernetes = local.deployment_kubernetes_settings })
   deployment_resources = [

--- a/crates/alien-test/src/distribution.rs
+++ b/crates/alien-test/src/distribution.rs
@@ -1822,6 +1822,7 @@ async fn write_manager_fetch_values(
             deployment_name: &deployment.name,
             manager_url: &prepared.manager.public_url,
             deployment_token: &deployment.token,
+            runtime_encryption_key: &crate::agent::generate_encryption_key(),
             stack: &stack,
             stack_state,
             stack_settings,


### PR DESCRIPTION
## Summary

- Adds GCP external account credential support so projected workload identity tokens can be exchanged through Google STS and optionally impersonate a service account.
- Updates remote stack management and Kubernetes registry plumbing across Terraform, CloudFormation, Helm, and preflight generation.
- Includes updated generator tests/snapshots for the new Kubernetes and remote-management output.

## Why

The hosted manager needs keyless runtime credentials for multi-cloud operations, and the generated deployment artifacts need to support the associated registry and remote-management wiring.

## Validation

- `cargo check -p alien-core -p alien-gcp-clients`
- `cargo fmt --check --package alien-core --package alien-gcp-clients`

