### PR TITLE
fix: apply manager delete state in pull agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-error",
  "chrono",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-error",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -971,14 +971,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-agent/src/loops/sync.rs
+++ b/crates/alien-agent/src/loops/sync.rs
@@ -212,10 +212,10 @@ async fn sync_with_manager(
             state_hydrated = true;
             info!("Hydrated deployment state from manager");
         } else if let Some(mut local_state) = local_state {
-            if apply_manager_retry_request(&mut local_state, &manager_state) {
+            if apply_manager_control_state(&mut local_state, &manager_state) {
                 state.db.set_deployment_state(&local_state).await?;
                 state_hydrated = true;
-                info!("Applied deployment retry request from manager");
+                info!("Applied deployment control state from manager");
             } else {
                 debug!("Manager returned deployment state, but local state is already initialized");
             }
@@ -303,19 +303,60 @@ fn is_uninitialized_deployment_state(state: &alien_core::DeploymentState) -> boo
         && state.runtime_metadata.is_none()
 }
 
-fn apply_manager_retry_request(
+fn apply_manager_control_state(
     local_state: &mut alien_core::DeploymentState,
     manager_state: &alien_core::DeploymentState,
 ) -> bool {
-    if !manager_state.retry_requested
-        || local_state.retry_requested
-        || !local_state.status.is_failed()
+    if manager_state_is_delete_command(manager_state)
+        && !local_state_is_delete_or_deleted(local_state)
     {
-        return false;
+        local_state.status = manager_state.status;
+        if local_state.target_release.is_none() {
+            local_state.target_release = manager_state.target_release.clone();
+        }
+        if local_state.stack_state.is_none() {
+            local_state.stack_state = manager_state.stack_state.clone();
+        }
+        if local_state.environment_info.is_none() {
+            local_state.environment_info = manager_state.environment_info.clone();
+        }
+        if local_state.runtime_metadata.is_none() {
+            local_state.runtime_metadata = manager_state.runtime_metadata.clone();
+        }
+        local_state.retry_requested = manager_state.retry_requested;
+        return true;
     }
 
-    local_state.retry_requested = true;
-    true
+    if manager_state.retry_requested
+        && !local_state.retry_requested
+        && local_state.status.is_failed()
+    {
+        local_state.retry_requested = true;
+        return true;
+    }
+
+    false
+}
+
+fn manager_state_is_delete_command(state: &alien_core::DeploymentState) -> bool {
+    matches!(
+        state.status,
+        alien_core::DeploymentStatus::DeletePending
+            | alien_core::DeploymentStatus::Deleting
+            | alien_core::DeploymentStatus::DeleteFailed
+    )
+}
+
+fn local_state_is_delete_or_deleted(state: &alien_core::DeploymentState) -> bool {
+    matches!(
+        state.status,
+        alien_core::DeploymentStatus::DeletePending
+            | alien_core::DeploymentStatus::Deleting
+            | alien_core::DeploymentStatus::DeleteFailed
+            | alien_core::DeploymentStatus::TeardownRequired
+            | alien_core::DeploymentStatus::TeardownFailed
+            | alien_core::DeploymentStatus::Deleted
+    )
 }
 
 #[cfg(test)]
@@ -324,7 +365,7 @@ mod tests {
         DeploymentState, DeploymentStatus, Platform, CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
     };
 
-    use super::{apply_manager_retry_request, is_uninitialized_deployment_state};
+    use super::{apply_manager_control_state, is_uninitialized_deployment_state};
 
     #[test]
     fn recognizes_empty_pending_state_as_uninitialized() {
@@ -381,7 +422,7 @@ mod tests {
             ..local_state.clone()
         };
 
-        assert!(apply_manager_retry_request(
+        assert!(apply_manager_control_state(
             &mut local_state,
             &manager_state
         ));
@@ -408,10 +449,63 @@ mod tests {
             ..local_state.clone()
         };
 
-        assert!(!apply_manager_retry_request(
+        assert!(!apply_manager_control_state(
             &mut local_state,
             &manager_state
         ));
         assert!(!local_state.retry_requested);
+    }
+
+    #[test]
+    fn applies_manager_delete_request_to_running_local_state() {
+        let mut local_state = DeploymentState {
+            platform: Platform::Local,
+            status: DeploymentStatus::Running,
+            current_release: None,
+            target_release: None,
+            stack_state: None,
+            error: None,
+            environment_info: None,
+            runtime_metadata: None,
+            retry_requested: false,
+            protocol_version: CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+        };
+        let manager_state = DeploymentState {
+            status: DeploymentStatus::DeletePending,
+            target_release: None,
+            ..local_state.clone()
+        };
+
+        assert!(apply_manager_control_state(
+            &mut local_state,
+            &manager_state
+        ));
+        assert_eq!(local_state.status, DeploymentStatus::DeletePending);
+    }
+
+    #[test]
+    fn does_not_rewind_local_delete_progress_from_manager_state() {
+        let mut local_state = DeploymentState {
+            platform: Platform::Local,
+            status: DeploymentStatus::Deleting,
+            current_release: None,
+            target_release: None,
+            stack_state: None,
+            error: None,
+            environment_info: None,
+            runtime_metadata: None,
+            retry_requested: false,
+            protocol_version: CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+        };
+        let manager_state = DeploymentState {
+            status: DeploymentStatus::DeletePending,
+            ..local_state.clone()
+        };
+
+        assert!(!apply_manager_control_state(
+            &mut local_state,
+            &manager_state
+        ));
+        assert_eq!(local_state.status, DeploymentStatus::Deleting);
     }
 }

--- a/crates/alien-manager/src/routes/sync.rs
+++ b/crates/alien-manager/src/routes/sync.rs
@@ -616,6 +616,26 @@ mod tests {
     }
 
     #[test]
+    fn ignores_running_agent_state_after_delete_was_requested() {
+        let deployment =
+            deployment_record_with_state("delete-pending", Some(StackState::new(Platform::Local)));
+        let mut agent_state = uninitialized_state();
+        agent_state.status = DeploymentStatus::Running;
+
+        assert!(should_ignore_agent_state_report(&deployment, &agent_state));
+    }
+
+    #[test]
+    fn accepts_agent_delete_progress_after_delete_was_requested() {
+        let deployment =
+            deployment_record_with_state("delete-pending", Some(StackState::new(Platform::Local)));
+        let mut agent_state = uninitialized_state();
+        agent_state.status = DeploymentStatus::Deleting;
+
+        assert!(!should_ignore_agent_state_report(&deployment, &agent_state));
+    }
+
+    #[test]
     fn returns_current_state_when_retry_is_pending() {
         let mut deployment = deployment_record_with_state(
             "provisioning-failed",
@@ -636,6 +656,17 @@ mod tests {
 
         assert!(should_return_current_state_for_agent_sync(
             true,
+            &deployment
+        ));
+    }
+
+    #[test]
+    fn returns_current_state_when_delete_was_requested() {
+        let deployment =
+            deployment_record_with_state("delete-pending", Some(StackState::new(Platform::Local)));
+
+        assert!(should_return_current_state_for_agent_sync(
+            false,
             &deployment
         ));
     }
@@ -1153,6 +1184,10 @@ fn should_ignore_agent_state_report(
     deployment: &DeploymentRecord,
     agent_state: &DeploymentState,
 ) -> bool {
+    if deployment_is_deleting(deployment) && !agent_state_is_delete_progress(agent_state) {
+        return true;
+    }
+
     agent_state_is_uninitialized(agent_state) && deployment_has_authoritative_state(deployment)
 }
 
@@ -1177,7 +1212,7 @@ fn should_return_current_state_for_agent_sync(
     ignored_agent_state_report: bool,
     deployment: &DeploymentRecord,
 ) -> bool {
-    ignored_agent_state_report || deployment.retry_requested
+    ignored_agent_state_report || deployment.retry_requested || deployment_is_deleting(deployment)
 }
 
 fn deployment_is_deleting(deployment: &DeploymentRecord) -> bool {
@@ -1188,6 +1223,18 @@ fn deployment_is_deleting(deployment: &DeploymentRecord) -> bool {
                 | DeploymentStatus::Deleting
                 | DeploymentStatus::DeleteFailed
         )
+    )
+}
+
+fn agent_state_is_delete_progress(state: &DeploymentState) -> bool {
+    matches!(
+        state.status,
+        DeploymentStatus::DeletePending
+            | DeploymentStatus::Deleting
+            | DeploymentStatus::DeleteFailed
+            | DeploymentStatus::TeardownRequired
+            | DeploymentStatus::TeardownFailed
+            | DeploymentStatus::Deleted
     )
 }
 


### PR DESCRIPTION
## Summary
- return manager delete state to pull agents while a deployment is being deleted
- make pull agents adopt manager delete control state even when they already have a local running state
- ignore stale non-delete agent reports after the manager has accepted a delete request
- update Cargo.lock package versions to match the v1.10.2 workspace release metadata

## Root cause
Pull-mode deletion requires two pieces from the manager: the target release/config needed to run cleanup, and the manager control state (`delete-pending` / `deleting`) that tells the agent to enter the delete loop. The previous fix sent the delete target, but a running agent kept its local `Running` state and only used manager state for first hydration or retry flags. That left the manager waiting for runtime cleanup handoff while the agent continued reporting running.

The manager also accepted stale running reports after deletion was requested, which could mask the delete command in subsequent syncs. This change makes the manager-side delete state authoritative until the agent reports real delete progress.

Linear note: attempted to create the required Linear issue from Codex, but the Linear MCP in this session returned OAuth authorization required.

## Validation
- `cargo fmt --package alien-agent --package alien-manager`
- `cargo test -p alien-agent loops::sync::tests --quiet`
- `cargo test -p alien-manager routes::sync::tests --quiet`
- `cargo test -p alien-agent --quiet`
- `cargo check -p alien-agent -p alien-manager --locked`
