### PR TITLE
feat(build): native-runner cross-arch builds and daemon source builds

### DIFF
--- a/crates/alien-build/src/lib.rs
+++ b/crates/alien-build/src/lib.rs
@@ -1,18 +1,26 @@
 pub(crate) mod command_output;
 pub mod dependencies;
 pub mod error;
+pub mod merge;
+pub mod plan;
 pub mod settings;
 pub mod toolchain;
 
 use alien_core::{
-    alien_event, AlienEvent, BinaryTarget, Container, ContainerCode, Platform, Stack,
-    ToolchainConfig, Worker, WorkerCode,
+    alien_event, AlienEvent, BinaryTarget, Container, ContainerCode, Daemon, DaemonCode, Platform,
+    Stack, ToolchainConfig, Worker, WorkerCode,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
 use alien_preflights::runner::PreflightRunner;
 use command_output::image_build_error_with_output;
 use dockdash::{Image as DockDashImage, Layer as DockDashLayer, PullPolicy};
 use error::{DockdashResultExt, ErrorData, Result};
+use oci_client::client::{Client as OciClient, ClientConfig as OciClientConfig};
+use oci_client::manifest::{
+    ImageIndexEntry, OciImageIndex, Platform as OciPlatform, IMAGE_MANIFEST_MEDIA_TYPE,
+    OCI_IMAGE_INDEX_MEDIA_TYPE, OCI_IMAGE_MEDIA_TYPE,
+};
+use oci_client::Reference;
 use rand::distr::Alphanumeric;
 use rand::Rng;
 use reqwest::Url;
@@ -101,6 +109,15 @@ impl DedupeKey {
             },
         }
     }
+}
+
+/// True when the caller explicitly requested only non-Linux (host-binary) targets, so a
+/// container — which is always a Linux image — has nothing to build here. `None` (the
+/// default, host OS) returns false, so a plain `alien build --platforms local` still builds
+/// containers as a host-Linux image; only an explicit `--targets darwin-arm64` (the macOS /
+/// Windows runner group of a native-runner CI build) skips them.
+fn requested_host_binary_only(targets: Option<&[BinaryTarget]>) -> bool {
+    targets.is_some_and(|ts| !ts.is_empty() && ts.iter().all(|t| t.oci_os() != "linux"))
 }
 
 /// Builds a given `Stack`, processing `WorkerCode::Source` into `WorkerCode::Image`,
@@ -193,32 +210,71 @@ pub async fn build_stack(mut stack: Stack, settings: &BuildSettings) -> Result<S
         }
     }
 
-    // Collect containers that need building or exporting
-    let mut containers_to_build = Vec::new();
-    let mut containers_to_export = Vec::new();
+    let mut daemons_to_build = Vec::new();
 
     for (id, resource_entry) in stack.resources() {
-        if let Some(container) = resource_entry.config.downcast_ref::<Container>() {
-            info!("Processing container: {}", container.id);
-            match &container.code {
-                ContainerCode::Source { src, toolchain } => {
-                    info!(
-                        "Container '{}' has source code. Queued for parallel build.",
-                        container.id
-                    );
-                    containers_to_build.push((
+        if let Some(daemon) = resource_entry.config.downcast_ref::<Daemon>() {
+            info!("Processing daemon: {}", daemon.id);
+            match &daemon.code {
+                DaemonCode::Source { src, toolchain } => {
+                    info!("Daemon '{}' has source code. Queued for build.", daemon.id);
+                    daemons_to_build.push((
                         id.clone(),
-                        container.clone(),
+                        daemon.clone(),
                         src.clone(),
                         toolchain.clone(),
                     ));
                 }
-                ContainerCode::Image { image } => {
-                    info!(
-                        "Container '{}' has image reference '{}'. Queued for pull and export.",
-                        container.id, image
-                    );
-                    containers_to_export.push((id.clone(), container.clone(), image.clone()));
+                DaemonCode::Image { .. } => {
+                    info!("Daemon '{}' already has an image. Skipping.", daemon.id);
+                }
+            }
+        }
+    }
+
+    // Collect containers that need building or exporting. On a host-binary-only build
+    // there is nothing to collect — see `requested_host_binary_only`; the containers'
+    // Linux images come from the Linux runner groups and are combined by `alien build merge`.
+    let mut containers_to_build = Vec::new();
+    let mut containers_to_export = Vec::new();
+    let skip_containers = requested_host_binary_only(settings.targets.as_deref());
+
+    if skip_containers {
+        let container_count = stack
+            .resources()
+            .filter(|(_, e)| e.config.downcast_ref::<Container>().is_some())
+            .count();
+        if container_count > 0 {
+            info!(
+                "Skipping {} container(s) for host-binary-only targets {:?}; their Linux images come from the Linux runner groups.",
+                container_count,
+                settings.get_targets()
+            );
+        }
+    } else {
+        for (id, resource_entry) in stack.resources() {
+            if let Some(container) = resource_entry.config.downcast_ref::<Container>() {
+                info!("Processing container: {}", container.id);
+                match &container.code {
+                    ContainerCode::Source { src, toolchain } => {
+                        info!(
+                            "Container '{}' has source code. Queued for parallel build.",
+                            container.id
+                        );
+                        containers_to_build.push((
+                            id.clone(),
+                            container.clone(),
+                            src.clone(),
+                            toolchain.clone(),
+                        ));
+                    }
+                    ContainerCode::Image { image } => {
+                        info!(
+                            "Container '{}' has image reference '{}'. Queued for pull and export.",
+                            container.id, image
+                        );
+                        containers_to_export.push((id.clone(), container.clone(), image.clone()));
+                    }
                 }
             }
         }
@@ -393,6 +449,46 @@ pub async fn build_stack(mut stack: Stack, settings: &BuildSettings) -> Result<S
             "Completed parallel building of {} functions",
             completed_tasks
         );
+    }
+
+    // Build daemons through the same per-resource pipeline as workers. Sequential across
+    // resources: stacks carry few daemons and `build_resource` already parallelizes across
+    // targets, so the worker block's spawn/cancellation scaffolding buys nothing here.
+    if !daemons_to_build.is_empty() {
+        let build_targets = settings.get_targets();
+        info!(
+            "Building {} daemon(s) for {} target(s): {:?}",
+            daemons_to_build.len(),
+            build_targets.len(),
+            build_targets
+        );
+
+        for (resource_id, daemon, src, toolchain) in daemons_to_build {
+            let image_uri = build_resource(
+                &src,
+                &toolchain,
+                &daemon.id,
+                &stack_id,
+                settings,
+                &output_dir,
+                false, // is_container = false: daemons run as native processes on local
+                "daemon",
+                &[],
+            )
+            .await?;
+
+            info!(
+                "Successfully built OCI image for daemon '{}' to: {}",
+                daemon.id, image_uri
+            );
+
+            let mut updated_daemon = daemon;
+            updated_daemon.code = DaemonCode::Image { image: image_uri };
+            if let Some(resource_entry) = stack.resources_mut().find(|(id, _)| *id == &resource_id)
+            {
+                resource_entry.1.config = alien_core::Resource::new(updated_daemon);
+            }
+        }
     }
 
     // Build all containers in parallel with fail-fast behavior
@@ -945,6 +1041,33 @@ fn collect_push_targets(stack: &Stack) -> Result<Vec<ResourcePushTarget>> {
                     }));
                 }
             }
+        } else if let Some(daemon) = resource_entry.config.downcast_ref::<Daemon>() {
+            match &daemon.code {
+                DaemonCode::Image { image } => {
+                    let path = PathBuf::from(image);
+                    if path.exists() && path.is_dir() {
+                        info!(
+                            "Daemon '{}' has local image directory, queuing for push",
+                            daemon.id
+                        );
+                        add_push_target_resource(
+                            &mut targets,
+                            resource_id.clone(),
+                            daemon.id.clone(),
+                            "daemon",
+                            path,
+                        );
+                    } else {
+                        info!("Daemon '{}' already has remote image: {}", daemon.id, image);
+                    }
+                }
+                DaemonCode::Source { .. } => {
+                    return Err(AlienError::new(ErrorData::InvalidResourceConfig {
+                        resource_id: daemon.id.clone(),
+                        reason: "Daemon has source code instead of built image. Run 'alien build' first.".to_string(),
+                    }));
+                }
+            }
         }
     }
 
@@ -962,6 +1085,8 @@ fn apply_pushed_images(stack: &mut Stack, updates: Vec<(String, String)>) {
                 func.code = WorkerCode::Image { image: image_uri };
             } else if let Some(container) = resource_entry.1.config.downcast_mut::<Container>() {
                 container.code = ContainerCode::Image { image: image_uri };
+            } else if let Some(daemon) = resource_entry.1.config.downcast_mut::<Daemon>() {
+                daemon.code = DaemonCode::Image { image: image_uri };
             }
         }
     }
@@ -1255,25 +1380,111 @@ async fn push_resource_images(
         resource_name: resource_name.to_string(),
     }));
 
-    // Push each OCI tarball (multi-architecture manifest)
-    for oci_file in &oci_files {
-        info!("Pushing {}", oci_file.display());
+    // Container images are linux; darwin/windows tarballs (produced for `local` host
+    // binaries) are not registry container images, so they're excluded from the push.
+    let linux_tarballs = select_linux_tarballs(&oci_files);
 
-        // Load the OCI tarball
-        let image = DockDashImage::from_tarball(oci_file).map_dockdash_err()?;
+    // No linux image (unusual) — push whatever tarballs are present.
+    if linux_tarballs.is_empty() {
+        for oci_file in &oci_files {
+            let image = DockDashImage::from_tarball(oci_file).map_dockdash_err()?;
+            image
+                .push(&image_uri, &push_opts_with_progress)
+                .await
+                .map_dockdash_err()?;
+        }
+        info!(
+            "Pushed resource '{}' in {:.2}s",
+            display_resource_name,
+            push_resource_started.elapsed().as_secs_f64()
+        );
 
-        // Push to registry with progress callback
+        return Ok(image_uri);
+    }
+
+    // Single arch: push the image straight to the tag — no index needed.
+    if let [(_, only)] = linux_tarballs.as_slice() {
+        info!("Pushing {} to {}", only.display(), image_uri);
+        let image = DockDashImage::from_tarball(only).map_dockdash_err()?;
         image
             .push(&image_uri, &push_opts_with_progress)
             .await
             .map_dockdash_err()?;
-
         info!(
-            "Successfully pushed {} to {}",
-            oci_file.display(),
-            image_uri
+            "Pushed resource '{}' in {:.2}s",
+            display_resource_name,
+            push_resource_started.elapsed().as_secs_f64()
         );
+
+        return Ok(image_uri);
     }
+
+    // Multi-arch: push each image to a per-arch child tag, then publish a manifest list
+    // (OCI image index) at the shared tag — otherwise the last single-arch push wins the tag.
+    let oci_client = OciClient::new(OciClientConfig {
+        protocol: push_options.protocol.clone(),
+        ..Default::default()
+    });
+    let mut entries = Vec::new();
+    for (target, oci_file) in &linux_tarballs {
+        let child_uri = format!("{}-{}", image_uri, target.runtime_platform_id());
+        info!("Pushing {} as {}", oci_file.display(), child_uri);
+        let image = DockDashImage::from_tarball(oci_file).map_dockdash_err()?;
+        image
+            .push(&child_uri, &push_opts_with_progress)
+            .await
+            .map_dockdash_err()?;
+
+        // The index entry's digest+size must reflect the manifest the registry stored
+        // (dockdash pushes a converted manifest), so read it back rather than hashing the tarball.
+        let child_ref = Reference::try_from(child_uri.as_str())
+            .into_alien_error()
+            .context(ErrorData::InvalidResourceConfig {
+                resource_id: resource_name.to_string(),
+                reason: format!("Invalid image reference '{child_uri}'"),
+            })?;
+        let (manifest_bytes, digest) = oci_client
+            .pull_manifest_raw(
+                &child_ref,
+                &push_options.auth,
+                &[OCI_IMAGE_MEDIA_TYPE, IMAGE_MANIFEST_MEDIA_TYPE],
+            )
+            .await
+            .into_alien_error()
+            .context(ErrorData::ImagePushFailed {
+                image: child_uri.clone(),
+                reason: "Failed to read back the pushed manifest".to_string(),
+            })?;
+        let media_type = manifest_media_type(&manifest_bytes)
+            .unwrap_or_else(|| OCI_IMAGE_MEDIA_TYPE.to_string());
+        entries.push(image_index_entry(
+            *target,
+            digest,
+            manifest_bytes.len() as i64,
+            media_type,
+        ));
+    }
+
+    let index = assemble_image_index(entries);
+    let index_ref = Reference::try_from(image_uri.as_str())
+        .into_alien_error()
+        .context(ErrorData::InvalidResourceConfig {
+            resource_id: resource_name.to_string(),
+            reason: format!("Invalid image reference '{image_uri}'"),
+        })?;
+    oci_client
+        .push_manifest_list(&index_ref, &push_options.auth, index)
+        .await
+        .into_alien_error()
+        .context(ErrorData::ImagePushFailed {
+            image: image_uri.clone(),
+            reason: "Failed to push the multi-arch manifest list".to_string(),
+        })?;
+    info!(
+        "Pushed multi-arch image {} ({} arches)",
+        image_uri,
+        linux_tarballs.len()
+    );
 
     info!(
         "Pushed resource '{}' in {:.2}s",
@@ -1282,6 +1493,67 @@ async fn push_resource_images(
     );
 
     Ok(image_uri)
+}
+
+/// Pair each linux OCI tarball with its target, sorted for deterministic ordering.
+/// darwin/windows tarballs are excluded — they are host binaries, not container images.
+fn select_linux_tarballs(oci_files: &[PathBuf]) -> Vec<(BinaryTarget, PathBuf)> {
+    let mut out: Vec<(BinaryTarget, PathBuf)> = oci_files
+        .iter()
+        .filter_map(|path| oci_tarball_target(path).map(|target| (target, path.clone())))
+        .filter(|(target, _)| target.oci_os() == "linux")
+        .collect();
+    out.sort_by_key(|(target, _)| target.runtime_platform_id());
+    out
+}
+
+/// `<runtime_platform_id>.oci.tar` → its `BinaryTarget`.
+fn oci_tarball_target(path: &Path) -> Option<BinaryTarget> {
+    let name = path.file_name()?.to_str()?;
+    BinaryTarget::from_runtime_platform_id(name.strip_suffix(".oci.tar")?)
+}
+
+/// One OCI image index entry for a built target.
+fn image_index_entry(
+    target: BinaryTarget,
+    digest: String,
+    size: i64,
+    media_type: String,
+) -> ImageIndexEntry {
+    ImageIndexEntry {
+        media_type,
+        digest,
+        size,
+        platform: Some(OciPlatform {
+            architecture: target.oci_arch().to_string(),
+            os: target.oci_os().to_string(),
+            os_version: None,
+            os_features: None,
+            variant: None,
+            features: None,
+        }),
+        annotations: None,
+    }
+}
+
+/// Wrap per-arch manifest entries in an OCI image index (manifest list).
+fn assemble_image_index(manifests: Vec<ImageIndexEntry>) -> OciImageIndex {
+    OciImageIndex {
+        schema_version: 2,
+        media_type: Some(OCI_IMAGE_INDEX_MEDIA_TYPE.to_string()),
+        manifests,
+        artifact_type: None,
+        annotations: None,
+    }
+}
+
+/// Read the `mediaType` field from a raw manifest, if present.
+fn manifest_media_type(bytes: &[u8]) -> Option<String> {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()?
+        .get("mediaType")?
+        .as_str()
+        .map(|s| s.to_string())
 }
 
 fn generate_unique_tag() -> String {
@@ -2386,6 +2658,12 @@ async fn pull_and_export_image(
             ));
         }
 
+        // Flatten the saved archive to a single image manifest before the OCI reader sees it.
+        crate::toolchain::docker::DockerToolchain::normalize_oci_archive(
+            &output_tarball,
+            arch_str,
+        )?;
+
         info!(
             "Successfully exported {} to {}",
             image,
@@ -2476,12 +2754,40 @@ mod tests {
     use std::process::Command;
     use tempfile::tempdir;
 
+    #[test]
+    fn requested_host_binary_only_gates_container_skip() {
+        use BinaryTarget::*;
+        // None (defaults to host OS) and empty → containers still build.
+        assert!(!requested_host_binary_only(None));
+        assert!(!requested_host_binary_only(Some(&[])));
+        // Explicit non-Linux-only → nothing for a container to build, skip it.
+        assert!(requested_host_binary_only(Some(&[DarwinArm64])));
+        assert!(requested_host_binary_only(Some(&[WindowsX64])));
+        assert!(requested_host_binary_only(Some(&[DarwinArm64, WindowsX64])));
+        // Any Linux target present → containers build for it.
+        assert!(!requested_host_binary_only(Some(&[LinuxArm64])));
+        assert!(!requested_host_binary_only(Some(&[LinuxX64])));
+        assert!(!requested_host_binary_only(Some(&[
+            DarwinArm64,
+            LinuxArm64
+        ])));
+    }
+
     fn docker_available() -> bool {
         Command::new("docker")
             .arg("info")
             .output()
             .map(|output| output.status.success())
             .unwrap_or(false)
+    }
+
+    /// True if a real OCI registry answers at `base/v2/` (200 or 401). Used to gate the
+    /// multi-arch push test. Run one with: `docker run -d -p 5050:5000 registry:2`.
+    async fn registry_available(base: &str) -> bool {
+        match reqwest::get(format!("{base}/v2/")).await {
+            Ok(resp) => resp.status().is_success() || resp.status().as_u16() == 401,
+            Err(_) => false,
+        }
     }
 
     fn test_container(name: &str, image: String) -> Container {
@@ -2539,6 +2845,68 @@ mod tests {
 
         assert!(!is_retryable_dockdash_image_pull_error(&auth_error));
         assert!(!is_retryable_dockdash_image_pull_error(&missing_error));
+    }
+
+    #[test]
+    fn oci_tarball_target_maps_runtime_platform_ids() {
+        assert_eq!(
+            oci_tarball_target(Path::new("/x/linux-aarch64.oci.tar")),
+            Some(BinaryTarget::LinuxArm64)
+        );
+        assert_eq!(
+            oci_tarball_target(Path::new("linux-x64.oci.tar")),
+            Some(BinaryTarget::LinuxX64)
+        );
+        assert_eq!(oci_tarball_target(Path::new("stack.json")), None);
+        assert_eq!(oci_tarball_target(Path::new("linux-arm64.oci.tar")), None); // CLI spelling, not a tarball name
+    }
+
+    #[test]
+    fn select_linux_tarballs_keeps_only_linux_sorted() {
+        let files = vec![
+            PathBuf::from("/b/windows-x64.oci.tar"),
+            PathBuf::from("/b/linux-x64.oci.tar"),
+            PathBuf::from("/b/darwin-aarch64.oci.tar"),
+            PathBuf::from("/b/linux-aarch64.oci.tar"),
+        ];
+        let selected = select_linux_tarballs(&files);
+        assert_eq!(
+            selected.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+            vec![BinaryTarget::LinuxArm64, BinaryTarget::LinuxX64], // sorted by runtime id: linux-aarch64 < linux-x64
+        );
+    }
+
+    #[test]
+    fn assemble_image_index_sets_oci_index_shape() {
+        let entry = image_index_entry(
+            BinaryTarget::LinuxArm64,
+            "sha256:abc".to_string(),
+            123,
+            OCI_IMAGE_MEDIA_TYPE.to_string(),
+        );
+        let platform = entry.platform.as_ref().unwrap();
+        assert_eq!(platform.architecture, "arm64");
+        assert_eq!(platform.os, "linux");
+
+        let index = assemble_image_index(vec![entry]);
+        assert_eq!(index.schema_version, 2);
+        assert_eq!(
+            index.media_type.as_deref(),
+            Some(OCI_IMAGE_INDEX_MEDIA_TYPE)
+        );
+        assert_eq!(index.manifests.len(), 1);
+        assert_eq!(index.manifests[0].digest, "sha256:abc");
+        assert_eq!(index.manifests[0].size, 123);
+    }
+
+    #[test]
+    fn manifest_media_type_reads_field_or_none() {
+        assert_eq!(
+            manifest_media_type(br#"{"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#),
+            Some("application/vnd.oci.image.manifest.v1+json".to_string())
+        );
+        assert_eq!(manifest_media_type(br#"{"schemaVersion":2}"#), None);
+        assert_eq!(manifest_media_type(b"not json"), None);
     }
 
     #[test]
@@ -2618,6 +2986,74 @@ mod tests {
             images.get("remote").unwrap(),
             "registry.example.com/remote:latest"
         );
+    }
+
+    #[test]
+    fn collect_push_targets_handles_daemons_like_other_compute() {
+        let temp_root = tempdir().unwrap();
+        let agent_dir = temp_root.path().join("agent-image");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+
+        let local_daemon = Daemon::new("agent".to_string())
+            .permissions("execution".to_string())
+            .code(DaemonCode::Image {
+                image: agent_dir.to_string_lossy().into_owned(),
+            })
+            .build();
+        let remote_daemon = Daemon::new("collector".to_string())
+            .permissions("execution".to_string())
+            .code(DaemonCode::Image {
+                image: "registry.example.com/collector:latest".to_string(),
+            })
+            .build();
+
+        let mut stack = Stack::new("daemon-push".to_string())
+            .add(local_daemon, alien_core::ResourceLifecycle::Live)
+            .add(remote_daemon, alien_core::ResourceLifecycle::Live)
+            .build();
+
+        let targets = collect_push_targets(&stack).unwrap();
+        assert_eq!(
+            targets.len(),
+            1,
+            "only the local-dir daemon is queued for push"
+        );
+        assert_eq!(targets[0].resource_names, vec!["agent".to_string()]);
+        assert_eq!(targets[0].resource_type, "daemon");
+        assert_eq!(targets[0].local_image_dir, agent_dir);
+
+        let updates = targets[0].push_result_updates("registry.example.com/agent:tag".into());
+        apply_pushed_images(&mut stack, updates);
+        let agent = stack
+            .resources()
+            .find(|(id, _)| *id == "agent")
+            .and_then(|(_, e)| e.config.downcast_ref::<Daemon>().cloned())
+            .expect("agent daemon should exist");
+        assert_eq!(
+            agent.code,
+            DaemonCode::Image {
+                image: "registry.example.com/agent:tag".to_string()
+            }
+        );
+
+        // An unbuilt source daemon fails fast, same as workers and containers.
+        let source_daemon = Daemon::new("raw".to_string())
+            .permissions("execution".to_string())
+            .code(DaemonCode::Source {
+                src: ".".to_string(),
+                toolchain: ToolchainConfig::Rust {
+                    binary_name: "raw".to_string(),
+                },
+            })
+            .build();
+        let source_stack = Stack::new("daemon-source".to_string())
+            .add(source_daemon, alien_core::ResourceLifecycle::Live)
+            .build();
+        let error = match collect_push_targets(&source_stack) {
+            Err(error) => error,
+            Ok(_) => panic!("source daemon must be rejected"),
+        };
+        assert!(error.to_string().contains("Run 'alien build' first"));
     }
 
     #[tokio::test]
@@ -2975,5 +3411,422 @@ mod tests {
             .unwrap()
             .to_string_lossy()
             .starts_with(".agent-tmp-"));
+    }
+
+    /// End-to-end: build two arches into one resource dir, push, and assert the pushed tag
+    /// resolves to a real multi-arch manifest list (not a single overwritten arch).
+    /// Gated on docker + a local registry (`docker run -d -p 5050:5000 registry:2`).
+    #[tokio::test]
+    async fn multiarch_push_produces_manifest_list() {
+        use crate::toolchain::{docker::DockerToolchain, Toolchain, ToolchainContext};
+
+        const REGISTRY: &str = "localhost:5050";
+        if !docker_available() {
+            eprintln!("Skipping multiarch_push_produces_manifest_list: docker not available");
+            return;
+        }
+        if !registry_available(&format!("http://{REGISTRY}")).await {
+            eprintln!(
+                "Skipping multiarch_push_produces_manifest_list: no registry at {REGISTRY} (run: docker run -d -p 5050:5000 registry:2)"
+            );
+            return;
+        }
+
+        let src = tempfile::tempdir().unwrap();
+        let build_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            src.path().join("Dockerfile"),
+            "FROM alpine:latest\nCMD [\"echo\", \"hi\"]\n",
+        )
+        .unwrap();
+
+        // Build both linux arches into the same resource dir.
+        for target in [BinaryTarget::LinuxArm64, BinaryTarget::LinuxX64] {
+            let toolchain = DockerToolchain {
+                dockerfile: None,
+                build_args: None,
+                target: None,
+            };
+            let context = ToolchainContext {
+                src_dir: src.path().to_path_buf(),
+                build_dir: build_dir.path().to_path_buf(),
+                cache_store: None,
+                cache_prefix: "test".to_string(),
+                build_target: target,
+                runtime_platform_name: "aws".to_string(),
+                debug_mode: false,
+                is_container: true,
+            };
+            toolchain
+                .build(&context)
+                .await
+                .expect("docker build should succeed");
+        }
+        assert!(build_dir.path().join("linux-aarch64.oci.tar").exists());
+        assert!(build_dir.path().join("linux-x64.oci.tar").exists());
+
+        let container = Container::new("web".to_string())
+            .code(ContainerCode::Image {
+                image: build_dir.path().to_string_lossy().into_owned(),
+            })
+            .cpu(alien_core::ResourceSpec {
+                min: "0.5".to_string(),
+                desired: "1".to_string(),
+            })
+            .memory(alien_core::ResourceSpec {
+                min: "512Mi".to_string(),
+                desired: "1Gi".to_string(),
+            })
+            .permissions("web".to_string())
+            .build();
+        let stack = Stack::new("multiarch-test".to_string())
+            .add(container, alien_core::ResourceLifecycle::Live)
+            .build();
+
+        let push_settings = PushSettings {
+            repository: format!("{REGISTRY}/alien-multiarch-test"),
+            destination_label: None,
+            options: dockdash::PushOptions {
+                auth: dockdash::RegistryAuth::Anonymous,
+                protocol: dockdash::ClientProtocol::Http,
+                ..Default::default()
+            },
+        };
+
+        let pushed = push_stack(stack, Platform::Aws, &push_settings)
+            .await
+            .expect("push should succeed");
+
+        let image_uri = pushed
+            .resources()
+            .filter_map(|(_, entry)| entry.config.downcast_ref::<Container>())
+            .find_map(|c| match &c.code {
+                ContainerCode::Image { image } => Some(image.clone()),
+                _ => None,
+            })
+            .expect("container should carry a pushed image URI");
+        assert!(
+            image_uri.contains(REGISTRY),
+            "expected a registry URI, got {image_uri}"
+        );
+
+        // The pushed tag must resolve to an image index with both linux arches.
+        let client = OciClient::new(OciClientConfig {
+            protocol: dockdash::ClientProtocol::Http,
+            ..Default::default()
+        });
+        let reference = Reference::try_from(image_uri.as_str()).unwrap();
+        let (bytes, _digest) = client
+            .pull_manifest_raw(
+                &reference,
+                &dockdash::RegistryAuth::Anonymous,
+                &[
+                    OCI_IMAGE_INDEX_MEDIA_TYPE,
+                    "application/vnd.docker.distribution.manifest.list.v2+json",
+                ],
+            )
+            .await
+            .expect("should pull a manifest list");
+        let index: OciImageIndex =
+            serde_json::from_slice(&bytes).expect("pushed tag should be an image index");
+        let mut platforms: Vec<(String, String)> = index
+            .manifests
+            .iter()
+            .filter_map(|m| {
+                m.platform
+                    .as_ref()
+                    .map(|p| (p.os.clone(), p.architecture.clone()))
+            })
+            .collect();
+        platforms.sort();
+        assert_eq!(
+            platforms,
+            vec![
+                ("linux".to_string(), "amd64".to_string()),
+                ("linux".to_string(), "arm64".to_string()),
+            ],
+            "pushed tag must be a real multi-arch index"
+        );
+    }
+
+    /// End-to-end: build a single arch into a resource dir, push, and assert the pushed tag
+    /// resolves to a plain image manifest (not an index). This is the path every current
+    /// single-platform release (aws/gcp/azure) takes, so the direct branch must stay intact.
+    /// Gated on docker + a local registry (`docker run -d -p 5050:5000 registry:2`).
+    #[tokio::test]
+    async fn singlearch_push_produces_single_manifest() {
+        use crate::toolchain::{docker::DockerToolchain, Toolchain, ToolchainContext};
+
+        const REGISTRY: &str = "localhost:5050";
+        if !docker_available() {
+            eprintln!("Skipping singlearch_push_produces_single_manifest: docker not available");
+            return;
+        }
+        if !registry_available(&format!("http://{REGISTRY}")).await {
+            eprintln!(
+                "Skipping singlearch_push_produces_single_manifest: no registry at {REGISTRY} (run: docker run -d -p 5050:5000 registry:2)"
+            );
+            return;
+        }
+
+        let src = tempfile::tempdir().unwrap();
+        let build_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            src.path().join("Dockerfile"),
+            "FROM alpine:latest\nCMD [\"echo\", \"hi\"]\n",
+        )
+        .unwrap();
+
+        // Build a single linux arch into the resource dir.
+        let toolchain = DockerToolchain {
+            dockerfile: None,
+            build_args: None,
+            target: None,
+        };
+        let context = ToolchainContext {
+            src_dir: src.path().to_path_buf(),
+            build_dir: build_dir.path().to_path_buf(),
+            cache_store: None,
+            cache_prefix: "test".to_string(),
+            build_target: BinaryTarget::LinuxArm64,
+            runtime_platform_name: "aws".to_string(),
+            debug_mode: false,
+            is_container: true,
+        };
+        toolchain
+            .build(&context)
+            .await
+            .expect("docker build should succeed");
+        assert!(build_dir.path().join("linux-aarch64.oci.tar").exists());
+
+        let container = Container::new("web".to_string())
+            .code(ContainerCode::Image {
+                image: build_dir.path().to_string_lossy().into_owned(),
+            })
+            .cpu(alien_core::ResourceSpec {
+                min: "0.5".to_string(),
+                desired: "1".to_string(),
+            })
+            .memory(alien_core::ResourceSpec {
+                min: "512Mi".to_string(),
+                desired: "1Gi".to_string(),
+            })
+            .permissions("web".to_string())
+            .build();
+        let stack = Stack::new("singlearch-test".to_string())
+            .add(container, alien_core::ResourceLifecycle::Live)
+            .build();
+
+        let push_settings = PushSettings {
+            repository: format!("{REGISTRY}/alien-singlearch-test"),
+            destination_label: None,
+            options: dockdash::PushOptions {
+                auth: dockdash::RegistryAuth::Anonymous,
+                protocol: dockdash::ClientProtocol::Http,
+                ..Default::default()
+            },
+        };
+
+        let pushed = push_stack(stack, Platform::Aws, &push_settings)
+            .await
+            .expect("push should succeed");
+
+        let image_uri = pushed
+            .resources()
+            .filter_map(|(_, entry)| entry.config.downcast_ref::<Container>())
+            .find_map(|c| match &c.code {
+                ContainerCode::Image { image } => Some(image.clone()),
+                _ => None,
+            })
+            .expect("container should carry a pushed image URI");
+        assert!(
+            image_uri.contains(REGISTRY),
+            "expected a registry URI, got {image_uri}"
+        );
+
+        // The pushed tag must resolve to a plain image manifest, NOT an index: it has a
+        // `config` descriptor and no `manifests` array.
+        let client = OciClient::new(OciClientConfig {
+            protocol: dockdash::ClientProtocol::Http,
+            ..Default::default()
+        });
+        let reference = Reference::try_from(image_uri.as_str()).unwrap();
+        let (bytes, _digest) = client
+            .pull_manifest_raw(
+                &reference,
+                &dockdash::RegistryAuth::Anonymous,
+                &[OCI_IMAGE_MEDIA_TYPE, IMAGE_MANIFEST_MEDIA_TYPE],
+            )
+            .await
+            .expect("should pull a manifest");
+        let value: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("pushed tag should be valid JSON");
+        assert!(
+            value.get("config").is_some(),
+            "single-arch push must produce an image manifest with a config descriptor, got: {value}"
+        );
+        assert!(
+            value.get("manifests").is_none(),
+            "single-arch push must not produce a manifest index, got: {value}"
+        );
+    }
+
+    /// End-to-end seam: build two arches into two separate partial outputs (one per native
+    /// runner), run `merge_build_outputs` to combine them, load the merged stack exactly as
+    /// the release path does (deserialize stack.json), then push — asserting the merged dir
+    /// resolves to a real multi-arch index. This exercises the merge→load→push chain as one
+    /// flow, not as independent halves. Gated on docker + a local registry.
+    #[tokio::test]
+    async fn merge_then_push_produces_manifest_list() {
+        use crate::toolchain::{docker::DockerToolchain, Toolchain, ToolchainContext};
+
+        const REGISTRY: &str = "localhost:5050";
+        if !docker_available() {
+            eprintln!("Skipping merge_then_push_produces_manifest_list: docker not available");
+            return;
+        }
+        if !registry_available(&format!("http://{REGISTRY}")).await {
+            eprintln!(
+                "Skipping merge_then_push_produces_manifest_list: no registry at {REGISTRY} (run: docker run -d -p 5050:5000 registry:2)"
+            );
+            return;
+        }
+
+        let src = tempfile::tempdir().unwrap();
+        let input_root = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        std::fs::write(
+            src.path().join("Dockerfile"),
+            "FROM alpine:latest\nCMD [\"echo\", \"hi\"]\n",
+        )
+        .unwrap();
+
+        // Build each arch into its own partial: <input>/<partial>/build/aws/<dir>/<tarball>,
+        // with a stack.json whose code.image is that partial's absolute artifact dir — the
+        // exact shape a native-runner `alien build --output-dir` upload produces.
+        for (partial, target, dir_name) in [
+            ("arm", BinaryTarget::LinuxArm64, "web-aaaa1111"),
+            ("x64", BinaryTarget::LinuxX64, "web-bbbb2222"),
+        ] {
+            let platform_dir = input_root.path().join(partial).join("build").join("aws");
+            let artifact_dir = platform_dir.join(dir_name);
+            std::fs::create_dir_all(&artifact_dir).unwrap();
+
+            let toolchain = DockerToolchain {
+                dockerfile: None,
+                build_args: None,
+                target: None,
+            };
+            let context = ToolchainContext {
+                src_dir: src.path().to_path_buf(),
+                build_dir: artifact_dir.clone(),
+                cache_store: None,
+                cache_prefix: "test".to_string(),
+                build_target: target,
+                runtime_platform_name: "aws".to_string(),
+                debug_mode: false,
+                is_container: true,
+            };
+            toolchain
+                .build(&context)
+                .await
+                .expect("docker build should succeed");
+
+            let image = artifact_dir
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            let container = Container::new("web".to_string())
+                .code(ContainerCode::Image { image })
+                .cpu(alien_core::ResourceSpec {
+                    min: "0.5".to_string(),
+                    desired: "1".to_string(),
+                })
+                .memory(alien_core::ResourceSpec {
+                    min: "512Mi".to_string(),
+                    desired: "1Gi".to_string(),
+                })
+                .permissions("web".to_string())
+                .build();
+            let stack = Stack::new("merge-push-test".to_string())
+                .add(container, alien_core::ResourceLifecycle::Live)
+                .build();
+            std::fs::write(
+                platform_dir.join("stack.json"),
+                serde_json::to_string_pretty(&stack).unwrap(),
+            )
+            .unwrap();
+        }
+
+        // Merge the two partials into one .alien.
+        let platforms = crate::merge::merge_build_outputs(input_root.path(), out.path())
+            .expect("merge should succeed");
+        assert_eq!(platforms, vec!["aws".to_string()]);
+
+        // Load the merged stack the way the release path does, then push it.
+        let merged_json = std::fs::read_to_string(out.path().join("build/aws/stack.json")).unwrap();
+        let merged_stack: Stack =
+            serde_json::from_str(&merged_json).expect("merged stack.json should deserialize");
+
+        let push_settings = PushSettings {
+            repository: format!("{REGISTRY}/alien-merge-push-test"),
+            destination_label: None,
+            options: dockdash::PushOptions {
+                auth: dockdash::RegistryAuth::Anonymous,
+                protocol: dockdash::ClientProtocol::Http,
+                ..Default::default()
+            },
+        };
+
+        let pushed = push_stack(merged_stack, Platform::Aws, &push_settings)
+            .await
+            .expect("push of the merged stack should succeed");
+
+        let image_uri = pushed
+            .resources()
+            .filter_map(|(_, entry)| entry.config.downcast_ref::<Container>())
+            .find_map(|c| match &c.code {
+                ContainerCode::Image { image } => Some(image.clone()),
+                _ => None,
+            })
+            .expect("container should carry a pushed image URI");
+
+        let client = OciClient::new(OciClientConfig {
+            protocol: dockdash::ClientProtocol::Http,
+            ..Default::default()
+        });
+        let reference = Reference::try_from(image_uri.as_str()).unwrap();
+        let (bytes, _digest) = client
+            .pull_manifest_raw(
+                &reference,
+                &dockdash::RegistryAuth::Anonymous,
+                &[
+                    OCI_IMAGE_INDEX_MEDIA_TYPE,
+                    "application/vnd.docker.distribution.manifest.list.v2+json",
+                ],
+            )
+            .await
+            .expect("should pull a manifest list");
+        let index: OciImageIndex = serde_json::from_slice(&bytes)
+            .expect("merged-then-pushed tag should be an image index");
+        let mut platforms: Vec<(String, String)> = index
+            .manifests
+            .iter()
+            .filter_map(|m| {
+                m.platform
+                    .as_ref()
+                    .map(|p| (p.os.clone(), p.architecture.clone()))
+            })
+            .collect();
+        platforms.sort();
+        assert_eq!(
+            platforms,
+            vec![
+                ("linux".to_string(), "amd64".to_string()),
+                ("linux".to_string(), "arm64".to_string()),
+            ],
+            "merged stack must push as a real multi-arch index"
+        );
     }
 }

--- a/crates/alien-build/src/merge.rs
+++ b/crates/alien-build/src/merge.rs
@@ -1,0 +1,730 @@
+//! Merge partial `.alien-*` build outputs (one per native-runner group) into one
+//! coherent `.alien` directory for a single all-platform release.
+//!
+//! Each native runner builds a subset of platform/target pairs into its own output dir
+//! and uploads it as a CI artifact. The release job downloads them all and runs
+//! `alien build merge` to combine them: per platform, the partials are identical except
+//! for each compute resource's per-target artifact dir, so merge unions those tarballs
+//! into one dir per resource and rewrites the stack to point at it.
+
+use crate::error::{ErrorData, Result};
+use alien_core::{Container, ContainerCode, Daemon, DaemonCode, Stack, Worker, WorkerCode};
+use alien_error::{AlienError, Context, IntoAlienError};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+/// A partial output for one platform: the on-disk `build/<platform>` dir (where the
+/// artifacts actually live after download) and the stack it declared.
+struct PartialPlatform {
+    /// `<input>/<artifact>/build/<platform>` — where this partial's files really are.
+    dir: PathBuf,
+    stack: Stack,
+}
+
+/// Merge every partial build output found under `input_dir` into `output_dir`.
+/// Returns the platforms that were merged. Fails fast on incompatible partials or on a
+/// duplicate target tarball that isn't byte-identical.
+pub fn merge_build_outputs(input_dir: &Path, output_dir: &Path) -> Result<Vec<String>> {
+    let mut by_platform: BTreeMap<String, Vec<PartialPlatform>> = BTreeMap::new();
+
+    for artifact in read_subdirs(input_dir)? {
+        let build_dir = artifact.join("build");
+        if !build_dir.is_dir() {
+            continue;
+        }
+        for platform_dir in read_subdirs(&build_dir)? {
+            let stack_json = platform_dir.join("stack.json");
+            if !stack_json.is_file() {
+                continue;
+            }
+            let platform = platform_dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .ok_or_else(|| {
+                    AlienError::new(ErrorData::BuildConfigInvalid {
+                        message: format!("Invalid platform dir name: {}", platform_dir.display()),
+                    })
+                })?
+                .to_string();
+            let stack = read_stack(&stack_json)?;
+            by_platform
+                .entry(platform)
+                .or_default()
+                .push(PartialPlatform {
+                    dir: platform_dir,
+                    stack,
+                });
+        }
+    }
+
+    if by_platform.is_empty() {
+        return Err(AlienError::new(ErrorData::BuildConfigInvalid {
+            message: format!(
+                "No partial build outputs found under {} (expected <artifact>/build/<platform>/stack.json)",
+                input_dir.display()
+            ),
+        }));
+    }
+
+    let mut merged = Vec::new();
+    for (platform, partials) in &by_platform {
+        merge_platform(platform, partials, output_dir)?;
+        merged.push(platform.clone());
+    }
+    Ok(merged)
+}
+
+fn merge_platform(platform: &str, partials: &[PartialPlatform], output_dir: &Path) -> Result<()> {
+    // All partials for a platform must be the same stack except for image references and
+    // whether each compute resource was built here (`blank_images` erases both — see its
+    // doc). The resource set and the rest of every resource's config must still match, so a
+    // resource present in one partial but absent from another still fails fast below.
+    let reference = blank_images(&partials[0].stack);
+    for partial in &partials[1..] {
+        if blank_images(&partial.stack) != reference {
+            return Err(AlienError::new(ErrorData::BuildConfigInvalid {
+                message: format!(
+                    "Partial stacks for platform '{platform}' are not compatible (they differ in something other than image references). Were they built from the same source?"
+                ),
+            }));
+        }
+    }
+
+    let out_platform_dir = output_dir.join("build").join(platform);
+    create_dir_all(&out_platform_dir)?;
+
+    let mut merged_stack = partials[0].stack.clone();
+    let resource_ids: Vec<String> = merged_stack.resources().map(|(id, _)| id.clone()).collect();
+
+    for resource_id in resource_ids {
+        // A partial's stored `code.image` is the build runner's absolute path, which doesn't
+        // exist here — resolve the artifact dir by joining its basename to the partial's real dir.
+        let mut tarballs: BTreeMap<String, PathBuf> = BTreeMap::new();
+        let mut is_local = false;
+
+        for partial in partials {
+            let Some(image) = compute_image(&partial.stack, &resource_id) else {
+                continue; // not a compute resource
+            };
+            let Some(basename) = Path::new(&image).file_name() else {
+                continue;
+            };
+            let artifact_dir = partial.dir.join(basename);
+            if !artifact_dir.is_dir() {
+                continue; // remote-URI image (no local dir) — leave it untouched
+            }
+            is_local = true;
+            for tar in read_oci_tarballs(&artifact_dir)? {
+                let name = tar
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .expect("read_oci_tarballs returns UTF-8 .oci.tar file names")
+                    .to_string();
+                match tarballs.get(&name) {
+                    Some(existing) if !files_equal(existing, &tar)? => {
+                        return Err(AlienError::new(ErrorData::BuildConfigInvalid {
+                            message: format!(
+                                "Resource '{resource_id}' on platform '{platform}' has two different '{name}' tarballs across partials"
+                            ),
+                        }));
+                    }
+                    Some(_) => {} // byte-identical duplicate — keep the first
+                    None => {
+                        tarballs.insert(name, tar);
+                    }
+                }
+            }
+        }
+
+        if !is_local {
+            continue; // remote-URI or non-compute resource passes through unchanged
+        }
+
+        let short_hash = content_hash(&tarballs)?;
+        let merged_dir = out_platform_dir.join(format!("{resource_id}-{short_hash}"));
+        create_dir_all(&merged_dir)?;
+        for (name, src) in &tarballs {
+            let dest = merged_dir.join(name);
+            std::fs::copy(src, &dest).into_alien_error().context(
+                ErrorData::FileOperationFailed {
+                    operation: "copy".to_string(),
+                    file_path: src.display().to_string(),
+                    reason: format!("Failed to copy tarball into merged dir {}", dest.display()),
+                },
+            )?;
+        }
+        let absolute = merged_dir.canonicalize().into_alien_error().context(
+            ErrorData::FileOperationFailed {
+                operation: "canonicalize".to_string(),
+                file_path: merged_dir.display().to_string(),
+                reason: "Failed to resolve merged artifact dir".to_string(),
+            },
+        )?;
+        set_compute_image(
+            &mut merged_stack,
+            &resource_id,
+            absolute.to_string_lossy().into_owned(),
+        );
+        info!(
+            "Merged {} tarball(s) for resource '{}' on platform '{}'",
+            tarballs.len(),
+            resource_id,
+            platform
+        );
+    }
+
+    let stack_json = serde_json::to_string_pretty(&merged_stack)
+        .into_alien_error()
+        .context(ErrorData::JsonSerializationError {
+            message: "Failed to serialize merged stack.json".to_string(),
+        })?;
+    let stack_path = out_platform_dir.join("stack.json");
+    std::fs::write(&stack_path, stack_json)
+        .into_alien_error()
+        .context(ErrorData::FileOperationFailed {
+            operation: "write".to_string(),
+            file_path: stack_path.display().to_string(),
+            reason: "Failed to write merged stack.json".to_string(),
+        })?;
+    Ok(())
+}
+
+/// Clone a stack with every compute resource forced to `Image{""}`, so two partials can be
+/// compared ignoring both the per-target image reference (expected to differ) and whether
+/// the resource was built here vs skipped (`Image` vs `Source` — a skipped container is left
+/// `Source`; see `set_compute_image`). Everything else must still match for the compat check.
+fn blank_images(stack: &Stack) -> Stack {
+    let mut blanked = stack.clone();
+    let ids: Vec<String> = blanked.resources().map(|(id, _)| id.clone()).collect();
+    for id in ids {
+        set_compute_image(&mut blanked, &id, String::new());
+    }
+    blanked
+}
+
+/// Read a compute resource's `code.image` (Worker, Container, or Daemon), if it is one.
+fn compute_image(stack: &Stack, resource_id: &str) -> Option<String> {
+    let entry = stack.resources().find(|(id, _)| *id == resource_id)?.1;
+    if let Some(worker) = entry.config.downcast_ref::<Worker>() {
+        if let WorkerCode::Image { image } = &worker.code {
+            return Some(image.clone());
+        }
+    } else if let Some(container) = entry.config.downcast_ref::<Container>() {
+        if let ContainerCode::Image { image } = &container.code {
+            return Some(image.clone());
+        }
+    } else if let Some(daemon) = entry.config.downcast_ref::<Daemon>() {
+        if let DaemonCode::Image { image } = &daemon.code {
+            return Some(image.clone());
+        }
+    }
+    None
+}
+
+/// Point a compute resource (Worker, Container, or Daemon) at `image`, converting it to
+/// `Image` code regardless of its current variant. No-op for non-compute resources.
+///
+/// Variant-insensitive on purpose — the write counterpart to the variant-sensitive
+/// [`compute_image`]: a container skipped on a non-Linux runner group is left as `Source`
+/// in that partial. Converting any variant lets [`blank_images`] normalize a `Source` and
+/// an `Image` of the same resource to the same `Image{""}` (the compat check treats "built
+/// here" vs "skipped here" as compatible), and lets the merge write-back stamp the merged
+/// dir even when `partials[0]` is the partial that skipped it.
+fn set_compute_image(stack: &mut Stack, resource_id: &str, image: String) {
+    let Some((_, entry)) = stack.resources_mut().find(|(id, _)| *id == resource_id) else {
+        return;
+    };
+    if let Some(worker) = entry.config.downcast_mut::<Worker>() {
+        worker.code = WorkerCode::Image { image };
+    } else if let Some(container) = entry.config.downcast_mut::<Container>() {
+        container.code = ContainerCode::Image { image };
+    } else if let Some(daemon) = entry.config.downcast_mut::<Daemon>() {
+        daemon.code = DaemonCode::Image { image };
+    }
+}
+
+/// Deterministic content hash (first 8 hex) over a target→path set, sorted by target name.
+fn content_hash(files: &BTreeMap<String, PathBuf>) -> Result<String> {
+    let mut hasher = Sha256::new();
+    for (name, path) in files {
+        hasher.update(name.as_bytes());
+        let bytes =
+            std::fs::read(path)
+                .into_alien_error()
+                .context(ErrorData::FileOperationFailed {
+                    operation: "read".to_string(),
+                    file_path: path.display().to_string(),
+                    reason: "Failed to read tarball for merged hash".to_string(),
+                })?;
+        hasher.update(&bytes);
+    }
+    Ok(format!("{:x}", hasher.finalize())[..8].to_string())
+}
+
+fn files_equal(a: &Path, b: &Path) -> Result<bool> {
+    let read = |p: &Path| {
+        std::fs::read(p)
+            .into_alien_error()
+            .context(ErrorData::FileOperationFailed {
+                operation: "read".to_string(),
+                file_path: p.display().to_string(),
+                reason: "Failed to read tarball for duplicate comparison".to_string(),
+            })
+    };
+    Ok(read(a)? == read(b)?)
+}
+
+fn read_stack(path: &Path) -> Result<Stack> {
+    let content = std::fs::read_to_string(path).into_alien_error().context(
+        ErrorData::FileOperationFailed {
+            operation: "read".to_string(),
+            file_path: path.display().to_string(),
+            reason: "Failed to read partial stack.json".to_string(),
+        },
+    )?;
+    serde_json::from_str(&content)
+        .into_alien_error()
+        .context(ErrorData::JsonSerializationError {
+            message: format!("Failed to parse {}", path.display()),
+        })
+}
+
+fn read_subdirs(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+    let entries =
+        std::fs::read_dir(dir)
+            .into_alien_error()
+            .context(ErrorData::FileOperationFailed {
+                operation: "read directory".to_string(),
+                file_path: dir.display().to_string(),
+                reason: "Failed to list directory".to_string(),
+            })?;
+    for entry in entries {
+        let entry = entry
+            .into_alien_error()
+            .context(ErrorData::FileOperationFailed {
+                operation: "read directory entry".to_string(),
+                file_path: dir.display().to_string(),
+                reason: "Failed to read directory entry".to_string(),
+            })?;
+        if entry.path().is_dir() {
+            dirs.push(entry.path());
+        }
+    }
+    dirs.sort();
+    Ok(dirs)
+}
+
+fn read_oci_tarballs(dir: &Path) -> Result<Vec<PathBuf>> {
+    Ok(read_files(dir)?
+        .into_iter()
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".oci.tar"))
+        })
+        .collect())
+}
+
+fn read_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let entries =
+        std::fs::read_dir(dir)
+            .into_alien_error()
+            .context(ErrorData::FileOperationFailed {
+                operation: "read directory".to_string(),
+                file_path: dir.display().to_string(),
+                reason: "Failed to list artifact dir".to_string(),
+            })?;
+    for entry in entries {
+        let entry = entry
+            .into_alien_error()
+            .context(ErrorData::FileOperationFailed {
+                operation: "read directory entry".to_string(),
+                file_path: dir.display().to_string(),
+                reason: "Failed to read artifact dir entry".to_string(),
+            })?;
+        if entry.path().is_file() {
+            files.push(entry.path());
+        }
+    }
+    Ok(files)
+}
+
+fn create_dir_all(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .into_alien_error()
+        .context(ErrorData::FileOperationFailed {
+            operation: "create directory".to_string(),
+            file_path: dir.display().to_string(),
+            reason: "Failed to create output directory".to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_core::{Container, ResourceLifecycle, ResourceSpec, ToolchainConfig};
+    use tempfile::tempdir;
+
+    fn container(name: &str, image: &str) -> Container {
+        Container::new(name.to_string())
+            .code(ContainerCode::Image {
+                image: image.to_string(),
+            })
+            .cpu(ResourceSpec {
+                min: "0.5".to_string(),
+                desired: "1".to_string(),
+            })
+            .memory(ResourceSpec {
+                min: "512Mi".to_string(),
+                desired: "1Gi".to_string(),
+            })
+            .permissions("web".to_string())
+            .build()
+    }
+
+    /// Same container as `container`, but still `Source` — mirrors what `build_stack` leaves
+    /// for a container skipped on a non-Linux runner group (config identical, code unbuilt).
+    fn container_source(name: &str) -> Container {
+        Container::new(name.to_string())
+            .code(ContainerCode::Source {
+                src: ".".to_string(),
+                toolchain: ToolchainConfig::Docker {
+                    dockerfile: None,
+                    build_args: None,
+                    target: None,
+                },
+            })
+            .cpu(ResourceSpec {
+                min: "0.5".to_string(),
+                desired: "1".to_string(),
+            })
+            .memory(ResourceSpec {
+                min: "512Mi".to_string(),
+                desired: "1Gi".to_string(),
+            })
+            .permissions("web".to_string())
+            .build()
+    }
+
+    fn stack_with(resource: &str, image: &str) -> Stack {
+        Stack::new("merge-test".to_string())
+            .add(container(resource, image), ResourceLifecycle::Live)
+            .build()
+    }
+
+    /// Write `<root>/<partial>/build/<platform>/{stack.json, <dir_name>/<tarballs>}` with the
+    /// stack's `code.image` pointing at the (absolute) artifact dir, mimicking a real partial.
+    fn write_partial(
+        root: &Path,
+        partial: &str,
+        platform: &str,
+        resource: &str,
+        dir_name: &str,
+        tarballs: &[(&str, &[u8])],
+    ) {
+        let platform_dir = root.join(partial).join("build").join(platform);
+        let image: String = if tarballs.is_empty() {
+            // remote-URI resource (no local dir)
+            dir_name.to_string()
+        } else {
+            let artifact_dir = platform_dir.join(dir_name);
+            std::fs::create_dir_all(&artifact_dir).unwrap();
+            for (name, bytes) in tarballs {
+                std::fs::write(artifact_dir.join(name), bytes).unwrap();
+            }
+            artifact_dir
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        };
+        std::fs::create_dir_all(&platform_dir).unwrap();
+        let stack = stack_with(resource, &image);
+        std::fs::write(
+            platform_dir.join("stack.json"),
+            serde_json::to_string_pretty(&stack).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn worker_image(name: &str, image: &str) -> Worker {
+        Worker::new(name.to_string())
+            .permissions("api".to_string())
+            .code(WorkerCode::Image {
+                image: image.to_string(),
+            })
+            .build()
+    }
+
+    /// Write a `local` partial for the mixed-stack test: a Worker `api` (always built, one
+    /// `tarball`) plus a Container `web` that is either built (`web_tarball`, a Linux group)
+    /// or skipped (`None`, a macOS/Windows group → left `Source`, no artifact dir).
+    fn write_mixed_partial(
+        root: &Path,
+        partial: &str,
+        api_tarball: &str,
+        web_tarball: Option<&str>,
+    ) {
+        let platform_dir = root.join(partial).join("build").join("local");
+        std::fs::create_dir_all(&platform_dir).unwrap();
+
+        let built_dir = |resource: &str, tarball: &str| -> String {
+            let dir = platform_dir.join(format!("{resource}-{partial}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(tarball), tarball.as_bytes()).unwrap();
+            dir.canonicalize().unwrap().to_string_lossy().into_owned()
+        };
+
+        let api = worker_image("api", &built_dir("api", api_tarball));
+        let web = match web_tarball {
+            Some(tarball) => container("web", &built_dir("web", tarball)),
+            None => container_source("web"),
+        };
+        // Same insertion order in every partial so the compat check sees one resource set.
+        let stack = Stack::new("merge-test".to_string())
+            .add(api, ResourceLifecycle::Live)
+            .add(web, ResourceLifecycle::Live)
+            .build();
+        std::fs::write(
+            platform_dir.join("stack.json"),
+            serde_json::to_string_pretty(&stack).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn merges_mixed_stack_with_container_skipped_on_host_groups() {
+        // The real scenario: a Worker `api` builds on all 4 native-runner groups; the Container
+        // `web` builds only on the two Linux groups and is skipped (left `Source`) on the macOS
+        // and Windows groups. Merge must union each resource over the partials that built it —
+        // `api` gets all 4 targets, `web` only the 2 Linux ones — independently.
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        write_mixed_partial(
+            root.path(),
+            "arm",
+            "linux-aarch64.oci.tar",
+            Some("linux-aarch64.oci.tar"),
+        );
+        write_mixed_partial(
+            root.path(),
+            "x64",
+            "linux-x64.oci.tar",
+            Some("linux-x64.oci.tar"),
+        );
+        write_mixed_partial(root.path(), "darwin", "darwin-aarch64.oci.tar", None);
+        write_mixed_partial(root.path(), "windows", "windows-x64.oci.tar", None);
+
+        let platforms = merge_build_outputs(root.path(), out.path()).unwrap();
+        assert_eq!(platforms, vec!["local".to_string()]);
+        let merged: Stack = read_stack(&out.path().join("build/local/stack.json")).unwrap();
+
+        let api_dir =
+            PathBuf::from(compute_image(&merged, "api").expect("api should be an Image dir"));
+        for tar in [
+            "linux-aarch64",
+            "linux-x64",
+            "darwin-aarch64",
+            "windows-x64",
+        ] {
+            assert!(
+                api_dir.join(format!("{tar}.oci.tar")).exists(),
+                "api missing {tar}"
+            );
+        }
+
+        let web_dir =
+            PathBuf::from(compute_image(&merged, "web").expect("web should be an Image dir"));
+        assert!(web_dir.join("linux-aarch64.oci.tar").exists());
+        assert!(web_dir.join("linux-x64.oci.tar").exists());
+        // The macOS/Windows groups skipped the container, so it has no host-binary tarballs.
+        assert!(!web_dir.join("darwin-aarch64.oci.tar").exists());
+        assert!(!web_dir.join("windows-x64.oci.tar").exists());
+    }
+
+    #[test]
+    fn merges_daemon_artifact_dirs_across_partials() {
+        // A daemon's per-target artifact dirs from two runner groups union into one dir.
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        let write_daemon_partial = |partial: &str, dir_name: &str, tarball: &str| {
+            let platform_dir = root.path().join(partial).join("build").join("local");
+            let artifact_dir = platform_dir.join(dir_name);
+            std::fs::create_dir_all(&artifact_dir).unwrap();
+            std::fs::write(artifact_dir.join(tarball), tarball.as_bytes()).unwrap();
+            let image = artifact_dir
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            let daemon = Daemon::new("agent".to_string())
+                .permissions("execution".to_string())
+                .code(DaemonCode::Image { image })
+                .build();
+            let stack = Stack::new("merge-test".to_string())
+                .add(daemon, ResourceLifecycle::Live)
+                .build();
+            std::fs::write(
+                platform_dir.join("stack.json"),
+                serde_json::to_string_pretty(&stack).unwrap(),
+            )
+            .unwrap();
+        };
+        write_daemon_partial("arm", "agent-aaaa1111", "darwin-aarch64.oci.tar");
+        write_daemon_partial("x64", "agent-bbbb2222", "linux-x64.oci.tar");
+
+        let platforms = merge_build_outputs(root.path(), out.path()).unwrap();
+        assert_eq!(platforms, vec!["local".to_string()]);
+
+        let merged: Stack = read_stack(&out.path().join("build/local/stack.json")).unwrap();
+        let image = compute_image(&merged, "agent").expect("agent should have a merged image dir");
+        let merged_dir = PathBuf::from(&image);
+        assert!(merged_dir.join("darwin-aarch64.oci.tar").exists());
+        assert!(merged_dir.join("linux-x64.oci.tar").exists());
+    }
+
+    #[test]
+    fn merges_two_arches_into_one_dir() {
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        write_partial(
+            root.path(),
+            "arm",
+            "kubernetes",
+            "web",
+            "web-aaaa1111",
+            &[("linux-aarch64.oci.tar", b"arm")],
+        );
+        write_partial(
+            root.path(),
+            "x64",
+            "kubernetes",
+            "web",
+            "web-bbbb2222",
+            &[("linux-x64.oci.tar", b"x64")],
+        );
+
+        let platforms = merge_build_outputs(root.path(), out.path()).unwrap();
+        assert_eq!(platforms, vec!["kubernetes".to_string()]);
+
+        let merged: Stack = read_stack(&out.path().join("build/kubernetes/stack.json")).unwrap();
+        let image = compute_image(&merged, "web").expect("web should still have an image dir");
+        let merged_dir = PathBuf::from(&image);
+        assert!(
+            merged_dir.is_dir(),
+            "merged image dir should exist: {image}"
+        );
+        assert!(merged_dir.join("linux-aarch64.oci.tar").exists());
+        assert!(merged_dir.join("linux-x64.oci.tar").exists());
+    }
+
+    #[test]
+    fn rejects_conflicting_duplicate_tarball() {
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        write_partial(
+            root.path(),
+            "a",
+            "aws",
+            "web",
+            "web-aaaa1111",
+            &[("linux-aarch64.oci.tar", b"one")],
+        );
+        write_partial(
+            root.path(),
+            "b",
+            "aws",
+            "web",
+            "web-bbbb2222",
+            &[("linux-aarch64.oci.tar", b"two")],
+        );
+        assert!(merge_build_outputs(root.path(), out.path()).is_err());
+    }
+
+    #[test]
+    fn accepts_byte_identical_duplicate() {
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        write_partial(
+            root.path(),
+            "a",
+            "aws",
+            "web",
+            "web-aaaa1111",
+            &[("linux-aarch64.oci.tar", b"same")],
+        );
+        write_partial(
+            root.path(),
+            "b",
+            "aws",
+            "web",
+            "web-bbbb2222",
+            &[("linux-aarch64.oci.tar", b"same")],
+        );
+        assert_eq!(
+            merge_build_outputs(root.path(), out.path()).unwrap(),
+            vec!["aws".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_incompatible_stacks() {
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        // Different resource sets across partials → not compatible.
+        write_partial(
+            root.path(),
+            "a",
+            "aws",
+            "web",
+            "web-aaaa1111",
+            &[("linux-aarch64.oci.tar", b"x")],
+        );
+        write_partial(
+            root.path(),
+            "b",
+            "aws",
+            "api",
+            "api-bbbb2222",
+            &[("linux-x64.oci.tar", b"y")],
+        );
+        assert!(merge_build_outputs(root.path(), out.path()).is_err());
+    }
+
+    #[test]
+    fn passes_through_remote_uri_resources() {
+        let root = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        // No tarballs → the stack's image is a remote URI with no local dir.
+        write_partial(
+            root.path(),
+            "a",
+            "aws",
+            "web",
+            "registry.example.com/web:tag",
+            &[],
+        );
+        write_partial(
+            root.path(),
+            "b",
+            "aws",
+            "web",
+            "registry.example.com/web:tag",
+            &[],
+        );
+
+        assert_eq!(
+            merge_build_outputs(root.path(), out.path()).unwrap(),
+            vec!["aws".to_string()]
+        );
+        let merged: Stack = read_stack(&out.path().join("build/aws/stack.json")).unwrap();
+        assert_eq!(
+            compute_image(&merged, "web").as_deref(),
+            Some("registry.example.com/web:tag")
+        );
+    }
+}

--- a/crates/alien-build/src/plan.rs
+++ b/crates/alien-build/src/plan.rs
@@ -1,0 +1,316 @@
+//! Build planning for native-runner CI.
+//!
+//! Derives the build targets each supported platform needs and groups them by the native
+//! GitHub runner that can build them, so the generated workflow builds on native runners
+//! (no emulation) and uses the fewest runners.
+
+use alien_core::{
+    BinaryTarget, Daemon, DaemonCode, Platform, Stack, ToolchainConfig, Worker, WorkerCode,
+};
+use serde::Serialize;
+
+/// One platform/target pair to build within a runner group.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildJob {
+    /// Platform id (e.g. "aws").
+    pub platform: String,
+    /// `alien build --targets` name (e.g. "linux-arm64").
+    pub target: String,
+}
+
+/// Builds that share one native runner.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunnerGroup {
+    /// Group name — the target name, also the output-dir suffix.
+    pub name: String,
+    /// GitHub runner label.
+    pub runner: String,
+    /// The platforms this group builds for, in `builds` order. A convenience for the
+    /// generated workflow: it can run `alien build --platforms <a,b,c> --targets <name>`
+    /// directly, without re-deriving the list from `builds`.
+    pub platforms: Vec<String>,
+    /// The platform/target pairs this runner builds.
+    pub builds: Vec<BuildJob>,
+}
+
+/// Build targets a platform needs in a *release* (distribution) plan. Same as
+/// `defaults_for_platform`, except `local`: it always needs both linux arches, plus the
+/// darwin/windows host targets when the stack has a native-host-binary resource — see
+/// [`stack_targets_native_host_binaries`].
+fn release_targets_for_platform(
+    platform: Platform,
+    local_includes_host_binaries: bool,
+) -> Vec<BinaryTarget> {
+    match platform {
+        Platform::Local if local_includes_host_binaries => vec![
+            BinaryTarget::LinuxArm64,
+            BinaryTarget::LinuxX64,
+            BinaryTarget::DarwinArm64,
+            BinaryTarget::WindowsX64,
+        ],
+        Platform::Local => vec![BinaryTarget::LinuxArm64, BinaryTarget::LinuxX64],
+        other => BinaryTarget::defaults_for_platform(other),
+    }
+}
+
+/// True when the stack has a compute resource that builds to a native host binary — a
+/// Worker or Daemon built from Rust or TypeScript source. On `local` those run as native
+/// processes, so a distributable build needs a per-OS binary (darwin/windows as well as
+/// linux). Containers, prebuilt images, and Docker-toolchain workers are linux-only images
+/// even on `local`, so a stack with only those needs just the two linux targets.
+pub fn stack_targets_native_host_binaries(stack: &Stack) -> bool {
+    stack.resources().any(|(_, entry)| {
+        let toolchain = if let Some(worker) = entry.config.downcast_ref::<Worker>() {
+            match &worker.code {
+                WorkerCode::Source { toolchain, .. } => Some(toolchain),
+                WorkerCode::Image { .. } => None,
+            }
+        } else if let Some(daemon) = entry.config.downcast_ref::<Daemon>() {
+            match &daemon.code {
+                DaemonCode::Source { toolchain, .. } => Some(toolchain),
+                DaemonCode::Image { .. } => None,
+            }
+        } else {
+            None
+        };
+        matches!(
+            toolchain,
+            Some(ToolchainConfig::Rust { .. } | ToolchainConfig::TypeScript { .. })
+        )
+    })
+}
+
+/// The `alien build --targets` name for a target (also the group name / output-dir suffix).
+fn target_name(target: BinaryTarget) -> &'static str {
+    match target {
+        BinaryTarget::LinuxArm64 => "linux-arm64",
+        BinaryTarget::LinuxX64 => "linux-x64",
+        BinaryTarget::DarwinArm64 => "darwin-arm64",
+        BinaryTarget::WindowsX64 => "windows-x64",
+    }
+}
+
+/// Native GitHub runner that can build a target without emulation.
+fn runner_for(target: BinaryTarget) -> &'static str {
+    match target {
+        BinaryTarget::LinuxArm64 => "ubuntu-24.04-arm",
+        BinaryTarget::LinuxX64 => "ubuntu-24.04",
+        BinaryTarget::DarwinArm64 => "macos-latest",
+        BinaryTarget::WindowsX64 => "windows-latest",
+    }
+}
+
+/// Group the build work for `supported` platforms by native runner — one group per target
+/// any platform needs. arm64 is listed before amd64 so it's preferred where a platform allows
+/// either (cheaper); amd64 still gets its own group when a platform requires it.
+///
+/// `local_includes_host_binaries` is [`stack_targets_native_host_binaries`] for the stack:
+/// when false (e.g. a Container-only stack), `local` contributes only the two linux targets,
+/// so no macOS/Windows runner group is created for builds that would just be linux images.
+pub fn plan_runner_groups(
+    supported: &[Platform],
+    local_includes_host_binaries: bool,
+) -> Vec<RunnerGroup> {
+    const ORDER: [BinaryTarget; 4] = [
+        BinaryTarget::LinuxArm64,
+        BinaryTarget::LinuxX64,
+        BinaryTarget::DarwinArm64,
+        BinaryTarget::WindowsX64,
+    ];
+    ORDER
+        .iter()
+        .filter_map(|&target| {
+            let builds: Vec<BuildJob> = supported
+                .iter()
+                .filter(|p| {
+                    release_targets_for_platform(**p, local_includes_host_binaries)
+                        .contains(&target)
+                })
+                .map(|p| BuildJob {
+                    platform: p.as_str().to_string(),
+                    target: target_name(target).to_string(),
+                })
+                .collect();
+            (!builds.is_empty()).then(|| RunnerGroup {
+                name: target_name(target).to_string(),
+                runner: runner_for(target).to_string(),
+                platforms: builds.iter().map(|b| b.platform.clone()).collect(),
+                builds,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_core::Platform::*;
+    use alien_core::{Container, ContainerCode, ResourceLifecycle, ResourceSpec};
+
+    fn platforms(group: &RunnerGroup) -> Vec<&str> {
+        assert_eq!(
+            group.platforms,
+            group
+                .builds
+                .iter()
+                .map(|b| b.platform.clone())
+                .collect::<Vec<_>>(),
+            "platforms field must mirror builds order"
+        );
+        group.platforms.iter().map(|s| s.as_str()).collect()
+    }
+
+    #[test]
+    fn local_with_host_binaries_groups_every_native_runner() {
+        let groups = plan_runner_groups(&[Aws, Gcp, Azure, Kubernetes, Local], true);
+
+        assert_eq!(
+            groups.iter().map(|g| g.name.as_str()).collect::<Vec<_>>(),
+            vec!["linux-arm64", "linux-x64", "darwin-arm64", "windows-x64"]
+        );
+
+        assert_eq!(groups[0].runner, "ubuntu-24.04-arm");
+        assert_eq!(platforms(&groups[0]), vec!["aws", "kubernetes", "local"]);
+
+        assert_eq!(groups[1].runner, "ubuntu-24.04");
+        assert_eq!(
+            platforms(&groups[1]),
+            vec!["gcp", "azure", "kubernetes", "local"]
+        );
+
+        assert_eq!(groups[2].runner, "macos-latest");
+        assert_eq!(platforms(&groups[2]), vec!["local"]);
+
+        assert_eq!(groups[3].runner, "windows-latest");
+        assert_eq!(platforms(&groups[3]), vec!["local"]);
+    }
+
+    #[test]
+    fn local_without_host_binaries_is_linux_only() {
+        // A Container-only local stack: no native host binary, so no macOS/Windows runner —
+        // those builds would just be linux images and collide on merge.
+        let groups = plan_runner_groups(&[Aws, Gcp, Azure, Kubernetes, Local], false);
+        assert_eq!(
+            groups.iter().map(|g| g.name.as_str()).collect::<Vec<_>>(),
+            vec!["linux-arm64", "linux-x64"]
+        );
+        assert_eq!(platforms(&groups[0]), vec!["aws", "kubernetes", "local"]);
+        assert_eq!(
+            platforms(&groups[1]),
+            vec!["gcp", "azure", "kubernetes", "local"]
+        );
+    }
+
+    #[test]
+    fn no_local_is_two_linux_groups() {
+        let groups = plan_runner_groups(&[Aws, Gcp], false);
+        assert_eq!(
+            groups.iter().map(|g| g.name.as_str()).collect::<Vec<_>>(),
+            vec!["linux-arm64", "linux-x64"]
+        );
+        assert_eq!(platforms(&groups[0]), vec!["aws"]);
+        assert_eq!(platforms(&groups[1]), vec!["gcp"]);
+    }
+
+    #[test]
+    fn each_build_job_carries_platform_and_target() {
+        let groups = plan_runner_groups(&[Aws], false);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(
+            groups[0].builds,
+            vec![BuildJob {
+                platform: "aws".into(),
+                target: "linux-arm64".into()
+            }]
+        );
+    }
+
+    fn worker_with(code: WorkerCode) -> Worker {
+        Worker::new("api".to_string())
+            .permissions("api".to_string())
+            .code(code)
+            .build()
+    }
+
+    fn rust_source() -> WorkerCode {
+        WorkerCode::Source {
+            src: ".".to_string(),
+            toolchain: ToolchainConfig::Rust {
+                binary_name: "api".to_string(),
+            },
+        }
+    }
+
+    fn stack_with<T: alien_core::ResourceDefinition>(resource: T) -> Stack {
+        Stack::new("plan-test".to_string())
+            .add(resource, ResourceLifecycle::Live)
+            .build()
+    }
+
+    fn container() -> Container {
+        Container::new("web".to_string())
+            .code(ContainerCode::Image {
+                image: "ghcr.io/x/web:latest".to_string(),
+            })
+            .cpu(ResourceSpec {
+                min: "0.5".to_string(),
+                desired: "1".to_string(),
+            })
+            .memory(ResourceSpec {
+                min: "512Mi".to_string(),
+                desired: "1Gi".to_string(),
+            })
+            .permissions("web".to_string())
+            .build()
+    }
+
+    #[test]
+    fn predicate_true_for_source_built_worker_or_daemon() {
+        assert!(stack_targets_native_host_binaries(&stack_with(
+            worker_with(rust_source())
+        )));
+        assert!(stack_targets_native_host_binaries(&stack_with(
+            worker_with(WorkerCode::Source {
+                src: ".".to_string(),
+                toolchain: ToolchainConfig::TypeScript { binary_name: None },
+            })
+        )));
+        let daemon = Daemon::new("agent".to_string())
+            .permissions("agent".to_string())
+            .code(DaemonCode::Source {
+                src: ".".to_string(),
+                toolchain: ToolchainConfig::Rust {
+                    binary_name: "agent".to_string(),
+                },
+            })
+            .build();
+        assert!(stack_targets_native_host_binaries(&stack_with(daemon)));
+    }
+
+    #[test]
+    fn predicate_false_for_containers_and_images() {
+        // Container → Docker (linux) image even on local.
+        assert!(!stack_targets_native_host_binaries(
+            &stack_with(container())
+        ));
+        // Prebuilt-image worker → linux image, not a host binary.
+        assert!(!stack_targets_native_host_binaries(&stack_with(
+            worker_with(WorkerCode::Image {
+                image: "ghcr.io/x/api:latest".to_string(),
+            })
+        )));
+        // Docker-toolchain worker → linux image, not a host binary.
+        assert!(!stack_targets_native_host_binaries(&stack_with(
+            worker_with(WorkerCode::Source {
+                src: ".".to_string(),
+                toolchain: ToolchainConfig::Docker {
+                    dockerfile: None,
+                    build_args: None,
+                    target: None
+                },
+            })
+        )));
+    }
+}

--- a/crates/alien-build/src/toolchain/docker.rs
+++ b/crates/alien-build/src/toolchain/docker.rs
@@ -5,7 +5,10 @@ use crate::settings::BinaryTargetExt;
 use alien_core::AlienEvent;
 use alien_error::{AlienError, Context, IntoAlienError};
 use async_trait::async_trait;
+use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 use std::process::Stdio;
 use tokio::process::Command;
@@ -63,6 +66,76 @@ impl DockerToolchain {
         }
         .to_string()
     }
+
+    /// `ImageBuildFailed` for a docker setup step (no captured build output).
+    fn docker_build_error(reason: impl Into<String>) -> ErrorData {
+        ErrorData::ImageBuildFailed {
+            resource_name: "docker-build".to_string(),
+            reason: reason.into(),
+            build_output: None,
+        }
+    }
+
+    /// std reports x86_64/aarch64; docker wants amd64/arm64 — map the host CPU.
+    fn host_docker_arch() -> Option<&'static str> {
+        match std::env::consts::ARCH {
+            "x86_64" => Some("amd64"),
+            "aarch64" => Some("arm64"),
+            _ => None,
+        }
+    }
+
+    /// Whether the builder's `Platforms:` line lists `linux/<arch>`. A substring
+    /// match is safe for our amd64/arm64 targets.
+    fn inspect_reports_platform(inspect_stdout: &str, target_arch: &str) -> bool {
+        let needle = format!("linux/{}", target_arch);
+        inspect_stdout
+            .lines()
+            .filter(|line| line.trim_start().starts_with("Platforms:"))
+            .any(|line| line.contains(&needle))
+    }
+
+    /// Whether the active builder already supports `target_arch` (the default `docker` builder
+    /// reflects the kernel's binfmt handlers). A failed inspect counts as "no".
+    async fn host_can_emulate(target_arch: &str) -> Result<bool> {
+        let output = Command::new("docker")
+            .args(["buildx", "inspect", "default"])
+            .output()
+            .await
+            .into_alien_error()
+            .context(Self::docker_build_error(
+                "Could not inspect the default buildx builder",
+            ))?;
+        if !output.status.success() {
+            return Ok(false);
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(Self::inspect_reports_platform(&stdout, target_arch))
+    }
+
+    /// Whether the build is blocked: a non-native target the active builder can't build.
+    /// Pure, so the decision is unit-tested without docker.
+    fn build_blocked(host_arch: Option<&str>, target_arch: &str, builder_supports: bool) -> bool {
+        host_arch != Some(target_arch) && !builder_supports
+    }
+
+    /// Fail fast when the active builder can't build `target_arch`. We don't set up emulation
+    /// here — that's the CI runner's job; a native target, or one the builder already supports,
+    /// passes through.
+    async fn ensure_builder_supports_arch(target_arch: &str) -> Result<()> {
+        let host_arch = Self::host_docker_arch();
+        if host_arch == Some(target_arch) {
+            return Ok(());
+        }
+        let builder_supports = Self::host_can_emulate(target_arch).await?;
+        if Self::build_blocked(host_arch, target_arch, builder_supports) {
+            return Err(AlienError::new(Self::docker_build_error(format!(
+                "Cannot build linux/{t} on this host: the active buildx builder doesn't support that architecture. Build on a native {t} runner, or configure a buildx builder with emulation for it.",
+                t = target_arch
+            ))));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -95,12 +168,14 @@ impl Toolchain for DockerToolchain {
         };
         let platform_str = format!("linux/{}", arch_str);
 
-        let mut args = vec![
+        Self::ensure_builder_supports_arch(arch_str).await?;
+
+        let mut args: Vec<&str> = vec![
             "buildx",
             "build",
             "--platform",
-            &platform_str,
-            "--load", // Load image into Docker daemon so we can export it
+            platform_str.as_str(),
+            "--load", // export into the docker daemon so we can `docker save` it
             "-f",
             dockerfile_name,
         ];
@@ -226,6 +301,9 @@ impl Toolchain for DockerToolchain {
 
         info!("Successfully exported Docker image to OCI tarball");
 
+        // Flatten the saved archive to a single image manifest before the OCI reader sees it.
+        Self::normalize_oci_archive(&output_tarball, arch_str)?;
+
         // Clean up the temporary image
         let _ = Command::new("docker")
             .args(&["rmi", &temp_tag])
@@ -279,6 +357,246 @@ impl DockerToolchain {
         // If no CMD, return empty vec (container will fail with "no command specified")
         Ok(metadata.cmd.unwrap_or_default())
     }
+
+    /// Rewrite an OCI archive's `index.json` to point straight at the single image manifest
+    /// for `target_arch`.
+    ///
+    /// The containerd image store's `docker save` writes a nested `index.json` → image-index →
+    /// [image manifest, attestation]; our reader (ocipkg, via dockdash) treats the first
+    /// descriptor as an image manifest and fails with "missing field `config`". The classic
+    /// store already writes a flat layout, so this is a no-op there.
+    pub(crate) fn normalize_oci_archive(tarball_path: &Path, target_arch: &str) -> Result<()> {
+        // Buffer the small JSON entries (index + manifests); layer blobs are large and not
+        // needed to resolve the descriptor, so skip reading their bodies.
+        const SMALL_BLOB_BYTES: u64 = 1 << 20;
+        let mut index: Option<Value> = None;
+        let mut blobs: HashMap<String, Value> = HashMap::new();
+
+        let archive_file =
+            File::open(tarball_path)
+                .into_alien_error()
+                .context(docker_read_error(
+                    "Failed to open OCI tarball for normalization",
+                ))?;
+        let mut archive = tar::Archive::new(archive_file);
+        for entry in archive
+            .entries()
+            .into_alien_error()
+            .context(docker_read_error("Failed to read OCI tarball entries"))?
+        {
+            let mut entry = entry
+                .into_alien_error()
+                .context(docker_read_error("Failed to read OCI tarball entry"))?;
+            let path = entry
+                .path()
+                .into_alien_error()
+                .context(docker_read_error("Failed to read OCI tarball entry path"))?
+                .to_string_lossy()
+                .into_owned();
+
+            if path == "index.json" {
+                index = Some(read_entry_json(&mut entry)?);
+            } else if path.starts_with("blobs/") && entry.size() <= SMALL_BLOB_BYTES {
+                // Only descriptors are stored by digest; key small blobs by "sha256:<hex>".
+                if let Some(digest) = blob_path_to_digest(&path) {
+                    if let Ok(value) = read_entry_json(&mut entry) {
+                        blobs.insert(digest, value);
+                    }
+                }
+            }
+        }
+
+        // No index.json means `docker save` produced something unusable — fail here with a
+        // precise message instead of letting it surface as an opaque read error downstream.
+        let index = index.ok_or_else(|| {
+            AlienError::new(docker_read_error("OCI tarball is missing index.json"))
+        })?;
+
+        let chosen = select_image_manifest_descriptor(&index, &blobs, target_arch)?;
+        if index_points_only_at(&index, &chosen) {
+            return Ok(());
+        }
+
+        let flat_index = json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [chosen],
+        });
+        let flat_index_bytes =
+            serde_json::to_vec(&flat_index)
+                .into_alien_error()
+                .context(docker_read_error(
+                    "Failed to serialize flattened index.json",
+                ))?;
+
+        rewrite_archive_index_json(tarball_path, &flat_index_bytes)
+    }
+}
+
+/// Build the read-side error variant used while normalizing the OCI archive.
+fn docker_read_error(reason: &str) -> ErrorData {
+    ErrorData::ImageBuildFailed {
+        resource_name: "docker-build".to_string(),
+        reason: reason.to_string(),
+        build_output: None,
+    }
+}
+
+/// Parse `blobs/sha256/<hex>` into the descriptor digest `sha256:<hex>`.
+fn blob_path_to_digest(path: &str) -> Option<String> {
+    let rest = path.strip_prefix("blobs/")?;
+    let (algorithm, hex) = rest.split_once('/')?;
+    Some(format!("{algorithm}:{hex}"))
+}
+
+fn read_entry_json<R: Read>(entry: &mut R) -> Result<Value> {
+    let mut buf = Vec::new();
+    entry
+        .read_to_end(&mut buf)
+        .into_alien_error()
+        .context(docker_read_error("Failed to read OCI tarball entry body"))?;
+    serde_json::from_slice(&buf)
+        .into_alien_error()
+        .context(docker_read_error("Failed to parse OCI JSON entry"))
+}
+
+fn is_index_media_type(media_type: &str) -> bool {
+    media_type == "application/vnd.oci.image.index.v1+json"
+        || media_type == "application/vnd.docker.distribution.manifest.list.v2+json"
+}
+
+fn is_manifest_media_type(media_type: &str) -> bool {
+    media_type == "application/vnd.oci.image.manifest.v1+json"
+        || media_type == "application/vnd.docker.distribution.manifest.v2+json"
+}
+
+fn descriptor_architecture(descriptor: &Value) -> Option<&str> {
+    descriptor
+        .get("platform")
+        .and_then(|p| p.get("architecture"))
+        .and_then(|a| a.as_str())
+}
+
+/// Walk an index's descriptors (following nested indexes) and collect the real image
+/// manifests, skipping attestation manifests (platform `unknown/unknown`).
+fn collect_image_manifests(
+    manifests: Option<&Value>,
+    blobs: &HashMap<String, Value>,
+    out: &mut Vec<Value>,
+) {
+    let Some(descriptors) = manifests.and_then(|m| m.as_array()) else {
+        return;
+    };
+    for descriptor in descriptors {
+        let media_type = descriptor
+            .get("mediaType")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+        if is_index_media_type(media_type) {
+            if let Some(nested) = descriptor
+                .get("digest")
+                .and_then(|d| d.as_str())
+                .and_then(|d| blobs.get(d))
+            {
+                collect_image_manifests(nested.get("manifests"), blobs, out);
+            }
+        } else if is_manifest_media_type(media_type)
+            && descriptor_architecture(descriptor) != Some("unknown")
+        {
+            out.push(descriptor.clone());
+        }
+    }
+}
+
+/// Resolve the one image-manifest descriptor to keep: the one matching `target_arch`, or
+/// the only candidate when architecture isn't recorded. Fails when none can be found.
+fn select_image_manifest_descriptor(
+    index: &Value,
+    blobs: &HashMap<String, Value>,
+    target_arch: &str,
+) -> Result<Value> {
+    let mut candidates = Vec::new();
+    collect_image_manifests(index.get("manifests"), blobs, &mut candidates);
+
+    if let Some(descriptor) = candidates
+        .iter()
+        .find(|d| descriptor_architecture(d) == Some(target_arch))
+    {
+        return Ok(descriptor.clone());
+    }
+    if let [only] = candidates.as_slice() {
+        return Ok(only.clone());
+    }
+    Err(AlienError::new(docker_read_error(&format!(
+        "OCI archive has no image manifest for architecture '{target_arch}'"
+    ))))
+}
+
+/// Whether `index.json` already contains exactly the chosen descriptor (classic store).
+fn index_points_only_at(index: &Value, chosen: &Value) -> bool {
+    index
+        .get("manifests")
+        .and_then(|m| m.as_array())
+        .is_some_and(|m| m.len() == 1 && m[0].get("digest") == chosen.get("digest"))
+}
+
+/// Stream the archive into a sibling temp file, replacing only `index.json`, then swap it
+/// in. Other entries (blobs, oci-layout) are copied verbatim.
+fn rewrite_archive_index_json(tarball_path: &Path, new_index: &[u8]) -> Result<()> {
+    let temp_path = tarball_path.with_extension("tar.normalizing");
+
+    {
+        let source = File::open(tarball_path)
+            .into_alien_error()
+            .context(docker_read_error("Failed to open OCI tarball for rewrite"))?;
+        let dest = File::create(&temp_path)
+            .into_alien_error()
+            .context(docker_read_error("Failed to create normalized OCI tarball"))?;
+        let mut archive = tar::Archive::new(source);
+        let mut builder = tar::Builder::new(dest);
+
+        for entry in archive
+            .entries()
+            .into_alien_error()
+            .context(docker_read_error("Failed to read OCI tarball entries"))?
+        {
+            let mut entry = entry
+                .into_alien_error()
+                .context(docker_read_error("Failed to read OCI tarball entry"))?;
+            let path = entry
+                .path()
+                .into_alien_error()
+                .context(docker_read_error("Failed to read OCI tarball entry path"))?
+                .into_owned();
+            let mut header = entry.header().clone();
+
+            if path == Path::new("index.json") {
+                header.set_size(new_index.len() as u64);
+                builder
+                    .append_data(&mut header, &path, new_index)
+                    .into_alien_error()
+                    .context(docker_read_error("Failed to write normalized index.json"))?;
+            } else {
+                builder
+                    .append_data(&mut header, &path, &mut entry)
+                    .into_alien_error()
+                    .context(docker_read_error("Failed to copy OCI tarball entry"))?;
+            }
+        }
+
+        builder
+            .into_inner()
+            .into_alien_error()
+            .context(docker_read_error(
+                "Failed to finalize normalized OCI tarball",
+            ))?;
+    }
+
+    std::fs::rename(&temp_path, tarball_path)
+        .into_alien_error()
+        .context(docker_read_error(
+            "Failed to replace OCI tarball with normalized copy",
+        ))
 }
 
 #[cfg(test)]
@@ -402,6 +720,124 @@ CMD ["cat", "hello.txt"]
             metadata.cmd.is_some(),
             "Image should have CMD from Dockerfile"
         );
+    }
+
+    #[test]
+    fn test_inspect_reports_platform() {
+        // A bare runner's default builder lists only the native arch (+ compatible variants).
+        let bare = "Name:   default\nDriver: docker\n\nNodes:\nName:      default\nStatus:    running\nPlatforms: linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/386\n";
+        assert!(DockerToolchain::inspect_reports_platform(bare, "amd64"));
+        assert!(
+            !DockerToolchain::inspect_reports_platform(bare, "arm64"),
+            "a bare amd64 runner must not report arm64 — that's what triggers the fail-fast"
+        );
+
+        // A machine with QEMU registered (Docker Desktop / OrbStack) lists emulated platforms too.
+        let emulated =
+            "Nodes:\nName: default\nPlatforms: linux/arm64, linux/amd64, linux/amd64/v2, linux/arm/v7\n";
+        assert!(DockerToolchain::inspect_reports_platform(emulated, "arm64"));
+        assert!(DockerToolchain::inspect_reports_platform(emulated, "amd64"));
+
+        // The needle is exact enough: arm64 must not match an arm/v7 entry, amd64 must not match arm64.
+        assert!(!DockerToolchain::inspect_reports_platform(
+            "Platforms: linux/arm/v7, linux/arm/v6\n",
+            "arm64"
+        ));
+        assert!(!DockerToolchain::inspect_reports_platform(
+            "Platforms: linux/arm64\n",
+            "amd64"
+        ));
+
+        // A non-Platforms line mentioning the arch must not count.
+        assert!(!DockerToolchain::inspect_reports_platform(
+            "Name: linux/arm64-builder\nPlatforms: linux/amd64\n",
+            "arm64"
+        ));
+    }
+
+    /// The capability decision is pure: a native target, or a non-native one the builder
+    /// supports, is allowed; a non-native target the builder can't build is blocked (→ fail-fast).
+    #[test]
+    fn test_build_blocked() {
+        // Native target — allowed regardless of builder support.
+        assert!(!DockerToolchain::build_blocked(
+            Some("amd64"),
+            "amd64",
+            false
+        ));
+        // Non-native but the builder supports it (e.g. a dev machine with emulation) — allowed.
+        assert!(!DockerToolchain::build_blocked(
+            Some("arm64"),
+            "amd64",
+            true
+        ));
+        // Non-native and the builder can't build it (a bare CI runner) — blocked.
+        assert!(DockerToolchain::build_blocked(
+            Some("arm64"),
+            "amd64",
+            false
+        ));
+        // Unrecognized host that can't build the target — blocked.
+        assert!(DockerToolchain::build_blocked(None, "amd64", false));
+        // Unrecognized host but the builder supports the target — allowed.
+        assert!(!DockerToolchain::build_blocked(None, "amd64", true));
+    }
+
+    #[test]
+    fn select_image_manifest_resolves_nested_index_and_skips_attestation() {
+        // The shape a containerd-store `docker save` writes: index.json points at a nested
+        // image-index whose entries are the real image manifest plus an attestation.
+        let index = json!({
+            "schemaVersion": 2,
+            "manifests": [
+                { "mediaType": "application/vnd.oci.image.index.v1+json", "digest": "sha256:nested" }
+            ]
+        });
+        let mut blobs = HashMap::new();
+        blobs.insert(
+            "sha256:nested".to_string(),
+            json!({
+                "manifests": [
+                    { "mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:image",
+                      "platform": { "architecture": "arm64", "os": "linux" } },
+                    { "mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:attest",
+                      "platform": { "architecture": "unknown", "os": "unknown" } }
+                ]
+            }),
+        );
+
+        let chosen = select_image_manifest_descriptor(&index, &blobs, "arm64").unwrap();
+        assert_eq!(chosen.get("digest").unwrap(), "sha256:image");
+        // The nested index is not flat, so a rewrite is required.
+        assert!(!index_points_only_at(&index, &chosen));
+    }
+
+    #[test]
+    fn select_image_manifest_leaves_flat_index_untouched() {
+        // The classic image store already writes index.json → single image manifest.
+        let index = json!({
+            "schemaVersion": 2,
+            "manifests": [
+                { "mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:image",
+                  "platform": { "architecture": "amd64", "os": "linux" } }
+            ]
+        });
+        let chosen = select_image_manifest_descriptor(&index, &HashMap::new(), "amd64").unwrap();
+        assert_eq!(chosen.get("digest").unwrap(), "sha256:image");
+        assert!(index_points_only_at(&index, &chosen));
+    }
+
+    #[test]
+    fn select_image_manifest_errors_when_arch_absent() {
+        let index = json!({
+            "manifests": [
+                { "mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:a",
+                  "platform": { "architecture": "arm64", "os": "linux" } },
+                { "mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:b",
+                  "platform": { "architecture": "amd64", "os": "linux" } }
+            ]
+        });
+        assert!(select_image_manifest_descriptor(&index, &HashMap::new(), "ppc64le").is_err());
     }
 
     #[tokio::test]

--- a/crates/alien-cli/src/commands/build.rs
+++ b/crates/alien-cli/src/commands/build.rs
@@ -3,11 +3,12 @@ use crate::error::{ErrorData, Result};
 use crate::get_current_dir;
 use crate::output::print_json;
 use crate::ui::{accent, command, contextual_heading, dim_label, success_line};
+use alien_build::plan::{plan_runner_groups, stack_targets_native_host_binaries};
 use alien_build::settings::{BuildSettings, PlatformBuildSettings};
 use alien_core::events::AlienEvent;
 use alien_core::{BinaryTarget, Platform};
 use alien_error::{AlienError, Context, IntoAlienError};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -45,14 +46,22 @@ struct PlatformBuildPlan {
 #[command(
     about = "Build the Alien application locally",
     long_about = "Build the Alien application locally, creating OCI tarballs without pushing to a registry. Use `alien release` to push images and create a release.",
+    args_conflicts_with_subcommands = true,
     after_help = "EXAMPLES:
     alien build --platform aws
     alien build --platforms aws,gcp
     alien build --platform aws --targets linux-arm64
     alien build --config ../my-app/alien.ts --output-dir ./build --platform aws
-    alien build --platform aws --json"
+    alien build --platform aws --json
+    alien build plan --json
+    alien build merge --input ./build-artifacts --output .alien"
 )]
 pub struct BuildArgs {
+    /// Subcommand: `plan` (compute native-runner groups) or `merge` (combine partial outputs).
+    /// When omitted, runs a normal build.
+    #[command(subcommand)]
+    pub command: Option<BuildSubcommand>,
+
     /// Path to alien.ts/js/json file or directory containing it
     #[arg(short = 'c', long)]
     pub config: Option<String>,
@@ -96,7 +105,52 @@ pub struct BuildArgs {
     pub json: bool,
 }
 
+#[derive(Subcommand, Debug, Clone)]
+pub enum BuildSubcommand {
+    /// Compute the native-runner build groups for the stack's supported platforms
+    #[command(after_help = "EXAMPLES:
+    alien build plan
+    alien build plan --json")]
+    Plan(BuildPlanArgs),
+    /// Merge partial build outputs (one per native runner) into one `.alien` directory
+    #[command(after_help = "EXAMPLES:
+    alien build merge --input ./build-artifacts --output .alien")]
+    Merge(BuildMergeArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct BuildPlanArgs {
+    /// Path to alien.ts/js/json file or directory containing it
+    #[arg(short = 'c', long)]
+    pub config: Option<String>,
+
+    /// Emit structured JSON output
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct BuildMergeArgs {
+    /// Directory of downloaded partial outputs (each subdir holds `build/<platform>/`)
+    #[arg(long)]
+    pub input: String,
+
+    /// Output directory for the merged `.alien` build
+    #[arg(long)]
+    pub output: String,
+
+    /// Emit structured JSON output
+    #[arg(long)]
+    pub json: bool,
+}
+
 pub async fn build_command(args: BuildArgs) -> Result<()> {
+    match &args.command {
+        Some(BuildSubcommand::Plan(plan_args)) => return plan_command(plan_args).await,
+        Some(BuildSubcommand::Merge(merge_args)) => return merge_command(merge_args),
+        None => {}
+    }
+
     if args.platforms.is_empty() {
         return Err(AlienError::new(ErrorData::ValidationError {
             field: "platforms".to_string(),
@@ -116,6 +170,72 @@ pub async fn build_command(args: BuildArgs) -> Result<()> {
         for output in &outputs {
             print_build_summary(output);
         }
+    }
+    Ok(())
+}
+
+/// `alien build plan` — derive the native-runner groups from the stack's supported platforms.
+async fn plan_command(args: &BuildPlanArgs) -> Result<()> {
+    let current_dir = get_current_dir()?;
+    let config_path = args
+        .config
+        .clone()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| current_dir.clone());
+
+    let stack = load_configuration(config_path)
+        .await
+        .context(ErrorData::ConfigurationError {
+            message: "Failed to load configuration".to_string(),
+        })?;
+
+    // None means the stack supports every deployable platform.
+    let supported: Vec<Platform> = match stack.supported_platforms() {
+        Some(platforms) => platforms.to_vec(),
+        None => Platform::DEPLOYABLE.to_vec(),
+    };
+    let groups = plan_runner_groups(&supported, stack_targets_native_host_binaries(&stack));
+
+    if args.json {
+        print_json(&groups)?;
+    } else {
+        println!(
+            "{}",
+            contextual_heading(
+                "Build plan",
+                stack.id(),
+                &[("groups", &groups.len().to_string())]
+            )
+        );
+        for group in &groups {
+            println!(
+                "  {} {} ({})",
+                accent(&group.name),
+                dim_label(&group.runner),
+                group.platforms.join(", ")
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `alien build merge` — combine partial native-runner outputs into one `.alien` directory.
+fn merge_command(args: &BuildMergeArgs) -> Result<()> {
+    let input = PathBuf::from(&args.input);
+    let output = PathBuf::from(&args.output);
+    let platforms =
+        alien_build::merge::merge_build_outputs(&input, &output).context(ErrorData::BuildFailed)?;
+
+    if args.json {
+        print_json(&serde_json::json!({
+            "success": true,
+            "output": args.output,
+            "platforms": platforms,
+        }))?;
+    } else {
+        println!("{}", success_line("Merge complete."));
+        println!("{} {}", dim_label("Output"), accent(&args.output));
+        println!("{} {}", dim_label("Platforms"), platforms.join(", "));
     }
     Ok(())
 }

--- a/crates/alien-cli/src/commands/mod.rs
+++ b/crates/alien-cli/src/commands/mod.rs
@@ -23,7 +23,7 @@ pub mod platform;
 #[cfg(feature = "platform")]
 pub mod manager;
 
-pub use build::{build_command, BuildArgs};
+pub use build::{build_command, BuildArgs, BuildSubcommand};
 pub use commands::{commands_task, commands_task_dev, CommandsArgs};
 pub use deploy::{deploy_task, DeployArgs};
 pub use deployments::{deployments_task, DeploymentsArgs};

--- a/crates/alien-cli/src/commands/release.rs
+++ b/crates/alien-cli/src/commands/release.rs
@@ -6,7 +6,8 @@ use crate::ui::{command, contextual_heading, dim_label, success_line};
 use crate::{ErrorData, Result};
 use alien_build::settings::PushSettings;
 use alien_core::{
-    alien_event, AlienEvent, Container, ContainerCode, Platform, Stack, Worker, WorkerCode,
+    alien_event, AlienEvent, Container, ContainerCode, Daemon, DaemonCode, Platform, Stack, Worker,
+    WorkerCode,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
 use alien_manager_api::types::{
@@ -38,7 +39,7 @@ use tracing::info;
     alien release --platforms aws
     alien release --platforms aws,gcp
 
-    # Use pre-built images (skip build, still push images)
+    # Skip the build and release the existing build output (still pushes local artifacts)
     alien release --prebuilt
 
     # Output JSON (for scripting/automation)
@@ -78,7 +79,8 @@ pub struct ReleaseArgs {
     #[arg(long)]
     pub base_platform: Option<String>,
 
-    /// Use pre-built images. Skips build and still pushes local build artifacts.
+    /// Skip the build and release the existing `.alien` output. Still pushes any local
+    /// artifacts it contains, and reuses images that are already remote URIs.
     #[arg(long)]
     pub prebuilt: bool,
 
@@ -397,7 +399,8 @@ async fn release_task_core(
         // Load built stack
         let mut built_stack = load_built_stack(&output_dir, platform_str)?;
 
-        // Push images if needed (test platform skips pushing).
+        // Push images if needed (the test platform skips pushing). --prebuilt skips the build,
+        // not the push: it reuses already-pushed artifacts via the cache and pushes any local ones.
         // Local platform pushes to a cloud registry — the alien-agent pulls from it.
         let pushed_stack = if platform != Platform::Test {
             if args.prebuilt {
@@ -1185,6 +1188,21 @@ fn rebase_prebuilt_stack_image_paths(
                     return Err(prebuilt_source_error("Container", &container.id));
                 }
             }
+        } else if let Some(daemon) = resource_entry.config.downcast_ref::<Daemon>() {
+            match &daemon.code {
+                DaemonCode::Image { image } => {
+                    if let Some(rebased) = rebase_prebuilt_image_path(
+                        "daemon", &daemon.id, image, output_dir, platform,
+                    )? {
+                        let mut updated = daemon.clone();
+                        updated.code = DaemonCode::Image { image: rebased };
+                        resource_entry.config = alien_core::Resource::new(updated);
+                    }
+                }
+                DaemonCode::Source { .. } => {
+                    return Err(prebuilt_source_error("Daemon", &daemon.id));
+                }
+            }
         }
     }
     Ok(())
@@ -1365,6 +1383,21 @@ fn apply_push_cache(stack: &mut Stack, cache: &HashMap<String, String>) -> usize
                     }
                 }
             }
+        } else if let Some(daemon) = resource_entry.config.downcast_mut::<Daemon>() {
+            if let DaemonCode::Image { ref image } = daemon.code {
+                if let Some(key) = cache_key_from_path(image) {
+                    if let Some(cached_uri) = cache.get(&key) {
+                        info!(
+                            "Push cache hit for daemon '{}': {} → {}",
+                            daemon.id, key, cached_uri
+                        );
+                        daemon.code = DaemonCode::Image {
+                            image: cached_uri.clone(),
+                        };
+                        hits += 1;
+                    }
+                }
+            }
         }
     }
 
@@ -1392,6 +1425,11 @@ fn collect_push_cache_entries(
                     return Some((id.clone(), image.clone()));
                 }
             }
+            if let Some(daemon) = entry.config.downcast_ref::<Daemon>() {
+                if let DaemonCode::Image { ref image } = daemon.code {
+                    return Some((id.clone(), image.clone()));
+                }
+            }
             None
         })
         .collect();
@@ -1405,6 +1443,12 @@ fn collect_push_cache_entries(
             }
         } else if let Some(container) = resource_entry.config.downcast_ref::<Container>() {
             if let ContainerCode::Image { ref image } = container.code {
+                Some(image.clone())
+            } else {
+                None
+            }
+        } else if let Some(daemon) = resource_entry.config.downcast_ref::<Daemon>() {
+            if let DaemonCode::Image { ref image } = daemon.code {
                 Some(image.clone())
             } else {
                 None
@@ -1433,6 +1477,62 @@ fn collect_push_cache_entries(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alien_core::ResourceLifecycle;
+
+    fn daemon_with_image(image: &str) -> Daemon {
+        Daemon::new("agent".to_string())
+            .permissions("execution".to_string())
+            .code(DaemonCode::Image {
+                image: image.to_string(),
+            })
+            .build()
+    }
+
+    #[test]
+    fn push_cache_applies_and_collects_for_daemons() {
+        let local_dir = tempfile::tempdir().unwrap();
+        let artifact_dir = local_dir.path().join("agent-a1b2c3d4");
+        std::fs::create_dir_all(&artifact_dir).unwrap();
+        let local_path = artifact_dir.to_string_lossy().into_owned();
+
+        // apply: a cached URI for the artifact dir's key replaces the daemon's local path.
+        let mut stack = Stack::new("cache-test".to_string())
+            .add(daemon_with_image(&local_path), ResourceLifecycle::Live)
+            .build();
+        let cache = HashMap::from([(
+            "agent-a1b2c3d4".to_string(),
+            "registry.example.com/agent:tag".to_string(),
+        )]);
+        let hits = apply_push_cache(&mut stack, &cache);
+        assert_eq!(hits, 1, "daemon local path should hit the cache");
+        let daemon = stack
+            .resources()
+            .find_map(|(_, e)| e.config.downcast_ref::<Daemon>().cloned())
+            .expect("daemon should exist");
+        assert_eq!(
+            daemon.code,
+            DaemonCode::Image {
+                image: "registry.example.com/agent:tag".to_string()
+            }
+        );
+
+        // collect: pushed daemon URI lands in the cache keyed by the original dir name.
+        let pre_push = Stack::new("cache-test".to_string())
+            .add(daemon_with_image(&local_path), ResourceLifecycle::Live)
+            .build();
+        let pushed = Stack::new("cache-test".to_string())
+            .add(
+                daemon_with_image("registry.example.com/agent:pushed"),
+                ResourceLifecycle::Live,
+            )
+            .build();
+        let mut collected = HashMap::new();
+        collect_push_cache_entries(&pushed, &pre_push, &mut collected);
+        assert_eq!(
+            collected.get("agent-a1b2c3d4").map(String::as_str),
+            Some("registry.example.com/agent:pushed")
+        );
+    }
 
     #[test]
     fn parse_kubernetes_base_platform_accepts_clouds_for_kubernetes_releases() {

--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -27,9 +27,9 @@ use crate::commands::{
     ensure_server_running_for_dev_session, ensure_server_running_with_env,
     fetch_all_dev_deployment_live_states, init_task, logs_task, onboard_task,
     prepare_dev_session_deployment, release_command, releases_task, render_task, vault_remote_task,
-    vault_task, whoami_task, write_dev_status, BuildArgs, CliEnvVar, CommandsArgs, DeployArgs,
-    DeploymentsArgs, DestroyArgs, InitArgs, LogsArgs, OnboardArgs, ReleaseArgs, ReleasesArgs,
-    RenderArgs, WhoamiArgs,
+    vault_task, whoami_task, write_dev_status, BuildArgs, BuildSubcommand, CliEnvVar, CommandsArgs,
+    DeployArgs, DeploymentsArgs, DestroyArgs, InitArgs, LogsArgs, OnboardArgs, ReleaseArgs,
+    ReleasesArgs, RenderArgs, WhoamiArgs,
 };
 use crate::error::{ErrorData, Result};
 use crate::execution_context::ExecutionMode;
@@ -82,7 +82,11 @@ pub struct Cli {
 impl Cli {
     pub fn wants_json_output(&self) -> bool {
         match &self.command {
-            Some(Commands::Build(args)) => args.json,
+            Some(Commands::Build(args)) => match &args.command {
+                Some(BuildSubcommand::Plan(plan)) => plan.json,
+                Some(BuildSubcommand::Merge(merge)) => merge.json,
+                None => args.json,
+            },
             Some(Commands::Release(args)) => args.json,
             Some(Commands::Render(args)) => args.json,
             Some(Commands::Onboard(args)) => args.json,

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -168,6 +168,18 @@ impl BinaryTarget {
         }
     }
 
+    /// Inverse of [`runtime_platform_id`] — the `.oci.tar` filename spelling
+    /// (`linux-aarch64`/`darwin-aarch64`), not the `linux-arm64`/`darwin-arm64` CLI names.
+    pub fn from_runtime_platform_id(id: &str) -> Option<Self> {
+        match id {
+            "windows-x64" => Some(Self::WindowsX64),
+            "linux-x64" => Some(Self::LinuxX64),
+            "linux-aarch64" => Some(Self::LinuxArm64),
+            "darwin-aarch64" => Some(Self::DarwinArm64),
+            _ => None,
+        }
+    }
+
     /// Get the OCI os string for this target
     pub fn oci_os(&self) -> &'static str {
         match self {
@@ -321,6 +333,24 @@ mod tests {
             BinaryTarget::defaults_for_platform(Platform::Local),
             vec![BinaryTarget::current_os()]
         );
+    }
+
+    #[test]
+    fn runtime_platform_id_round_trips() {
+        for target in BinaryTarget::ALL {
+            assert_eq!(
+                BinaryTarget::from_runtime_platform_id(target.runtime_platform_id()),
+                Some(*target),
+                "round-trip failed for {target}"
+            );
+        }
+        // The tarball spelling differs from the CLI/FromStr spelling.
+        assert_eq!(
+            BinaryTarget::from_runtime_platform_id("linux-aarch64"),
+            Some(BinaryTarget::LinuxArm64)
+        );
+        assert_eq!(BinaryTarget::from_runtime_platform_id("linux-arm64"), None);
+        assert_eq!(BinaryTarget::from_runtime_platform_id("nonsense"), None);
     }
 
     #[test]

--- a/crates/alien-core/src/deployment/config.rs
+++ b/crates/alien-core/src/deployment/config.rs
@@ -112,10 +112,12 @@ pub struct DeploymentConfig {
 
 /// OTLP log export configuration for a deployment.
 ///
-/// When set, worker runtimes export captured application logs through the
-/// given endpoint via OTLP/HTTP. Auth headers are runtime-owned secret material:
-/// deployment code must sync them to a runtime-only secret and avoid putting
-/// them into user application environment variables.
+/// When set, injected compute runtimes export captured application logs
+/// through the given endpoint via OTLP/HTTP; which resources are injected
+/// is platform-dependent. Workers and daemons read auth headers from a
+/// runtime-only secret — never from application environment variables.
+/// Containers have no runtime wrapper, so they get the endpoint and auth
+/// header as plain OTEL env vars for the application's own exporter.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]

--- a/crates/alien-deployment/src/helpers.rs
+++ b/crates/alien-deployment/src/helpers.rs
@@ -17,6 +17,8 @@ use tracing::{debug, info};
 const OTEL_RESOURCE_ATTRIBUTES: &str = "OTEL_RESOURCE_ATTRIBUTES";
 const OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT";
 const OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+const OTEL_EXPORTER_OTLP_HEADERS: &str = "OTEL_EXPORTER_OTLP_HEADERS";
+const OTEL_EXPORTER_OTLP_METRICS_HEADERS: &str = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 const RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET: &str = "__alien_runtime_otlp_logs_auth_header";
 const RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET: &str = "__alien_runtime_otlp_metrics_auth_header";
@@ -186,7 +188,23 @@ struct AlienRuntimeSecretsConfig {
     hash: String,
 }
 
-/// Inject OTLP monitoring environment variables into worker runtimes.
+/// Whether containers and daemons get OTLP env vars on this platform.
+///
+/// On managed cloud platforms, containers and daemons run inside the hosted
+/// container runtime, which already ships their telemetry — only workers need
+/// the vars there. Self-hosted platforms have no such runtime, so every
+/// compute resource gets them. Exhaustive so a new platform must pick a side.
+fn otlp_injection_covers_containers_and_daemons(platform: Platform) -> bool {
+    match platform {
+        Platform::Aws | Platform::Gcp | Platform::Azure => false,
+        Platform::Kubernetes | Platform::Local | Platform::Test => true,
+    }
+}
+
+/// Inject OTLP monitoring environment variables into compute resources.
+///
+/// Workers are injected on every platform; containers and daemons only where
+/// `otlp_injection_covers_containers_and_daemons` says so.
 ///
 /// When `DeploymentConfig.monitoring` is set, this injects:
 /// - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` — the OTLP logs endpoint URL
@@ -196,16 +214,30 @@ struct AlienRuntimeSecretsConfig {
 ///   has already set `OTEL_SERVICE_NAME` via plain or secret env vars.
 /// - `OTEL_RESOURCE_ATTRIBUTES`       — deployment-level resource attributes
 ///   such as `alien.deployment_id`, merged with any user-provided value.
-/// - `ALIEN_RUNTIME_SECRETS`          — points alien-runtime at runtime-owned
-///   vault secrets. These are not forwarded to the child application process.
+/// - `ALIEN_RUNTIME_SECRETS`          — workers and daemons only; points
+///   alien-runtime at runtime-owned vault secrets. These are not forwarded to
+///   the child application process.
+/// - `OTEL_EXPORTER_OTLP_HEADERS` (and `..._METRICS_HEADERS`) — containers
+///   only; a container has no alien-runtime wrapper to resolve the vault
+///   pointer, so its auth header goes in as the standard plain OTEL env var.
 pub fn inject_monitoring_environment_variables(
     stack: &mut Stack,
     monitoring: &OtlpConfig,
+    platform: Platform,
 ) -> Result<()> {
-    info!("Injecting OTLP monitoring env vars into worker and daemon runtimes");
+    let covers_containers_and_daemons = otlp_injection_covers_containers_and_daemons(platform);
+    info!(
+        "Injecting OTLP monitoring env vars into {} runtimes",
+        if covers_containers_and_daemons {
+            "worker, container, and daemon"
+        } else {
+            "worker"
+        }
+    );
 
     for (resource_name, resource_entry) in &mut stack.resources {
         let resource_type = resource_entry.config.resource_type();
+        let is_container = resource_type == alien_core::Container::RESOURCE_TYPE;
 
         let environment = if resource_type == alien_core::Worker::RESOURCE_TYPE {
             Some(
@@ -222,7 +254,9 @@ pub fn inject_monitoring_environment_variables(
                     })?
                     .environment,
             )
-        } else if resource_type == alien_core::Daemon::RESOURCE_TYPE {
+        } else if covers_containers_and_daemons
+            && resource_type == alien_core::Daemon::RESOURCE_TYPE
+        {
             Some(
                 &mut resource_entry
                     .config
@@ -231,6 +265,21 @@ pub fn inject_monitoring_environment_variables(
                         AlienError::new(ErrorData::InternalError {
                             message: format!(
                                 "Failed to downcast resource '{}' to Daemon",
+                                resource_name
+                            ),
+                        })
+                    })?
+                    .environment,
+            )
+        } else if covers_containers_and_daemons && is_container {
+            Some(
+                &mut resource_entry
+                    .config
+                    .downcast_mut::<alien_core::Container>()
+                    .ok_or_else(|| {
+                        AlienError::new(ErrorData::InternalError {
+                            message: format!(
+                                "Failed to downcast resource '{}' to Container",
                                 resource_name
                             ),
                         })
@@ -269,20 +318,37 @@ pub fn inject_monitoring_environment_variables(
                     metrics_endpoint.clone(),
                 );
             }
-            let runtime_secrets = AlienRuntimeSecretsConfig {
-                otlp_logs_auth_header: Some(RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string()),
-                otlp_metrics_auth_header: monitoring
-                    .metrics_endpoint
-                    .as_ref()
-                    .map(|_| RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET.to_string()),
-                hash: runtime_monitoring_secrets_hash(monitoring),
-            };
-            let runtime_secrets_json = serde_json::to_string(&runtime_secrets)
-                .into_alien_error()
-                .context(ErrorData::InternalError {
-                message: "Failed to serialize ALIEN_RUNTIME_SECRETS config".to_string(),
-            })?;
-            env.insert(ENV_ALIEN_RUNTIME_SECRETS.to_string(), runtime_secrets_json);
+            if is_container {
+                env.insert(
+                    OTEL_EXPORTER_OTLP_HEADERS.to_string(),
+                    monitoring.logs_auth_header.clone(),
+                );
+                if monitoring.metrics_endpoint.is_some() {
+                    let metrics_header = monitoring
+                        .metrics_auth_header
+                        .as_ref()
+                        .unwrap_or(&monitoring.logs_auth_header);
+                    env.insert(
+                        OTEL_EXPORTER_OTLP_METRICS_HEADERS.to_string(),
+                        metrics_header.clone(),
+                    );
+                }
+            } else {
+                let runtime_secrets = AlienRuntimeSecretsConfig {
+                    otlp_logs_auth_header: Some(RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string()),
+                    otlp_metrics_auth_header: monitoring
+                        .metrics_endpoint
+                        .as_ref()
+                        .map(|_| RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET.to_string()),
+                    hash: runtime_monitoring_secrets_hash(monitoring),
+                };
+                let runtime_secrets_json = serde_json::to_string(&runtime_secrets)
+                    .into_alien_error()
+                    .context(ErrorData::InternalError {
+                        message: "Failed to serialize ALIEN_RUNTIME_SECRETS config".to_string(),
+                    })?;
+                env.insert(ENV_ALIEN_RUNTIME_SECRETS.to_string(), runtime_secrets_json);
+            }
 
             debug!(
                 "Injected runtime OTLP monitoring vars into '{}'",
@@ -336,7 +402,10 @@ fn inject_into_compute_resource(
 ) -> Result<()> {
     if let Some(worker) = resource_entry.config.downcast_mut::<alien_core::Worker>() {
         inject_into_environment(resource_name, "worker", &mut worker.environment, snapshot)
-    } else if let Some(container) = resource_entry.config.downcast_mut::<alien_core::Container>() {
+    } else if let Some(container) = resource_entry
+        .config
+        .downcast_mut::<alien_core::Container>()
+    {
         inject_into_environment(
             resource_name,
             "container",
@@ -1005,7 +1074,7 @@ mod tests {
             ]),
         };
 
-        inject_monitoring_environment_variables(&mut stack, &monitoring).unwrap();
+        inject_monitoring_environment_variables(&mut stack, &monitoring, Platform::Aws).unwrap();
 
         let func = stack
             .resources
@@ -1046,7 +1115,7 @@ mod tests {
             )]),
         };
 
-        inject_monitoring_environment_variables(&mut stack, &monitoring).unwrap();
+        inject_monitoring_environment_variables(&mut stack, &monitoring, Platform::Aws).unwrap();
 
         let func = stack
             .resources
@@ -1060,5 +1129,163 @@ mod tests {
             func.environment.get(OTEL_RESOURCE_ATTRIBUTES).unwrap(),
             "alien.deployment_id=dep_test,custom=value"
         );
+    }
+
+    fn make_compute_stack() -> Stack {
+        let mut stack = make_single_function_stack("worker");
+
+        let container = alien_core::Container::new("web".to_string())
+            .code(alien_core::ContainerCode::Image {
+                image: "test:latest".to_string(),
+            })
+            .cpu(alien_core::ResourceSpec {
+                min: "0.25".to_string(),
+                desired: "0.5".to_string(),
+            })
+            .memory(alien_core::ResourceSpec {
+                min: "256Mi".to_string(),
+                desired: "512Mi".to_string(),
+            })
+            .permissions("default".to_string())
+            .build();
+        stack.resources.insert(
+            "web".to_string(),
+            ResourceEntry {
+                config: Resource::new(container),
+                lifecycle: ResourceLifecycle::Live,
+                dependencies: Vec::new(),
+                remote_access: false,
+            },
+        );
+
+        let daemon = alien_core::Daemon::new("agent".to_string())
+            .code(alien_core::DaemonCode::Image {
+                image: "test:latest".to_string(),
+            })
+            .permissions("default".to_string())
+            .build();
+        stack.resources.insert(
+            "agent".to_string(),
+            ResourceEntry {
+                config: Resource::new(daemon),
+                lifecycle: ResourceLifecycle::Live,
+                dependencies: Vec::new(),
+                remote_access: false,
+            },
+        );
+
+        stack
+    }
+
+    fn make_monitoring_with_metrics() -> OtlpConfig {
+        OtlpConfig {
+            logs_endpoint: "https://manager.test/v1/logs".to_string(),
+            logs_auth_header: "authorization=Bearer logs-token".to_string(),
+            metrics_endpoint: Some("https://manager.test/v1/metrics".to_string()),
+            metrics_auth_header: None,
+            resource_attributes: std::collections::HashMap::new(),
+        }
+    }
+
+    fn resource_env<'a>(stack: &'a Stack, id: &str) -> &'a HashMap<String, String> {
+        let entry = &stack.resources.get(id).expect("resource exists").config;
+        if let Some(worker) = entry.downcast_ref::<Worker>() {
+            &worker.environment
+        } else if let Some(container) = entry.downcast_ref::<alien_core::Container>() {
+            &container.environment
+        } else if let Some(daemon) = entry.downcast_ref::<alien_core::Daemon>() {
+            &daemon.environment
+        } else {
+            panic!("resource '{id}' is not a compute resource");
+        }
+    }
+
+    #[test]
+    fn monitoring_cloud_platforms_inject_worker_only() {
+        for platform in [Platform::Aws, Platform::Gcp, Platform::Azure] {
+            let mut stack = make_compute_stack();
+            let monitoring = make_monitoring_with_metrics();
+
+            inject_monitoring_environment_variables(&mut stack, &monitoring, platform).unwrap();
+
+            let worker_env = resource_env(&stack, "worker");
+            assert_eq!(
+                worker_env.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).unwrap(),
+                "https://manager.test/v1/logs",
+                "{platform:?}: worker gets the logs endpoint"
+            );
+            assert!(
+                worker_env.contains_key(ENV_ALIEN_RUNTIME_SECRETS),
+                "{platform:?}: worker gets the runtime-secrets pointer"
+            );
+
+            for id in ["web", "agent"] {
+                let env = resource_env(&stack, id);
+                assert!(
+                    env.is_empty(),
+                    "{platform:?}: '{id}' must get no OTLP vars (got {:?})",
+                    env.keys().collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn monitoring_self_hosted_platforms_inject_all_compute() {
+        for platform in [Platform::Kubernetes, Platform::Local, Platform::Test] {
+            let mut stack = make_compute_stack();
+            let monitoring = make_monitoring_with_metrics();
+
+            inject_monitoring_environment_variables(&mut stack, &monitoring, platform).unwrap();
+
+            for id in ["worker", "web", "agent"] {
+                let env = resource_env(&stack, id);
+                assert_eq!(
+                    env.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).unwrap(),
+                    "https://manager.test/v1/logs",
+                    "{platform:?}: '{id}' gets the logs endpoint"
+                );
+                assert_eq!(
+                    env.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).unwrap(),
+                    "https://manager.test/v1/metrics",
+                    "{platform:?}: '{id}' gets the metrics endpoint"
+                );
+                assert_eq!(
+                    env.get(OTEL_SERVICE_NAME).unwrap(),
+                    id,
+                    "{platform:?}: '{id}' gets its name as service name"
+                );
+            }
+
+            for id in ["worker", "agent"] {
+                let env = resource_env(&stack, id);
+                assert!(
+                    env.contains_key(ENV_ALIEN_RUNTIME_SECRETS),
+                    "{platform:?}: '{id}' gets the runtime-secrets pointer"
+                );
+                assert!(
+                    !env.contains_key(OTEL_EXPORTER_OTLP_HEADERS),
+                    "{platform:?}: '{id}' must not carry a plain auth header"
+                );
+            }
+
+            let container_env = resource_env(&stack, "web");
+            assert_eq!(
+                container_env.get(OTEL_EXPORTER_OTLP_HEADERS).unwrap(),
+                "authorization=Bearer logs-token",
+                "{platform:?}: container gets the plain logs auth header"
+            );
+            assert_eq!(
+                container_env
+                    .get(OTEL_EXPORTER_OTLP_METRICS_HEADERS)
+                    .unwrap(),
+                "authorization=Bearer logs-token",
+                "{platform:?}: container metrics header falls back to the logs header"
+            );
+            assert!(
+                !container_env.contains_key(ENV_ALIEN_RUNTIME_SECRETS),
+                "{platform:?}: container must not get the runtime-secrets pointer"
+            );
+        }
     }
 }

--- a/crates/alien-deployment/src/helpers.rs
+++ b/crates/alien-deployment/src/helpers.rs
@@ -11,7 +11,7 @@ use alien_error::{AlienError, Context, IntoAlienError as _};
 use alien_gcp_clients::{ResourceManagerApi, ResourceManagerClient};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use tracing::{debug, info};
 
 const OTEL_RESOURCE_ATTRIBUTES: &str = "OTEL_RESOURCE_ATTRIBUTES";
@@ -163,10 +163,11 @@ pub fn inject_environment_variables(stack: &mut Stack, config: &DeploymentConfig
     for (resource_name, resource_entry) in &mut stack.resources {
         let resource_type = resource_entry.config.resource_type();
 
-        if resource_type == alien_core::Worker::RESOURCE_TYPE {
-            inject_into_compute_resource(resource_name, resource_entry, snapshot, true)?;
-        } else if resource_type == alien_core::Container::RESOURCE_TYPE {
-            inject_into_compute_resource(resource_name, resource_entry, snapshot, false)?;
+        if resource_type == alien_core::Worker::RESOURCE_TYPE
+            || resource_type == alien_core::Container::RESOURCE_TYPE
+            || resource_type == alien_core::Daemon::RESOURCE_TYPE
+        {
+            inject_into_compute_resource(resource_name, resource_entry, snapshot)?;
         }
     }
 
@@ -201,7 +202,7 @@ pub fn inject_monitoring_environment_variables(
     stack: &mut Stack,
     monitoring: &OtlpConfig,
 ) -> Result<()> {
-    info!("Injecting OTLP monitoring env vars into worker runtimes");
+    info!("Injecting OTLP monitoring env vars into worker and daemon runtimes");
 
     for (resource_name, resource_entry) in &mut stack.resources {
         let resource_type = resource_entry.config.resource_type();
@@ -215,6 +216,21 @@ pub fn inject_monitoring_environment_variables(
                         AlienError::new(ErrorData::InternalError {
                             message: format!(
                                 "Failed to downcast resource '{}' to Worker",
+                                resource_name
+                            ),
+                        })
+                    })?
+                    .environment,
+            )
+        } else if resource_type == alien_core::Daemon::RESOURCE_TYPE {
+            Some(
+                &mut resource_entry
+                    .config
+                    .downcast_mut::<alien_core::Daemon>()
+                    .ok_or_else(|| {
+                        AlienError::new(ErrorData::InternalError {
+                            message: format!(
+                                "Failed to downcast resource '{}' to Daemon",
                                 resource_name
                             ),
                         })
@@ -308,7 +324,7 @@ fn parse_otel_resource_attributes(existing: Option<&str>) -> BTreeMap<String, St
     attributes
 }
 
-/// Inject environment variables into a Worker or Container compute resource.
+/// Inject environment variables into a compute resource (Worker, Container, or Daemon).
 ///
 /// - Plain variables: inserted directly into resource.environment.
 /// - Secret variables: their keys are collected into ALIEN_SECRETS so
@@ -317,34 +333,34 @@ fn inject_into_compute_resource(
     resource_name: &str,
     resource_entry: &mut alien_core::ResourceEntry,
     snapshot: &EnvironmentVariablesSnapshot,
-    is_worker: bool,
 ) -> Result<()> {
-    // Get the environment map (same interface for Worker and Container)
-    let environment = if is_worker {
-        &mut resource_entry
-            .config
-            .downcast_mut::<alien_core::Worker>()
-            .ok_or_else(|| {
-                AlienError::new(ErrorData::InternalError {
-                    message: format!("Failed to downcast resource '{}' to Worker", resource_name),
-                })
-            })?
-            .environment
+    if let Some(worker) = resource_entry.config.downcast_mut::<alien_core::Worker>() {
+        inject_into_environment(resource_name, "worker", &mut worker.environment, snapshot)
+    } else if let Some(container) = resource_entry.config.downcast_mut::<alien_core::Container>() {
+        inject_into_environment(
+            resource_name,
+            "container",
+            &mut container.environment,
+            snapshot,
+        )
+    } else if let Some(daemon) = resource_entry.config.downcast_mut::<alien_core::Daemon>() {
+        inject_into_environment(resource_name, "daemon", &mut daemon.environment, snapshot)
     } else {
-        &mut resource_entry
-            .config
-            .downcast_mut::<alien_core::Container>()
-            .ok_or_else(|| {
-                AlienError::new(ErrorData::InternalError {
-                    message: format!(
-                        "Failed to downcast resource '{}' to Container",
-                        resource_name
-                    ),
-                })
-            })?
-            .environment
-    };
+        Err(AlienError::new(ErrorData::InternalError {
+            message: format!(
+                "Failed to downcast resource '{}' to a compute resource",
+                resource_name
+            ),
+        }))
+    }
+}
 
+fn inject_into_environment(
+    resource_name: &str,
+    resource_type: &str,
+    environment: &mut HashMap<String, String>,
+    snapshot: &EnvironmentVariablesSnapshot,
+) -> Result<()> {
     // Filter variables that apply to this resource
     let applicable_vars: Vec<&EnvironmentVariable> = snapshot
         .variables
@@ -386,7 +402,6 @@ fn inject_into_compute_resource(
 
         environment.insert(ENV_ALIEN_SECRETS.to_string(), alien_secrets_json);
 
-        let resource_type = if is_worker { "worker" } else { "container" };
         debug!(
             "Added ALIEN_SECRETS to {} '{}' with {} secret keys",
             resource_type,

--- a/crates/alien-deployment/src/initial_setup.rs
+++ b/crates/alien-deployment/src/initial_setup.rs
@@ -60,7 +60,11 @@ pub async fn handle_initial_setup(
 
     // Inject OTLP monitoring env vars if monitoring is configured
     if let Some(monitoring) = &config.monitoring {
-        crate::helpers::inject_monitoring_environment_variables(&mut target_stack, monitoring)?;
+        crate::helpers::inject_monitoring_environment_variables(
+            &mut target_stack,
+            monitoring,
+            current.platform,
+        )?;
     }
 
     // Sync secrets to vault if the vault is already Running (from a previous

--- a/crates/alien-deployment/src/pending.rs
+++ b/crates/alien-deployment/src/pending.rs
@@ -78,6 +78,7 @@ pub async fn handle_pending(
         crate::helpers::inject_monitoring_environment_variables(
             &mut mutated_stack_with_env,
             monitoring,
+            current.platform,
         )?;
     }
 

--- a/crates/alien-deployment/src/provisioning.rs
+++ b/crates/alien-deployment/src/provisioning.rs
@@ -68,7 +68,11 @@ pub async fn handle_provisioning(
 
     // Inject OTLP monitoring env vars if monitoring is configured
     if let Some(monitoring) = &config.monitoring {
-        crate::helpers::inject_monitoring_environment_variables(&mut target_stack, monitoring)?;
+        crate::helpers::inject_monitoring_environment_variables(
+            &mut target_stack,
+            monitoring,
+            current.platform,
+        )?;
     }
 
     // Sync secrets to vault before deploying workload resources.

--- a/crates/alien-deployment/src/running.rs
+++ b/crates/alien-deployment/src/running.rs
@@ -54,7 +54,11 @@ pub async fn handle_running(
 
     // Inject OTLP monitoring env vars if monitoring is configured
     if let Some(monitoring) = &config.monitoring {
-        crate::helpers::inject_monitoring_environment_variables(&mut target_stack, monitoring)?;
+        crate::helpers::inject_monitoring_environment_variables(
+            &mut target_stack,
+            monitoring,
+            current.platform,
+        )?;
     }
 
     // TODO: Add mechanism to limit executor to only perform read-only health checks

--- a/crates/alien-deployment/src/updating.rs
+++ b/crates/alien-deployment/src/updating.rs
@@ -125,7 +125,11 @@ pub async fn handle_updating(
 
     // Inject OTLP monitoring env vars if monitoring is configured
     if let Some(monitoring) = &config.monitoring {
-        crate::helpers::inject_monitoring_environment_variables(&mut target_stack, monitoring)?;
+        crate::helpers::inject_monitoring_environment_variables(
+            &mut target_stack,
+            monitoring,
+            current.platform,
+        )?;
     }
 
     // Sync secrets to vault before updating workload resources.

--- a/crates/alien-infra/src/core/controller.rs
+++ b/crates/alien-infra/src/core/controller.rs
@@ -942,6 +942,12 @@ fn deserialize_controller_by_tag(
         #[cfg(feature = "local")]
         "LocalContainerController" => deser!(crate::container::LocalContainerController),
 
+        // Daemon controllers
+        #[cfg(feature = "kubernetes")]
+        "KubernetesDaemonController" => deser!(crate::daemon::KubernetesDaemonController),
+        #[cfg(feature = "local")]
+        "LocalDaemonController" => deser!(crate::daemon::LocalDaemonController),
+
         // Container cluster controllers
         #[cfg(feature = "local")]
         "LocalComputeClusterController" => {

--- a/crates/alien-local/src/worker_manager.rs
+++ b/crates/alien-local/src/worker_manager.rs
@@ -1358,10 +1358,7 @@ impl LocalWorkerManager {
                     }));
                 }
 
-                // For now, just use the first tarball
-                // TODO: In the future, we could detect the current platform and select the matching tarball
-                // (e.g., darwin-aarch64.oci.tar vs linux-x86_64.oci.tar)
-                let selected_tarball = &tarball_files[0];
+                let selected_tarball = select_host_tarball(&tarball_files)?;
 
                 debug!(
                     worker_id = %worker_id,
@@ -1568,4 +1565,102 @@ fn allocate_port_with_preference(saved_port: Option<u16>, resource_id: &str) -> 
     }
 
     Ok(port)
+}
+
+/// Pick the tarball to extract from an artifact directory. A native process can only exec
+/// the host's binary, so when the directory holds several per-target tarballs the host's
+/// must be chosen — another OS's binary would fail at spawn with an opaque exec error.
+/// A single tarball is a single-target build output and is used as-is.
+fn select_host_tarball(tarball_files: &[PathBuf]) -> Result<&PathBuf> {
+    if tarball_files.len() == 1 {
+        return Ok(&tarball_files[0]);
+    }
+    let host = alien_core::BinaryTarget::current_os();
+    let host_tarball = format!("{}.oci.tar", host.runtime_platform_id());
+    tarball_files
+        .iter()
+        .find(|path| path.file_name().and_then(|name| name.to_str()) == Some(host_tarball.as_str()))
+        .ok_or_else(|| {
+            let available: Vec<String> = tarball_files
+                .iter()
+                .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+                .map(str::to_string)
+                .collect();
+            AlienError::new(ErrorData::Other {
+                message: format!(
+                    "No tarball for host target '{}' in artifact directory (found: {}). \
+                     Rebuild with this host among the targets.",
+                    host.runtime_platform_id(),
+                    available.join(", "),
+                ),
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(names: &[&str]) -> Vec<PathBuf> {
+        names
+            .iter()
+            .map(|name| PathBuf::from(format!("/artifacts/{name}")))
+            .collect()
+    }
+
+    #[test]
+    fn single_tarball_is_used_as_is_regardless_of_target() {
+        let files = paths(&["linux-x64.oci.tar"]);
+        let selected = select_host_tarball(&files).expect("single tarball should be selected");
+        assert_eq!(selected, &files[0]);
+    }
+
+    #[test]
+    fn multiple_tarballs_select_the_host_target() {
+        let host = alien_core::BinaryTarget::current_os();
+        let host_name = format!("{}.oci.tar", host.runtime_platform_id());
+        let files = paths(&[
+            "darwin-aarch64.oci.tar",
+            "linux-aarch64.oci.tar",
+            "linux-x64.oci.tar",
+            "windows-x64.oci.tar",
+        ]);
+        let selected = select_host_tarball(&files).expect("host tarball should be present");
+        assert_eq!(
+            selected.file_name().and_then(|name| name.to_str()),
+            Some(host_name.as_str())
+        );
+    }
+
+    #[test]
+    fn multiple_tarballs_without_host_target_fail_fast() {
+        // Exclude the host's own tarball so no entry matches, on any host OS.
+        let host = alien_core::BinaryTarget::current_os();
+        let all = [
+            "darwin-aarch64.oci.tar",
+            "linux-aarch64.oci.tar",
+            "linux-x64.oci.tar",
+            "windows-x64.oci.tar",
+        ];
+        let host_name = format!("{}.oci.tar", host.runtime_platform_id());
+        let without_host: Vec<&str> = all
+            .iter()
+            .copied()
+            .filter(|name| *name != host_name)
+            .collect();
+        let files = paths(&without_host);
+
+        let error = match select_host_tarball(&files) {
+            Err(error) => error,
+            Ok(path) => panic!("expected failure, selected {}", path.display()),
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains(host.runtime_platform_id()),
+            "error names the host target: {message}"
+        );
+        for name in &without_host {
+            assert!(message.contains(name), "error lists {name}: {message}");
+        }
+    }
 }

--- a/crates/alien-preflights/src/deployment_prerequisites.rs
+++ b/crates/alien-preflights/src/deployment_prerequisites.rs
@@ -8,7 +8,7 @@
 use crate::error::Result;
 use crate::{CheckResult, DeploymentPrerequisiteCheck};
 use alien_core::{
-    ComputeBackend, ComputeCluster, Container, DeploymentConfig, EnvironmentVariable,
+    ComputeBackend, ComputeCluster, Container, Daemon, DeploymentConfig, EnvironmentVariable,
     ExposeProtocol, Platform, Stack, StackState, Worker,
 };
 
@@ -178,6 +178,7 @@ fn environment_variable_target_resource_ids(stack: &Stack) -> Vec<&str> {
         .filter_map(|(id, entry)| {
             if entry.config.downcast_ref::<Worker>().is_some()
                 || entry.config.downcast_ref::<Container>().is_some()
+                || entry.config.downcast_ref::<Daemon>().is_some()
             {
                 Some(id.as_str())
             } else {

--- a/packages/testing/src/deploy.ts
+++ b/packages/testing/src/deploy.ts
@@ -157,19 +157,12 @@ async function deployViaDev(options: DeployOptions): Promise<Deployment> {
 
     const agent = findPrimaryAgent(status)
 
+    // A stack with no URL-exposing resource (e.g. daemon-only) has no public URL;
+    // commands are still reachable through commandsUrl.
     const publicUrl = findPublicUrl(agent.resources)
-    if (!publicUrl) {
-      throw new AlienError(
-        TestingOperationFailedError.create({
-          operation: "resolve-public-url",
-          message: "No public URL found in deployment resources",
-          details: { resources: agent.resources },
-        }),
-      )
-    }
 
     if (verbose) {
-      console.log(`[testing] Public URL: ${publicUrl}`)
+      console.log(`[testing] Public URL: ${publicUrl ?? "(none)"}`)
       if (agent.commandsUrl) {
         console.log(`[testing] Commands URL: ${agent.commandsUrl}`)
       }
@@ -305,7 +298,7 @@ async function deployViaApi(options: DeployOptions): Promise<Deployment> {
   return new Deployment({
     id: running.id,
     name: running.name,
-    url: running.url!,
+    url: running.url,
     platform,
     commandsUrl: running.commandsUrl!,
     appPath: options.app,
@@ -426,10 +419,8 @@ async function waitForPlatformDeploymentRunning(
           console.log(`[testing] Deployment ${deploymentId} status: ${data.status}`)
         }
 
+        // A running deployment may have no URL (e.g. daemon-only stacks) — url stays optional.
         if (data.status === "running") {
-          if (!data.url) {
-            throw new Error(`Deployment is running but has no URL: ${JSON.stringify(data)}`)
-          }
           return data
         }
 

--- a/packages/testing/src/deployment.ts
+++ b/packages/testing/src/deployment.ts
@@ -19,7 +19,8 @@ const execFileAsync = promisify(execFile)
 export class Deployment {
   readonly id: string
   readonly name: string
-  readonly url: string
+  /** Public URL of the app. Undefined for stacks with no URL-exposing resource (e.g. daemon-only). */
+  readonly url: string | undefined
   readonly platform: Platform
 
   /** Whether the deployment has been destroyed */

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -72,7 +72,8 @@ export interface DeploymentInfo {
 export interface DeploymentInit {
   id: string
   name: string
-  url: string
+  /** Public URL of the app, when the stack has a resource that exposes one. */
+  url?: string
   platform: Platform
   commandsUrl: string
   appPath: string


### PR DESCRIPTION
## Summary

`alien build` could only build container images for the machine it runs on, and a daemon with source code was never built at all. Now the release workflow builds each target on a native runner and merges the results into one multi-arch release, and daemon source compiles per-OS like a worker — including a local run path.

What a release run looks like now:

1. `alien build plan --json` reads the stack and groups the platform/target pairs by which runner can build them natively (arm64 goes to the cheaper arm runners).
2. Each runner group builds its share with the existing `alien build` flags and uploads a partial output.
3. `alien build merge` combines the partials into one `.alien` directory, and `alien release --prebuilt` publishes it — with a real manifest list when a resource has more than one architecture.   ← the new bit

So cross-arch goes from emulated-on-one-machine to native-per-runner, and daemons go from image-only to buildable from source.

## What was broken

- Building an arm64 image on a plain amd64 runner died with `exec format error`.
- A source daemon produced zero artifacts, and deploying one locally failed at every layer: the controller couldn't be restored, env vars never reached it, and the testing harness refused a stack with no URL.
- `docker save` on the containerd store (Docker's current default) writes a nested index our OCI reader couldn't parse.
- With two architectures for one resource, push wrote both tarballs to the same tag — the second overwrote the first.

## What I did

- Added a builder capability check, so a target the machine can't build fails fast with a clear error instead of the raw `exec format error`.
- Added `alien build plan [--json]` and `alien build merge`. Merge rejects duplicate target files unless they're byte-identical. No new build mode — the groups just reuse the existing flags.
- `alien release --prebuilt` now means "already built, don't rebuild": local artifacts get pushed, remote image URIs get reused.
- Multiple linux tarballs for one resource push as an OCI image index. darwin/windows host binaries never push — they stay local.
- On `local`, macOS/Windows runners are only planned when something actually needs a host binary. A container is always a linux image, so those runners skip it and merge accepts a resource that some groups built and others skipped.
- Daemons build from source like workers, per target, and run locally as native processes. Along the way: controller restore, env-var injection, picking the right host tarball out of a multi-target artifact, push-cache support, and letting the testing harness accept a stack with no URL.
- Monitoring env vars now depend on the platform: on aws/gcp/azure only workers get them — containers and daemons run inside the hosted container runtime, which already ships their logs. On kubernetes and local everything gets them, and a container gets the auth header as a plain env var, because it has no runtime wrapper to read it from the vault like workers do.
- Flattened `docker save` output from the containerd store so the OCI reader always sees a single manifest.

## How I tested

- `cargo test` across the touched crates: alien-build 68, alien-cli 84, alien-deployment 38 (including tests that pin exactly which resources get monitoring vars on which platform), alien-local 6, alien-preflights 167.
- Real GitHub Actions run on a demo app (aws/gcp/azure): plan → native builds on `ubuntu-24.04-arm` and `ubuntu-24.04` → merge → `release --prebuilt`. All green, release created end-to-end.
- A second Actions run on a daemon app added `macos-latest`: merge produced one artifact directory with all three host tarballs, asserted in CI.
- `examples/endpoint-agent` (Rust source daemon, local) — `vitest run` 6/6: deploys, runs as a native process, gets its env vars, answers real commands.
- `alien build plan --json`: a source-daemon stack plans all four runner groups; a container-only local stack plans just the two linux ones.
- On the registry changes: per-arch child tags stay inside the same repository path, so pull authorization doesn't change; the pull token is used during extraction and never stored in controller state; manifest-list entries use digests read back from the registry, not recomputed. Nothing turned up.

