### PR TITLE
feat(cli): structured error for non-interactive workspace selection

### DIFF
--- a/crates/alien-cli/src/commands/platform/login.rs
+++ b/crates/alien-cli/src/commands/platform/login.rs
@@ -2,10 +2,8 @@ use crate::auth::{force_login, save_workspace};
 use crate::commands::platform::workspace::{prompt_workspace, validate_workspace_name};
 use crate::error::Result;
 use crate::execution_context::ExecutionMode;
-use crate::output::print_json;
 use crate::ui::{command, contextual_heading, dim_label, success_line};
 use clap::Parser;
-use serde::Serialize;
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -13,25 +11,12 @@ use serde::Serialize;
     long_about = "Authenticate with the Alien platform and set the default workspace used by platform-managed commands.",
     after_help = "EXAMPLES:
     alien login
-    alien login --workspace my-workspace
-    alien login --workspace my-workspace --json"
+    alien login --workspace my-workspace"
 )]
-pub struct LoginArgs {
-    /// Emit structured JSON output
-    #[arg(long)]
-    pub json: bool,
-}
+pub struct LoginArgs {}
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct LoginOutput {
-    workspace: String,
-    used_api_key: bool,
-}
-
-pub async fn login_task(args: LoginArgs, ctx: ExecutionMode) -> Result<()> {
+pub async fn login_task(_args: LoginArgs, ctx: ExecutionMode) -> Result<()> {
     let auth_opts = ctx.auth_opts();
-    let used_api_key = auth_opts.api_key.is_some();
     let http = force_login(&auth_opts).await?;
 
     let workspace = if let ExecutionMode::Platform {
@@ -41,26 +26,19 @@ pub async fn login_task(args: LoginArgs, ctx: ExecutionMode) -> Result<()> {
     {
         validate_workspace_name(&http, workspace).await?
     } else {
-        prompt_workspace(&http, args.json).await?
+        prompt_workspace(&http, false).await?
     };
 
     save_workspace(&workspace)?;
 
-    if args.json {
-        print_json(&LoginOutput {
-            workspace,
-            used_api_key,
-        })?;
-    } else {
-        println!("{}", contextual_heading("Logged in to", &workspace, &[]));
-        println!("{}", success_line("Workspace ready."));
-        println!(
-            "{} run {} in a project directory or {}.",
-            dim_label("Next"),
-            command("alien link"),
-            command("alien release --project <name>")
-        );
-    }
+    println!("{}", contextual_heading("Logged in to", &workspace, &[]));
+    println!("{}", success_line("Workspace ready."));
+    println!(
+        "{} run {} in a project directory or {}.",
+        dim_label("Next"),
+        command("alien link"),
+        command("alien release --project <name>")
+    );
 
     Ok(())
 }

--- a/crates/alien-cli/src/commands/platform/workspace.rs
+++ b/crates/alien-cli/src/commands/platform/workspace.rs
@@ -2,7 +2,7 @@ use crate::auth::{load_workspace, save_workspace};
 use crate::error::{ErrorData, Result};
 use crate::execution_context::ExecutionMode;
 use crate::interaction::InteractionMode;
-use crate::output::{can_prompt, print_json, prompt_select};
+use crate::output::{print_json, prompt_select};
 use crate::ui::{command, dim_label, make_table, print_table, success_line};
 use alien_error::{AlienError, Context};
 use alien_platform_api::SdkResultExt;
@@ -167,9 +167,11 @@ pub async fn prompt_workspace(http: &crate::auth::AuthHttp, json_mode: bool) -> 
         return Ok(workspaces[0].clone());
     }
 
-    InteractionMode::new(json_mode, can_prompt()).require_prompt(
-        "Workspace selection requires a real terminal. Pass `--workspace <name>` or run `alien workspaces set <name>` first.",
-    )?;
+    if InteractionMode::current(json_mode).is_machine() {
+        return Err(AlienError::new(ErrorData::WorkspaceSelectionRequired {
+            workspaces,
+        }));
+    }
 
     prompt_select("Select a workspace:", &workspaces)
 }

--- a/crates/alien-cli/src/error.rs
+++ b/crates/alien-cli/src/error.rs
@@ -177,6 +177,19 @@ pub enum ErrorData {
         field: String,
     },
 
+    /// Several workspaces exist but one can't be chosen without a terminal.
+    #[error(
+        code = "WORKSPACE_SELECTION_REQUIRED",
+        message = "Several workspaces are available; selecting one needs an interactive terminal",
+        hint = "Run `alien workspaces ls` to see them, then `alien workspaces set <name>` (or pass `--workspace <name>`).",
+        retryable = "false",
+        internal = "false"
+    )]
+    WorkspaceSelectionRequired {
+        /// Names the caller can pass to `--workspace`, exposed under `context.workspaces`.
+        workspaces: Vec<String>,
+    },
+
     /// Invalid project name specified.
     #[error(
         code = "INVALID_PROJECT_NAME",
@@ -294,3 +307,28 @@ pub enum ErrorData {
 }
 
 pub type Result<T> = alien_error::Result<T, ErrorData>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_error::AlienErrorData;
+
+    #[test]
+    fn workspace_selection_required_exposes_names_in_context() {
+        let err = ErrorData::WorkspaceSelectionRequired {
+            workspaces: vec!["alpha".to_string(), "beta".to_string()],
+        };
+
+        assert_eq!(err.code(), "WORKSPACE_SELECTION_REQUIRED");
+
+        let context = err.context().expect("variant exposes a context payload");
+        let names: Vec<&str> = context
+            .get("workspaces")
+            .and_then(|value| value.as_array())
+            .expect("context.workspaces is an array")
+            .iter()
+            .filter_map(|value| value.as_str())
+            .collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+}

--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -94,7 +94,7 @@ impl Cli {
             #[cfg(feature = "platform")]
             Some(Commands::Platform(PlatformCommand::Link(args))) => args.json,
             #[cfg(feature = "platform")]
-            Some(Commands::Platform(PlatformCommand::Login(args))) => args.json,
+            Some(Commands::Platform(PlatformCommand::Login(_))) => false,
             #[cfg(feature = "platform")]
             Some(Commands::Platform(PlatformCommand::Workspaces(args))) => args.json,
             #[cfg(feature = "platform")]

--- a/crates/alien-cli/src/ui.rs
+++ b/crates/alien-cli/src/ui.rs
@@ -1531,7 +1531,7 @@ fn build_resource_noun(
 }
 
 #[cfg(test)]
-mod tests {
+mod command_event_tests {
     use super::*;
 
     fn empty_command_state() -> CommandEventState {


### PR DESCRIPTION
## Summary

When something automated runs `alien login` — an agent like Claude, a script, anything without a real terminal — it can't use the arrow-key menu to pick a workspace. Before, it hit a dead end ("needs a real terminal"). Now it gets the actual list of workspaces back, so it can pick one with a follow-up command.

What an agent sees when it runs `alien login`:

1. The browser opens and you log in — same as always.
2. It needs a workspace but can't show the menu, so it returns `WORKSPACE_SELECTION_REQUIRED` with the names under `context.workspaces`.   ← the new bit
3. It reads the names and runs `alien workspaces set <name>`.

So instead of a dead-end string, you get back something a machine can act on. I also removed `alien login --json` — an agent can get the same list from `alien workspaces ls --json`, so login didn't need its own JSON mode.

## How I tested it

On a local stack, logged in fresh, on an account with 3 workspaces:

- Ran `alien login`, finished in the browser — it ended on `WORKSPACE_SELECTION_REQUIRED` with the 3 names and a hint pointing at `alien workspaces ls` / `set`.
- `alien workspaces ls --json` gave the list, `alien workspaces set <name>` saved it, `alien workspaces current` confirmed it.
- `alien login --json` now says "unexpected argument".
- `cargo test -p alien-cli --features platform` is green, including a test that checks the names actually land in `context.workspaces`.
