### PR TITLE
fix(manager): refresh running deployments in heartbeat loop

### DIFF
--- a/crates/alien-deployment/src/runner.rs
+++ b/crates/alien-deployment/src/runner.rs
@@ -91,14 +91,74 @@ pub async fn run_step_loop(
     service_provider: Option<Arc<dyn alien_infra::PlatformServiceProvider>>,
     on_progress: Option<&ProgressCallback>,
 ) -> Result<RunnerResult> {
+    run_step_loop_inner(
+        state,
+        config,
+        client_config,
+        deployment_id,
+        policy,
+        transport,
+        service_provider,
+        on_progress,
+        false,
+    )
+    .await
+}
+
+/// Run one refresh step for a deployment whose initial status is already Running.
+///
+/// Normal deployment loops treat Running as already synced and stop before
+/// calling [`crate::step()`]. Heartbeat loops use this entry point to execute the
+/// Running refresh path exactly once, then checkpoint emitted resource
+/// heartbeats through the provided transport.
+pub async fn run_running_refresh_step_loop(
+    state: &mut DeploymentState,
+    config: &mut DeploymentConfig,
+    client_config: &ClientConfig,
+    deployment_id: &str,
+    policy: &RunnerPolicy,
+    transport: &dyn DeploymentLoopTransport,
+    service_provider: Option<Arc<dyn alien_infra::PlatformServiceProvider>>,
+    on_progress: Option<&ProgressCallback>,
+) -> Result<RunnerResult> {
+    run_step_loop_inner(
+        state,
+        config,
+        client_config,
+        deployment_id,
+        policy,
+        transport,
+        service_provider,
+        on_progress,
+        true,
+    )
+    .await
+}
+
+async fn run_step_loop_inner(
+    state: &mut DeploymentState,
+    config: &mut DeploymentConfig,
+    client_config: &ClientConfig,
+    deployment_id: &str,
+    policy: &RunnerPolicy,
+    transport: &dyn DeploymentLoopTransport,
+    service_provider: Option<Arc<dyn alien_infra::PlatformServiceProvider>>,
+    on_progress: Option<&ProgressCallback>,
+    allow_initial_running_step: bool,
+) -> Result<RunnerResult> {
     for step_count in 1..=policy.max_steps {
         // Pre-step terminal check
         if !should_step_retryable_failure(state) {
+            let should_run_initial_running_refresh = allow_initial_running_step
+                && step_count == 1
+                && state.status == DeploymentStatus::Running;
             if let Some(result) = classify_status(&state.status, policy.operation) {
-                return Ok(RunnerResult {
-                    loop_result: result,
-                    steps_executed: step_count - 1,
-                });
+                if !should_run_initial_running_refresh {
+                    return Ok(RunnerResult {
+                        loop_result: result,
+                        steps_executed: step_count - 1,
+                    });
+                }
             }
         }
 
@@ -607,5 +667,46 @@ mod tests {
         assert_eq!(result.steps_executed, 0);
         assert_eq!(state.status, DeploymentStatus::ProvisioningFailed);
         assert_eq!(transport.attempts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn initial_running_runs_one_step_when_policy_allows_running_start() {
+        let transport = FailFirstCheckpointTransport::default();
+        let mut state = test_state();
+        state.status = DeploymentStatus::Running;
+        state.stack_state = Some(StackState::new(Platform::Test));
+        let mut config = test_config();
+        let policy = RunnerPolicy {
+            max_steps: 1,
+            operation: LoopOperation::Deploy,
+            delay_threshold: None,
+        };
+
+        let result = run_running_refresh_step_loop(
+            &mut state,
+            &mut config,
+            &ClientConfig::Test,
+            "dep_test",
+            &policy,
+            &transport,
+            None,
+            None,
+        )
+        .await
+        .expect("runner should run one heartbeat step for an initially running deployment");
+
+        assert_eq!(result.steps_executed, 1);
+        assert_eq!(state.status, DeploymentStatus::RefreshFailed);
+        assert_eq!(
+            transport
+                .checkpointed_statuses
+                .lock()
+                .expect("statuses lock poisoned")
+                .as_slice(),
+            &[
+                DeploymentStatus::RefreshFailed,
+                DeploymentStatus::RefreshFailed
+            ],
+        );
     }
 }

--- a/crates/alien-deployment/src/running.rs
+++ b/crates/alien-deployment/src/running.rs
@@ -122,7 +122,7 @@ pub async fn handle_running(
 
         Ok(DeploymentStepResult {
             state: next,
-            suggested_delay_ms: None,
+            suggested_delay_ms: step_result.suggested_delay_ms,
             update_heartbeat: true, // Update heartbeat timestamp for Running status
             heartbeats,
         })

--- a/crates/alien-manager/src/loops/deployment.rs
+++ b/crates/alien-manager/src/loops/deployment.rs
@@ -37,12 +37,35 @@ use crate::transports::ManagerTransport;
 
 /// Maximum number of step() calls per deployment per tick.
 const MAX_STEPS_PER_TICK: usize = 100;
+const MAX_STEPS_PER_HEARTBEAT: usize = 1;
 /// Maximum number of deployments to process concurrently per tick.
-const MAX_CONCURRENT_DEPLOYMENTS: usize = 4;
+pub(crate) const MAX_CONCURRENT_DEPLOYMENTS: usize = 4;
 /// Maximum acquire/process batches before yielding back to the interval sleep.
 const MAX_ACQUIRE_BATCHES_PER_TICK: usize = 16;
 /// Suggested delay threshold (ms) — if step suggests waiting longer, yield.
 const SUGGESTED_DELAY_THRESHOLD_MS: u64 = 500;
+
+#[derive(Debug, Clone, Copy)]
+struct ProcessOptions {
+    max_steps: usize,
+    require_heartbeats_enabled: bool,
+}
+
+impl ProcessOptions {
+    fn deployment_tick() -> Self {
+        Self {
+            max_steps: MAX_STEPS_PER_TICK,
+            require_heartbeats_enabled: false,
+        }
+    }
+
+    fn heartbeat_tick() -> Self {
+        Self {
+            max_steps: MAX_STEPS_PER_HEARTBEAT,
+            require_heartbeats_enabled: true,
+        }
+    }
+}
 fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
     if let Some(message) = payload.downcast_ref::<&'static str>() {
         message
@@ -205,7 +228,12 @@ impl DeploymentLoop {
                     );
                     stream::iter(acquired)
                         .for_each_concurrent(MAX_CONCURRENT_DEPLOYMENTS, |item| async {
-                            self.process_deployment(item.deployment, &session).await;
+                            self.process_deployment(
+                                item.deployment,
+                                &session,
+                                ProcessOptions::deployment_tick(),
+                            )
+                            .await;
                         })
                         .await;
                 }
@@ -222,12 +250,28 @@ impl DeploymentLoop {
         );
     }
 
+    pub(crate) async fn process_heartbeat_deployment(
+        &self,
+        deployment: DeploymentRecord,
+        session: &str,
+    ) {
+        self.process_deployment(deployment, session, ProcessOptions::heartbeat_tick())
+            .await;
+    }
+
     /// Process a single deployment: step until stable, reconcile, release.
-    async fn process_deployment(&self, deployment: DeploymentRecord, session: &str) {
+    async fn process_deployment(
+        &self,
+        deployment: DeploymentRecord,
+        session: &str,
+        options: ProcessOptions,
+    ) {
         let deployment_id = deployment.id.clone();
 
         // Always release the lock when we are done, even on error.
-        let result = self.process_deployment_inner(deployment, session).await;
+        let result = self
+            .process_deployment_inner(deployment, session, options)
+            .await;
 
         if let Err(e) = &result {
             error!(
@@ -256,18 +300,17 @@ impl DeploymentLoop {
         &self,
         deployment: DeploymentRecord,
         session: &str,
+        options: ProcessOptions,
     ) -> Result<(), AlienError> {
         let deployment_id = deployment.id.clone();
+        let stack_settings = deployment
+            .stack_settings
+            .as_ref()
+            .expect("stored deployment carries stack_settings");
 
         // Pull-mode deployments are entirely driven by the alien-agent running in the
         // target environment. The manager must not attempt to provision or deploy them.
-        if deployment
-            .stack_settings
-            .as_ref()
-            .expect("stored deployment carries stack_settings")
-            .deployment_model
-            == alien_core::DeploymentModel::Pull
-        {
+        if stack_settings.deployment_model == alien_core::DeploymentModel::Pull {
             debug!(
                 deployment_id = %deployment_id,
                 "Skipping pull-mode deployment — handled by alien-agent"
@@ -276,6 +319,14 @@ impl DeploymentLoop {
         }
 
         let status = parse_status(&deployment.status);
+
+        if options.require_heartbeats_enabled && !stack_settings.heartbeats.is_enabled() {
+            debug!(
+                deployment_id = %deployment_id,
+                "Skipping heartbeat because heartbeats are disabled for this deployment"
+            );
+            return Ok(());
+        }
 
         // 1. Get the release for this deployment.
         let target_release_id = deployment
@@ -525,7 +576,7 @@ impl DeploymentLoop {
         };
 
         let policy = RunnerPolicy {
-            max_steps: MAX_STEPS_PER_TICK,
+            max_steps: options.max_steps,
             operation,
             delay_threshold: Some(Duration::from_millis(SUGGESTED_DELAY_THRESHOLD_MS)),
         };
@@ -538,17 +589,31 @@ impl DeploymentLoop {
         );
 
         let mut config = config;
-        let runner_result = alien_deployment::runner::run_step_loop(
-            &mut state,
-            &mut config,
-            &client_config,
-            &deployment_id,
-            &policy,
-            &transport,
-            Some(service_provider),
-            None,
-        )
-        .await;
+        let runner_result = if options.require_heartbeats_enabled {
+            alien_deployment::runner::run_running_refresh_step_loop(
+                &mut state,
+                &mut config,
+                &client_config,
+                &deployment_id,
+                &policy,
+                &transport,
+                Some(service_provider),
+                None,
+            )
+            .await
+        } else {
+            alien_deployment::runner::run_step_loop(
+                &mut state,
+                &mut config,
+                &client_config,
+                &deployment_id,
+                &policy,
+                &transport,
+                Some(service_provider),
+                None,
+            )
+            .await
+        };
 
         match &runner_result {
             Ok(RunnerResult {

--- a/crates/alien-manager/src/loops/heartbeat.rs
+++ b/crates/alien-manager/src/loops/heartbeat.rs
@@ -1,28 +1,35 @@
-//! Heartbeat loop — polls running deployments and updates heartbeat timestamps.
-//!
-//! This keeps track of which deployments are still alive. The deployment store
-//! updates the `updated_at` timestamp for each running deployment on every tick.
+//! Heartbeat loop — periodically refreshes running deployments.
 
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::{stream, StreamExt};
 use tracing::{debug, error};
 
 use crate::auth::Subject;
 use crate::config::ManagerConfig;
+use crate::loops::deployment::{DeploymentLoop, MAX_CONCURRENT_DEPLOYMENTS};
 use crate::traits::deployment_store::DeploymentFilter;
 use crate::traits::DeploymentStore;
+
+const HEARTBEAT_ACQUIRE_LIMIT: u32 = 100;
 
 pub struct HeartbeatLoop {
     config: Arc<ManagerConfig>,
     deployment_store: Arc<dyn DeploymentStore>,
+    deployment_loop: Arc<DeploymentLoop>,
 }
 
 impl HeartbeatLoop {
-    pub fn new(config: Arc<ManagerConfig>, deployment_store: Arc<dyn DeploymentStore>) -> Self {
+    pub fn new(
+        config: Arc<ManagerConfig>,
+        deployment_store: Arc<dyn DeploymentStore>,
+        deployment_loop: Arc<DeploymentLoop>,
+    ) -> Self {
         Self {
             config,
             deployment_store,
+            deployment_loop,
         }
     }
 
@@ -39,10 +46,15 @@ impl HeartbeatLoop {
         }
     }
 
-    /// One heartbeat tick: list running deployments and update their timestamps.
+    /// One heartbeat tick: acquire running deployments and run one health-check step.
     async fn tick(&self) {
         let filter = DeploymentFilter {
             statuses: Some(vec!["running".to_string()]),
+            platforms: if self.config.targets.is_empty() {
+                None
+            } else {
+                Some(self.config.targets.clone())
+            },
             ..Default::default()
         };
 
@@ -50,34 +62,30 @@ impl HeartbeatLoop {
         // empty `bearer_token` — the documented signal to embedders that
         // no caller passthrough is available.
         let caller = Subject::system();
+        let session = uuid::Uuid::new_v4().to_string();
         match self
             .deployment_store
-            .list_deployments(&caller, &filter)
+            .acquire(&caller, &session, &filter, HEARTBEAT_ACQUIRE_LIMIT)
             .await
         {
-            Ok(deployments) => {
-                if !deployments.is_empty() {
+            Ok(acquired) => {
+                if !acquired.is_empty() {
                     debug!(
-                        count = deployments.len(),
-                        "Heartbeat: found running deployments"
+                        count = acquired.len(),
+                        session = %session,
+                        "Heartbeat: acquired running deployments"
                     );
                 }
-                for deployment in &deployments {
-                    // Use reconcile with update_heartbeat to bump the timestamp,
-                    // or simply re-list. For now, listing is sufficient —
-                    // the deployment loop's reconcile already sets update_heartbeat
-                    // for running deployments.
-                    //
-                    // In the future, a dedicated heartbeat_update method could
-                    // detect stale deployments and mark them as unhealthy.
-                    debug!(
-                        deployment_id = %deployment.id,
-                        "Heartbeat: deployment alive"
-                    );
-                }
+                stream::iter(acquired)
+                    .for_each_concurrent(MAX_CONCURRENT_DEPLOYMENTS, |item| async {
+                        self.deployment_loop
+                            .process_heartbeat_deployment(item.deployment, &session)
+                            .await;
+                    })
+                    .await;
             }
             Err(e) => {
-                error!(error = %e, "Heartbeat: failed to list running deployments");
+                error!(error = %e, "Heartbeat: failed to acquire running deployments");
             }
         }
     }

--- a/crates/alien-manager/src/server.rs
+++ b/crates/alien-manager/src/server.rs
@@ -51,16 +51,26 @@ impl AlienManager {
     /// This method spawns the deployment loop and heartbeat loop as background
     /// tasks, then runs the axum HTTP server. It blocks until the server shuts down.
     pub async fn start(self, addr: SocketAddr) -> crate::error::Result<()> {
+        let deployment_loop =
+            if !self.config.disable_deployment_loop || !self.config.disable_heartbeat_loop {
+                Some(Arc::new(DeploymentLoop::new(
+                    self.config.clone(),
+                    self.deployment_store.clone(),
+                    self.release_store.clone(),
+                    self.credential_resolver.clone(),
+                    self.server_bindings.clone(),
+                    self.dev_status_tx,
+                )))
+            } else {
+                None
+            };
+
         // Spawn the deployment loop
         if !self.config.disable_deployment_loop {
-            let deployment_loop = DeploymentLoop::new(
-                self.config.clone(),
-                self.deployment_store.clone(),
-                self.release_store.clone(),
-                self.credential_resolver.clone(),
-                self.server_bindings.clone(),
-                self.dev_status_tx,
-            );
+            let deployment_loop = deployment_loop
+                .as_ref()
+                .expect("deployment loop is constructed when enabled")
+                .clone();
             tokio::spawn(async move {
                 deployment_loop.run().await;
             });
@@ -70,8 +80,12 @@ impl AlienManager {
 
         // Spawn the heartbeat loop
         if !self.config.disable_heartbeat_loop {
-            let heartbeat_loop =
-                HeartbeatLoop::new(self.config.clone(), self.deployment_store.clone());
+            let heartbeat_loop = HeartbeatLoop::new(
+                self.config.clone(),
+                self.deployment_store.clone(),
+                deployment_loop
+                    .expect("deployment loop processor is constructed when heartbeat is enabled"),
+            );
             tokio::spawn(async move {
                 heartbeat_loop.run().await;
             });

--- a/crates/alien-manager/src/stores/sqlite/deployment.rs
+++ b/crates/alien-manager/src/stores/sqlite/deployment.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
-use sea_query::{Expr, Order, Query, SqliteQueryBuilder};
+use sea_query::{Cond, Expr, Order, Query, SqliteQueryBuilder};
 use std::sync::Arc;
 use tracing::warn;
 
@@ -30,8 +30,76 @@ pub struct SqliteDeploymentStore {
 }
 
 impl SqliteDeploymentStore {
+    const WORK_STATUSES: [&'static str; 7] = [
+        "pending",
+        "initial-setup",
+        "provisioning",
+        "updating",
+        "deleting",
+        "update-pending",
+        "delete-pending",
+    ];
+    const FAILED_STATUSES: [&'static str; 6] = [
+        "preflights-failed",
+        "initial-setup-failed",
+        "provisioning-failed",
+        "refresh-failed",
+        "update-failed",
+        "delete-failed",
+    ];
+    const SETUP_TEARDOWN_STATUSES: [&'static str; 2] = ["teardown-required", "teardown-failed"];
+    const RUNNING_STATUS: &'static str = "running";
+
     pub fn new(db: Arc<SqliteDatabase>) -> Self {
         Self { db }
+    }
+
+    fn acquire_status_condition(statuses: Option<&Vec<String>>) -> sea_query::Condition {
+        let retryable_failed = Cond::all()
+            .add(Expr::col(Deployments::Status).is_in(Self::FAILED_STATUSES))
+            .add(Expr::col(Deployments::RetryRequested).eq(1));
+
+        if let Some(statuses) = statuses {
+            let requested_active: Vec<&str> = statuses
+                .iter()
+                .map(String::as_str)
+                .filter(|status| {
+                    Self::WORK_STATUSES.contains(status)
+                        || Self::SETUP_TEARDOWN_STATUSES.contains(status)
+                        || *status == Self::RUNNING_STATUS
+                })
+                .collect();
+            let requested_failed: Vec<&str> = statuses
+                .iter()
+                .map(String::as_str)
+                .filter(|status| Self::FAILED_STATUSES.contains(status))
+                .collect();
+
+            let mut condition = Cond::any();
+            let mut has_status = false;
+            if !requested_active.is_empty() {
+                has_status = true;
+                condition = condition.add(Expr::col(Deployments::Status).is_in(requested_active));
+            }
+            if !requested_failed.is_empty() {
+                has_status = true;
+                condition = condition.add(
+                    Cond::all()
+                        .add(Expr::col(Deployments::Status).is_in(requested_failed))
+                        .add(Expr::col(Deployments::RetryRequested).eq(1)),
+                );
+            }
+
+            if has_status {
+                condition
+            } else {
+                Cond::all().add(Expr::cust("1 = 0"))
+            }
+        } else {
+            Cond::any()
+                .add(Expr::col(Deployments::Status).is_in(Self::WORK_STATUSES))
+                .add(retryable_failed)
+        }
     }
 
     fn stale_lock_condition_sql() -> String {
@@ -781,28 +849,6 @@ impl DeploymentStore for SqliteDeploymentStore {
     ) -> Result<Vec<AcquiredDeployment>, AlienError> {
         let now = Utc::now();
 
-        // Work statuses that need active deployment work
-        let work_statuses = [
-            "pending",
-            "initial-setup",
-            "provisioning",
-            "updating",
-            "deleting",
-            "update-pending",
-            "delete-pending",
-        ];
-
-        // Failed statuses that can be retried when retry_requested is true
-        let failed_statuses = [
-            "preflights-failed",
-            "initial-setup-failed",
-            "provisioning-failed",
-            "refresh-failed",
-            "update-failed",
-            "delete-failed",
-        ];
-        let setup_teardown_statuses = ["teardown-required", "teardown-failed"];
-
         // Stale lock threshold: 5 minutes. If a manager crashed mid-processing,
         // the lock will self-heal after this period.
         let stale_lock_condition = Self::stale_lock_condition_sql();
@@ -818,25 +864,7 @@ impl DeploymentStore for SqliteDeploymentStore {
                 .columns(Self::DEPLOYMENT_COLUMNS)
                 .from(Deployments::Table);
 
-            let work_eligibility = sea_query::Cond::any()
-                .add(Expr::col(Deployments::Status).is_in(work_statuses))
-                .add(
-                    sea_query::Cond::all()
-                        .add(Expr::col(Deployments::Status).is_in(failed_statuses))
-                        .add(Expr::col(Deployments::RetryRequested).eq(1)),
-                );
-
-            if let Some(statuses) = explicit_status_filter {
-                let status_strs: Vec<&str> = statuses.iter().map(|s| s.as_str()).collect();
-                query
-                    .and_where(Expr::col(Deployments::Status).is_in(status_strs))
-                    .cond_where(
-                        work_eligibility
-                            .add(Expr::col(Deployments::Status).is_in(setup_teardown_statuses)),
-                    );
-            } else {
-                query.cond_where(work_eligibility);
-            }
+            query.cond_where(Self::acquire_status_condition(explicit_status_filter));
 
             query
                 // Unlocked OR stale-locked (locked_at older than 5 minutes)
@@ -895,25 +923,7 @@ impl DeploymentStore for SqliteDeploymentStore {
                     .value(Deployments::RetryRequested, 0i64)
                     .and_where(Expr::col(Deployments::Id).eq(dep.id.as_str()));
 
-                let work_eligibility = sea_query::Cond::any()
-                    .add(Expr::col(Deployments::Status).is_in(work_statuses))
-                    .add(
-                        sea_query::Cond::all()
-                            .add(Expr::col(Deployments::Status).is_in(failed_statuses))
-                            .add(Expr::col(Deployments::RetryRequested).eq(1)),
-                    );
-
-                if let Some(statuses) = explicit_status_filter {
-                    let status_strs: Vec<&str> = statuses.iter().map(|s| s.as_str()).collect();
-                    query
-                        .and_where(Expr::col(Deployments::Status).is_in(status_strs))
-                        .cond_where(
-                            work_eligibility
-                                .add(Expr::col(Deployments::Status).is_in(setup_teardown_statuses)),
-                        );
-                } else {
-                    query.cond_where(work_eligibility);
-                }
+                query.cond_where(Self::acquire_status_condition(explicit_status_filter));
 
                 query
                     .cond_where(

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -408,6 +408,58 @@ async fn acquire_does_not_pick_failed_status_without_retry_request() {
 }
 
 #[tokio::test]
+async fn acquire_only_picks_running_when_explicitly_requested() {
+    let db = fresh_db().await;
+    let store = SqliteDeploymentStore::new(db.clone());
+    let group_id = create_test_group(&store).await;
+    let dep = create_test_deployment(&store, &group_id, "dep", Platform::Aws).await;
+
+    let sql = format!(
+        "UPDATE deployments SET status = 'running' WHERE id = '{}'",
+        dep.id
+    );
+    db.conn().lock().await.execute(&sql, ()).await.unwrap();
+
+    let default_acquired = store
+        .acquire(
+            &test_subject(),
+            "default-session",
+            &DeploymentFilter {
+                deployment_ids: Some(vec![dep.id.clone()]),
+                ..Default::default()
+            },
+            10,
+        )
+        .await
+        .unwrap();
+    assert!(
+        default_acquired.is_empty(),
+        "normal deployment loop acquire must not pick stable running deployments"
+    );
+
+    let heartbeat_acquired = store
+        .acquire(
+            &test_subject(),
+            "heartbeat-session",
+            &DeploymentFilter {
+                statuses: Some(vec!["running".to_string()]),
+                deployment_ids: Some(vec![dep.id.clone()]),
+                ..Default::default()
+            },
+            10,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(heartbeat_acquired.len(), 1);
+    assert_eq!(heartbeat_acquired[0].deployment.id, dep.id);
+    assert_eq!(
+        heartbeat_acquired[0].deployment.locked_by.as_deref(),
+        Some("heartbeat-session")
+    );
+}
+
+#[tokio::test]
 async fn acquire_picks_failed_status_with_retry_request_once() {
     let db = fresh_db().await;
     let store = SqliteDeploymentStore::new(db.clone());


### PR DESCRIPTION
## Summary
- refresh running deployments from the manager heartbeat loop
- reuse the existing deployment runner for one bounded health-check step
- preserve heartbeat retry delay and standalone SQLite acquisition behavior

## Validation
- cargo fmt
- cargo test -p alien-deployment runner::tests
- cargo test -p alien-manager --test sqlite_store_tests acquire_only_picks_running_when_explicitly_requested
- cargo check -p alien-cli -p alien-agent -p alien-deploy-cli
- git diff --check