### PR TITLE
fix: compile AWS live management grants in setup

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
@@ -16,11 +16,13 @@ use crate::{
     template::{CfExpression, CfResource},
 };
 use alien_core::{
-    import::EmitContext, ErrorData, PermissionProfile, PermissionSetReference,
-    RemoteStackManagement, Result,
+    import::EmitContext, ErrorData, KubernetesCluster, PermissionProfile, PermissionSetReference,
+    RemoteStackManagement, ResourceLifecycle, Result, Worker,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
-use alien_permissions::{generators::AwsCloudFormationPermissionsGenerator, BindingTarget};
+use alien_permissions::{
+    generators::AwsCloudFormationPermissionsGenerator, BindingTarget, PermissionContext,
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AwsRemoteStackManagementEmitter;
@@ -136,21 +138,25 @@ fn remote_management_policy_documents(ctx: &EmitContext<'_>) -> Result<Vec<CfExp
         }
 
         for (resource_id, permission_set_ref) in resource_scoped_permission_refs(profile) {
+            if permission_set_ref.id().ends_with("/provision") {
+                continue;
+            }
             let Some(resource_entry) = ctx.stack.resources.get(resource_id) else {
                 continue;
             };
+            if resource_entry.lifecycle != ResourceLifecycle::Live {
+                continue;
+            }
             let Some(permission_set) = permission_set_ref
                 .resolve(|name| alien_permissions::get_permission_set(name).cloned())
             else {
                 continue;
             };
-            if permission_set.platforms.aws.is_none()
-                || !resource_scoped_aws_permission_applies(&permission_set.id, resource_entry)
-            {
+            if permission_set.platforms.aws.is_none() {
                 continue;
             }
-
-            let resource_context = context.clone().with_resource_name(resource_id.to_string());
+            let resource_context =
+                resource_scoped_aws_permission_context(resource_id, resource_entry, &context);
             let policy = generator
                 .generate_policy(&permission_set, BindingTarget::Resource, &resource_context)
                 .context(ErrorData::GenericError {
@@ -292,9 +298,72 @@ fn resource_scoped_permission_refs(
         .collect()
 }
 
-fn resource_scoped_aws_permission_applies(
-    permission_set_id: &str,
-    _resource_entry: &alien_core::ResourceEntry,
-) -> bool {
-    permission_set_id == "kubernetes-public-endpoint/management"
+fn resource_scoped_aws_permission_context(
+    resource_id: &str,
+    resource_entry: &alien_core::ResourceEntry,
+    base_context: &PermissionContext,
+) -> PermissionContext {
+    let mut context = base_context
+        .clone()
+        .with_resource_id(resource_id.to_string());
+    context.resource_name = None;
+
+    if resource_entry.config.downcast_ref::<Worker>().is_some() {
+        return context.with_resource_name(format!("${{AWS::StackName}}-{resource_id}"));
+    }
+
+    if resource_entry
+        .config
+        .downcast_ref::<KubernetesCluster>()
+        .is_some()
+    {
+        return context.with_resource_name(resource_id.to_string());
+    }
+
+    context
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_core::{Resource, ResourceEntry, ResourceLifecycle, Worker, WorkerCode};
+
+    fn live_worker_entry(id: &str) -> ResourceEntry {
+        ResourceEntry {
+            config: Resource::new(
+                Worker::new(id.to_string())
+                    .code(WorkerCode::Image {
+                        image: "test:latest".to_string(),
+                    })
+                    .permissions("default".to_string())
+                    .build(),
+            ),
+            lifecycle: ResourceLifecycle::Live,
+            dependencies: Vec::new(),
+            remote_access: false,
+        }
+    }
+
+    #[test]
+    fn aws_remote_management_resource_scope_names_future_worker_lambda() {
+        let entry = live_worker_entry("jobs");
+        let context = resource_scoped_aws_permission_context("jobs", &entry, &permission_context());
+
+        assert_eq!(context.resource_id.as_deref(), Some("jobs"));
+        assert_eq!(
+            context.resource_name.as_deref(),
+            Some("${AWS::StackName}-jobs")
+        );
+    }
+
+    #[test]
+    fn aws_remote_management_resource_scope_does_not_filter_by_permission_id() {
+        let entry = live_worker_entry("jobs");
+        let context = resource_scoped_aws_permission_context("jobs", &entry, &permission_context());
+
+        assert_eq!(
+            context.resource_name.as_deref(),
+            Some("${AWS::StackName}-jobs")
+        );
+    }
 }

--- a/crates/alien-cloudformation/tests/generator/aws_compute_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_compute_tests.rs
@@ -10,8 +10,9 @@
 use super::helpers::render_built_ins;
 use alien_cloudformation::{generate_cloudformation_template, CfRegistry, RegistrationMode};
 use alien_core::{
-    ArtifactRegistry, Build, CapacityGroup, ComputeCluster, ErrorData, Ingress, Network,
-    NetworkSettings, Platform, ResourceLifecycle, Stack, StackSettings, Worker, WorkerCode,
+    ArtifactRegistry, Build, CapacityGroup, ComputeCluster, ErrorData, Ingress,
+    ManagementPermissions, Network, NetworkSettings, PermissionProfile, Platform,
+    RemoteStackManagement, ResourceLifecycle, Stack, StackSettings, Worker, WorkerCode,
 };
 
 #[test]
@@ -73,6 +74,39 @@ fn aws_function_basic_lambda() {
         "aws_function_basic",
     );
     insta::assert_snapshot!("aws_function_basic", yaml);
+}
+
+#[test]
+fn aws_remote_stack_management_skips_live_provision_sets() {
+    let stack = Stack::new("acme-mgmt".to_string())
+        .management(ManagementPermissions::extend(
+            PermissionProfile::new()
+                .resource("job", ["worker/provision", "worker/dispatch-command"]),
+        ))
+        .add(
+            RemoteStackManagement::new("management".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            Worker::new("job".to_string())
+                .code(WorkerCode::Image {
+                    image: "123456789012.dkr.ecr.us-east-1.amazonaws.com/app/job:1.2.3".to_string(),
+                })
+                .permissions("execution".to_string())
+                .build(),
+            ResourceLifecycle::Live,
+        )
+        .build();
+
+    let yaml = render_built_ins(
+        &stack,
+        StackSettings::default(),
+        RegistrationMode::OutputsFallback,
+        "aws_remote_stack_management_skips_live_provision_sets",
+    );
+
+    assert!(yaml.contains("lambda:InvokeFunction"));
+    assert!(!yaml.contains("lambda:CreateFunction"));
 }
 
 #[test]

--- a/crates/alien-infra/src/core/resource_permissions_helper.rs
+++ b/crates/alien-infra/src/core/resource_permissions_helper.rs
@@ -15,7 +15,7 @@ use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 use alien_gcp_clients::iam::{Binding, IamPolicy};
 use alien_permissions::{generators::*, BindingTarget, PermissionContext};
 
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 fn gcp_custom_role_matches(
     existing: &alien_gcp_clients::iam::Role,
@@ -1034,8 +1034,9 @@ impl ResourcePermissionsHelper {
     /// 3. Generates an IAM policy with `BindingTarget::Resource` and attaches it as
     ///    an inline policy on the SA role.
     ///
-    /// After processing all app SA profiles it also applies **management SA**
-    /// resource-scoped permissions (non-provision sets from the management profile).
+    /// For setup-owned resources, it also applies concrete **management SA**
+    /// resource-scoped permissions. Live resources do not broaden the management
+    /// role at runtime; AWS setup output must grant those permissions up front.
     pub async fn apply_aws_resource_scoped_permissions(
         ctx: &ResourceControllerContext<'_>,
         resource_id: &str,
@@ -1049,6 +1050,7 @@ impl ResourcePermissionsHelper {
             .with_aws_account_id(aws_config.account_id.to_string())
             .with_aws_region(aws_config.region.clone())
             .with_stack_prefix(ctx.resource_prefix.to_string())
+            .with_resource_id(resource_id.to_string())
             .with_resource_name(resource_name.to_string());
 
         if let Some(aws_management) = ctx.get_aws_management_config()? {
@@ -1104,18 +1106,43 @@ impl ResourcePermissionsHelper {
             }
         }
 
-        // Process management SA resource-scoped permissions
-        Self::apply_aws_management_resource_permissions(
-            ctx,
-            resource_id,
-            resource_name,
-            resource_type,
-            &generator,
-            &permission_context,
-        )
-        .await?;
+        if Self::resource_is_setup_owned(ctx, resource_id) {
+            // Setup-owned resources run while setup credentials are still active.
+            // Live resource controllers must not edit the management role after
+            // the deployment has moved to provisioning credentials.
+            Self::apply_aws_management_resource_permissions(
+                ctx,
+                resource_id,
+                resource_name,
+                resource_type,
+                &generator,
+                &permission_context,
+            )
+            .await?;
+        } else if ctx
+            .desired_stack
+            .management()
+            .profile()
+            .map(|profile| {
+                !Self::aws_management_resource_permission_refs(profile, resource_id).is_empty()
+            })
+            .unwrap_or(false)
+        {
+            debug!(
+                resource_id = %resource_id,
+                resource_name = %resource_name,
+                "Skipping AWS management resource-scoped permissions for live resource; setup must grant them"
+            );
+        }
 
         Ok(())
+    }
+
+    fn resource_is_setup_owned(ctx: &ResourceControllerContext<'_>, resource_id: &str) -> bool {
+        ctx.desired_stack
+            .resources
+            .get(resource_id)
+            .is_some_and(|entry| entry.lifecycle == ResourceLifecycle::Frozen)
     }
 
     /// Process AWS permissions for a specific profile by attaching inline policies

--- a/crates/alien-infra/src/remote_stack_management/aws.rs
+++ b/crates/alien-infra/src/remote_stack_management/aws.rs
@@ -8,8 +8,8 @@ use alien_core::{
     standard_resource_tags, AwsRemoteStackManagementHeartbeatData, HeartbeatBackend,
     KubernetesCluster, ObservedHealth, Platform, ProviderLifecycleState, RemoteStackManagement,
     RemoteStackManagementHeartbeatData, RemoteStackManagementHeartbeatStatus,
-    RemoteStackManagementOutputs, ResourceHeartbeat, ResourceHeartbeatData, ResourceOutputs,
-    ResourceStatus,
+    RemoteStackManagementOutputs, ResourceHeartbeat, ResourceHeartbeatData, ResourceLifecycle,
+    ResourceOutputs, ResourceStatus, Worker,
 };
 use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 use alien_macros::controller;
@@ -627,6 +627,7 @@ impl AwsRemoteStackManagementController {
         self.append_resource_scoped_management_statements(
             ctx,
             management_profile,
+            &permission_context,
             &generator,
             &mut all_statements,
         )?;
@@ -656,6 +657,7 @@ impl AwsRemoteStackManagementController {
         &self,
         ctx: &ResourceControllerContext<'_>,
         management_profile: &alien_core::permissions::PermissionProfile,
+        base_permission_context: &PermissionContext,
         generator: &AwsRuntimePermissionsGenerator,
         all_statements: &mut Vec<AwsIamStatement>,
     ) -> Result<()> {
@@ -668,14 +670,21 @@ impl AwsRemoteStackManagementController {
             let Some(resource_entry) = ctx.desired_stack.resources.get(resource_id) else {
                 continue;
             };
-            let Some(cluster) = resource_entry.config.downcast_ref::<KubernetesCluster>() else {
+            if resource_entry.lifecycle != ResourceLifecycle::Live {
                 continue;
-            };
-            let permission_context =
-                ResourcePermissionsHelper::aws_kubernetes_cluster_permission_context(ctx, cluster)?;
+            }
+            let permission_context = Self::resource_scoped_management_permission_context(
+                ctx,
+                base_permission_context,
+                resource_id,
+                resource_entry,
+            )?;
 
             for permission_set_ref in permission_set_refs {
                 if !seen.insert((resource_id.clone(), permission_set_ref.id().to_string())) {
+                    continue;
+                }
+                if permission_set_ref.id().ends_with("/provision") {
                     continue;
                 }
                 let Some(permission_set) =
@@ -702,6 +711,33 @@ impl AwsRemoteStackManagementController {
         }
 
         Ok(())
+    }
+
+    fn resource_scoped_management_permission_context(
+        ctx: &ResourceControllerContext<'_>,
+        base_permission_context: &PermissionContext,
+        resource_id: &str,
+        resource_entry: &alien_core::ResourceEntry,
+    ) -> Result<PermissionContext> {
+        if let Some(cluster) = resource_entry.config.downcast_ref::<KubernetesCluster>() {
+            return ResourcePermissionsHelper::aws_kubernetes_cluster_permission_context(
+                ctx, cluster,
+            )
+            .map(|context| context.with_resource_id(resource_id.to_string()));
+        }
+
+        let mut context = base_permission_context
+            .clone()
+            .with_resource_id(resource_id.to_string());
+        context.resource_name = None;
+
+        if resource_entry.config.downcast_ref::<Worker>().is_some() {
+            return Ok(
+                context.with_resource_name(format!("{}-{}", ctx.resource_prefix, resource_id))
+            );
+        }
+
+        Ok(context)
     }
 
     fn chunk_management_policy_documents(

--- a/crates/alien-permissions/permission-sets/container/management.jsonc
+++ b/crates/alien-permissions/permission-sets/container/management.jsonc
@@ -48,7 +48,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -74,7 +74,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -104,7 +104,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }

--- a/crates/alien-permissions/permission-sets/container/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/container/provision.jsonc
@@ -40,7 +40,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -82,7 +82,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -109,7 +109,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -135,7 +135,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -205,7 +205,7 @@
               "StringEquals": {
                 "ec2:CreateAction": "CreateSecurityGroup",
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -235,7 +235,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -307,7 +307,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -337,7 +337,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }

--- a/crates/alien-permissions/permission-sets/kubernetes-public-endpoint/management.jsonc
+++ b/crates/alien-permissions/permission-sets/kubernetes-public-endpoint/management.jsonc
@@ -15,7 +15,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -39,7 +39,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }

--- a/crates/alien-permissions/permission-sets/worker/management.jsonc
+++ b/crates/alien-permissions/permission-sets/worker/management.jsonc
@@ -49,7 +49,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -125,7 +125,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -158,7 +158,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -195,7 +195,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -232,7 +232,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -273,7 +273,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -311,7 +311,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -342,7 +342,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -377,7 +377,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }

--- a/crates/alien-permissions/permission-sets/worker/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/worker/provision.jsonc
@@ -24,7 +24,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -84,7 +84,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -225,7 +225,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -258,7 +258,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -295,7 +295,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -332,7 +332,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -373,7 +373,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -412,7 +412,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }
@@ -443,7 +443,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
-                "aws:RequestTag/${resourceTag}": "${resourceName}",
+                "aws:RequestTag/${resourceTag}": "${resourceId}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -478,7 +478,7 @@
             "condition": {
               "StringEquals": {
                 "aws:ResourceTag/${stackTag}": "${stackPrefix}",
-                "aws:ResourceTag/${resourceTag}": "${resourceName}",
+                "aws:ResourceTag/${resourceTag}": "${resourceId}",
                 "aws:ResourceTag/${managedByTag}": "runtime"
               }
             }

--- a/crates/alien-permissions/src/generators/aws_cloudformation.rs
+++ b/crates/alien-permissions/src/generators/aws_cloudformation.rs
@@ -170,6 +170,7 @@ impl AwsCloudFormationPermissionsGenerator {
         let contains_cf_vars = template.contains("${AWS::") || template.contains("${!");
         let contains_regular_vars = [
             "${stackPrefix}",
+            "${resourceId}",
             "${resourceName}",
             "${awsRegion}",
             "${awsAccountId}",
@@ -210,6 +211,9 @@ impl AwsCloudFormationPermissionsGenerator {
                     // Simple resource reference, just use the name
                     result = result.replace("${resourceName}", resource_name);
                 }
+            }
+            if let Some(resource_id) = context.resource_id.as_ref() {
+                result = result.replace("${resourceId}", resource_id);
             }
 
             // Handle AWS-specific variables that should map to CloudFormation pseudo parameters

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -40,6 +40,7 @@ pub struct PermissionContext {
     pub stack_prefix: Option<String>,
     pub stack_name: Option<String>,
     pub deployment_name: Option<String>,
+    pub resource_id: Option<String>,
     pub resource_name: Option<String>,
     pub service_account_name: Option<String>,
     pub principal_id: Option<String>,
@@ -66,6 +67,7 @@ impl PermissionContext {
             stack_prefix: None,
             stack_name: None,
             deployment_name: None,
+            resource_id: None,
             resource_name: None,
             service_account_name: None,
             principal_id: None,
@@ -159,6 +161,12 @@ impl PermissionContext {
         self
     }
 
+    /// Builder pattern for the Alien logical resource ID.
+    pub fn with_resource_id(mut self, resource_id: impl Into<String>) -> Self {
+        self.resource_id = Some(resource_id.into());
+        self
+    }
+
     /// Builder pattern for resource name
     pub fn with_resource_name(mut self, resource_name: impl Into<String>) -> Self {
         self.resource_name = Some(resource_name.into());
@@ -220,6 +228,7 @@ impl PermissionContext {
             "stackPrefix" => self.stack_prefix.as_deref(),
             "stackName" => self.stack_name.as_deref(),
             "deploymentName" => self.deployment_name.as_deref(),
+            "resourceId" => self.resource_id.as_deref(),
             "resourceName" => self.resource_name.as_deref(),
             "serviceAccountName" => self.service_account_name.as_deref(),
             "principalId" => self.principal_id.as_deref(),

--- a/crates/alien-permissions/tests/aws_cloudformation.rs
+++ b/crates/alien-permissions/tests/aws_cloudformation.rs
@@ -209,6 +209,7 @@ fn test_aws_cloudformation_container_provision_can_manage_setup_compute_security
     let permission_set = get_permission_set("container/provision").expect("permission set exists");
     let context = PermissionContext::new()
         .with_stack_prefix("")
+        .with_resource_id("api")
         .with_resource_name("alien-manager")
         .with_aws_region("${AWS::Region}")
         .with_aws_account_id("${AWS::AccountId}");
@@ -263,6 +264,44 @@ fn test_aws_cloudformation_container_provision_can_manage_setup_compute_security
     assert_eq!(
         string_equals.get("aws:ResourceTag/resource"),
         Some(&json!("compute"))
+    );
+}
+
+#[test]
+fn test_aws_cloudformation_resource_id_interpolates_in_conditions() {
+    let generator = AwsCloudFormationPermissionsGenerator::new();
+    let permission_set = get_permission_set("worker/provision").expect("permission set exists");
+    let context = PermissionContext::new()
+        .with_stack_prefix("")
+        .with_resource_id("job")
+        .with_resource_name("${AWS::StackName}-job")
+        .with_aws_region("${AWS::Region}")
+        .with_aws_account_id("${AWS::AccountId}");
+
+    let result = generator
+        .generate_policy(permission_set, BindingTarget::Resource, &context)
+        .expect("Should generate AWS CloudFormation policy successfully");
+
+    let create_function_statement = result
+        .statement
+        .iter()
+        .find(|statement| {
+            statement.action.contains(&json!("lambda:CreateFunction"))
+                && statement.resource.contains(&json!({
+                    "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-job"
+                }))
+        })
+        .expect("worker provision should allow creating the physical Lambda function");
+
+    let string_equals = create_function_statement
+        .condition
+        .as_ref()
+        .and_then(|condition| condition.get("StringEquals"))
+        .expect("Lambda creation should be request-tag conditioned");
+
+    assert_eq!(
+        string_equals.get("aws:RequestTag/resource"),
+        Some(&json!("job"))
     );
 }
 

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -409,6 +409,38 @@ fn test_aws_variable_interpolation() {
 }
 
 #[test]
+fn test_worker_provision_uses_resource_name_for_arn_and_resource_id_for_tags() {
+    let generator = AwsRuntimePermissionsGenerator::new();
+    let permission_set = get_permission_set("worker/provision").expect("permission set exists");
+    let context = create_test_context()
+        .with_resource_id("job")
+        .with_resource_name("my-stack-job");
+
+    let result = generator
+        .generate_policy(permission_set, BindingTarget::Resource, &context)
+        .expect("Should generate AWS policy successfully");
+
+    let create_function_statement = result
+        .statement
+        .iter()
+        .find(|statement| {
+            statement
+                .action
+                .contains(&"lambda:CreateFunction".to_string())
+                && statement.resource.contains(
+                    &"arn:aws:lambda:us-east-1:123456789012:function:my-stack-job".to_string(),
+                )
+        })
+        .expect("worker provision should allow creating the physical Lambda function");
+
+    assert!(condition_equals(
+        create_function_statement,
+        "aws:RequestTag/resource",
+        "job"
+    ));
+}
+
+#[test]
 fn test_aws_missing_variable_error() {
     let generator = AwsRuntimePermissionsGenerator::new();
 

--- a/crates/alien-permissions/tests/common/mod.rs
+++ b/crates/alien-permissions/tests/common/mod.rs
@@ -12,6 +12,7 @@ pub fn create_test_context() -> PermissionContext {
         .with_stack_prefix("my-stack")
         .with_stack_name("byoc-database")
         .with_deployment_name("Payment Processor")
+        .with_resource_id("payments-data")
         .with_resource_name("my-stack-payments-data")
         .with_project_name("my-project")
         .with_project_number("123456789012")
@@ -24,6 +25,7 @@ pub fn create_test_context() -> PermissionContext {
         .with_external_id("my-external-id")
         .with_aws_account_id("123456789012")
         .with_aws_region("us-east-1")
+        .with_managing_account_id("210987654321")
 }
 
 /// Test helper to create AWS storage data read permission set
@@ -339,10 +341,12 @@ pub fn create_empty_context() -> PermissionContext {
 pub fn create_cloudformation_context() -> PermissionContext {
     PermissionContext::new()
         .with_stack_prefix("my-stack")
+        .with_resource_id("payments-data")
         .with_resource_name("PaymentsDataBucket") // CloudFormation logical ID
         .with_aws_account_id("123456789012") // Managing account ID
         .with_aws_region("us-east-1")
         .with_external_id("my-external-id")
+        .with_managing_account_id("210987654321")
 }
 
 /// Test helper to create AWS permission set with CloudFormation-specific resource references

--- a/crates/alien-preflights/src/deployment_prerequisites.rs
+++ b/crates/alien-preflights/src/deployment_prerequisites.rs
@@ -9,7 +9,11 @@ use crate::error::Result;
 use crate::{CheckResult, DeploymentPrerequisiteCheck};
 use alien_core::{
     ComputeBackend, ComputeCluster, Container, Daemon, DeploymentConfig, EnvironmentVariable,
-    ExposeProtocol, Platform, Stack, StackState, Worker,
+    ExposeProtocol, KubernetesCluster, PermissionSet, Platform, ResourceEntry, ResourceLifecycle,
+    Stack, StackState, Worker,
+};
+use alien_permissions::{
+    generators::AwsRuntimePermissionsGenerator, BindingTarget, PermissionContext,
 };
 
 fn is_cloud_platform(platform: Platform) -> bool {
@@ -127,6 +131,120 @@ impl DeploymentPrerequisiteCheck for DomainMetadataRequiredCheck {
              The deployment config must include domainMetadata for cloud platforms."
         )]))
     }
+}
+
+/// Validates that AWS Live resource-scoped management permissions are emitted by setup.
+pub struct AwsLiveManagementPermissionsSetupCheck;
+
+#[async_trait::async_trait]
+impl DeploymentPrerequisiteCheck for AwsLiveManagementPermissionsSetupCheck {
+    fn description(&self) -> &'static str {
+        "AWS Live management permissions should be setup-owned"
+    }
+
+    fn should_run(
+        &self,
+        stack: &Stack,
+        stack_state: &StackState,
+        _config: &DeploymentConfig,
+    ) -> bool {
+        stack_state.platform == Platform::Aws && stack.management().profile().is_some()
+    }
+
+    async fn check(
+        &self,
+        stack: &Stack,
+        _stack_state: &StackState,
+        _config: &DeploymentConfig,
+    ) -> Result<CheckResult> {
+        let mut errors = Vec::new();
+        let Some(profile) = stack.management().profile() else {
+            return Ok(CheckResult::success());
+        };
+
+        for (resource_id, permission_set_refs) in
+            profile.0.iter().filter(|(scope, _)| *scope != "*")
+        {
+            let Some(resource_entry) = stack.resources.get(resource_id) else {
+                continue;
+            };
+            if resource_entry.lifecycle != ResourceLifecycle::Live {
+                continue;
+            }
+
+            for permission_set_ref in permission_set_refs {
+                let Some(permission_set) = permission_set_ref
+                    .resolve(|name| alien_permissions::get_permission_set(name).cloned())
+                else {
+                    continue;
+                };
+                if permission_set.platforms.aws.is_none()
+                    || permission_set.id.ends_with("/provision")
+                {
+                    continue;
+                }
+                if aws_live_management_permission_is_setup_compilable(
+                    resource_id,
+                    resource_entry,
+                    &permission_set,
+                ) {
+                    continue;
+                }
+
+                errors.push(format!(
+                    "AWS management permission '{}' is scoped to Live resource '{}', but setup cannot compile a concrete grant for it before provisioning. The permission requires provider resource context that AWS setup does not know yet.",
+                    permission_set.id, resource_id
+                ));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(CheckResult::success())
+        } else {
+            Ok(CheckResult::failed(errors))
+        }
+    }
+}
+
+fn aws_live_management_permission_is_setup_compilable(
+    resource_id: &str,
+    resource_entry: &ResourceEntry,
+    permission_set: &PermissionSet,
+) -> bool {
+    // This validates the provider-neutral AWS permission template with
+    // concrete setup-shaped values. Backend emitters still own Terraform or
+    // CloudFormation rendering details, so AWS permission JSONC should not use
+    // backend-only syntax such as CloudFormation ${!Sub} escapes.
+    let context = aws_live_management_setup_context(resource_id, resource_entry);
+    AwsRuntimePermissionsGenerator::new()
+        .generate_policy(permission_set, BindingTarget::Resource, &context)
+        .is_ok()
+}
+
+fn aws_live_management_setup_context(
+    resource_id: &str,
+    resource_entry: &ResourceEntry,
+) -> PermissionContext {
+    let context = PermissionContext::new()
+        .with_stack_prefix("stack")
+        .with_aws_region("us-east-1")
+        .with_aws_account_id("123456789012")
+        .with_managing_account_id("210987654321")
+        .with_resource_id(resource_id.to_string());
+
+    if resource_entry.config.downcast_ref::<Worker>().is_some() {
+        return context.with_resource_name(format!("stack-{resource_id}"));
+    }
+
+    if resource_entry
+        .config
+        .downcast_ref::<KubernetesCluster>()
+        .is_some()
+    {
+        return context.with_resource_name(resource_id.to_string());
+    }
+
+    context
 }
 
 /// Validates that targeted environment variables resolve to resources in the final stack.
@@ -249,7 +367,7 @@ fn target_resource_pattern_matches(
 mod tests {
     use super::*;
     use crate::runner::PreflightRunner;
-    use alien_core::permissions::PermissionProfile;
+    use alien_core::permissions::{ManagementPermissions, PermissionProfile};
     use alien_core::{
         permissions::PermissionsConfig, CertificateStatus, ContainerCode, DnsRecordStatus,
         DomainMetadata, EnvironmentVariable, EnvironmentVariableType, EnvironmentVariablesSnapshot,
@@ -420,6 +538,15 @@ mod tests {
         }
     }
 
+    fn create_live_storage_entry(id: &str) -> ResourceEntry {
+        ResourceEntry {
+            config: Resource::new(Storage::new(id.to_string()).build()),
+            lifecycle: ResourceLifecycle::Live,
+            dependencies: Vec::new(),
+            remote_access: false,
+        }
+    }
+
     #[tokio::test]
     async fn managed_container_backend_fails_without_compute_backend_on_cloud() {
         let mut resources = IndexMap::new();
@@ -511,6 +638,82 @@ mod tests {
         let check = DomainMetadataRequiredCheck;
 
         assert!(!check.should_run(&stack, &stack_state(Platform::Aws), &config));
+    }
+
+    #[tokio::test]
+    async fn aws_live_management_permissions_allow_worker_dispatch_command() {
+        let mut resources = IndexMap::new();
+        resources.insert("job".to_string(), create_public_function_entry("job"));
+        let mut stack = create_stack(resources);
+        stack.permissions.management = ManagementPermissions::override_(
+            PermissionProfile::new().resource("job", ["worker/dispatch-command"]),
+        );
+        let config = deployment_config();
+        let check = AwsLiveManagementPermissionsSetupCheck;
+
+        assert!(check.should_run(&stack, &stack_state(Platform::Aws), &config));
+        let result = check
+            .check(&stack, &stack_state(Platform::Aws), &config)
+            .await
+            .unwrap();
+
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn aws_live_management_permissions_fail_for_unsupported_live_resource_scope() {
+        let mut resources = IndexMap::new();
+        resources.insert("uploads".to_string(), create_live_storage_entry("uploads"));
+        let mut stack = create_stack(resources);
+        stack.permissions.management = ManagementPermissions::override_(
+            PermissionProfile::new().resource("uploads", ["storage/data-read"]),
+        );
+        let config = deployment_config();
+        let check = AwsLiveManagementPermissionsSetupCheck;
+
+        let result = check
+            .check(&stack, &stack_state(Platform::Aws), &config)
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.errors[0].contains("storage/data-read"));
+        assert!(result.errors[0].contains("uploads"));
+        assert!(result.errors[0].contains("setup cannot compile"));
+    }
+
+    #[tokio::test]
+    async fn aws_live_management_permissions_ignore_frozen_resource_scope() {
+        let mut resources = IndexMap::new();
+        resources.insert("uploads".to_string(), create_storage_entry("uploads"));
+        let mut stack = create_stack(resources);
+        stack.permissions.management = ManagementPermissions::override_(
+            PermissionProfile::new().resource("uploads", ["storage/data-read"]),
+        );
+        let config = deployment_config();
+        let check = AwsLiveManagementPermissionsSetupCheck;
+
+        let result = check
+            .check(&stack, &stack_state(Platform::Aws), &config)
+            .await
+            .unwrap();
+
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn aws_live_management_permissions_do_not_run_for_gcp_or_azure() {
+        let mut resources = IndexMap::new();
+        resources.insert("uploads".to_string(), create_live_storage_entry("uploads"));
+        let mut stack = create_stack(resources);
+        stack.permissions.management = ManagementPermissions::override_(
+            PermissionProfile::new().resource("uploads", ["storage/data-read"]),
+        );
+        let config = deployment_config();
+        let check = AwsLiveManagementPermissionsSetupCheck;
+
+        assert!(!check.should_run(&stack, &stack_state(Platform::Gcp), &config));
+        assert!(!check.should_run(&stack, &stack_state(Platform::Azure), &config));
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/lib.rs
+++ b/crates/alien-preflights/src/lib.rs
@@ -258,6 +258,9 @@ impl PreflightRegistry {
             deployment_prerequisites::DomainMetadataRequiredCheck,
         ));
         registry.add_deployment_prerequisite_check(Box::new(
+            deployment_prerequisites::AwsLiveManagementPermissionsSetupCheck,
+        ));
+        registry.add_deployment_prerequisite_check(Box::new(
             deployment_prerequisites::TargetResourcesResolveCheck,
         ));
 

--- a/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
@@ -22,12 +22,12 @@ use crate::{
 };
 use alien_core::{
     import::EmitContext, ErrorData, KubernetesCluster, PermissionProfile, PermissionSetReference,
-    RemoteStackManagement, Result,
+    RemoteStackManagement, ResourceLifecycle, Result, Worker,
 };
 use alien_error::Context;
 use alien_permissions::{
     generators::{AwsIamStatement, AwsRuntimePermissionsGenerator},
-    BindingTarget,
+    BindingTarget, PermissionContext,
 };
 use hcl::expr::Expression;
 
@@ -51,8 +51,8 @@ impl TfEmitter for AwsRemoteStackManagementEmitter {
         ));
 
         let generator = AwsRuntimePermissionsGenerator::new();
-        let context =
-            aws_terraform_permission_context().with_resource_name("management".to_string());
+        let context = aws_terraform_permission_context();
+        let stack_context = context.clone().with_resource_name("management".to_string());
         let mut statements = Vec::<AwsIamStatement>::new();
         if let Some(profile) = ctx.stack.management().profile() {
             for permission_set_ref in global_permission_refs(profile) {
@@ -64,7 +64,7 @@ impl TfEmitter for AwsRemoteStackManagementEmitter {
                     }
 
                     let policy = generator
-                        .generate_policy(&permission_set, BindingTarget::Stack, &context)
+                        .generate_policy(&permission_set, BindingTarget::Stack, &stack_context)
                         .context(ErrorData::GenericError {
                             message: format!(
                                 "failed to generate AWS Terraform management policy for permission set '{}'",
@@ -76,9 +76,15 @@ impl TfEmitter for AwsRemoteStackManagementEmitter {
             }
 
             for (resource_id, permission_set_ref) in resource_scoped_permission_refs(profile) {
+                if permission_set_ref.id().ends_with("/provision") {
+                    continue;
+                }
                 let Some(resource_entry) = ctx.stack.resources.get(resource_id) else {
                     continue;
                 };
+                if resource_entry.lifecycle != ResourceLifecycle::Live {
+                    continue;
+                }
                 let Some(permission_set) = permission_set_ref
                     .resolve(|name| alien_permissions::get_permission_set(name).cloned())
                 else {
@@ -87,15 +93,9 @@ impl TfEmitter for AwsRemoteStackManagementEmitter {
                 if permission_set.platforms.aws.is_none() {
                     continue;
                 }
-                let Some(resource_name) = resource_scoped_aws_resource_name(
-                    resource_id,
-                    resource_entry,
-                    &permission_set.id,
-                ) else {
-                    continue;
-                };
 
-                let resource_context = context.clone().with_resource_name(resource_name);
+                let resource_context =
+                    resource_scoped_aws_permission_context(resource_id, resource_entry, &context);
                 let policy = generator
                     .generate_policy(&permission_set, BindingTarget::Resource, &resource_context)
                     .context(ErrorData::GenericError {
@@ -211,19 +211,25 @@ fn resource_scoped_permission_refs(
         .collect()
 }
 
-fn resource_scoped_aws_resource_name(
+fn resource_scoped_aws_permission_context(
     resource_id: &str,
     resource_entry: &alien_core::ResourceEntry,
-    permission_set_id: &str,
-) -> Option<String> {
-    if permission_set_id == "kubernetes-public-endpoint/management" {
-        return Some(resource_id.to_string());
+    base_context: &PermissionContext,
+) -> PermissionContext {
+    let mut context = base_context
+        .clone()
+        .with_resource_id(resource_id.to_string());
+    context.resource_name = None;
+
+    if resource_entry.config.downcast_ref::<Worker>().is_some() {
+        return context.with_resource_name(format!("${{local.resource_prefix}}-{resource_id}"));
     }
 
-    resource_entry
-        .config
-        .downcast_ref::<KubernetesCluster>()
-        .map(kubernetes_cluster_name)
+    if let Some(cluster) = resource_entry.config.downcast_ref::<KubernetesCluster>() {
+        return context.with_resource_name(kubernetes_cluster_name(cluster));
+    }
+
+    context
 }
 
 fn kubernetes_cluster_name(cluster: &KubernetesCluster) -> String {
@@ -234,4 +240,60 @@ fn kubernetes_cluster_name(cluster: &KubernetesCluster) -> String {
         .unwrap_or_else(|| {
             "${var.kubernetes_cluster_mode == \"create\" ? format(\"%s-k8s\", local.resource_prefix) : var.eks_cluster_name}".to_string()
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_core::{Resource, ResourceEntry, ResourceLifecycle, Storage, Worker, WorkerCode};
+
+    fn live_worker_entry(id: &str) -> ResourceEntry {
+        ResourceEntry {
+            config: Resource::new(
+                Worker::new(id.to_string())
+                    .code(WorkerCode::Image {
+                        image: "test:latest".to_string(),
+                    })
+                    .permissions("default".to_string())
+                    .build(),
+            ),
+            lifecycle: ResourceLifecycle::Live,
+            dependencies: Vec::new(),
+            remote_access: false,
+        }
+    }
+
+    #[test]
+    fn aws_remote_management_resource_scope_names_future_worker_lambda() {
+        let entry = live_worker_entry("jobs");
+        let context = resource_scoped_aws_permission_context(
+            "jobs",
+            &entry,
+            &aws_terraform_permission_context(),
+        );
+
+        assert_eq!(context.resource_id.as_deref(), Some("jobs"));
+        assert_eq!(
+            context.resource_name.as_deref(),
+            Some("${local.resource_prefix}-jobs")
+        );
+    }
+
+    #[test]
+    fn aws_remote_management_resource_scope_does_not_inherit_management_name() {
+        let entry = ResourceEntry {
+            config: Resource::new(Storage::new("uploads".to_string()).build()),
+            lifecycle: ResourceLifecycle::Live,
+            dependencies: Vec::new(),
+            remote_access: false,
+        };
+        let context = resource_scoped_aws_permission_context(
+            "uploads",
+            &entry,
+            &aws_terraform_permission_context().with_resource_name("management"),
+        );
+
+        assert_eq!(context.resource_id.as_deref(), Some("uploads"));
+        assert_eq!(context.resource_name, None);
+    }
 }

--- a/crates/alien-terraform/tests/generator/aws_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_identity_tests.rs
@@ -4,7 +4,7 @@
 use super::helpers::{assert_terraform_valid, render, snapshot_module};
 use alien_core::{
     ManagementPermissions, Network, NetworkSettings, PermissionProfile, RemoteStackManagement,
-    ResourceLifecycle, ServiceAccount, Stack, StackSettings,
+    ResourceLifecycle, ServiceAccount, Stack, StackSettings, Worker, WorkerCode,
 };
 use alien_terraform::TerraformTarget;
 
@@ -39,6 +39,43 @@ fn aws_remote_stack_management_role() {
     let module = render(&stack, TerraformTarget::Aws, StackSettings::default());
     snapshot_module("aws_remote_stack_management", &module);
     assert_terraform_valid(&module, "aws_remote_stack_management");
+}
+
+#[test]
+fn aws_remote_stack_management_skips_live_provision_sets() {
+    let stack = Stack::new("acme-mgmt".to_string())
+        .management(ManagementPermissions::extend(
+            PermissionProfile::new()
+                .resource("job", ["worker/provision", "worker/dispatch-command"]),
+        ))
+        .add(
+            RemoteStackManagement::new("management".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            Worker::new("job".to_string())
+                .code(WorkerCode::Image {
+                    image: "123456789012.dkr.ecr.us-east-1.amazonaws.com/app/job:1.2.3".to_string(),
+                })
+                .permissions("execution".to_string())
+                .build(),
+            ResourceLifecycle::Live,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Aws, StackSettings::default());
+    let mut rendered = String::new();
+    for (_, contents) in module.iter() {
+        rendered.push_str(contents);
+        rendered.push('\n');
+    }
+
+    assert!(rendered.contains("lambda:InvokeFunction"));
+    assert!(!rendered.contains("lambda:CreateFunction"));
+    assert_terraform_valid(
+        &module,
+        "aws_remote_stack_management_skips_live_provision_sets",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes AWS management permission handoff by compiling setup-time AWS management grants from the final permission profile, instead of special-casing individual permission-set IDs or letting Live controllers broaden the management role during provisioning.

Linear: ALIEN-201

## First Principles

1. Alien has a handoff boundary: setup creates Frozen infrastructure and the management role; provisioning uses that management role to create and update Live resources.
2. A resource-scoped management permission is authority for Alien itself, not for an app service account. If it is needed for a Live resource, setup must grant it before provisioning starts whenever AWS can describe the target scope up front.
3. AWS IAM can grant access to future resources when the ARN or tag conditions are deterministic. For example, a future worker Lambda name is derived from the stack prefix and worker id.
4. The permission templates need two different values:
   - `resourceId`: Alien's logical resource id, used for `aws:RequestTag/resource` and `aws:ResourceTag/resource` conditions.
   - `resourceName`: the provider physical resource name/scope, used in ARNs.
5. Frozen resource-scoped management grants should stay with setup-owned resource emitters/controllers because those resources exist during setup and those emitters know the real resource name.
6. If a Live AWS resource-scoped management permission needs provider context setup cannot know yet, preflight should fail before cloud mutation.

## What Changed

- Added `resourceId` to `PermissionContext` and CloudFormation interpolation.
- Updated AWS permission JSONC tag conditions for worker, container, and Kubernetes public endpoint permissions to use `${resourceId}` for the Alien resource tag value.
- Kept `${resourceName}` for physical provider ARNs and scopes.
- Updated AWS runtime resource permission application to pass both logical id and physical name.
- Updated AWS RemoteStackManagement setup generation in direct, Terraform, and CloudFormation paths to compile concrete Live resource-scoped management grants from the permission profile.
- Removed permission-set-id-specific setup filters like `worker/dispatch-command` checks from the AWS setup emitters.
- Skipped Frozen resource-scoped management grants in RemoteStackManagement setup generation so resource-owned setup emitters/controllers keep applying those with real resource names.
- Skipped `/provision` permission sets in setup-time management grants so accidental provision authority in a management profile is not emitted.
- Replaced the AWS Live management preflight allowlist with a real setup-compilability check, with an explicit note that it validates backend-neutral AWS permission JSONC rather than Terraform/CloudFormation-only syntax.

## Validation

Passed:

- `cargo test -p alien-permissions --test aws_runtime --all-features test_worker_provision_uses_resource_name_for_arn_and_resource_id_for_tags`
- `cargo test -p alien-permissions --test aws_cloudformation --all-features test_aws_cloudformation_resource_id_interpolates_in_conditions`
- `cargo test -p alien-preflights --all-features`
- `cargo test -p alien-preflights aws_live_management_permissions --all-features`
- `cargo test -p alien-infra aws_management_resource_permissions --all-features`
- `cargo test -p alien-terraform aws_remote_management_resource_scope --all-features`
- `cargo test -p alien-terraform --test generator --all-features aws_full_stack_renders_audit_ready_module`
- `cargo test -p alien-terraform --test generator --all-features aws_remote_stack_management_skips_live_provision_sets`
- `cargo test -p alien-cloudformation --test generator --all-features aws_remote_stack_management_skips_live_provision_sets`
- `cargo test -p alien-cloudformation aws_remote_management_resource_scope --all-features`
- `cargo test -p alien-cloudformation --all-features`

Known unrelated test state:

- `cargo test -p alien-permissions --all-features` currently fails in `aws_wildcard_resources_are_read_only_or_conditioned_unless_documented` for existing `worker/execute` wildcard ENI permissions. I did not change that here; it appears covered by Alan's CI/test branch.
