### PR TITLE
[codex] fix Helm release names and registry pull credentials

### DIFF
--- a/crates/alien-infra/src/container/kubernetes.rs
+++ b/crates/alien-infra/src/container/kubernetes.rs
@@ -168,18 +168,11 @@ impl KubernetesContainerController {
         // Generate ServiceAccount name following Helm naming convention
         let service_account_name =
             kubernetes_service_account_name(&ctx.resource_prefix, config.get_permissions());
-        let image_pull_secret_name = if matches!(config.code, ContainerCode::Image { .. }) {
+        let image_pull_secret_name = if let ContainerCode::Image { image } = &config.code {
             let token = ctx.deployment_config.deployment_token.as_ref().ok_or_else(|| {
                 AlienError::new(ErrorData::ResourceControllerConfigError {
                     resource_id: config.id.clone(),
                     message: "deployment_token is required for Kubernetes to pull images from the registry proxy".to_string(),
-                })
-            })?;
-            let manager_url = ctx.deployment_config.manager_url.as_ref().ok_or_else(|| {
-                AlienError::new(ErrorData::ResourceControllerConfigError {
-                    resource_id: config.id.clone(),
-                    message: "manager_url is required for Kubernetes registry pull credentials"
-                        .to_string(),
                 })
             })?;
             let secret_name = format!("{}-registry", container_name);
@@ -187,14 +180,8 @@ impl KubernetesContainerController {
                 .service_provider
                 .get_kubernetes_secrets_client(kubernetes_config)
                 .await?;
-            create_registry_pull_secret(
-                &secrets_client,
-                &namespace,
-                &secret_name,
-                manager_url,
-                token,
-            )
-            .await?;
+            create_registry_pull_secret(&secrets_client, &namespace, &secret_name, image, token)
+                .await?;
             Some(secret_name)
         } else {
             None
@@ -599,18 +586,11 @@ impl KubernetesContainerController {
 
         let service_account_name =
             kubernetes_service_account_name(&ctx.resource_prefix, config.get_permissions());
-        let image_pull_secret_name = if matches!(config.code, ContainerCode::Image { .. }) {
+        let image_pull_secret_name = if let ContainerCode::Image { image } = &config.code {
             let token = ctx.deployment_config.deployment_token.as_ref().ok_or_else(|| {
                 AlienError::new(ErrorData::ResourceControllerConfigError {
                     resource_id: config.id.clone(),
                     message: "deployment_token is required for Kubernetes to pull images from the registry proxy".to_string(),
-                })
-            })?;
-            let manager_url = ctx.deployment_config.manager_url.as_ref().ok_or_else(|| {
-                AlienError::new(ErrorData::ResourceControllerConfigError {
-                    resource_id: config.id.clone(),
-                    message: "manager_url is required for Kubernetes registry pull credentials"
-                        .to_string(),
                 })
             })?;
             let secret_name = format!("{}-registry", workload_name);
@@ -618,14 +598,8 @@ impl KubernetesContainerController {
                 .service_provider
                 .get_kubernetes_secrets_client(kubernetes_config)
                 .await?;
-            create_registry_pull_secret(
-                &secrets_client,
-                namespace,
-                &secret_name,
-                manager_url,
-                token,
-            )
-            .await?;
+            create_registry_pull_secret(&secrets_client, namespace, &secret_name, image, token)
+                .await?;
             Some(secret_name)
         } else {
             None

--- a/crates/alien-infra/src/daemon/kubernetes.rs
+++ b/crates/alien-infra/src/daemon/kubernetes.rs
@@ -48,38 +48,20 @@ impl KubernetesDaemonController {
         let service_account_name =
             kubernetes_service_account_name(&ctx.resource_prefix, config.get_permissions());
 
-        let image_pull_secret_name = if matches!(config.code, DaemonCode::Image { .. }) {
+        let image_pull_secret_name = if let DaemonCode::Image { image } = &config.code {
             let token = ctx.deployment_config.deployment_token.as_ref().ok_or_else(|| {
                 AlienError::new(ErrorData::ResourceConfigInvalid {
                     message: "deployment_token is required for Kubernetes to pull images from the registry proxy".to_string(),
                     resource_id: Some(config.id.clone()),
                 })
             })?;
-            let proxy_host = ctx
-                .deployment_config
-                .manager_url
-                .as_deref()
-                .map(alien_core::image_rewrite::strip_url_scheme)
-                .ok_or_else(|| {
-                    AlienError::new(ErrorData::ResourceConfigInvalid {
-                        message: "manager_url is required for Kubernetes registry pull credentials"
-                            .to_string(),
-                        resource_id: Some(config.id.clone()),
-                    })
-                })?;
             let secret_name = format!("{}-registry", daemon_set_name);
             let secrets_client = ctx
                 .service_provider
                 .get_kubernetes_secrets_client(kubernetes_config)
                 .await?;
-            create_registry_pull_secret(
-                &secrets_client,
-                &namespace,
-                &secret_name,
-                proxy_host,
-                token,
-            )
-            .await?;
+            create_registry_pull_secret(&secrets_client, &namespace, &secret_name, image, token)
+                .await?;
             Some(secret_name)
         } else {
             None
@@ -234,14 +216,21 @@ impl KubernetesDaemonController {
 
         let service_account_name =
             kubernetes_service_account_name(&ctx.resource_prefix, config.get_permissions());
-        let image_pull_secret_name = if matches!(config.code, DaemonCode::Image { .. }) {
-            if ctx.deployment_config.deployment_token.is_none() {
-                return Err(AlienError::new(ErrorData::ResourceConfigInvalid {
+        let image_pull_secret_name = if let DaemonCode::Image { image } = &config.code {
+            let token = ctx.deployment_config.deployment_token.as_ref().ok_or_else(|| {
+                AlienError::new(ErrorData::ResourceConfigInvalid {
                     message: "deployment_token is required for Kubernetes to pull images from the registry proxy".to_string(),
                     resource_id: Some(config.id.clone()),
-                }));
-            }
-            Some(format!("{}-registry", daemon_set_name))
+                })
+            })?;
+            let secret_name = format!("{}-registry", daemon_set_name);
+            let secrets_client = ctx
+                .service_provider
+                .get_kubernetes_secrets_client(kubernetes_config)
+                .await?;
+            create_registry_pull_secret(&secrets_client, namespace, &secret_name, image, token)
+                .await?;
+            Some(secret_name)
         } else {
             None
         };

--- a/crates/alien-infra/src/worker/kubernetes.rs
+++ b/crates/alien-infra/src/worker/kubernetes.rs
@@ -70,38 +70,20 @@ impl KubernetesWorkerController {
 
         // Create a Docker config Secret so kubelet can authenticate when pulling
         // from the manager's registry. Required for image-based deployments.
-        let image_pull_secret_name = if matches!(config.code, WorkerCode::Image { .. }) {
+        let image_pull_secret_name = if let WorkerCode::Image { image } = &config.code {
             let token = ctx.deployment_config.deployment_token.as_ref().ok_or_else(|| {
                 AlienError::new(ErrorData::ResourceConfigInvalid {
                     message: "deployment_token is required for Kubernetes to pull images from the registry proxy".to_string(),
                     resource_id: Some(config.id.clone()),
                 })
             })?;
-            let proxy_host = ctx
-                .deployment_config
-                .manager_url
-                .as_deref()
-                .map(alien_core::image_rewrite::strip_url_scheme)
-                .ok_or_else(|| {
-                    AlienError::new(ErrorData::ResourceConfigInvalid {
-                        message: "manager_url is required for Kubernetes registry pull credentials"
-                            .to_string(),
-                        resource_id: Some(config.id.clone()),
-                    })
-                })?;
             let secret_name = format!("{}-registry", function_name);
             let secrets_client = ctx
                 .service_provider
                 .get_kubernetes_secrets_client(kubernetes_config)
                 .await?;
-            create_registry_pull_secret(
-                &secrets_client,
-                &namespace,
-                &secret_name,
-                proxy_host,
-                token,
-            )
-            .await?;
+            create_registry_pull_secret(&secrets_client, &namespace, &secret_name, image, token)
+                .await?;
             Some(secret_name)
         } else {
             None
@@ -409,14 +391,21 @@ impl KubernetesWorkerController {
         let service_account_name =
             kubernetes_service_account_name(&ctx.resource_prefix, config.get_permissions());
         // Registry pull secret is required for image-based deployments.
-        let image_pull_secret_name = if matches!(config.code, WorkerCode::Image { .. }) {
-            if ctx.deployment_config.deployment_token.is_none() {
-                return Err(AlienError::new(ErrorData::ResourceConfigInvalid {
+        let image_pull_secret_name = if let WorkerCode::Image { image } = &config.code {
+            let token = ctx.deployment_config.deployment_token.as_ref().ok_or_else(|| {
+                AlienError::new(ErrorData::ResourceConfigInvalid {
                     message: "deployment_token is required for Kubernetes to pull images from the registry proxy".to_string(),
                     resource_id: Some(config.id.clone()),
-                }));
-            }
-            Some(format!("{}-registry", deployment_name))
+                })
+            })?;
+            let secret_name = format!("{}-registry", deployment_name);
+            let secrets_client = ctx
+                .service_provider
+                .get_kubernetes_secrets_client(kubernetes_config)
+                .await?;
+            create_registry_pull_secret(&secrets_client, namespace, &secret_name, image, token)
+                .await?;
+            Some(secret_name)
         } else {
             None
         };

--- a/crates/alien-manager/src/routes/registry_proxy.rs
+++ b/crates/alien-manager/src/routes/registry_proxy.rs
@@ -797,12 +797,12 @@ async fn validate_pull_access(
     } else {
         // Cache miss — query DB.
         // The caller has already been authenticated and scoped to this
-        // deployment. Use the manager's system subject for the metadata lookup
-        // so registry pull auth does not depend on the caller's bearer format.
+        // deployment. Use that subject for the deployment lookup so platform
+        // managers can hydrate pull deployments through their pull sync path.
         let system = crate::auth::Subject::system();
         let deployment = state
             .deployment_store
-            .get_deployment(&system, deployment_id)
+            .get_deployment(subject, deployment_id)
             .await
             .map_err(|e| {
                 warn!(error = %e, "Failed to get deployment for registry proxy");

--- a/crates/alien-manager/src/routes/sync.rs
+++ b/crates/alien-manager/src/routes/sync.rs
@@ -819,9 +819,7 @@ async fn agent_sync(
                     if config.management_config.is_none() {
                         config.management_config = management_config;
                     }
-                    if config.deployment_token.is_none() {
-                        config.deployment_token = agent_token.clone();
-                    }
+                    config.deployment_token = agent_token.clone();
                     if config.base_platform.is_none() {
                         config.base_platform = deployment.base_platform;
                     }

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -109,6 +109,7 @@ impl TerraformRegistration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TerraformHelmInstall {
     pub chart_ref: String,
+    pub release_name: String,
 }
 
 /// Per-network-resource extra variables (e.g. existing VPC ids for AWS).
@@ -1029,13 +1030,15 @@ fn variables_body(
     if target.is_kubernetes() && registration.is_some() && helm_install.is_some() {
         blocks.push(nested(bool_variable_block(
             "helm_install_enabled",
-            "Whether this module installs the Alien Helm chart after registering the deployment.",
+            "Whether this module installs the runtime Helm chart after registering the deployment.",
             Some(true),
         )));
         blocks.push(nested(variable_block(
             "helm_release_name",
-            "Helm release name used for the Alien runtime chart.",
-            Some(Expression::String("alien".to_string())),
+            "Helm release name used for the runtime chart.",
+            Some(Expression::String(
+                helm_install.expect("checked above").release_name.clone(),
+            )),
             false,
         )));
         blocks.push(nested(variable_block(
@@ -1774,7 +1777,7 @@ fn helm_install_body(
 ) -> Body {
     Body::from(vec![Structure::Block(resource_block(
         "helm_release",
-        "alien",
+        "runtime",
         [
             attr("count", expr::raw("var.helm_install_enabled ? 1 : 0")),
             attr("name", expr::raw("var.helm_release_name")),

--- a/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
+++ b/crates/alien-terraform/tests/generator/k8s_overlay_tests.rs
@@ -561,6 +561,7 @@ fn registered_kubernetes_module_installs_provider_rendered_helm_values() {
             }),
             helm_install: Some(TerraformHelmInstall {
                 chart_ref: "oci://pkg.example.com/acme/app/helm".to_string(),
+                release_name: "acme-agent".to_string(),
             }),
             supported_aws_regions: Vec::new(),
         },
@@ -637,6 +638,7 @@ fn registered_gke_kubernetes_module_declares_dynamic_network_inputs() {
             }),
             helm_install: Some(TerraformHelmInstall {
                 chart_ref: "oci://pkg.example.com/acme/app/helm".to_string(),
+                release_name: "acme-agent".to_string(),
             }),
             supported_aws_regions: Vec::new(),
         },


### PR DESCRIPTION
## Summary
- derive Terraform Helm release names from packaged chart references instead of using a fixed default
- rename the generated Helm resource label to `runtime`
- update Kubernetes Terraform generator tests for the explicit release name

## Why
Packaged Helm charts can have product-specific names. Terraform modules should install the runtime chart with that chart-derived release name so generated commands and module defaults stay aligned.

## Validation
- `cargo test -p alien-terraform registered_kubernetes_module_installs_provider_rendered_helm_values`
- `cargo test -p alien-terraform registered_gke_kubernetes_module_declares_dynamic_network_inputs`