### PR TITLE
fix(cli): require `dep_<id>` or `<group>/<name>`, drop fuzzy name match (ALIEN-200)

### DIFF
--- a/crates/alien-cli/src/commands/commands.rs
+++ b/crates/alien-cli/src/commands/commands.rs
@@ -9,7 +9,6 @@ use crate::execution_context::ExecutionMode;
 use alien_commands_client::{CommandsClient, CommandsClientConfig};
 use alien_core::DeploymentStatus;
 use alien_error::{AlienError, Context, IntoAlienError};
-use alien_manager_api::SdkResultExt;
 use clap::{Parser, Subcommand};
 use std::time::Duration;
 
@@ -148,69 +147,46 @@ async fn invoke_command(
     Ok(())
 }
 
-/// Resolve a deployment name to its ID using the typed manager SDK.
+/// Resolve a deployment spec to its ID and assert it's ready for commands.
+///
+/// Delegates lookup to the shared `deployment_resolver`; this wrapper layers
+/// on the "must be Running" check that's specific to command dispatch.
 async fn resolve_deployment_id(
     manager: &alien_manager_api::Client,
     name: &str,
     is_dev: bool,
 ) -> Result<String> {
-    let response = manager
-        .list_deployments()
-        .send()
-        .await
-        .into_sdk_error()
-        .context(ErrorData::ApiRequestFailed {
-            message: "Failed to list deployments".to_string(),
-            url: None,
-        })?;
+    let deployment = crate::deployment_resolver::resolve(manager, name, is_dev).await?;
 
-    let deployments = response.into_inner();
+    let status_raw = deployment.status.to_string();
+    let status = parse_deployment_status(&status_raw).ok_or_else(|| {
+        AlienError::new(ErrorData::ValidationError {
+            field: "deployment.status".to_string(),
+            message: format!(
+                "Unknown deployment status '{}' for deployment '{}'.",
+                status_raw, name
+            ),
+        })
+    })?;
 
-    for deployment in &deployments.items {
-        if deployment.name.as_str() == name || deployment.id.as_str() == name {
-            let status_raw = deployment.status.to_string();
-            let status = parse_deployment_status(&status_raw).ok_or_else(|| {
-                AlienError::new(ErrorData::ValidationError {
-                    field: "deployment.status".to_string(),
-                    message: format!(
-                        "Unknown deployment status '{}' for deployment '{}'.",
-                        status_raw, name
-                    ),
-                })
-            })?;
-
-            if status != DeploymentStatus::Running {
-                let status_cmd = if is_dev {
-                    "alien dev deployments ls"
-                } else {
-                    "alien deployments ls"
-                };
-                return Err(AlienError::new(ErrorData::ValidationError {
-                    field: "deployment".to_string(),
-                    message: format!(
-                        "Deployment '{}' is '{}' and cannot receive commands yet. Wait until it reaches 'running' (check with `{}`).",
-                        name,
-                        deployment_status_str(status),
-                        status_cmd
-                    ),
-                }));
-            }
-            return Ok(deployment.id.to_string());
-        }
+    if status != DeploymentStatus::Running {
+        let status_cmd = if is_dev {
+            "alien dev deployments ls"
+        } else {
+            "alien deployments ls"
+        };
+        return Err(AlienError::new(ErrorData::ValidationError {
+            field: "deployment".to_string(),
+            message: format!(
+                "Deployment '{}' is '{}' and cannot receive commands yet. Wait until it reaches 'running' (check with `{}`).",
+                name,
+                deployment_status_str(status),
+                status_cmd
+            ),
+        }));
     }
 
-    let list_cmd = if is_dev {
-        "alien dev deployments ls"
-    } else {
-        "alien deployments ls"
-    };
-    Err(AlienError::new(ErrorData::ValidationError {
-        field: "deployment".to_string(),
-        message: format!(
-            "Deployment '{}' not found. Use '{}' to see available deployments.",
-            name, list_cmd
-        ),
-    }))
+    Ok(deployment.id.to_string())
 }
 
 fn parse_deployment_status(raw: &str) -> Option<DeploymentStatus> {

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -292,32 +292,16 @@ pub(crate) async fn resolve_manager_client(
     Ok(manager_ctx.client)
 }
 
-/// Resolve a deployment by name or ID.
+/// Resolve a deployment by name or ID via the shared resolver. The `is_dev`
+/// argument only affects the "not found" hint surfaced to the user; the
+/// `deployments` subcommand doesn't carry a dev/platform flag at this layer
+/// so we conservatively assume non-dev (callers in dev mode go through
+/// `dev_helpers`).
 async fn resolve_deployment_reference(
     client: &alien_manager_api::Client,
     reference: &str,
 ) -> Result<DeploymentResponse> {
-    let response = client
-        .list_deployments()
-        .send()
-        .await
-        .into_sdk_error()
-        .context(ErrorData::ApiRequestFailed {
-            message: "listing deployments for resolution".to_string(),
-            url: None,
-        })?
-        .into_inner();
-
-    response
-        .items
-        .into_iter()
-        .find(|d| d.id == reference || d.name == reference)
-        .ok_or_else(|| {
-            AlienError::new(ErrorData::ValidationError {
-                field: "deployment".to_string(),
-                message: format!("Deployment '{}' was not found.", reference),
-            })
-        })
+    crate::deployment_resolver::resolve(client, reference, false).await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/alien-cli/src/deployment_resolver.rs
+++ b/crates/alien-cli/src/deployment_resolver.rs
@@ -1,0 +1,137 @@
+//! Resolve a user-supplied deployment spec to a deployment record.
+//!
+//! Three commands (`debug`, `commands`, `deployments {get,delete,retry,
+//! redeploy}`) all accept the same spec forms and used to each carry a
+//! near-identical resolver that walked `list_deployments` and matched on
+//! name. That had two problems: it broke once a workspace had more
+//! deployments than fit in one page, and the loose name-only matching
+//! could silently target the wrong deployment in a multi-tenant workspace
+//! where the same name exists under different groups.
+//!
+//! This module is the single resolver. It accepts exactly two spec forms:
+//!
+//! - `dep_<id>` — looked up directly via `get_deployment(id)`.
+//! - `<group>/<name>` — listed with the `deployment_group` filter pinned
+//!   to `<group>` (the platform resolves the group name to an ID
+//!   server-side); the result set is then filtered locally for an exact
+//!   `name` match.
+//!
+//! Anything else (bare names, empty parts, more than one `/`) is rejected
+//! up front with an actionable error. There is intentionally no fuzzy
+//! search or pagination walk — both invite the same class of bug.
+
+use crate::error::{ErrorData, Result};
+use alien_error::{AlienError, Context};
+use alien_manager_api::types::DeploymentResponse;
+use alien_manager_api::{Client, SdkResultExt};
+
+/// Resolve `spec` to a deployment.
+///
+/// `is_dev` only affects the hint surfaced in error messages
+/// (`alien dev deployments ls` vs `alien deployments ls`).
+pub async fn resolve(
+    manager: &Client,
+    spec: &str,
+    is_dev: bool,
+) -> Result<DeploymentResponse> {
+    if spec.starts_with("dep_") {
+        return resolve_by_id(manager, spec).await;
+    }
+
+    match spec.split_once('/') {
+        Some((group, name)) if !group.is_empty() && !name.is_empty() && !name.contains('/') => {
+            resolve_by_group_and_name(manager, group, name, is_dev).await
+        }
+        _ => Err(invalid_spec_error(spec)),
+    }
+}
+
+async fn resolve_by_id(manager: &Client, id: &str) -> Result<DeploymentResponse> {
+    manager
+        .get_deployment()
+        .id(id)
+        .send()
+        .await
+        .into_sdk_error()
+        .context(ErrorData::ApiRequestFailed {
+            message: format!("Deployment '{}' was not found.", id),
+            url: None,
+        })
+        .map(|r| r.into_inner())
+}
+
+async fn resolve_by_group_and_name(
+    manager: &Client,
+    group: &str,
+    name: &str,
+    is_dev: bool,
+) -> Result<DeploymentResponse> {
+    // The platform's `deploymentGroup` filter accepts either an ID or an
+    // exact name (it resolves name→id internally) — so this is the strict
+    // path: server narrows by group, we then filter the (small) result set
+    // for an exact name match.
+    // The manager SDK exposes the filter as `deployment_group_id`, but the
+    // platform accepts either an ID or a group *name* on that param — it
+    // resolves name→id internally. We pass the user-supplied group name.
+    let response = manager
+        .list_deployments()
+        .deployment_group_id(group)
+        .include(vec!["deploymentGroup".to_string()])
+        .send()
+        .await
+        .into_sdk_error()
+        .context(ErrorData::ApiRequestFailed {
+            message: format!(
+                "Failed to list deployments in group '{}' for resolution",
+                group
+            ),
+            url: None,
+        })?
+        .into_inner();
+
+    let matches: Vec<DeploymentResponse> = response
+        .items
+        .into_iter()
+        .filter(|d| {
+            d.name.as_str() == name
+                && d.deployment_group
+                    .as_ref()
+                    .map(|dg| dg.name.as_str())
+                    == Some(group)
+        })
+        .collect();
+
+    let list_cmd = if is_dev {
+        "alien dev deployments ls"
+    } else {
+        "alien deployments ls"
+    };
+
+    match matches.len() {
+        0 => Err(AlienError::new(ErrorData::ValidationError {
+            field: "deployment".to_string(),
+            message: format!(
+                "Deployment '{group}/{name}' not found. Verify the group and name with `{list_cmd}`."
+            ),
+        })),
+        1 => Ok(matches.into_iter().next().expect("len == 1")),
+        // Same workspace can't legitimately have two deployments with the
+        // same `<group>/<name>` pair — the platform enforces uniqueness.
+        // Surface loudly rather than pick one.
+        _ => Err(AlienError::new(ErrorData::ValidationError {
+            field: "deployment".to_string(),
+            message: format!(
+                "Multiple deployments matched '{group}/{name}'. Resolve by `dep_...` ID instead."
+            ),
+        })),
+    }
+}
+
+fn invalid_spec_error(spec: &str) -> AlienError<ErrorData> {
+    AlienError::new(ErrorData::ValidationError {
+        field: "deployment".to_string(),
+        message: format!(
+            "Invalid deployment spec '{spec}'. Expected either:\n  - `dep_<id>` (e.g. dep_7i6ynan6zoil4rj2eldvw95hmfua), or\n  - `<group>/<name>` (e.g. acme/prod).\nBare names are no longer accepted; the same name can exist under multiple groups."
+        ),
+    })
+}

--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auth;
 pub mod commands;
 pub mod config;
+pub mod deployment_resolver;
 pub mod deployment_tracking;
 pub mod error;
 pub mod execution_context;


### PR DESCRIPTION
## Summary

Replaces three near-identical deployment-name resolvers (in `debug`, `commands invoke`, and `deployments {get,delete,retry,redeploy}`) with a single, **strict** resolver at `crates/alien-cli/src/deployment_resolver.rs`.

Accepted spec forms — these are the only two:

- `dep_<id>` — looked up directly via `get_deployment(id)`. No list call.
- `<group>/<name>` — listed with the `deployment_group` filter pinned to `<group>` (the platform accepts the group name and resolves to ID server-side); result set is filtered locally for an exact `name` match.

Anything else (bare names, empty parts, multiple `/`) is rejected with an actionable error.

## Why

The old resolvers walked `list_deployments()` and matched on `.name`, which:

- Missed deployments past the first page on workspaces with many deployments (the platform paginates).
- Could silently target the wrong deployment in a workspace where the same name exists under multiple groups.

The fix is structural, not a tweak to filters: strict spec forms + exact-match lookups. No fuzzy `search`, no pagination walk — both invite the same class of bug.

## Pairs with

- [platform#45](https://github.com/alienplatform/platform/pull/45) — managerx fix so API-key (`ax_ws_*` / `ax_proj_*`) callers also route through the user-facing endpoint (where group-name resolution happens).

## Per-command logic stays at the call site

- `commands invoke` still asserts the deployment is `Running` after resolution.
- `debug` still parses the spec the same way (this PR moves the parsing into the shared resolver).

## Test plan

- [ ] `cargo build -p alien-cli && cargo build -p alien-manager` clean.
- [ ] After platform#45 lands + managerx restarted:
  - [ ] `alien debug <group>/<name> -- aws sts get-caller-identity` resolves with both OAuth and API-key auth.
  - [ ] `alien debug dep_xxx -- …` resolves directly.
  - [ ] `alien debug alan` (bare) is rejected with the new actionable error.
  - [ ] `alien commands invoke --deployment <group>/<name> --command <cmd>` resolves.
  - [ ] `alien deployments get <group>/<name>` resolves.

Closes ALIEN-200.