### PR TITLE
fix: compute releases from latest version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Compute next version
         id: bump
         run: |
-          LATEST_TAG=$(git describe --tags --match "v[0-9]*" --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST_TAG=$(git tag --list "v[0-9]*" --sort=-v:refname | head -n1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
           CURRENT_VERSION=${LATEST_TAG#v}
           echo "Latest tag: $LATEST_TAG"
 


### PR DESCRIPTION
## Summary
- compute the next release version from the highest semver tag in the repository instead of only tags reachable from the current branch
- handles partial release tags that exist off the mainline

## Validation
- locally evaluated the workflow version logic and confirmed current state resolves latest tag v1.9.0 and next version 1.10.0