### PR TITLE
fix: send delete targets to pull agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -971,14 +971,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-manager/src/routes/sync.rs
+++ b/crates/alien-manager/src/routes/sync.rs
@@ -471,9 +471,9 @@ mod tests {
 
     use super::{
         build_target_deployment_config, deployment_needs_target, deployment_state_from_record,
-        management_platform, release_stack_platform, should_ignore_agent_state_report,
-        should_return_current_state_for_agent_sync, validate_initialize_base_platform,
-        ReconcileRequest,
+        deployment_target_release_id, management_platform, release_stack_platform,
+        should_ignore_agent_state_report, should_return_current_state_for_agent_sync,
+        validate_initialize_base_platform, ReconcileRequest,
     };
 
     #[test]
@@ -671,6 +671,34 @@ mod tests {
         deployment.desired_release_id = Some("rel_test".to_string());
 
         assert!(!deployment_needs_target(&deployment));
+    }
+
+    #[test]
+    fn deleting_deployment_needs_target_even_when_current_matches_desired() {
+        let mut deployment = deployment_record_with_state("delete-pending", None);
+        deployment.current_release_id = Some("rel_test".to_string());
+        deployment.desired_release_id = Some("rel_test".to_string());
+
+        assert!(deployment_needs_target(&deployment));
+    }
+
+    #[test]
+    fn delete_failed_deployment_needs_target_for_retry() {
+        let mut deployment = deployment_record_with_state("delete-failed", None);
+        deployment.current_release_id = Some("rel_test".to_string());
+        deployment.desired_release_id = Some("rel_test".to_string());
+
+        assert!(deployment_needs_target(&deployment));
+    }
+
+    #[test]
+    fn deleting_deployment_uses_current_release_when_desired_was_cleared() {
+        let mut deployment = deployment_record_with_state("delete-pending", None);
+        deployment.current_release_id = Some("rel_test".to_string());
+        deployment.desired_release_id = None;
+
+        assert_eq!(deployment_target_release_id(&deployment), Some("rel_test"));
+        assert!(deployment_needs_target(&deployment));
     }
 
     #[test]
@@ -898,7 +926,7 @@ async fn agent_sync(
 
     // Return target state if deployment needs updating
     let target = if deployment_needs_target(&deployment) {
-        let release = if let Some(ref release_id) = deployment.desired_release_id {
+        let release = if let Some(release_id) = deployment_target_release_id(&deployment) {
             let system = crate::auth::Subject::system();
             match state.release_store.get_release(&system, release_id).await {
                 Ok(Some(r)) => Some(r),
@@ -1152,12 +1180,38 @@ fn should_return_current_state_for_agent_sync(
     ignored_agent_state_report || deployment.retry_requested
 }
 
+fn deployment_is_deleting(deployment: &DeploymentRecord) -> bool {
+    matches!(
+        deployment_status_from_record(&deployment.status),
+        Some(
+            DeploymentStatus::DeletePending
+                | DeploymentStatus::Deleting
+                | DeploymentStatus::DeleteFailed
+        )
+    )
+}
+
+fn deployment_target_release_id(deployment: &DeploymentRecord) -> Option<&str> {
+    if deployment_is_deleting(deployment) {
+        deployment
+            .desired_release_id
+            .as_deref()
+            .or(deployment.current_release_id.as_deref())
+    } else {
+        deployment.desired_release_id.as_deref()
+    }
+}
+
 fn deployment_needs_target(deployment: &DeploymentRecord) -> bool {
-    let Some(desired_release_id) = deployment.desired_release_id.as_ref() else {
+    let Some(target_release_id) = deployment_target_release_id(deployment) else {
         return false;
     };
 
-    if deployment.current_release_id.as_ref() != Some(desired_release_id) {
+    if deployment_is_deleting(deployment) {
+        return true;
+    }
+
+    if deployment.current_release_id.as_deref() != Some(target_release_id) {
         return true;
     }
 


### PR DESCRIPTION
## Summary
- return a sync target for pull-mode deployments while they are deleting or retrying deletion
- use the current release as the delete target when desired_release_id has already been cleared after a successful deploy
- add regression coverage for delete target selection

## Validation
- cargo test -p alien-manager routes::sync::tests -- --nocapture
- cargo check -p alien-manager --locked