### PR TITLE
fix: drive local destroy runtime cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-error",
  "chrono",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-error",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -971,14 +971,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-deploy-cli/src/commands/up.rs
+++ b/crates/alien-deploy-cli/src/commands/up.rs
@@ -20,8 +20,9 @@ use alien_core::{
 use alien_deployment::{
     loop_contract::{LoopOperation, LoopOutcome, LoopResult, LoopStopReason},
     manager_api_transport::{
-        acquire_setup_delete_deployment, acquire_setup_run_deployment, final_reconcile,
-        release_deployment, ManagerApiTransport, SetupDeleteAcquireOutcome,
+        acquire_runtime_delete_deployment, acquire_setup_delete_deployment,
+        acquire_setup_run_deployment, final_reconcile, release_deployment, ManagerApiTransport,
+        SetupDeleteAcquireOutcome,
     },
     runner::{run_step_loop as shared_run_step_loop, RunnerPolicy, RunnerResult},
 };
@@ -3052,12 +3053,139 @@ pub async fn push_deletion(
 
     apply_external_bindings_from_stack_settings(&mut config, &stack_settings);
 
-    // Acquire sync lock with retry
-    let session = format!("push-deletion-{}", uuid::Uuid::new_v4());
+    if platform == Platform::Local
+        && !matches!(
+            state.status,
+            DeploymentStatus::TeardownRequired | DeploymentStatus::TeardownFailed
+        )
+    {
+        run_runtime_deletion(
+            client,
+            deployment_id,
+            &mut state,
+            &mut config,
+            &client_config,
+        )
+        .await?;
+
+        if state.status == DeploymentStatus::Deleted {
+            output::success("Deployment deleted successfully.");
+            return Ok(());
+        }
+    }
+
+    run_setup_deletion(
+        client,
+        deployment_id,
+        &mut state,
+        &mut config,
+        &client_config,
+    )
+    .await
+}
+
+async fn run_runtime_deletion(
+    client: &ServerClient,
+    deployment_id: &str,
+    state: &mut DeploymentState,
+    config: &mut DeploymentConfig,
+    client_config: &ClientConfig,
+) -> Result<()> {
+    let session = format!("push-runtime-deletion-{}", uuid::Uuid::new_v4());
+    acquire_runtime_delete_deployment(client, deployment_id, &session)
+        .await
+        .context(ErrorData::DeploymentFailed {
+            operation: "acquire runtime deletion lock".to_string(),
+        })?;
+
+    // Re-fetch deployment under lock
+    let deployment = client
+        .get_deployment()
+        .id(deployment_id)
+        .send()
+        .await
+        .into_sdk_error()
+        .context(ErrorData::ConfigurationError {
+            message: "Failed to get deployment from manager".to_string(),
+        })?
+        .into_inner();
+
+    let status = parse_deployment_status(&deployment.status)?;
+    state.status = status;
+    state.stack_state = deployment
+        .stack_state
+        .map(serde_json::from_value)
+        .transpose()
+        .into_alien_error()
+        .context(ErrorData::ConfigurationError {
+            message: "Failed to deserialize stack_state from manager".to_string(),
+        })?;
+    state.runtime_metadata = deployment
+        .runtime_metadata
+        .map(|rm| serde_json::to_value(rm).and_then(serde_json::from_value))
+        .transpose()
+        .into_alien_error()
+        .context(ErrorData::ConfigurationError {
+            message: "Failed to deserialize runtime_metadata from manager".to_string(),
+        })?;
+
+    let transport = ManagerApiTransport::new(client.clone(), session.clone());
+    let policy = RunnerPolicy {
+        max_steps: 400,
+        operation: LoopOperation::Delete,
+        delay_threshold: None,
+    };
+
+    let runner_result = shared_run_step_loop(
+        state,
+        config,
+        client_config,
+        deployment_id,
+        &policy,
+        &transport,
+        None,
+        None,
+    )
+    .await;
+
+    // Always reconcile + release, even on error
+    final_reconcile(client, deployment_id, &session, state).await;
+    release_deployment(client, deployment_id, &session).await;
+
+    // Handle runner result after lock release
+    let result = runner_result.context(ErrorData::DeploymentFailed {
+        operation: "deletion".to_string(),
+    })?;
+
+    match result.loop_result.outcome {
+        LoopOutcome::Success => Ok(()),
+        LoopOutcome::Failure => {
+            let operation = format!(
+                "deletion failed at status {}",
+                deployment_status_str(result.loop_result.final_status)
+            );
+            if let Some(error) = state.error.clone() {
+                Err(error.context(ErrorData::DeploymentFailed { operation }))
+            } else {
+                Err(AlienError::new(ErrorData::DeploymentFailed { operation }))
+            }
+        }
+        LoopOutcome::Neutral => Ok(()),
+    }
+}
+
+async fn run_setup_deletion(
+    client: &ServerClient,
+    deployment_id: &str,
+    state: &mut DeploymentState,
+    config: &mut DeploymentConfig,
+    client_config: &ClientConfig,
+) -> Result<()> {
+    let session = format!("push-setup-deletion-{}", uuid::Uuid::new_v4());
     let acquire_outcome = acquire_setup_delete_deployment(client, deployment_id, &session)
         .await
         .context(ErrorData::DeploymentFailed {
-            operation: "acquire sync lock for deletion".to_string(),
+            operation: "acquire setup teardown lock".to_string(),
         })?;
 
     if matches!(acquire_outcome, SetupDeleteAcquireOutcome::AlreadyDeleted) {
@@ -3078,7 +3206,6 @@ pub async fn push_deletion(
         .into_inner();
 
     let status = parse_deployment_status(&deployment.status)?;
-
     state.status = status;
     state.stack_state = deployment
         .stack_state
@@ -3097,7 +3224,6 @@ pub async fn push_deletion(
             message: "Failed to deserialize runtime_metadata from manager".to_string(),
         })?;
 
-    // Run the shared step loop with per-step reconciliation via the manager API
     let transport = ManagerApiTransport::new(client.clone(), session.clone());
     let policy = RunnerPolicy {
         max_steps: 400,
@@ -3105,70 +3231,33 @@ pub async fn push_deletion(
         delay_threshold: None,
     };
 
-    let runner_result = if matches!(
-        state.status,
-        DeploymentStatus::TeardownRequired | DeploymentStatus::TeardownFailed
-    ) {
-        alien_deployment::setup_teardown::run_setup_teardown_after_handoff(
-            &mut state,
-            &mut config,
-            &client_config,
-            deployment_id,
-            &policy,
-            &transport,
-            None,
-        )
-        .await
-        .map(|setup_result| {
-            setup_result.unwrap_or_else(|| RunnerResult {
-                loop_result: LoopResult {
-                    stop_reason: LoopStopReason::Synced,
-                    outcome: LoopOutcome::Neutral,
-                    final_status: state.status,
-                },
-                steps_executed: 0,
-            })
+    let runner_result = alien_deployment::setup_teardown::run_setup_teardown_after_handoff(
+        state,
+        config,
+        client_config,
+        deployment_id,
+        &policy,
+        &transport,
+        None,
+    )
+    .await
+    .map(|setup_result| {
+        setup_result.unwrap_or_else(|| RunnerResult {
+            loop_result: LoopResult {
+                stop_reason: LoopStopReason::Synced,
+                outcome: LoopOutcome::Neutral,
+                final_status: state.status,
+            },
+            steps_executed: 0,
         })
-    } else {
-        match shared_run_step_loop(
-            &mut state,
-            &mut config,
-            &client_config,
-            deployment_id,
-            &policy,
-            &transport,
-            None,
-            None,
-        )
-        .await
-        {
-            Ok(result)
-                if result.loop_result.outcome == LoopOutcome::Success
-                    && state.status == DeploymentStatus::TeardownRequired =>
-            {
-                alien_deployment::setup_teardown::run_setup_teardown_after_handoff(
-                    &mut state,
-                    &mut config,
-                    &client_config,
-                    deployment_id,
-                    &policy,
-                    &transport,
-                    None,
-                )
-                .await
-                .map(|setup_result| setup_result.unwrap_or(result))
-            }
-            other => other,
-        }
-    };
+    });
 
     // Always reconcile + release, even on error
-    final_reconcile(client, deployment_id, &session, &state).await;
+    final_reconcile(client, deployment_id, &session, state).await;
     release_deployment(client, deployment_id, &session).await;
 
-    // Handle runner result after lock release
     let result = runner_result.context(ErrorData::DeploymentFailed {
-        operation: "deletion".to_string(),
+        operation: "setup teardown".to_string(),
     })?;
 
     match result.loop_result.outcome {
@@ -3178,7 +3267,7 @@ pub async fn push_deletion(
         }
         LoopOutcome::Failure => {
             let operation = format!(
-                "deletion failed at status {}",
+                "setup teardown failed at status {}",
                 deployment_status_str(result.loop_result.final_status)
             );
             if let Some(error) = state.error.clone() {

--- a/crates/alien-deployment/src/manager_api_transport.rs
+++ b/crates/alien-deployment/src/manager_api_transport.rs
@@ -166,6 +166,33 @@ pub enum SetupDeleteAcquireOutcome {
     AlreadyDeleted,
 }
 
+/// Acquire a deployment lock for CLI-owned runtime deletion.
+///
+/// Local/pull-model deployments do not have a manager-side runtime that can
+/// delete host-local resources. The deploy CLI must first drive
+/// `delete-pending` / `deleting` to the normal runtime cleanup handoff, and
+/// only then acquire setup teardown if frozen setup resources remain.
+pub async fn acquire_runtime_delete_deployment(
+    client: &ManagerClient,
+    deployment_id: &str,
+    session: &str,
+) -> Result<(), AlienError> {
+    acquire_deployment_with_statuses(
+        client,
+        deployment_id,
+        session,
+        Some("runtime".to_string()),
+        Some("cli".to_string()),
+        Some(vec![
+            "delete-pending".to_string(),
+            "deleting".to_string(),
+            "delete-failed".to_string(),
+        ]),
+    )
+    .await
+    .map(|_| ())
+}
+
 /// Acquire a deployment lock from the manager, retrying until the lock is granted
 /// or the timeout is reached.
 ///


### PR DESCRIPTION
## Summary
- add a runtime delete acquire path for CLI-owned local deployments
- make deploy CLI destroy run local runtime cleanup before setup teardown
- preserve the existing setup-teardown wait path for cloud push deployments

## Root Cause
Local/on-prem deployments have no manager-side runtime that can delete host-local resources. `alien-deploy destroy` requested cleanup, then immediately waited for `teardown-required` via setup-teardown acquire. That wait is correct only after runtime cleanup has happened. For local deployments the deploy CLI itself owns that runtime cleanup, so it could remain stuck at `delete-pending` until timeout.

## Validation
- `cargo check -p alien-deployment -p alien-deploy-cli`

Linear: ticket creation was attempted from Codex, but the Linear MCP session requires OAuth re-login before issue creation can succeed.
