### PR TITLE
chore: use published core package in examples

### DIFF
--- a/examples/byoc-database/bun.lock
+++ b/examples/byoc-database/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "byoc-database",
       "devDependencies": {
-        "@alienplatform/core": "^1.0.1",
+        "@alienplatform/core": "^1.7.0",
         "@alienplatform/testing": "^0.1.0",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.3",
@@ -15,7 +16,7 @@
   "packages": {
     "@alienplatform/commands-client": ["@alienplatform/commands-client@1.0.0", "", { "dependencies": { "@alienplatform/core": "^1.0.1", "@alienplatform/platform-api": "^1.0.68", "zod": "4.3.2" } }, "sha512-+RNIzP7F3K49WRDRMusgi0IWSUgraCut49mlJOXCfeRKS7V7L4Alkr/jD1Nhpg7TXfwANGLdQHR2FFEP1axyjg=="],
 
-    "@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
+    "@alienplatform/core": ["@alienplatform/core@1.7.0", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-dCUDGBOUMVZDo+cjSPCuGHb/pLcq2LkEC9Eih1AZCjQr6SvBlPTVdL0B/RQZWXaGPOp48WaMIpqaRFUIYwMDKg=="],
 
     "@alienplatform/platform-api": ["@alienplatform/platform-api@1.3.5", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-+BvWSUgnQ6kzT5ijHg3ac5zeDPjIuRyxSsuegxRBinpKnmFkYADhKglWllOsmgMczpBGM0e1pH2TIxyaVPuCRA=="],
 
@@ -254,6 +255,8 @@
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+
+    "@alienplatform/commands-client/@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
 
     "@alienplatform/testing/@alienplatform/core": ["@alienplatform/core@1.0.1", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-6J67tqZIbLBzQHRF+WEVWs+kAlS+1nIUrw82n05+07DxSkgTmE/YyHysqA6rbn+WUhlbK/GtWe1PPdD03fMqpA=="],
   }

--- a/examples/byoc-database/package.json
+++ b/examples/byoc-database/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@alienplatform/core": "link:../../packages/core",
+    "@alienplatform/core": "^1.7.0",
     "@alienplatform/testing": "^0.1.0",
     "@types/node": "^22.10.5",
     "typescript": "^5.7.3",

--- a/examples/endpoint-agent/bun.lock
+++ b/examples/endpoint-agent/bun.lock
@@ -1,12 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@alienplatform/example-endpoint-agent",
-      "dependencies": {
-        "@alienplatform/core": "^1.0.1",
-      },
       "devDependencies": {
+        "@alienplatform/core": "^1.7.0",
         "@alienplatform/testing": "^0.1.0",
         "@types/node": "^22.10.5",
         "typescript": "~5.7.2",
@@ -17,7 +16,7 @@
   "packages": {
     "@alienplatform/commands-client": ["@alienplatform/commands-client@1.0.0", "", { "dependencies": { "@alienplatform/core": "^1.0.1", "@alienplatform/platform-api": "^1.0.68", "zod": "4.3.2" } }, "sha512-+RNIzP7F3K49WRDRMusgi0IWSUgraCut49mlJOXCfeRKS7V7L4Alkr/jD1Nhpg7TXfwANGLdQHR2FFEP1axyjg=="],
 
-    "@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
+    "@alienplatform/core": ["@alienplatform/core@1.7.0", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-dCUDGBOUMVZDo+cjSPCuGHb/pLcq2LkEC9Eih1AZCjQr6SvBlPTVdL0B/RQZWXaGPOp48WaMIpqaRFUIYwMDKg=="],
 
     "@alienplatform/platform-api": ["@alienplatform/platform-api@1.3.5", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-+BvWSUgnQ6kzT5ijHg3ac5zeDPjIuRyxSsuegxRBinpKnmFkYADhKglWllOsmgMczpBGM0e1pH2TIxyaVPuCRA=="],
 
@@ -256,6 +255,8 @@
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+
+    "@alienplatform/commands-client/@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
 
     "@alienplatform/testing/@alienplatform/core": ["@alienplatform/core@1.0.1", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-6J67tqZIbLBzQHRF+WEVWs+kAlS+1nIUrw82n05+07DxSkgTmE/YyHysqA6rbn+WUhlbK/GtWe1PPdD03fMqpA=="],
   }

--- a/examples/endpoint-agent/package.json
+++ b/examples/endpoint-agent/package.json
@@ -8,7 +8,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@alienplatform/core": "link:../../packages/core",
+    "@alienplatform/core": "^1.7.0",
     "@alienplatform/testing": "^0.1.0",
     "@types/node": "^22.10.5",
     "typescript": "~5.7.2",

--- a/examples/full-stack-microservices/package.json
+++ b/examples/full-stack-microservices/package.json
@@ -8,7 +8,7 @@
     "test:ts": "pnpm --filter './services/*' test:ts"
   },
   "devDependencies": {
-    "@alienplatform/core": "link:../../packages/core",
+    "@alienplatform/core": "^1.7.0",
     "typescript": "^5.7.3"
   }
 }

--- a/examples/github-agent/packages/remote-agent/bun.lock
+++ b/examples/github-agent/packages/remote-agent/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "github-agent-remote-agent",
       "dependencies": {
-        "@alienplatform/core": "^1.0.1",
+        "@alienplatform/core": "^1.7.0",
         "@alienplatform/sdk": "^1.0.0",
         "hono": "^4.0.0",
         "zod": "^3.24.1",
@@ -20,7 +21,7 @@
   "packages": {
     "@alienplatform/commands-client": ["@alienplatform/commands-client@1.0.0", "", { "dependencies": { "@alienplatform/core": "^1.0.1", "@alienplatform/platform-api": "^1.0.68", "zod": "4.3.2" } }, "sha512-+RNIzP7F3K49WRDRMusgi0IWSUgraCut49mlJOXCfeRKS7V7L4Alkr/jD1Nhpg7TXfwANGLdQHR2FFEP1axyjg=="],
 
-    "@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
+    "@alienplatform/core": ["@alienplatform/core@1.7.0", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-dCUDGBOUMVZDo+cjSPCuGHb/pLcq2LkEC9Eih1AZCjQr6SvBlPTVdL0B/RQZWXaGPOp48WaMIpqaRFUIYwMDKg=="],
 
     "@alienplatform/platform-api": ["@alienplatform/platform-api@1.3.5", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-+BvWSUgnQ6kzT5ijHg3ac5zeDPjIuRyxSsuegxRBinpKnmFkYADhKglWllOsmgMczpBGM0e1pH2TIxyaVPuCRA=="],
 
@@ -336,11 +337,15 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@alienplatform/commands-client/@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
+
     "@alienplatform/commands-client/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
 
     "@alienplatform/core/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
 
     "@alienplatform/platform-api/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+
+    "@alienplatform/sdk/@alienplatform/core": ["@alienplatform/core@1.3.5", "", { "dependencies": { "@openapi-contrib/json-schema-to-openapi-schema": "^4.0.0", "serialize-error": "^12.0.0", "zod": "4.3.2" } }, "sha512-P4pj4Q57g09Z+5zVaPRuNVIcWnHlGpknewm3Z0GkZn2yk+21/aZ6aoi0I2aMwbC4/E11HF4+mENPCUnu47J1EA=="],
 
     "@alienplatform/sdk/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
 

--- a/examples/github-agent/packages/remote-agent/package.json
+++ b/examples/github-agent/packages/remote-agent/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@alienplatform/sdk": "^1.0.0",
-    "@alienplatform/core": "link:../../../../packages/core",
+    "@alienplatform/core": "^1.7.0",
     "hono": "^4.0.0",
     "zod": "^3.24.1"
   },


### PR DESCRIPTION
Fixes ALIEN-189.

Updates examples to depend on the published @alienplatform/core package instead of repo-local link dependencies, so downloaded examples install cleanly.

Validation:
- clean bun install --frozen-lockfile for byoc-database, endpoint-agent, and github-agent remote-agent