### PR TITLE
chore: fix release publishing OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Build
         run: pnpm build
         env:
-          NODE_OPTIONS: "--max-old-space-size=4096"
+          NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Publish npm packages
         env:
@@ -245,6 +245,7 @@ jobs:
         working-directory: client-sdks/platform/typescript
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_OPTIONS: "--max-old-space-size=8192"
         run: |
           npm install
           npm run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -959,14 +959,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -1,7 +1,7 @@
 use crate::error::{ErrorData, Result};
 use crate::execution_context::ExecutionMode;
 use crate::interaction::{ConfirmationMode, InteractionMode};
-use crate::output::prompt_confirm;
+use crate::output::{print_json, prompt_confirm};
 use crate::ui::{
     command, contextual_heading, deployment_resource_detail, dim_label, format_resource_status,
     heading, make_table, print_table, render_human_error, status_cell, success_line,
@@ -108,11 +108,19 @@ pub enum DeploymentsCmd {
         /// Project to list deployments for (optional, uses linked project by default)
         #[arg(long)]
         project: Option<String>,
+
+        /// Print machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Get deployment details
     Get {
         /// Deployment name or ID
         id: String,
+
+        /// Print machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Delete a deployment
     Delete {
@@ -164,24 +172,24 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
 
     match args.cmd {
         // --- Manager API operations (all modes: dev, standalone, platform) ---
-        DeploymentsCmd::Ls { project } => {
-            let manager = resolve_manager_client(&ctx, project.as_deref()).await?;
-            list_deployments_task(&manager).await
+        DeploymentsCmd::Ls { project, json } => {
+            let manager = resolve_manager_client(&ctx, project.as_deref(), !json).await?;
+            list_deployments_task(&manager, json).await
         }
-        DeploymentsCmd::Get { id } => {
-            let manager = resolve_manager_client(&ctx, None).await?;
-            get_deployment_task(&manager, &id).await
+        DeploymentsCmd::Get { id, json } => {
+            let manager = resolve_manager_client(&ctx, None, !json).await?;
+            get_deployment_task(&manager, &id, json).await
         }
         DeploymentsCmd::Delete { id, yes } => {
-            let manager = resolve_manager_client(&ctx, None).await?;
+            let manager = resolve_manager_client(&ctx, None, true).await?;
             delete_deployment_task(&manager, &id, yes).await
         }
         DeploymentsCmd::Retry { id } => {
-            let manager = resolve_manager_client(&ctx, None).await?;
+            let manager = resolve_manager_client(&ctx, None, true).await?;
             retry_deployment_task(&manager, &id).await
         }
         DeploymentsCmd::Redeploy { id } => {
-            let manager = resolve_manager_client(&ctx, None).await?;
+            let manager = resolve_manager_client(&ctx, None, true).await?;
             redeploy_deployment_task(&manager, &id).await
         }
 
@@ -273,8 +281,11 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
 pub(crate) async fn resolve_manager_client(
     ctx: &ExecutionMode,
     project_override: Option<&str>,
+    allow_bootstrap: bool,
 ) -> Result<alien_manager_api::Client> {
-    let (_, project_link) = ctx.resolve_project(project_override, true).await?;
+    let (_, project_link) = ctx
+        .resolve_project(project_override, allow_bootstrap)
+        .await?;
     // The platform parameter is only used in platform mode for build-config
     // discovery; the manager URL is the same regardless of platform.
     let manager_ctx = ctx.resolve_manager(&project_link.project_id, "aws").await?;
@@ -313,7 +324,7 @@ async fn resolve_deployment_reference(
 // Manager API operations (unified for all modes)
 // ---------------------------------------------------------------------------
 
-async fn list_deployments_task(client: &alien_manager_api::Client) -> Result<()> {
+async fn list_deployments_task(client: &alien_manager_api::Client, json: bool) -> Result<()> {
     let response = client
         .list_deployments()
         .send()
@@ -324,6 +335,10 @@ async fn list_deployments_task(client: &alien_manager_api::Client) -> Result<()>
             url: None,
         })?
         .into_inner();
+
+    if json {
+        return print_json(&response.items);
+    }
 
     if response.items.is_empty() {
         println!("(no deployments)");
@@ -354,8 +369,16 @@ async fn list_deployments_task(client: &alien_manager_api::Client) -> Result<()>
     Ok(())
 }
 
-async fn get_deployment_task(client: &alien_manager_api::Client, reference: &str) -> Result<()> {
+async fn get_deployment_task(
+    client: &alien_manager_api::Client,
+    reference: &str,
+    json: bool,
+) -> Result<()> {
     let deployment = resolve_deployment_reference(client, reference).await?;
+
+    if json {
+        return print_json(&deployment);
+    }
 
     println!(
         "{}",

--- a/crates/alien-cli/src/commands/logs.rs
+++ b/crates/alien-cli/src/commands/logs.rs
@@ -23,6 +23,7 @@ use crate::ui::supports_ansi;
 const DEFAULT_LIMIT: usize = 200;
 const MAX_LIMIT: usize = 1000;
 const SEEN_KEYS_LIMIT: usize = 20_000;
+const DEFAULT_LOG_SEARCH_FIELDS: &[&str] = &["body.message"];
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -669,6 +670,12 @@ async fn fetch_logs(
             end_time,
             max_hits: Some(limit),
             sort_by: Some("-timestamp_nanos".to_string()),
+            search_fields: Some(
+                DEFAULT_LOG_SEARCH_FIELDS
+                    .iter()
+                    .map(|field| field.to_string())
+                    .collect(),
+            ),
             ..Default::default()
         })
         .await

--- a/crates/alien-cli/src/commands/releases.rs
+++ b/crates/alien-cli/src/commands/releases.rs
@@ -32,9 +32,12 @@ pub async fn releases_task(args: ReleasesArgs, ctx: ExecutionMode) -> Result<()>
         ReleasesCmd::Ls { project } => {
             // Releases are a core feature, so they go through the manager, not
             // the platform API directly.
-            let manager =
-                crate::commands::deployments::resolve_manager_client(&ctx, project.as_deref())
-                    .await?;
+            let manager = crate::commands::deployments::resolve_manager_client(
+                &ctx,
+                project.as_deref(),
+                true,
+            )
+            .await?;
             list_releases_task(&manager).await
         }
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "turbo build",
     "build:images": "echo 'Use GitHub Actions workflows (.github/workflows/images*.yml) for canonical image builds'",
     "generate": "turbo run generate",
-    "generate:platform-api": "speakeasy generate sdk --lang typescript --schema ./client-sdks/platform/openapi.json --out client-sdks/platform/typescript && pnpm -C ./client-sdks/platform/typescript build",
+    "generate:platform-api": "speakeasy generate sdk --lang typescript --schema ./client-sdks/platform/openapi.json --out client-sdks/platform/typescript && NODE_OPTIONS=--max-old-space-size=8192 pnpm -C ./client-sdks/platform/typescript build",
     "generate:manager-api": "speakeasy generate sdk --lang typescript --schema ./client-sdks/manager/openapi.json --out client-sdks/manager/typescript && pnpm -C ./client-sdks/manager/typescript build",
     "generate:manager-openapi": "cargo run --bin alien-manager-schema-exporter --features openapi -p alien-manager -- --output crates/alien-manager/openapi.json && cp crates/alien-manager/openapi.json client-sdks/manager/openapi.json",
     "generate:manager-rust-sdk": "pnpm run generate:manager-openapi && openapi-down-convert -i crates/alien-manager/openapi.json -o client-sdks/manager/rust/openapi-3.0.json && cd client-sdks/manager/rust && node ../scripts/fix-openapi.mjs",


### PR DESCRIPTION
Linear: ALIEN-188

## Summary
- raise Node heap to 8192 MB for platform SDK release/generation builds
- keep Cargo.lock workspace package versions aligned with 1.6.0
- add JSON output for deployment list/get and constrain log search to body.message

## Root cause
The release workflow failed while building @alienplatform/platform-api because tsc exhausted Node's default heap around 4 GB. ../platform already builds the same SDK with --max-old-space-size=8192.

## Validation
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -C ./client-sdks/platform/typescript build
- cargo fmt --check
- cargo check -p alien-cli
- cargo test -p alien-cli
