### PR TITLE
fix: allow management role to manage its own inline policies

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
@@ -189,6 +189,32 @@ fn remote_management_policy_documents(ctx: &EmitContext<'_>) -> Result<Vec<CfExp
         ),
     ]));
 
+    // Resource-scoped management permissions are re-applied at runtime via
+    // PutRolePolicy when a deployment adds or removes resources after setup.
+    // The role must therefore be able to mutate its own inline policies.
+    // Scoped to the role's own ARN — the role can grant itself arbitrary
+    // permissions, but it's already the highest-privilege identity in the
+    // stack so this isn't a meaningful widening.
+    statements.push(CfExpression::object([
+        ("Sid", CfExpression::from("ManageOwnInlinePolicies")),
+        ("Effect", CfExpression::from("Allow")),
+        (
+            "Action",
+            CfExpression::list([
+                CfExpression::from("iam:PutRolePolicy"),
+                CfExpression::from("iam:GetRolePolicy"),
+                CfExpression::from("iam:DeleteRolePolicy"),
+                CfExpression::from("iam:ListRolePolicies"),
+            ]),
+        ),
+        (
+            "Resource",
+            CfExpression::sub(
+                "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-management",
+            ),
+        ),
+    ]));
+
     chunk_policy_statements(uniquify_iam_statement_sids(statements))
 }
 

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -931,6 +931,15 @@ Resources:
           Action: iam:GetRole
           Resource:
             Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-management
+        - Sid: ManageOwnInlinePolicies
+          Effect: Allow
+          Action:
+          - iam:PutRolePolicy
+          - iam:GetRolePolicy
+          - iam:DeleteRolePolicy
+          - iam:ListRolePolicies
+          Resource:
+            Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-management
       Roles:
       - Ref: ManagementRole
     DependsOn:

--- a/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
@@ -115,11 +115,18 @@ impl TfEmitter for AwsRemoteStackManagementEmitter {
             statements,
         )?;
 
-        // The management role always needs to read its own role —
-        // `iam:GetRole` is what the manager calls to verify the role
-        // still exists at heartbeat time. Lives outside alien-permissions
-        // because it's a self-reference the controller can't model
-        // through a permission set without weird circular naming.
+        // The management role manages its own role policies at runtime:
+        // - `iam:GetRole` is what the manager calls to verify the role still
+        //   exists at heartbeat time.
+        // - `iam:PutRolePolicy` / `iam:GetRolePolicy` / `iam:DeleteRolePolicy`
+        //   / `iam:ListRolePolicies` let the runtime add or remove
+        //   resource-scoped management policies when a deployment evolves
+        //   (resources added or removed after the initial setup).
+        // Lives outside alien-permissions because it's a self-reference the
+        // controller can't model through a permission set without weird
+        // circular naming. Scoped to the role's own ARN — the role can grant
+        // itself arbitrary permissions, but it's already the highest-privilege
+        // identity in the stack so this isn't a meaningful widening.
         fragment.resource_blocks.push(resource_block(
             "aws_iam_role_policy",
             &format!("{label}_self_read"),
@@ -129,7 +136,7 @@ impl TfEmitter for AwsRemoteStackManagementEmitter {
                     Expression::String("deployment-management-self-read".to_string()),
                 ),
                 attr("role", expr::traversal(["aws_iam_role", label, "id"])),
-                attr("policy", self_read_policy(label)),
+                attr("policy", self_manage_policy(label)),
             ],
         ));
 
@@ -171,20 +178,40 @@ fn trust_policy() -> Expression {
     ]))
 }
 
-fn self_read_policy(label: &str) -> Expression {
+fn self_manage_policy(label: &str) -> Expression {
+    let role_arn = || expr::traversal(["aws_iam_role", label, "arn"]);
     jsonencode(expr::object([
         ("Version", Expression::String("2012-10-17".to_string())),
         (
             "Statement",
-            Expression::Array(vec![expr::object([
-                (
-                    "Sid",
-                    Expression::String("ReadOwnManagementRole".to_string()),
-                ),
-                ("Effect", Expression::String("Allow".to_string())),
-                ("Action", Expression::String("iam:GetRole".to_string())),
-                ("Resource", expr::traversal(["aws_iam_role", label, "arn"])),
-            ])]),
+            Expression::Array(vec![
+                expr::object([
+                    (
+                        "Sid",
+                        Expression::String("ReadOwnManagementRole".to_string()),
+                    ),
+                    ("Effect", Expression::String("Allow".to_string())),
+                    ("Action", Expression::String("iam:GetRole".to_string())),
+                    ("Resource", role_arn()),
+                ]),
+                expr::object([
+                    (
+                        "Sid",
+                        Expression::String("ManageOwnInlinePolicies".to_string()),
+                    ),
+                    ("Effect", Expression::String("Allow".to_string())),
+                    (
+                        "Action",
+                        Expression::Array(vec![
+                            Expression::String("iam:PutRolePolicy".to_string()),
+                            Expression::String("iam:GetRolePolicy".to_string()),
+                            Expression::String("iam:DeleteRolePolicy".to_string()),
+                            Expression::String("iam:ListRolePolicies".to_string()),
+                        ]),
+                    ),
+                    ("Resource", role_arn()),
+                ]),
+            ]),
         ),
     ]))
 }

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_full_stack.snap
@@ -475,7 +475,7 @@ resource "aws_iam_role_policy_attachment" "management_managed_policy_1_attachmen
 resource "aws_iam_role_policy" "management_self_read" {
   name   = "deployment-management-self-read"
   role   = aws_iam_role.management.id
-  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ReadOwnManagementRole", Effect = "Allow", Action = "iam:GetRole", Resource = aws_iam_role.management.arn }] })
+  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ReadOwnManagementRole", Effect = "Allow", Action = "iam:GetRole", Resource = aws_iam_role.management.arn }, { Sid = "ManageOwnInlinePolicies", Effect = "Allow", Action = ["iam:PutRolePolicy", "iam:GetRolePolicy", "iam:DeleteRolePolicy", "iam:ListRolePolicies"], Resource = aws_iam_role.management.arn }] })
 }
 
 === assets.tf ===

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_remote_stack_management.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_remote_stack_management.snap
@@ -177,7 +177,7 @@ resource "aws_iam_role_policy_attachment" "management_managed_policy_0_attachmen
 resource "aws_iam_role_policy" "management_self_read" {
   name   = "deployment-management-self-read"
   role   = aws_iam_role.management.id
-  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ReadOwnManagementRole", Effect = "Allow", Action = "iam:GetRole", Resource = aws_iam_role.management.arn }] })
+  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ReadOwnManagementRole", Effect = "Allow", Action = "iam:GetRole", Resource = aws_iam_role.management.arn }, { Sid = "ManageOwnInlinePolicies", Effect = "Allow", Action = ["iam:PutRolePolicy", "iam:GetRolePolicy", "iam:DeleteRolePolicy", "iam:ListRolePolicies"], Resource = aws_iam_role.management.arn }] })
 }
 
 === registration.tf ===

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_managed_cluster_remote_management_irsa.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_managed_cluster_remote_management_irsa.snap
@@ -574,7 +574,7 @@ resource "aws_iam_role_policy_attachment" "management_managed_policy_0_attachmen
 resource "aws_iam_role_policy" "management_self_read" {
   name   = "deployment-management-self-read"
   role   = aws_iam_role.management.id
-  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ReadOwnManagementRole", Effect = "Allow", Action = "iam:GetRole", Resource = aws_iam_role.management.arn }] })
+  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ReadOwnManagementRole", Effect = "Allow", Action = "iam:GetRole", Resource = aws_iam_role.management.arn }, { Sid = "ManageOwnInlinePolicies", Effect = "Allow", Action = ["iam:PutRolePolicy", "iam:GetRolePolicy", "iam:DeleteRolePolicy", "iam:ListRolePolicies"], Resource = aws_iam_role.management.arn }] })
 }
 
 === registration.tf ===


### PR DESCRIPTION
The manager re-applies resource-scoped management permissions to the management role via iam:PutRolePolicy when a deployment adds or removes resources after setup. The role previously only had iam:GetRole on itself, so the call failed with:

  CLOUD_PLATFORM_ERROR: Failed to apply management permission
  'worker/dispatch-command' to role '<stack>-management'

Grant the role iam:PutRolePolicy / GetRolePolicy / DeleteRolePolicy / ListRolePolicies, scoped to its own ARN. The role is already the highest-privilege identity in the stack, so this is not a meaningful widening.

Closes ALIEN-198.