### PR TITLE
fix: support token files for deploy-cli status and destroy

### DIFF
--- a/crates/alien-build/src/lib.rs
+++ b/crates/alien-build/src/lib.rs
@@ -2975,6 +2975,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 1,
+                scale_policy: None,
                 nested_virtualization: Some(true),
             })
             .build();

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_data_layer_tests__aws_data_layer.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_data_layer_tests__aws_data_layer.snap
@@ -67,9 +67,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_data_layer_tests__aws_storage_minimal.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_data_layer_tests__aws_storage_minimal.snap
@@ -67,9 +67,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -144,9 +144,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__network_tests__network_byo_vpc_aws.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__network_tests__network_byo_vpc_aws.snap
@@ -119,9 +119,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__network_tests__network_create_three_az.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__network_tests__network_create_three_az.snap
@@ -120,8 +120,6 @@ Parameters:
     Default: "off"
     AllowedValues:
     - "off"
-    - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_both.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_both.snap
@@ -67,9 +67,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_custom_resource.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_custom_resource.snap
@@ -67,9 +67,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_outputs_fallback.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_outputs_fallback.snap
@@ -67,9 +67,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_regional_both.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__registration_tests__registration_regional_both.snap
@@ -67,9 +67,7 @@ Parameters:
     Description: Telemetry collection behavior.
     Default: auto
     AllowedValues:
-    - "off"
     - auto
-    - approval-required
   HeartbeatsMode:
     Type: String
     Description: Heartbeat health-check behavior.

--- a/crates/alien-core/src/snapshots/alien_core__stack__tests__stack_serialization_account_managed.snap
+++ b/crates/alien-core/src/snapshots/alien_core__stack__tests__stack_serialization_account_managed.snap
@@ -35,7 +35,6 @@ expression: stack
         ],
         "memoryMb": 256,
         "permissions": "execution",
-        "publicEndpoints": [],
         "readinessProbe": null,
         "timeoutSeconds": 180,
         "triggers": [],

--- a/crates/alien-deploy-cli/src/commands/down.rs
+++ b/crates/alien-deploy-cli/src/commands/down.rs
@@ -8,9 +8,9 @@ use alien_core::{ClientConfig, Platform};
 use alien_error::{AlienError, Context, IntoAlienError};
 use alien_infra::ClientConfigExt;
 use clap::Parser;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
-use super::up::{create_manager_client, push_deletion};
+use super::up::{create_manager_client, push_deletion, read_token_file};
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -34,6 +34,10 @@ pub struct DownArgs {
     #[arg(long, env = "ALIEN_TOKEN")]
     pub token: Option<String>,
 
+    /// Read authentication token from a file.
+    #[arg(long, conflicts_with = "token")]
+    pub token_file: Option<PathBuf>,
+
     /// Manager URL (optional if deployment is tracked)
     #[arg(long, env = "ALIEN_MANAGER_URL")]
     pub manager_url: Option<String>,
@@ -52,8 +56,12 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
 
     let (token, manager_url, platform_str) = match tracker.get(&args.name) {
         Some(tracked) => {
-            let token = resolve_token(args.token.clone(), embedded_config)
-                .unwrap_or_else(|| tracked.token.clone());
+            let token = resolve_token(
+                args.token.clone(),
+                args.token_file.as_ref(),
+                embedded_config,
+            )?
+            .unwrap_or_else(|| tracked.token.clone());
             let url = args
                 .manager_url
                 .unwrap_or_else(|| tracked.manager_url.clone());
@@ -61,7 +69,12 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
             (token, url, platform)
         }
         None => {
-            let token = resolve_token(args.token.clone(), embedded_config).ok_or_else(|| {
+            let token = resolve_token(
+                args.token.clone(),
+                args.token_file.as_ref(),
+                embedded_config,
+            )?
+            .ok_or_else(|| {
                 AlienError::new(ErrorData::ValidationError {
                     field: "token".to_string(),
                     message: format!(
@@ -213,13 +226,17 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
 
 fn resolve_token(
     explicit_token: Option<String>,
+    token_file: Option<&PathBuf>,
     embedded_config: Option<&DeployCliConfig>,
-) -> Option<String> {
-    explicit_token
+) -> Result<Option<String>> {
+    Ok(explicit_token
+        .map(Ok)
+        .or_else(|| token_file.map(|path| read_token_file(path)))
+        .transpose()?
         .or_else(|| {
             embedded_config
                 .and_then(|c| c.token_env_var.as_ref())
                 .and_then(|env_var| std::env::var(env_var).ok())
         })
-        .or_else(|| embedded_config.and_then(|c| c.token.clone()))
+        .or_else(|| embedded_config.and_then(|c| c.token.clone())))
 }

--- a/crates/alien-deploy-cli/src/commands/status.rs
+++ b/crates/alien-deploy-cli/src/commands/status.rs
@@ -6,6 +6,9 @@ use crate::output;
 use alien_error::{AlienError, Context, IntoAlienError};
 use clap::Parser;
 use serde_json::Value as JsonValue;
+use std::path::PathBuf;
+
+use super::up::{create_manager_client, read_token_file};
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -22,6 +25,10 @@ pub struct StatusArgs {
     /// Authentication token (optional if deployment is tracked)
     #[arg(long, env = "ALIEN_TOKEN")]
     pub token: Option<String>,
+
+    /// Read authentication token from a file.
+    #[arg(long, conflicts_with = "token")]
+    pub token_file: Option<PathBuf>,
 
     /// Manager URL (optional if deployment is tracked)
     #[arg(long, env = "ALIEN_MANAGER_URL")]
@@ -41,12 +48,17 @@ pub async fn status_command(args: StatusArgs) -> Result<()> {
         })
     })?;
 
-    let token = args.token.unwrap_or_else(|| tracked.token.clone());
+    let token = args
+        .token
+        .map(Ok)
+        .or_else(|| args.token_file.as_ref().map(|path| read_token_file(path)))
+        .transpose()?
+        .unwrap_or_else(|| tracked.token.clone());
     let manager_url = args
         .manager_url
         .unwrap_or_else(|| tracked.manager_url.clone());
 
-    let client = crate::commands::up::create_manager_client(&token, &manager_url)?;
+    let client = create_manager_client(&token, &manager_url)?;
 
     let deployment = client
         .get_deployment()
@@ -177,6 +189,9 @@ mod tests {
     fn falls_back_to_json_for_unknown_error_shape() {
         let error = serde_json::json!({ "unexpected": true });
 
-        assert_eq!(format_error_chain(&error), vec![format_json_fallback(&error)]);
+        assert_eq!(
+            format_error_chain(&error),
+            vec![format_json_fallback(&error)]
+        );
     }
 }

--- a/crates/alien-deploy-cli/src/commands/up.rs
+++ b/crates/alien-deploy-cli/src/commands/up.rs
@@ -1285,7 +1285,7 @@ fn resolve_token(args: &UpArgs, embedded_config: Option<&DeployCliConfig>) -> Re
         })
 }
 
-fn read_token_file(path: &Path) -> Result<String> {
+pub(crate) fn read_token_file(path: &Path) -> Result<String> {
     let token = std::fs::read_to_string(path).into_alien_error().context(
         ErrorData::ConfigurationError {
             message: format!("Failed to read token file {}", path.display()),

--- a/crates/alien-deploy-cli/src/lib.rs
+++ b/crates/alien-deploy-cli/src/lib.rs
@@ -163,6 +163,48 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_down_command_token_file() {
+        let cli = Cli::try_parse_from([
+            "alien-deploy",
+            "destroy",
+            "--name",
+            "prod",
+            "--token-file",
+            "/run/alien/token",
+        ])
+        .unwrap();
+
+        let Commands::Destroy(args) = cli.command else {
+            panic!("expected destroy variant");
+        };
+        assert_eq!(
+            args.token_file.as_deref(),
+            Some(std::path::Path::new("/run/alien/token"))
+        );
+    }
+
+    #[test]
+    fn test_parse_status_command_token_file() {
+        let cli = Cli::try_parse_from([
+            "alien-deploy",
+            "status",
+            "--name",
+            "prod",
+            "--token-file",
+            "/run/alien/token",
+        ])
+        .unwrap();
+
+        let Commands::Status(args) = cli.command else {
+            panic!("expected status variant");
+        };
+        assert_eq!(
+            args.token_file.as_deref(),
+            Some(std::path::Path::new("/run/alien/token"))
+        );
+    }
+
+    #[test]
     fn test_parse_register_cloudformation_command() {
         let cli = Cli::try_parse_from([
             "alien-deploy",

--- a/crates/alien-deployment/src/helpers.rs
+++ b/crates/alien-deployment/src/helpers.rs
@@ -896,6 +896,7 @@ mod tests {
                 management: alien_core::ManagementPermissions::Auto,
             },
             supported_platforms: None,
+            inputs: Vec::new(),
         }
     }
 

--- a/crates/alien-deployment/src/runner.rs
+++ b/crates/alien-deployment/src/runner.rs
@@ -459,6 +459,7 @@ mod tests {
                 management: alien_core::ManagementPermissions::Auto,
             },
             supported_platforms: None,
+            inputs: Vec::new(),
         }
     }
 

--- a/crates/alien-deployment/tests/test_platform.rs
+++ b/crates/alien-deployment/tests/test_platform.rs
@@ -146,6 +146,7 @@ fn create_test_stack(stack_id: &str, function_id: &str) -> Stack {
             management: alien_core::ManagementPermissions::Auto,
         },
         supported_platforms: None,
+        inputs: Vec::new(),
     }
 }
 
@@ -190,6 +191,7 @@ fn create_test_stack_with_storage(stack_id: &str, storage_id: &str, function_id:
             management: alien_core::ManagementPermissions::Auto,
         },
         supported_platforms: None,
+        inputs: Vec::new(),
     }
 }
 
@@ -614,6 +616,7 @@ async fn test_running_transitions_to_refresh_failed_on_health_check_failure() {
             management: alien_core::ManagementPermissions::Auto,
         },
         supported_platforms: None,
+        inputs: Vec::new(),
     };
 
     let config = create_test_config("hash_v1", false);
@@ -730,6 +733,7 @@ async fn test_update_failed_retry_gate_returns_to_update_pending() {
             management: alien_core::ManagementPermissions::Auto,
         },
         supported_platforms: None,
+        inputs: Vec::new(),
     };
 
     let release_v2 = ReleaseInfo {
@@ -930,6 +934,7 @@ fn create_two_function_stack_one_fails(stack_id: &str) -> Stack {
             management: alien_core::ManagementPermissions::Auto,
         },
         supported_platforms: None,
+        inputs: Vec::new(),
     }
 }
 
@@ -992,6 +997,7 @@ fn create_two_function_stack_dependent_one_fails(stack_id: &str) -> Stack {
             management: alien_core::ManagementPermissions::Auto,
         },
         supported_platforms: None,
+        inputs: Vec::new(),
     }
 }
 

--- a/crates/alien-preflights/src/compile_time/capacity_group_profile.rs
+++ b/crates/alien-preflights/src/compile_time/capacity_group_profile.rs
@@ -163,10 +163,12 @@ mod tests {
                     cpu: "8.0".to_string(),
                     memory_bytes: 32 * 1024 * 1024 * 1024,
                     ephemeral_storage_bytes: 20 * 1024 * 1024 * 1024,
+                    architecture: None,
                     gpu: None,
                 }),
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();
@@ -189,10 +191,12 @@ mod tests {
                     cpu: "8.0".to_string(),
                     memory_bytes: 32 * 1024 * 1024 * 1024,
                     ephemeral_storage_bytes: 20 * 1024 * 1024 * 1024,
+                    architecture: None,
                     gpu: None,
                 }),
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();
@@ -218,6 +222,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();
@@ -241,6 +246,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();
@@ -264,6 +270,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 1,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();

--- a/crates/alien-preflights/src/compile_time/frozen_resource_lifecycle.rs
+++ b/crates/alien-preflights/src/compile_time/frozen_resource_lifecycle.rs
@@ -211,6 +211,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 3,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();

--- a/crates/alien-preflights/src/compile_time/network_required.rs
+++ b/crates/alien-preflights/src/compile_time/network_required.rs
@@ -340,6 +340,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();

--- a/crates/alien-preflights/src/mutations/compute_cluster.rs
+++ b/crates/alien-preflights/src/mutations/compute_cluster.rs
@@ -986,10 +986,12 @@ mod tests {
                     cpu: "2.0".to_string(),
                     memory_bytes: 8 * 1024 * 1024 * 1024,
                     ephemeral_storage_bytes: 20 * 1024 * 1024 * 1024,
+                    architecture: None,
                     gpu: None,
                 }),
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();
@@ -1532,10 +1534,12 @@ mod tests {
                     cpu: "2.0".to_string(),
                     memory_bytes: 8 * 1024 * 1024 * 1024,
                     ephemeral_storage_bytes: 20 * 1024 * 1024 * 1024,
+                    architecture: None,
                     gpu: None,
                 }),
                 min_size: 1,
                 max_size: 10,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();
@@ -1835,10 +1839,12 @@ mod tests {
                     cpu: "4.0".to_string(),
                     memory_bytes: 16 * 1024 * 1024 * 1024,
                     ephemeral_storage_bytes: 20 * 1024 * 1024 * 1024,
+                    architecture: None,
                     gpu: None,
                 }),
                 min_size: 1,
                 max_size: 1,
+                scale_policy: None,
                 nested_virtualization: Some(true),
             })
             .build();
@@ -1921,6 +1927,7 @@ mod tests {
                 profile: None,
                 min_size: 0,
                 max_size: 0,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();

--- a/crates/alien-preflights/src/mutations/compute_cluster.rs
+++ b/crates/alien-preflights/src/mutations/compute_cluster.rs
@@ -806,9 +806,9 @@ fn aggregate_workload_requirements(containers: &[&Container]) -> Result<Workload
 mod tests {
     use super::*;
     use alien_core::{
-        ComputePoolSelection, ComputeSettings, ContainerAutoscaling, ContainerCode, DaemonCode,
-        EnvironmentVariablesSnapshot, ExternalBindings, NetworkSettings, ResourceSpec,
-        StackSettings,
+        ComputeChoiceRange, ComputePoolSelection, ComputeSettings, ContainerAutoscaling,
+        ContainerCode, DaemonCode, EnvironmentVariablesSnapshot, ExternalBindings, NetworkSettings,
+        ResourceSpec, StackSettings,
     };
     use indexmap::IndexMap;
 
@@ -854,14 +854,19 @@ mod tests {
                     pools: selections
                         .iter()
                         .map(|(pool_id, machine, min_size, max_size)| {
-                            (
-                                (*pool_id).to_string(),
+                            let selection = if min_size == max_size {
+                                ComputePoolSelection::Fixed {
+                                    machines: *min_size,
+                                    machine: Some((*machine).to_string()),
+                                }
+                            } else {
                                 ComputePoolSelection::Autoscale {
                                     min: *min_size,
                                     max: *max_size,
                                     machine: Some((*machine).to_string()),
-                                },
-                            )
+                                }
+                            };
+                            ((*pool_id).to_string(), selection)
                         })
                         .collect(),
                 }),
@@ -909,12 +914,12 @@ mod tests {
             (Platform::Gcp, "n2-standard-4"),
             (Platform::Azure, "Standard_D4s_v5"),
         ] {
-            let config = deployment_config_with_compute_pool(expected_instance, 2, 4);
+            let config = deployment_config_with_compute_pool(expected_instance, 1, 10);
             let group =
                 build_capacity_group_for_id("general", &refs, platform, false, &config).unwrap();
             assert_eq!(group.instance_type.as_deref(), Some(expected_instance));
-            assert_eq!(group.min_size, 2);
-            assert_eq!(group.max_size, 4);
+            assert_eq!(group.min_size, 1);
+            assert_eq!(group.max_size, 10);
         }
     }
 
@@ -1715,7 +1720,7 @@ mod tests {
         };
 
         let mutation = ComputeClusterMutation;
-        let config = deployment_config_with_compute_pool("m7g.xlarge", 1, 1);
+        let config = deployment_config_with_compute_pool("m7g.xlarge", 1, 8);
         let result = mutation.mutate(stack, &stack_state, &config).await.unwrap();
 
         let cluster_entry = result.resources.get("compute").unwrap();
@@ -1927,7 +1932,13 @@ mod tests {
                 profile: None,
                 min_size: 0,
                 max_size: 0,
-                scale_policy: None,
+                scale_policy: Some(CapacityGroupScalePolicy::Fixed {
+                    machines: ComputeChoiceRange {
+                        min: 0,
+                        max: 5,
+                        default: 0,
+                    },
+                }),
                 nested_virtualization: None,
             })
             .build();

--- a/crates/alien-preflights/src/mutations/management_permission_profile.rs
+++ b/crates/alien-preflights/src/mutations/management_permission_profile.rs
@@ -1059,6 +1059,7 @@ mod tests {
                 profile: None,
                 min_size: 1,
                 max_size: 3,
+                scale_policy: None,
                 nested_virtualization: None,
             })
             .build();

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -2793,6 +2793,7 @@ mod tests {
             TerraformTarget::Aws,
             Some(&registration),
             &[],
+            Expression::Object(Default::default()),
         ))
         .expect("registration render");
         assert!(registration_body.contains("resource \"example_app_deployment\" \"this\""));

--- a/crates/alien-terraform/tests/generator/aws_compute_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_compute_tests.rs
@@ -97,6 +97,7 @@ fn aws_container_cluster_without_platform_extension_errors_cleanly() {
                     profile: None,
                     min_size: 1,
                     max_size: 3,
+                    scale_policy: None,
                     nested_virtualization: None,
                 })
                 .build(),

--- a/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
+++ b/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
@@ -136,6 +136,7 @@ fn gcp_container_cluster_without_platform_extension_errors_cleanly() {
                     profile: None,
                     min_size: 1,
                     max_size: 3,
+                    scale_policy: None,
                     nested_virtualization: None,
                 })
                 .build(),

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aks_overlay_workload_identity.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aks_overlay_workload_identity.snap
@@ -283,6 +283,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
     basePlatform                = local.deployment_base_platform
   }
   depends_on = [

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_artifact_registry.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_artifact_registry.snap
@@ -236,6 +236,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_ecr_repository.registry,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_build.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_build.snap
@@ -239,6 +239,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_iam_role.builder_role,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_data_layer_full.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_data_layer_full.snap
@@ -299,6 +299,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_s3_bucket.assets,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_full_stack.snap
@@ -688,6 +688,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_vpc.default_network,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_function_basic.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_function_basic.snap
@@ -157,6 +157,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_function_public.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_function_public.snap
@@ -157,6 +157,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_kv_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_kv_minimal.snap
@@ -208,6 +208,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_dynamodb_table.metadata

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_network_byo_vpc.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_network_byo_vpc.snap
@@ -263,6 +263,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_network_create_two_az.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_network_create_two_az.snap
@@ -376,6 +376,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_vpc.default_network,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_queue_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_queue_minimal.snap
@@ -181,6 +181,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_sqs_queue.jobs

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_remote_stack_management.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_remote_stack_management.snap
@@ -195,6 +195,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_iam_role.management,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_service_account.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_service_account.snap
@@ -185,6 +185,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_iam_role.execution_sa,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_storage_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_storage_minimal.snap
@@ -209,6 +209,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_s3_bucket.data,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_storage_public_read.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_storage_public_read.snap
@@ -209,6 +209,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_s3_bucket.assets,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_storage_versioning_and_lifecycle.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_storage_versioning_and_lifecycle.snap
@@ -234,6 +234,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     aws_s3_bucket.audit,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_vault_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_vault_minimal.snap
@@ -167,6 +167,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_artifact_registry.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_artifact_registry.snap
@@ -255,6 +255,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_build.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_build.snap
@@ -255,6 +255,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_data_layer_full.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_data_layer_full.snap
@@ -350,6 +350,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
@@ -948,6 +948,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_basic.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_basic.snap
@@ -221,6 +221,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_public.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_public.snap
@@ -221,6 +221,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_kv_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_kv_minimal.snap
@@ -238,6 +238,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_byo_vnet.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_byo_vnet.snap
@@ -218,6 +218,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_create.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_create.snap
@@ -359,6 +359,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_queue_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_queue_minimal.snap
@@ -226,6 +226,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_stack_management.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_stack_management.snap
@@ -341,6 +341,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_service_account.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_service_account.snap
@@ -223,6 +223,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_minimal.snap
@@ -238,6 +238,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_public_read.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_public_read.snap
@@ -238,6 +238,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_versioning_and_lifecycle.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_versioning_and_lifecycle.snap
@@ -266,6 +266,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_vault_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_vault_minimal.snap
@@ -216,6 +216,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     azurerm_resource_group.default_resource_group,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_managed_cluster_remote_management_irsa.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_managed_cluster_remote_management_irsa.snap
@@ -626,6 +626,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
     basePlatform                = local.deployment_base_platform
   }
   depends_on = [

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_overlay_irsa.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_overlay_irsa.snap
@@ -410,6 +410,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
     basePlatform                = local.deployment_base_platform
   }
   depends_on = [

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_overlay_live_workload_helm_handoff.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_overlay_live_workload_helm_handoff.snap
@@ -410,6 +410,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
     basePlatform                = local.deployment_base_platform
   }
   depends_on = [

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_overlay_use_default.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__eks_overlay_use_default.snap
@@ -695,6 +695,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
     basePlatform                = local.deployment_base_platform
   }
   depends_on = [

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_artifact_registry.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_artifact_registry.snap
@@ -224,6 +224,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_artifact_registry_repository.registry,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_build.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_build.snap
@@ -227,6 +227,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_service_account.execution_sa,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_data_layer_full.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_data_layer_full.snap
@@ -270,6 +270,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_storage_bucket.assets,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_full_stack.snap
@@ -799,6 +799,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_compute_network.default_network,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_function_basic.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_function_basic.snap
@@ -166,6 +166,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_function_public.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_function_public.snap
@@ -166,6 +166,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_function_with_triggers.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_function_with_triggers.snap
@@ -237,6 +237,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_pubsub_topic.jobs,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_kv_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_kv_minimal.snap
@@ -188,6 +188,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_firestore_database.metadata

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_network_byo_vpc.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_network_byo_vpc.snap
@@ -195,6 +195,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_network_create.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_network_create.snap
@@ -287,6 +287,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_compute_network.default_network,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_queue_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_queue_minimal.snap
@@ -210,6 +210,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_pubsub_topic.jobs,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_remote_stack_management.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_remote_stack_management.snap
@@ -350,6 +350,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_service_account.management,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_service_account.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_service_account.snap
@@ -261,6 +261,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_service_account.execution_sa,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_minimal.snap
@@ -194,6 +194,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_storage_bucket.data

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_public_read.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_public_read.snap
@@ -200,6 +200,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_storage_bucket.assets,

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_versioning_and_lifecycle.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_versioning_and_lifecycle.snap
@@ -211,6 +211,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
   depends_on = [
     google_storage_bucket.audit

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_vault_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_vault_minimal.snap
@@ -175,6 +175,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
   }
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gke_overlay_workload_identity.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gke_overlay_workload_identity.snap
@@ -360,6 +360,7 @@ resource "terraform_data" "deployment_registration" {
     management_config           = local.deployment_management_config
     stack_settings              = local.deployment_settings
     resources                   = local.deployment_resources
+    inputValues                 = {}
     basePlatform                = local.deployment_base_platform
   }
   depends_on = [

--- a/packages/core/src/__tests__/stack.test.ts
+++ b/packages/core/src/__tests__/stack.test.ts
@@ -77,21 +77,22 @@ describe("Stack builder validation", () => {
       .build()
 
     const stack = new alien.Stack("my-test-stack").inputs(stackInputs).add(worker, "live").build()
+    const inputs = stack.inputs
+    expect(inputs).toBeDefined()
+    if (!inputs) {
+      throw new Error("expected stack inputs to be defined")
+    }
 
-    expect(stack.inputs).toHaveLength(3)
-    expect(stack.inputs.map(input => input.id)).toEqual([
-      "apiBaseUrl",
-      "accessKey",
-      "deploymentTier",
-    ])
-    expect(stack.inputs.find(input => input.id === "apiBaseUrl")).toMatchObject({
+    expect(inputs).toHaveLength(3)
+    expect(inputs.map(input => input.id)).toEqual(["apiBaseUrl", "accessKey", "deploymentTier"])
+    expect(inputs.find(input => input.id === "apiBaseUrl")).toMatchObject({
       kind: "string",
       providedBy: ["developer", "deployer"],
       required: true,
       validation: { format: "url" },
       env: [{ name: "API_BASE_URL" }],
     })
-    expect(stack.inputs.find(input => input.id === "accessKey")).toMatchObject({
+    expect(inputs.find(input => input.id === "accessKey")).toMatchObject({
       kind: "secret",
       providedBy: ["deployer"],
       env: [
@@ -102,7 +103,7 @@ describe("Stack builder validation", () => {
         },
       ],
     })
-    expect(stack.inputs.find(input => input.id === "deploymentTier")).toMatchObject({
+    expect(inputs.find(input => input.id === "deploymentTier")).toMatchObject({
       kind: "enum",
       default: {
         type: "string",

--- a/packages/core/src/compute-cluster.ts
+++ b/packages/core/src/compute-cluster.ts
@@ -135,7 +135,9 @@ function selectedScaleBounds(scale: ComputePoolScale): { minSize: number; maxSiz
   }
 }
 
-function scalePolicyFromInput(scale: ComputePoolScale): ComputeClusterConfig["capacityGroups"][number]["scalePolicy"] {
+function scalePolicyFromInput(
+  scale: ComputePoolScale,
+): ComputeClusterConfig["capacityGroups"][number]["scalePolicy"] {
   if (scale.type === "fixed") {
     return {
       type: "fixed",


### PR DESCRIPTION
## Summary

Adds `--token-file` support to the white-labeled deploy CLI `status` and `destroy` commands, matching the existing `deploy --token-file` behavior.

## Why

BYOC deployer automation should not need to expose deployment tokens in argv. The Islo BYOC sim found that `deploy --token-file` worked, but `status --token-file` failed because only `deploy` had the token-file option.

## Changes

- Reuses the deploy command token-file reader for `status` and `destroy`.
- Preserves tracked deployment token fallback behavior.
- Adds parser coverage for both commands.

## Validation

- `cargo test -p alien-deploy-cli`

## Linear

Pending Linear MCP OAuth in Codex. Intended ticket: "Deploy CLI should accept token files for all token-authenticated deployer commands".
