### PR TITLE
fix: Azure/GCP infrastructure fixes (Postgres groundwork)

### DIFF
--- a/crates/alien-infra/src/build/azure.rs
+++ b/crates/alien-infra/src/build/azure.rs
@@ -116,15 +116,21 @@ impl AzureBuildController {
     async fn ready(&mut self, ctx: &ResourceControllerContext<'_>) -> Result<HandlerAction> {
         let config = ctx.desired_resource_config::<Build>()?;
 
-        // Heartbeat check: Azure Build doesn't create persistent jobs like AWS CodeBuild.
-        // Jobs are created on-demand, so heartbeat is essentially a no-op.
-        // We just verify our managed environment configuration is still valid.
-        if self.managed_environment_id.is_none() || self.managed_identity_id.is_none() {
-            return Err(AlienError::new(ErrorData::ResourceDrift {
-                resource_id: config.id.clone(),
-                message: "Azure Build configuration is missing managed environment or identity"
-                    .to_string(),
-            }));
+        // Azure Build creates no persistent job (unlike AWS CodeBuild); jobs run on-demand, so the
+        // heartbeat resolves the managed environment + identity from their dependencies rather than
+        // inspecting standing infra. Imported (Frozen) builds skip the Provisioning flow that sets
+        // these, so they arrive `None` here and are resolved now, at heartbeat time, as the importer
+        // documents. A genuinely missing dependency still errors (and the executor retries).
+        if self.managed_environment_id.is_none() {
+            self.managed_environment_id = Some(self.get_managed_environment_id(ctx)?);
+        }
+        if self.managed_identity_id.is_none() {
+            let service_account_ref = ResourceRef::new(
+                alien_core::ServiceAccount::RESOURCE_TYPE,
+                format!("{}-sa", config.get_permissions()),
+            );
+            self.managed_identity_id =
+                Some(self.get_managed_identity_id(ctx, &service_account_ref).await?);
         }
 
         emit_azure_build_heartbeat(ctx, &config.id, self);
@@ -552,5 +558,52 @@ mod tests {
         // Run the update flow
         executor.run_until_terminal().await.unwrap();
         assert_eq!(executor.status(), ResourceStatus::Running);
+    }
+
+    /// Regression: an imported (Frozen) Azure build arrives with `managed_environment_id` and
+    /// `managed_identity_id` = `None` (the importer skips the Provisioning flow that sets them).
+    /// The Ready/heartbeat handler must resolve them from their dependencies, not flag
+    /// RESOURCE_DRIFT, which would fail the deployment non-retryably.
+    #[tokio::test]
+    async fn test_imported_build_resolves_env_and_identity_at_heartbeat() {
+        use super::AzureBuildState;
+
+        // Mirrors AzureBuildImporter's output: Frozen import leaves env + identity unresolved.
+        let imported = AzureBuildController {
+            state: AzureBuildState::Ready,
+            managed_environment_id: None,
+            resource_group_name: Some("test-rg".to_string()),
+            build_env_vars: Some(std::collections::HashMap::new()),
+            managed_identity_id: None,
+            resource_prefix: None,
+            _internal_stay_count: None,
+        };
+
+        let mock_provider = Arc::new(MockPlatformServiceProvider::new());
+        let mut executor = SingleControllerExecutor::builder()
+            .resource(basic_build())
+            .controller(imported)
+            .platform(Platform::Azure)
+            .service_provider(mock_provider)
+            .with_test_dependencies()
+            .build()
+            .await
+            .unwrap();
+
+        // One heartbeat step resolves env + identity from the dependencies instead of drifting.
+        executor.step().await.unwrap();
+        assert_eq!(executor.status(), ResourceStatus::Running);
+
+        let ctrl = executor
+            .internal_state::<AzureBuildController>()
+            .expect("controller state");
+        assert!(
+            ctrl.managed_environment_id.is_some(),
+            "heartbeat should resolve managed_environment_id for an imported build"
+        );
+        assert!(
+            ctrl.managed_identity_id.is_some(),
+            "heartbeat should resolve managed_identity_id for an imported build"
+        );
     }
 }

--- a/crates/alien-infra/src/build/azure.rs
+++ b/crates/alien-infra/src/build/azure.rs
@@ -117,10 +117,15 @@ impl AzureBuildController {
         let config = ctx.desired_resource_config::<Build>()?;
 
         // Azure Build creates no persistent job (unlike AWS CodeBuild); jobs run on-demand, so the
-        // heartbeat resolves the managed environment + identity from their dependencies rather than
+        // heartbeat resolves the managed environment, identity, and resource prefix rather than
         // inspecting standing infra. Imported (Frozen) builds skip the Provisioning flow that sets
         // these, so they arrive `None` here and are resolved now, at heartbeat time, as the importer
-        // documents. A genuinely missing dependency still errors (and the executor retries).
+        // documents. All three are required for `get_binding_params` to emit a binding, so resolving
+        // them here lets an imported build submit jobs without waiting for an update. A genuinely
+        // missing dependency still errors (and the executor retries).
+        if self.resource_prefix.is_none() {
+            self.resource_prefix = Some(ctx.resource_prefix.to_string());
+        }
         if self.managed_environment_id.is_none() {
             self.managed_environment_id = Some(self.get_managed_environment_id(ctx)?);
         }
@@ -470,7 +475,7 @@ mod tests {
     use crate::build::{fixtures::*, AzureBuildController};
     use crate::core::{
         controller_test::{SingleControllerExecutor, SingleControllerExecutorBuilder},
-        MockPlatformServiceProvider,
+        MockPlatformServiceProvider, ResourceController,
     };
 
     #[rstest]
@@ -590,7 +595,7 @@ mod tests {
             .await
             .unwrap();
 
-        // One heartbeat step resolves env + identity from the dependencies instead of drifting.
+        // One heartbeat step resolves env, identity, and resource prefix instead of drifting.
         executor.step().await.unwrap();
         assert_eq!(executor.status(), ResourceStatus::Running);
 
@@ -604,6 +609,18 @@ mod tests {
         assert!(
             ctrl.managed_identity_id.is_some(),
             "heartbeat should resolve managed_identity_id for an imported build"
+        );
+        assert!(
+            ctrl.resource_prefix.is_some(),
+            "heartbeat should resolve resource_prefix for an imported build"
+        );
+        // The point of resolving all three: an imported build must emit binding params (and so be
+        // able to submit jobs) straight after heartbeat, without waiting for an update.
+        assert!(
+            ctrl.get_binding_params()
+                .expect("get_binding_params should not error")
+                .is_some(),
+            "imported build should emit binding params once heartbeat resolves all fields"
         );
     }
 }

--- a/crates/alien-infra/src/network/gcp_import.rs
+++ b/crates/alien-infra/src/network/gcp_import.rs
@@ -28,6 +28,16 @@ impl ResourceImporter for GcpNetworkImporter {
         // first entry from the wire payload and stores the rest as
         // metadata-only via the network self-link.
         let subnetwork_self_link = data.subnet_self_links.first().cloned();
+        // Recover the subnet name from its self-link (`.../subnetworks/<name>`) so the imported
+        // Frozen network exposes the same `subnetwork_name` the runtime create path sets. Without
+        // it a live worker's `get_vpc_access` short-circuits on the `subnetwork_name` check and the
+        // Cloud Run service gets no Direct VPC egress — unable to reach a private Cloud SQL PSC
+        // endpoint in this subnet. Mirrors the Azure importer's self-link name parse.
+        let subnetwork_name = subnetwork_self_link
+            .as_deref()
+            .and_then(|link| link.rsplit('/').next())
+            .filter(|name| !name.is_empty())
+            .map(str::to_string);
         let _ = data.project_id;
 
         let controller = GcpNetworkController {
@@ -35,7 +45,7 @@ impl ResourceImporter for GcpNetworkImporter {
             desired_settings: None,
             network_name: data.vpc_name,
             network_self_link: data.vpc_self_link,
-            subnetwork_name: None,
+            subnetwork_name,
             subnetwork_self_link,
             router_name: None,
             cloud_nat_name: data.nat_name,

--- a/crates/alien-infra/src/worker/azure.rs
+++ b/crates/alien-infra/src/worker/azure.rs
@@ -339,6 +339,12 @@ pub struct AzureWorkerController {
     /// Public URL (if `Ingress::Public`).
     pub(crate) url: Option<String>,
 
+    /// The Container App's own ingress host (`*.azurecontainerapps.io`). `url` may be overridden to
+    /// the public display FQDN (from `public_urls`), but DNS records must target THIS host:
+    /// targeting the public FQDN makes the CNAME self-referential (target == record name) and the
+    /// DNS provider rejects it as a loop. See `build_outputs`.
+    pub(crate) container_app_url: Option<String>,
+
     /// URL returned by Azure ARM for *current* long‑running operation.
     pub(crate) pending_operation_url: Option<String>,
     /// Retry‑after seconds for the current LRO (populated when Azure returns it).
@@ -1983,6 +1989,10 @@ impl AzureWorkerController {
             }
         }
 
+        // Imported workers skip the create flow, so the heartbeat is where they pick up the ingress
+        // host (the DNS CNAME target — see `container_app_url`).
+        self.container_app_url = self.extract_url_from_container_app(&container_app);
+
         // Check for certificate renewal on auto-managed public domains.
         if func_cfg.ingress == Ingress::Public && !self.uses_custom_domain {
             let metadata = ctx
@@ -2324,6 +2334,8 @@ impl AzureWorkerController {
                     info!(name=%container_app_name, "Update provisioning succeeded – updating Dapr components");
 
                     let container_app_url = self.extract_url_from_container_app(&app);
+                    // Capture the ingress host (DNS CNAME target) before `url` is overridden below.
+                    self.container_app_url = container_app_url.clone();
 
                     // Check for URL override in deployment config, otherwise use Container App URL
                     self.url = ctx
@@ -3212,13 +3224,15 @@ impl AzureWorkerController {
     // Implementation of get_outputs trait method
     fn build_outputs(&self) -> Option<ResourceOutputs> {
         self.resource_id.as_ref().map(|id| {
-            let load_balancer_endpoint =
-                self.url
-                    .as_ref()
-                    .map(|url| alien_core::LoadBalancerEndpoint {
-                        dns_name: dns_name_from_url(url),
-                        hosted_zone_id: None,
-                    });
+            // CNAME target = the ingress host; fall back to `url` when `container_app_url` is unset.
+            let load_balancer_endpoint = self
+                .container_app_url
+                .as_ref()
+                .or(self.url.as_ref())
+                .map(|host| alien_core::LoadBalancerEndpoint {
+                    dns_name: dns_name_from_url(host),
+                    hosted_zone_id: None,
+                });
 
             ResourceOutputs::new(WorkerOutputs {
                 worker_name: self
@@ -3688,6 +3702,7 @@ impl AzureWorkerController {
         self.container_app_name = None;
         self.resource_id = None;
         self.url = None;
+        self.container_app_url = None;
         self.pending_operation_url = None;
         self.pending_operation_retry_after = None;
         self.dapr_components.clear();
@@ -3702,6 +3717,9 @@ impl AzureWorkerController {
         self.resource_id = app.id.clone();
 
         let container_app_url = self.extract_url_from_container_app(app);
+
+        // Capture the ingress host (DNS CNAME target) before `url` is overridden below.
+        self.container_app_url = container_app_url.clone();
 
         // Check for URL override in deployment config, otherwise use Container App URL
         if let Ok(config) = ctx.desired_resource_config::<Worker>() {
@@ -4519,6 +4537,7 @@ impl AzureWorkerController {
                 function_name
             )),
             url: Some(format!("https://{}.azurecontainerapps.io", function_name)),
+            container_app_url: None,
             pending_operation_url: None,
             pending_operation_retry_after: None,
             dapr_components: Vec::new(),
@@ -4613,6 +4632,84 @@ mod tests {
                 .map(|endpoint| endpoint.dns_name.as_str()),
             Some("test-worker.azurecontainerapps.io")
         );
+    }
+
+    #[test]
+    fn dns_target_is_ingress_host_when_url_is_overridden_to_public_fqdn() {
+        // Regression: when `url` is overridden to the public display FQDN (from `public_urls`), the
+        // CNAME target must still be the Container App ingress host. Otherwise the record name (the
+        // public FQDN) and the target collide into a self-referential CNAME, which the DNS provider
+        // rejects — the bug that deadlocked the Azure worker in `waitingForDns`.
+        let mut controller = AzureWorkerController::mock_ready("test-worker");
+        controller.url = Some("https://test-worker.abc123.dev.vpc.direct".to_string());
+        controller.container_app_url =
+            Some("https://test-worker.kindsky.eastus2.azurecontainerapps.io".to_string());
+
+        let outputs = controller.build_outputs().unwrap();
+        let worker_outputs = outputs.downcast_ref::<WorkerOutputs>().unwrap();
+
+        // Display URL stays the public FQDN.
+        assert_eq!(
+            worker_outputs.url.as_deref(),
+            Some("https://test-worker.abc123.dev.vpc.direct")
+        );
+        // The CNAME target is the ingress host — and crucially NOT the record's own public FQDN.
+        let dns_name = worker_outputs
+            .load_balancer_endpoint
+            .as_ref()
+            .map(|endpoint| endpoint.dns_name.as_str());
+        assert_eq!(
+            dns_name,
+            Some("test-worker.kindsky.eastus2.azurecontainerapps.io")
+        );
+        assert_ne!(dns_name, Some("test-worker.abc123.dev.vpc.direct"));
+    }
+
+    #[tokio::test]
+    async fn imported_worker_heartbeat_rebuilds_ingress_host_for_dns() {
+        // Regression for the create-path-only gap: an imported worker starts Ready with
+        // `container_app_url = None` and `url` = the public display FQDN (the importer skips the
+        // create flow). The heartbeat must rebuild `container_app_url` from the live Container App,
+        // so the DNS CNAME targets the ingress host rather than the self-referential public FQDN.
+        let app_name = "test-imported-worker";
+        let mut mock = MockContainerAppsApi::new();
+        mock.expect_get_container_app()
+            .returning(move |_, _| Ok(create_successful_container_app_response(app_name, true)))
+            .times(0..);
+        let mock_provider = setup_mock_service_provider(Arc::new(mock), None);
+
+        // Imported shape: ingress host unset, url is the public display FQDN.
+        let mut controller = AzureWorkerController::mock_ready(app_name);
+        controller.container_app_url = None;
+        controller.url = Some("https://test-imported-worker.abc123.dev.vpc.direct".to_string());
+
+        let mut executor = SingleControllerExecutor::builder()
+            .resource(basic_function())
+            .controller(controller)
+            .platform(Platform::Azure)
+            .service_provider(mock_provider)
+            .with_test_dependencies()
+            .build()
+            .await
+            .unwrap();
+
+        executor.step().await.unwrap();
+        let controller = executor.internal_state::<AzureWorkerController>().unwrap();
+
+        // The heartbeat rebuilt the ingress host…
+        assert_eq!(
+            controller.container_app_url.as_deref(),
+            Some("https://test-imported-worker.azurecontainerapps.io")
+        );
+        // …so build_outputs targets it, NOT the public display FQDN.
+        let outputs = controller.build_outputs().unwrap();
+        let worker_outputs = outputs.downcast_ref::<WorkerOutputs>().unwrap();
+        let dns_name = worker_outputs
+            .load_balancer_endpoint
+            .as_ref()
+            .map(|endpoint| endpoint.dns_name.as_str());
+        assert_eq!(dns_name, Some("test-imported-worker.azurecontainerapps.io"));
+        assert_ne!(dns_name, Some("test-imported-worker.abc123.dev.vpc.direct"));
     }
 
     #[test]
@@ -5752,6 +5849,7 @@ mod tests {
             container_app_name: None, // This is the key - no container app name set
             resource_id: None,
             url: None,
+            container_app_url: None,
             pending_operation_url: None,
             pending_operation_retry_after: None,
             dapr_components: Vec::new(),

--- a/crates/alien-infra/src/worker/azure_import.rs
+++ b/crates/alien-infra/src/worker/azure_import.rs
@@ -32,6 +32,8 @@ impl ResourceImporter for AzureWorkerImporter {
             container_app_name: Some(data.container_app_name),
             resource_id: None,
             url: data.fqdn.as_ref().map(|f| format!("https://{}", f)),
+            // The ingress host (CNAME target) isn't in ImportData; the heartbeat handler rebuilds it.
+            container_app_url: None,
             pending_operation_url: None,
             pending_operation_retry_after: None,
             dapr_components: Vec::new(),

--- a/crates/alien-infra/tests/importers.rs
+++ b/crates/alien-infra/tests/importers.rs
@@ -28,7 +28,8 @@ use alien_core::import::{
         AwsStorageImportData, AzureContainerAppsEnvironmentImportData,
         AzureRemoteStackManagementImportData, AzureResourceGroupImportData,
         AzureServiceAccountImportData, AzureStorageAccountImportData, AzureStorageImportData,
-        GcpBuildImportData, GcpKvImportData, GcpServiceActivationImportData, GcpStorageImportData,
+        GcpBuildImportData, GcpKvImportData, GcpNetworkImportData, GcpServiceActivationImportData,
+        GcpStorageImportData,
         KubernetesClusterImportData,
     },
     ImportContext,
@@ -39,7 +40,8 @@ use alien_core::{
     AzureResourceGroupOutputs, AzureServiceBusNamespace, AzureStorageAccount,
     AzureStorageAccountOutputs, Build, GcpManagementConfig, KubernetesCluster,
     KubernetesClusterOutputs, KubernetesClusterOwnership, KubernetesClusterProvider,
-    KubernetesHeartbeatMode, Kv, ManagementConfig, Network, Platform, Queue, RemoteStackManagement,
+    KubernetesHeartbeatMode, Kv, ManagementConfig, Network, NetworkSettings, Platform, Queue,
+    RemoteStackManagement,
     RemoteStackManagementOutputs, Resource, ResourceDefinition, ResourceEntry, ResourceLifecycle,
     ResourceStatus, ResourceType, ServiceAccount, ServiceActivation, StackSettings, Storage, Vault,
     Worker,
@@ -408,6 +410,47 @@ fn gcp_service_activation_round_trip() {
         &gcp_management_config(),
     );
     assert_running_with_internal_state(&state);
+}
+
+#[test]
+fn gcp_network_import_derives_subnetwork_name() {
+    // Regression: the importer must reconstruct `subnetwork_name` from the subnet self-link.
+    // Without it the live worker's `get_vpc_access` short-circuits and the Cloud Run service gets
+    // no Direct VPC egress — unable to reach a private Cloud SQL PSC endpoint in that subnet.
+    let entry = entry(
+        Network::new("default-network".to_string())
+            .settings(NetworkSettings::UseDefault)
+            .build(),
+    );
+    let data = GcpNetworkImportData {
+        project_id: "my-project".to_string(),
+        vpc_self_link: Some(
+            "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/alien-stack-vpc"
+                .to_string(),
+        ),
+        vpc_name: Some("alien-stack-vpc".to_string()),
+        subnet_self_links: vec![
+            "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/alien-stack-workload"
+                .to_string(),
+        ],
+        cidr_block: Some("10.0.0.0/20".to_string()),
+        router_self_link: None,
+        nat_name: None,
+        is_byo_vpc: false,
+    };
+    let state = run_through_registry(
+        &Network::RESOURCE_TYPE,
+        Platform::Gcp,
+        serde_json::to_value(&data).unwrap(),
+        &entry,
+        "us-central1",
+        &gcp_management_config(),
+    );
+    assert_running_with_internal_state(&state);
+    assert_eq!(
+        internal_state(&state)["subnetworkName"], "alien-stack-workload",
+        "importer must derive subnetwork_name from the subnet self-link, else the worker gets no VPC egress"
+    );
 }
 
 #[test]

--- a/crates/alien-terraform/src/emitters/azure/container_apps_environment.rs
+++ b/crates/alien-terraform/src/emitters/azure/container_apps_environment.rs
@@ -21,7 +21,9 @@ use crate::{
     },
     expr,
 };
-use alien_core::{import::EmitContext, AzureContainerAppsEnvironment, Result};
+use alien_core::{
+    import::EmitContext, AzureContainerAppsEnvironment, Network, NetworkSettings, Result,
+};
 use hcl::expr::Expression;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -64,27 +66,43 @@ impl TfEmitter for AzureContainerAppsEnvironmentEmitter {
             ],
         ));
 
+        let mut env_body = vec![
+            attr(
+                "name",
+                expr::raw(format!(
+                    "replace(lower(\"${{local.resource_prefix}}-{label}\"), \"_\", \"-\")"
+                )),
+            ),
+            attr(
+                "resource_group_name",
+                expr::raw("var.azure_resource_group_name"),
+            ),
+            attr("location", expr::raw("var.azure_location")),
+            attr(
+                "log_analytics_workspace_id",
+                expr::traversal(["azurerm_log_analytics_workspace", &workspace_label, "id"]),
+            ),
+        ];
+
+        // VNet-integrate the environment when the stack has a Network, so Container Apps can reach
+        // private-only resources (a Flexible Server reachable only through its private endpoint).
+        // Without this the environment is public and a worker's connection to the private server
+        // times out. The stack private subnet IS the infrastructure subnet (the network emitter
+        // delegates it to `Microsoft.App/environments`; the postgres private endpoint gets its own
+        // subnet); `internal_load_balancer_enabled = false` keeps public ingress while egressing
+        // through the VNet. Mirrors the runtime controller's `get_vnet_configuration` — a
+        // consumption environment on the /24 private subnet, proven to reach a private server.
+        if let Some(infrastructure_subnet_id) = infrastructure_subnet_id(ctx) {
+            env_body.push(attr("infrastructure_subnet_id", infrastructure_subnet_id));
+            env_body.push(attr("internal_load_balancer_enabled", Expression::Bool(false)));
+        }
+
+        env_body.push(attr("tags", tags(ctx, "container-apps-environment")));
+
         fragment.resource_blocks.push(resource_block(
             "azurerm_container_app_environment",
             label,
-            [
-                attr(
-                    "name",
-                    expr::raw(format!(
-                        "replace(lower(\"${{local.resource_prefix}}-{label}\"), \"_\", \"-\")"
-                    )),
-                ),
-                attr(
-                    "resource_group_name",
-                    expr::raw("var.azure_resource_group_name"),
-                ),
-                attr("location", expr::raw("var.azure_location")),
-                attr(
-                    "log_analytics_workspace_id",
-                    expr::traversal(["azurerm_log_analytics_workspace", &workspace_label, "id"]),
-                ),
-                attr("tags", tags(ctx, "container-apps-environment")),
-            ],
+            env_body,
         ));
 
         Ok(fragment)
@@ -216,4 +234,28 @@ impl TfEmitter for AzureContainerAppsEnvironmentEmitter {
             ),
         ])))
     }
+}
+
+/// The `infrastructure_subnet_id` expression for the environment, or `None` when the stack has no
+/// Network (then the environment stays public, matching the runtime controller's
+/// `get_vnet_configuration` returning `None`).
+///
+/// Resolves to the network emitter's private subnet, matching how the Azure network emitter
+/// materializes it: a managed `azurerm_subnet.<network>_private` in create / use-default mode, a
+/// looked-up `data.azurerm_subnet.<network>_private` in bring-your-own-VNet mode.
+fn infrastructure_subnet_id(ctx: &EmitContext<'_>) -> Option<Expression> {
+    let (network_id, entry) = ctx
+        .stack
+        .resources()
+        .find(|(_id, entry)| entry.config.resource_type() == Network::RESOURCE_TYPE)?;
+    let network = entry.config.downcast_ref::<Network>()?;
+    let network_label = ctx.name_for(network_id)?;
+    let private_subnet_label = format!("{network_label}_private");
+
+    let byo = matches!(network.settings, NetworkSettings::ByoVnetAzure { .. });
+    Some(if byo {
+        expr::traversal(["data", "azurerm_subnet", &private_subnet_label, "id"])
+    } else {
+        expr::traversal(["azurerm_subnet", &private_subnet_label, "id"])
+    })
 }

--- a/crates/alien-terraform/src/emitters/azure/network.rs
+++ b/crates/alien-terraform/src/emitters/azure/network.rs
@@ -203,6 +203,12 @@ fn create_topology(ctx: &EmitContext<'_>, label: &str, cidr: Option<String>) -> 
         ],
     ));
 
+    // The private subnet doubles as the Container Apps environment infrastructure subnet (the
+    // env emitter points `infrastructure_subnet_id` here, mirroring the runtime controller). Azure
+    // requires that subnet to be delegated to `Microsoft.App/environments`; unlike the `az` CLI,
+    // the azurerm provider does not auto-delegate, so the delegation is declared here. A /24 is
+    // sufficient for the consumption environment the env emitter creates (proven against real
+    // Azure: a consumption env on a /24 delegated subnet provisions and schedules apps).
     fragment.resource_blocks.push(resource_block(
         "azurerm_subnet",
         &private_label,
@@ -225,6 +231,31 @@ fn create_topology(ctx: &EmitContext<'_>, label: &str, cidr: Option<String>) -> 
                     "cidrsubnet(tolist(azurerm_virtual_network.{label}.address_space)[0], 8, 1)"
                 ))]),
             ),
+            nested(crate::block::block(
+                "delegation",
+                [
+                    attr(
+                        "name",
+                        Expression::String("container-apps-environment".to_string()),
+                    ),
+                    nested(crate::block::block(
+                        "service_delegation",
+                        [
+                            attr(
+                                "name",
+                                Expression::String("Microsoft.App/environments".to_string()),
+                            ),
+                            attr(
+                                "actions",
+                                Expression::Array(vec![Expression::String(
+                                    "Microsoft.Network/virtualNetworks/subnets/join/action"
+                                        .to_string(),
+                                )]),
+                            ),
+                        ],
+                    )),
+                ],
+            )),
         ],
     ));
 

--- a/crates/alien-terraform/tests/generator/azure_full_stack_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_full_stack_tests.rs
@@ -123,5 +123,33 @@ fn azure_full_stack_renders_audit_ready_module() {
 
     let module = render(&stack, TerraformTarget::Azure, settings);
     snapshot_module("azure_full_stack", &module);
+
+    // The Container Apps environment must VNet-integrate so workers can reach private-only
+    // resources (e.g. a Flexible Server reachable only via its private endpoint). Assert the
+    // wiring literally — the snapshot's exact `=` alignment shifts whenever a sibling attribute is
+    // added, so these literal checks are what actually guard the integration. Per-line whitespace
+    // is normalized so a future sibling attribute can't silently break them.
+    let rendered = module
+        .iter()
+        .map(|(_, contents)| contents.lines())
+        .flatten()
+        .map(str::trim)
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect::<Vec<_>>();
+    let has = |needle: &str| rendered.iter().any(|line| line == needle);
+
+    assert!(
+        has("infrastructure_subnet_id = azurerm_subnet.default_network_private.id"),
+        "container apps environment must point its infrastructure subnet at the network private subnet"
+    );
+    assert!(
+        has("internal_load_balancer_enabled = false"),
+        "container apps environment must keep a public ingress while egressing through the VNet"
+    );
+    assert!(
+        has("name = \"Microsoft.App/environments\""),
+        "the private subnet must be delegated to Microsoft.App/environments for the env infra subnet"
+    );
+
     assert_terraform_valid(&module, "azure_full_stack");
 }

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
@@ -448,10 +448,12 @@ resource "azurerm_log_analytics_workspace" "default_container_apps_environment_l
 }
 
 resource "azurerm_container_app_environment" "default_container_apps_environment" {
-  name                       = replace(lower("${local.resource_prefix}-default_container_apps_environment"), "_", "-")
-  resource_group_name        = var.azure_resource_group_name
-  location                   = var.azure_location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.default_container_apps_environment_logs.id
+  name                           = replace(lower("${local.resource_prefix}-default_container_apps_environment"), "_", "-")
+  resource_group_name            = var.azure_resource_group_name
+  location                       = var.azure_location
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.default_container_apps_environment_logs.id
+  infrastructure_subnet_id       = azurerm_subnet.default_network_private.id
+  internal_load_balancer_enabled = false
   tags = {
     "managed-by"    = "setup"
     deployment      = local.resource_prefix
@@ -501,6 +503,18 @@ resource "azurerm_subnet" "default_network_private" {
   address_prefixes = [
     cidrsubnet(tolist(azurerm_virtual_network.default_network.address_space)[0], 8, 1)
   ]
+
+  delegation {
+    name = "container-apps-environment"
+
+    service_delegation {
+      name = "Microsoft.App/environments"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+      ]
+    }
+  }
+
   depends_on = [
     azurerm_resource_group.default_resource_group
   ]

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_create.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_create.snap
@@ -217,6 +217,18 @@ resource "azurerm_subnet" "default_network_private" {
   address_prefixes = [
     cidrsubnet(tolist(azurerm_virtual_network.default_network.address_space)[0], 8, 1)
   ]
+
+  delegation {
+    name = "container-apps-environment"
+
+    service_delegation {
+      name = "Microsoft.App/environments"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+      ]
+    }
+  }
+
   depends_on = [
     azurerm_resource_group.default_resource_group
   ]


### PR DESCRIPTION
Four pre-existing Azure/GCP infrastructure bugs, surfaced while getting the Postgres cloud e2e green. They are independent of the Postgres feature but sit underneath it, so the runtime (#89) and setup (#90) stack on this PR. Splitting them out lets them land and be reviewed on their own.

## What was broken, and what I did
Four small, self-contained fixes:

- **GCP network import dropped the subnet name.** The importer built everything from the subnet but never recorded `subnetwork_name`, so VPC egress to a private PSC Cloud SQL had nothing to resolve against. It now parses the name out of the subnet self-link on import.
- **Azure build read a frozen import as fatal drift.** An imported (frozen) build arrives with its managed environment, identity, and `resource_prefix` unset; the controller treated those as drift and failed. The heartbeat now resolves all three from their dependencies, so an imported build can submit jobs without waiting for an update.
- **Azure worker pointed the DNS CNAME at the wrong host.** It targeted the public display FQDN, which can equal the record name and make the record point at itself; the provider rejects that as a loop and the worker hangs waiting for DNS. It now targets the Container App's own ingress host.
- **Azure Terraform left the Container Apps environment outside the VNet.** Added the VNet integration (and the matching network emitter) so the environment lands in the stack VNet.

## Files touched
- `crates/alien-infra/src/network/gcp_import.rs` — subnet name on import
- `crates/alien-infra/src/build/azure.rs` — heartbeat resolves env, identity, prefix
- `crates/alien-infra/src/worker/azure.rs` (+ `azure_import.rs`) — CNAME targets the ingress host
- `crates/alien-terraform/src/emitters/azure/*` — Container Apps environment VNet integration
- `crates/alien-infra/tests/importers.rs` + the azure generator/snapshot tests — coverage

## How I tested
- `cargo test -p alien-infra` and the `alien-terraform` azure generator + snapshot tests pass.
- Validated end to end as part of the full Postgres cloud e2e on AWS, GCP, and Azure (the stack on top of this PR provisions, connects, and runs pgvector).

Base of the stacked Postgres work; #89 (runtime) and #90 (setup) build on it. Supersedes the infrastructure portion of the original combined PR.
