### PR TITLE
fix: clean up local destroy from deploy cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-error",
  "chrono",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-error",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -971,14 +971,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.10.4"
+version = "1.10.6"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-deploy-cli/Cargo.toml
+++ b/crates/alien-deploy-cli/Cargo.toml
@@ -21,7 +21,7 @@ alien-cli-common = { workspace = true }
 alien-error = { workspace = true }
 alien-deployment = { workspace = true }
 alien-helm = { workspace = true }
-alien-infra = { workspace = true, features = ["aws", "gcp", "azure", "test"] }
+alien-infra = { workspace = true, features = ["aws", "gcp", "azure", "test", "local"] }
 alien-local = { workspace = true }
 alien-agent = { path = "../alien-agent" }
 alien-manager-api = { path = "../../client-sdks/manager/rust" }

--- a/crates/alien-deploy-cli/src/commands/agent.rs
+++ b/crates/alien-deploy-cli/src/commands/agent.rs
@@ -107,9 +107,56 @@ pub fn install_service(args: InstallArgs) -> Result<()> {
     install(args)
 }
 
+/// Stop the service when it is installed and running.
+pub fn stop_service_if_running() -> Result<()> {
+    let manager = get_manager()?;
+    match manager
+        .status(ServiceStatusCtx { label: label() })
+        .into_alien_error()
+        .context(ErrorData::AgentServiceError {
+            message: "Failed to check service status".to_string(),
+        })? {
+        ServiceStatus::Running => stop(),
+        ServiceStatus::Stopped(_) => {
+            output::info("alien-agent service is already stopped");
+            Ok(())
+        }
+        ServiceStatus::NotInstalled => {
+            output::info("alien-agent service is not installed");
+            Ok(())
+        }
+    }
+}
+
+/// Remove the service when it is installed.
+pub fn uninstall_service_if_installed() -> Result<()> {
+    let manager = get_manager()?;
+    match manager
+        .status(ServiceStatusCtx { label: label() })
+        .into_alien_error()
+        .context(ErrorData::AgentServiceError {
+            message: "Failed to check service status".to_string(),
+        })? {
+        ServiceStatus::Running | ServiceStatus::Stopped(_) => uninstall(),
+        ServiceStatus::NotInstalled => {
+            output::info("alien-agent service is not installed");
+            Ok(())
+        }
+    }
+}
+
 /// Generate an encryption key (public for reuse from up.rs).
 pub fn generate_encryption_key_public() -> String {
     generate_encryption_key()
+}
+
+/// Default data directory for the installed agent service.
+pub fn default_service_data_dir() -> String {
+    if cfg!(windows) {
+        r"C:\ProgramData\alien-agent".to_string()
+    } else {
+        "/var/lib/alien-agent".to_string()
+    }
 }
 
 fn install(args: InstallArgs) -> Result<()> {
@@ -126,13 +173,7 @@ fn install(args: InstallArgs) -> Result<()> {
         }));
     }
 
-    let data_dir = args.data_dir.unwrap_or_else(|| {
-        if cfg!(windows) {
-            r"C:\ProgramData\alien-agent".to_string()
-        } else {
-            "/var/lib/alien-agent".to_string()
-        }
-    });
+    let data_dir = args.data_dir.unwrap_or_else(default_service_data_dir);
 
     // Create data directory before writing secret files into it.
     if let Err(e) = std::fs::create_dir_all(&data_dir) {

--- a/crates/alien-deploy-cli/src/commands/down.rs
+++ b/crates/alien-deploy-cli/src/commands/down.rs
@@ -1,6 +1,6 @@
 //! Destroy command — tears down a deployment.
 
-use crate::deployment_tracking::DeploymentTracker;
+use crate::deployment_tracking::{DeploymentTracker, TrackedLocalDeployment};
 use crate::error::{ErrorData, Result};
 use crate::output;
 use alien_core::embedded_config::DeployCliConfig;
@@ -22,7 +22,7 @@ use super::up::{create_manager_client, push_deletion, read_token_file};
     # Force-delete an imported deployment record
     alien-deploy destroy --name production --force-delete-record
 
-    # Destroy using explicit token
+    # Destroy a tracked deployment using explicit manager credentials
     alien-deploy destroy --name production --token ax_dg_abc123... --manager-url https://manager.example.com"
 )]
 pub struct DownArgs {
@@ -52,9 +52,10 @@ pub struct DownArgs {
 }
 
 pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConfig>) -> Result<()> {
-    let tracker = DeploymentTracker::new()?;
+    let mut tracker = DeploymentTracker::new()?;
+    let tracked = tracker.get(&args.name).cloned();
 
-    let (token, manager_url, platform_str) = match tracker.get(&args.name) {
+    let (token, manager_url, platform_str, deployment_id, tracked_local) = match tracked {
         Some(tracked) => {
             let token = resolve_token(
                 args.token.clone(),
@@ -64,32 +65,25 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
             .unwrap_or_else(|| tracked.token.clone());
             let url = args
                 .manager_url
+                .clone()
                 .unwrap_or_else(|| tracked.manager_url.clone());
             let platform = tracked.platform.clone();
-            (token, url, platform)
+            (
+                token,
+                url,
+                platform,
+                tracked.deployment_id.clone(),
+                tracked.local.clone(),
+            )
         }
         None => {
-            let token = resolve_token(
-                args.token.clone(),
-                args.token_file.as_ref(),
-                embedded_config,
-            )?
-            .ok_or_else(|| {
-                AlienError::new(ErrorData::ValidationError {
-                    field: "token".to_string(),
-                    message: format!(
-                        "Deployment '{}' is not tracked. Provide --token and --manager-url.",
-                        args.name
-                    ),
-                })
-            })?;
-            let url = args.manager_url.ok_or_else(|| {
-                AlienError::new(ErrorData::ValidationError {
-                    field: "manager_url".to_string(),
-                    message: "--manager-url is required for untracked deployments".to_string(),
-                })
-            })?;
-            (token, url, "aws".to_string())
+            return Err(AlienError::new(ErrorData::ValidationError {
+                field: "name".to_string(),
+                message: format!(
+                    "Deployment '{}' is not tracked. Destroy requires a tracked deployment name.",
+                    args.name
+                ),
+            }));
         }
     };
 
@@ -98,15 +92,6 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
     output::status("Manager:", &manager_url);
 
     let client = create_manager_client(&token, &manager_url)?;
-
-    let tracked = tracker.get(&args.name).ok_or_else(|| {
-        AlienError::new(ErrorData::ValidationError {
-            field: "name".to_string(),
-            message: format!("Deployment '{}' not found in tracker", args.name),
-        })
-    })?;
-
-    let deployment_id = tracked.deployment_id.clone();
 
     let deployment = client
         .get_deployment()
@@ -160,6 +145,7 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
             })?;
 
         output::step(2, 2, "Done!");
+        tracker.remove(&args.name)?;
         if import_source.is_some() {
             output::success(
                 "Imported deployment record removed. No resource teardown was performed.",
@@ -207,21 +193,59 @@ pub async fn down_command(args: DownArgs, embedded_config: Option<&DeployCliConf
         })
     })?;
 
-    let client_config = ClientConfig::from_std_env(platform)
+    let client_config = destroy_client_config(platform, tracked_local.as_ref()).await?;
+
+    if let Some(local) = tracked_local.as_ref().filter(|local| local.service_managed) {
+        output::info("Stopping local agent service before cleanup...");
+        super::agent::stop_service_if_running().context(ErrorData::AgentServiceError {
+            message: format!(
+                "Failed to stop local agent service before cleanup for data directory '{}'",
+                local.data_dir
+            ),
+        })?;
+    }
+
+    push_deletion(&client, &deployment_id, platform, client_config).await?;
+
+    if let Some(local) = tracked_local.as_ref().filter(|local| local.service_managed) {
+        output::info("Uninstalling local agent service...");
+        super::agent::uninstall_service_if_installed().context(ErrorData::AgentServiceError {
+            message: format!(
+                "Failed to uninstall local agent service after cleanup for data directory '{}'",
+                local.data_dir
+            ),
+        })?;
+    }
+
+    tracker.remove(&args.name)?;
+
+    output::step(total_steps, total_steps, "Done!");
+    output::success("Deployment destroyed successfully.");
+
+    Ok(())
+}
+
+async fn destroy_client_config(
+    platform: Platform,
+    tracked_local: Option<&TrackedLocalDeployment>,
+) -> Result<ClientConfig> {
+    if platform == Platform::Local {
+        let state_directory = tracked_local
+            .map(|local| local.data_dir.clone())
+            .or_else(|| std::env::var("ALIEN_LOCAL_STATE_DIRECTORY").ok())
+            .unwrap_or_else(super::agent::default_service_data_dir);
+
+        return Ok(ClientConfig::Local { state_directory });
+    }
+
+    ClientConfig::from_std_env(platform)
         .await
         .context(ErrorData::ConfigurationError {
             message: format!(
                 "Failed to load {} credentials from environment. Ensure the required environment variables are set.",
                 platform
             ),
-        })?;
-
-    push_deletion(&client, &deployment_id, platform, client_config).await?;
-
-    output::step(total_steps, total_steps, "Done!");
-    output::success("Deployment destroyed successfully.");
-
-    Ok(())
+        })
 }
 
 fn resolve_token(
@@ -239,4 +263,28 @@ fn resolve_token(
                 .and_then(|env_var| std::env::var(env_var).ok())
         })
         .or_else(|| embedded_config.and_then(|c| c.token.clone())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_destroy_uses_tracked_data_dir() {
+        let local = TrackedLocalDeployment {
+            data_dir: "/tmp/alien-tracked-state".to_string(),
+            service_managed: true,
+        };
+
+        let config = destroy_client_config(Platform::Local, Some(&local))
+            .await
+            .expect("local config should resolve");
+
+        assert_eq!(
+            config,
+            ClientConfig::Local {
+                state_directory: "/tmp/alien-tracked-state".to_string(),
+            }
+        );
+    }
 }

--- a/crates/alien-deploy-cli/src/commands/up.rs
+++ b/crates/alien-deploy-cli/src/commands/up.rs
@@ -5,7 +5,7 @@
 //!
 //! Pull model (Local, Kubernetes): installs and starts the alien-agent service.
 
-use crate::deployment_tracking::DeploymentTracker;
+use crate::deployment_tracking::{DeploymentTracker, TrackedLocalDeployment};
 use crate::error::{ErrorData, Result};
 use crate::output;
 use alien_cli_common::network::{self, NetworkArgs, NetworkMode};
@@ -36,6 +36,7 @@ use std::{
     io::{IsTerminal, Write},
     path::{Path, PathBuf},
     str::FromStr,
+    sync::Arc,
 };
 
 #[derive(Parser, Debug, Clone)]
@@ -108,8 +109,8 @@ pub struct UpArgs {
     #[arg(long)]
     pub foreground: bool,
 
-    /// Data directory for agent state (foreground mode only).
-    /// Defaults to ~/.alien/agent-data.
+    /// Data directory for local agent state.
+    /// Defaults to the service data directory, or ~/.alien/agent-data in foreground mode.
     #[arg(long)]
     pub data_dir: Option<String>,
 
@@ -284,6 +285,36 @@ mod tests {
         assert!(!requires_install_context(Platform::Kubernetes));
         assert!(!requires_install_context(Platform::Local));
         assert!(!requires_install_context(Platform::Test));
+    }
+
+    #[test]
+    fn local_tracking_uses_service_data_dir_by_default() {
+        let args = UpArgs::parse_from(["alien-deploy", "--platform", "local"]);
+        let local = local_tracking_metadata(&args, Platform::Local)
+            .expect("local deployments should be tracked with local metadata");
+
+        assert_eq!(
+            local.data_dir,
+            crate::commands::agent::default_service_data_dir()
+        );
+        assert!(local.service_managed);
+    }
+
+    #[test]
+    fn local_tracking_uses_foreground_data_dir() {
+        let args = UpArgs::parse_from([
+            "alien-deploy",
+            "--platform",
+            "local",
+            "--foreground",
+            "--data-dir",
+            "/tmp/alien-foreground-state",
+        ]);
+        let local = local_tracking_metadata(&args, Platform::Local)
+            .expect("local deployments should be tracked with local metadata");
+
+        assert_eq!(local.data_dir, "/tmp/alien-foreground-state");
+        assert!(!local.service_managed);
     }
 
     #[test]
@@ -835,6 +866,7 @@ pub async fn up_command(args: UpArgs, embedded_config: Option<&DeployCliConfig>)
     // Use deployment-scoped token if the manager returned one, otherwise keep the original.
     let effective_token = init.deployment_token.unwrap_or_else(|| token.clone());
     let client = create_manager_client(&effective_token, &manager_url)?;
+    let local_tracking = local_tracking_metadata(&args, platform);
 
     // Track the deployment locally
     let mut tracker = DeploymentTracker::new()?;
@@ -844,6 +876,7 @@ pub async fn up_command(args: UpArgs, embedded_config: Option<&DeployCliConfig>)
         effective_token.clone(),
         manager_url.clone(),
         platform_str.clone(),
+        local_tracking,
     )?;
 
     // Check if the deployment is already active — nothing to do.
@@ -1963,6 +1996,7 @@ async fn run_pull_model(
             .await
         }
         _ => {
+            let data_dir = local_agent_data_dir(args);
             run_local_pull_model(
                 args,
                 manager_url,
@@ -1972,10 +2006,39 @@ async fn run_pull_model(
                 &platform.to_string(),
                 embedded_config,
                 public_endpoints,
+                data_dir.as_deref(),
             )
             .await
         }
     }
+}
+
+fn default_foreground_data_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".alien")
+        .join("agent-data")
+}
+
+fn local_agent_data_dir(args: &UpArgs) -> Option<String> {
+    args.data_dir.clone().or_else(|| {
+        if args.foreground {
+            Some(default_foreground_data_dir().to_string_lossy().to_string())
+        } else {
+            Some(super::agent::default_service_data_dir())
+        }
+    })
+}
+
+fn local_tracking_metadata(args: &UpArgs, platform: Platform) -> Option<TrackedLocalDeployment> {
+    if platform != Platform::Local {
+        return None;
+    }
+
+    local_agent_data_dir(args).map(|data_dir| TrackedLocalDeployment {
+        data_dir,
+        service_managed: !args.foreground,
+    })
 }
 
 async fn run_local_pull_model(
@@ -1987,6 +2050,7 @@ async fn run_local_pull_model(
     platform: &str,
     embedded_config: Option<&DeployCliConfig>,
     public_endpoints: Option<&PublicEndpointUrls>,
+    data_dir: Option<&str>,
 ) -> Result<()> {
     // Find or download the alien-agent binary
     let binary_path = find_or_download_agent_binary(embedded_config).await?;
@@ -2007,7 +2071,7 @@ async fn run_local_pull_model(
             deployment_name,
             platform,
             &encryption_key,
-            args.data_dir.as_deref(),
+            data_dir,
             public_endpoints,
             args.enable_local_debug,
             args.local_debug_shell_command.as_deref(),
@@ -2025,7 +2089,7 @@ async fn run_local_pull_model(
         deployment_id: Some(deployment_id.to_string()),
         agent_name: Some(deployment_name.to_string()),
         platform: platform.to_string(),
-        data_dir: None,
+        data_dir: data_dir.map(ToOwned::to_owned),
         encryption_key: args.encryption_key.clone(),
         public_endpoints: public_endpoints.cloned(),
         enable_local_debug: args.enable_local_debug,
@@ -2062,10 +2126,7 @@ async fn run_agent_foreground(
     let data_dir = if let Some(dir) = data_dir_override {
         std::path::PathBuf::from(dir)
     } else {
-        dirs::home_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-            .join(".alien")
-            .join("agent-data")
+        default_foreground_data_dir()
     };
 
     // The agent rejects `--sync-token`/`--encryption-key` because argv is
@@ -3057,6 +3118,7 @@ pub async fn push_deletion(
     })?;
 
     apply_external_bindings_from_stack_settings(&mut config, &stack_settings);
+    let service_provider = runtime_service_provider(&client_config)?;
 
     if platform == Platform::Local
         && !matches!(
@@ -3071,6 +3133,7 @@ pub async fn push_deletion(
             &mut config,
             &client_config,
             stack_settings.deployment_model,
+            service_provider.clone(),
         )
         .await?;
 
@@ -3087,8 +3150,29 @@ pub async fn push_deletion(
         &mut config,
         &client_config,
         stack_settings.deployment_model,
+        service_provider,
     )
     .await
+}
+
+fn runtime_service_provider(
+    client_config: &ClientConfig,
+) -> Result<Option<Arc<dyn alien_infra::PlatformServiceProvider>>> {
+    let ClientConfig::Local { state_directory } = client_config else {
+        return Ok(None);
+    };
+
+    let local_bindings = alien_local::LocalBindingsProvider::new(Path::new(state_directory))
+        .context(ErrorData::ConfigurationError {
+            message: format!(
+                "Failed to create local runtime provider from '{}'",
+                state_directory
+            ),
+        })?;
+
+    Ok(Some(Arc::new(
+        alien_infra::DefaultPlatformServiceProvider::with_local_bindings(local_bindings),
+    )))
 }
 
 async fn run_runtime_deletion(
@@ -3098,6 +3182,7 @@ async fn run_runtime_deletion(
     config: &mut DeploymentConfig,
     client_config: &ClientConfig,
     deployment_model: alien_core::DeploymentModel,
+    service_provider: Option<Arc<dyn alien_infra::PlatformServiceProvider>>,
 ) -> Result<()> {
     let session = format!("push-runtime-deletion-{}", uuid::Uuid::new_v4());
     acquire_runtime_delete_deployment(client, deployment_id, &session, deployment_model)
@@ -3151,7 +3236,7 @@ async fn run_runtime_deletion(
         deployment_id,
         &policy,
         &transport,
-        None,
+        service_provider,
         None,
     )
     .await;
@@ -3189,6 +3274,7 @@ async fn run_setup_deletion(
     config: &mut DeploymentConfig,
     client_config: &ClientConfig,
     deployment_model: alien_core::DeploymentModel,
+    service_provider: Option<Arc<dyn alien_infra::PlatformServiceProvider>>,
 ) -> Result<()> {
     let session = format!("push-setup-deletion-{}", uuid::Uuid::new_v4());
     let acquire_outcome =
@@ -3248,7 +3334,7 @@ async fn run_setup_deletion(
         deployment_id,
         &policy,
         &transport,
-        None,
+        service_provider,
     )
     .await
     .map(|setup_result| {

--- a/crates/alien-deploy-cli/src/deployment_tracking.rs
+++ b/crates/alien-deploy-cli/src/deployment_tracking.rs
@@ -1,7 +1,6 @@
 //! Deployment tracking — stores tracked deployments in a local JSON file.
 //!
-//! Unlike the platform project-cli which uses keyring, the OSS deploy-cli
-//! stores deployment info in `~/.config/alien/deployments.json`.
+//! The deploy CLI stores deployment info in `~/.config/alien/deployments.json`.
 
 use crate::error::{ErrorData, Result};
 use alien_error::{Context, IntoAlienError};
@@ -23,8 +22,21 @@ pub struct TrackedDeployment {
     pub manager_url: String,
     /// Target platform
     pub platform: String,
+    /// Local platform metadata needed to destroy pull-model resources later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local: Option<TrackedLocalDeployment>,
     /// When the deployment was tracked
     pub tracked_at: String,
+}
+
+/// Metadata for deployments managed by the local agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackedLocalDeployment {
+    /// Data directory used by the local agent for runtime state.
+    pub data_dir: String,
+    /// Whether deploy installed the local agent as an OS service.
+    pub service_managed: bool,
 }
 
 /// Deployment tracking manager
@@ -61,6 +73,7 @@ impl DeploymentTracker {
         token: String,
         manager_url: String,
         platform: String,
+        local: Option<TrackedLocalDeployment>,
     ) -> Result<TrackedDeployment> {
         let tracked = TrackedDeployment {
             name: name.clone(),
@@ -68,6 +81,7 @@ impl DeploymentTracker {
             token,
             manager_url,
             platform,
+            local,
             tracked_at: chrono::Utc::now().to_rfc3339(),
         };
 
@@ -195,6 +209,7 @@ mod tests {
                 "ax_dg_abc".to_string(),
                 "https://manager.example.com".to_string(),
                 "aws".to_string(),
+                None,
             )
             .unwrap();
 
@@ -220,6 +235,10 @@ mod tests {
                     "ax_dg_def".to_string(),
                     "https://manager.test.com".to_string(),
                     "local".to_string(),
+                    Some(TrackedLocalDeployment {
+                        data_dir: "/tmp/alien-agent-state".to_string(),
+                        service_managed: true,
+                    }),
                 )
                 .unwrap();
         }
@@ -228,6 +247,13 @@ mod tests {
         let tracker = DeploymentTracker::with_path(path.clone()).unwrap();
         let dep = tracker.get("staging").unwrap();
         assert_eq!(dep.deployment_id, "dep_456");
+        assert_eq!(
+            dep.local,
+            Some(TrackedLocalDeployment {
+                data_dir: "/tmp/alien-agent-state".to_string(),
+                service_managed: true,
+            })
+        );
 
         let _ = std::fs::remove_file(&path);
     }
@@ -244,6 +270,7 @@ mod tests {
                 "tok".to_string(),
                 "url".to_string(),
                 "aws".to_string(),
+                None,
             )
             .unwrap();
 
@@ -271,6 +298,7 @@ mod tests {
                 "t".into(),
                 "u".into(),
                 "aws".into(),
+                None,
             )
             .unwrap();
         tracker
@@ -280,6 +308,7 @@ mod tests {
                 "t".into(),
                 "u".into(),
                 "gcp".into(),
+                None,
             )
             .unwrap();
 
@@ -301,6 +330,7 @@ mod tests {
                 "t".into(),
                 "u".into(),
                 "aws".into(),
+                None,
             )
             .unwrap();
         tracker
@@ -310,6 +340,7 @@ mod tests {
                 "t".into(),
                 "u".into(),
                 "aws".into(),
+                None,
             )
             .unwrap();
 
@@ -327,6 +358,7 @@ mod tests {
             token: "ax_dg_abc".to_string(),
             manager_url: "https://example.com".to_string(),
             platform: "aws".to_string(),
+            local: None,
             tracked_at: "2025-01-01T00:00:00Z".to_string(),
         };
 

--- a/crates/alien-deployment/src/deleting.rs
+++ b/crates/alien-deployment/src/deleting.rs
@@ -281,12 +281,19 @@ fn has_remaining_setup_resources(stack_state: &StackState) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use alien_core::{
-        ComputeCluster, Platform, Resource, ResourceLifecycle, ResourceStatus, StackResourceState,
-        StackState, StackStatus, Storage,
-    };
+    use std::sync::Arc;
 
-    use super::{compute_runtime_cleanup_status, has_remaining_setup_resources};
+    use alien_core::{
+        ComputeCluster, Daemon, DaemonCode, DeploymentConfig, DeploymentState, DeploymentStatus,
+        EnvironmentVariablesSnapshot, ExternalBindings, Platform, Resource, ResourceLifecycle,
+        ResourceStatus, StackResourceState, StackSettings, StackState, StackStatus, Storage,
+    };
+    use alien_infra::DefaultPlatformServiceProvider;
+
+    use super::{
+        compute_runtime_cleanup_status, handle_delete_pending, handle_deleting,
+        has_remaining_setup_resources,
+    };
 
     fn resource_state(
         resource: Resource,
@@ -335,5 +342,97 @@ mod tests {
             StackStatus::Deleted
         );
         assert!(has_remaining_setup_resources(&stack_state));
+    }
+
+    #[tokio::test]
+    async fn local_daemon_runtime_delete_without_local_provider_fails_at_resource() {
+        let daemon = Daemon::new("gateway".to_string())
+            .code(DaemonCode::Image {
+                image: "gateway:test".to_string(),
+            })
+            .permissions("default".to_string())
+            .build();
+        let mut stack_state = StackState::new(Platform::Local);
+        let mut daemon_state = resource_state(
+            Resource::new(daemon),
+            ResourceLifecycle::Live,
+            ResourceStatus::Running,
+        );
+        daemon_state.internal_state = Some(serde_json::json!({
+            "type": "LocalDaemonController",
+            "_controllerStateVersion": 1,
+            "extractedImagePath": "/var/lib/alien-agent/daemons/gateway",
+            "daemonName": "gateway",
+            "publicUrl": null,
+            "state": "ready",
+            "internalStayCount": null
+        }));
+        stack_state
+            .resources
+            .insert("gateway".to_string(), daemon_state);
+
+        let config = DeploymentConfig::builder()
+            .stack_settings(StackSettings::default())
+            .environment_variables(EnvironmentVariablesSnapshot {
+                variables: vec![],
+                hash: String::new(),
+                created_at: String::new(),
+            })
+            .external_bindings(ExternalBindings::default())
+            .allow_frozen_changes(false)
+            .build();
+        let current = DeploymentState {
+            status: DeploymentStatus::DeletePending,
+            platform: Platform::Local,
+            current_release: None,
+            target_release: None,
+            stack_state: Some(stack_state),
+            error: None,
+            environment_info: None,
+            runtime_metadata: None,
+            retry_requested: false,
+            protocol_version: alien_core::CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+        };
+        let client_config = alien_core::ClientConfig::Local {
+            state_directory: "/var/lib/alien-agent".to_string(),
+        };
+        let service_provider = Arc::new(DefaultPlatformServiceProvider::default());
+
+        let delete_pending = handle_delete_pending(
+            current,
+            config.clone(),
+            client_config.clone(),
+            service_provider.clone(),
+        )
+        .await
+        .expect("delete-pending should transition to deleting");
+
+        let deleting = handle_deleting(
+            delete_pending.state,
+            config,
+            client_config,
+            service_provider,
+        )
+        .await
+        .expect("deleting handler should checkpoint resource failure");
+
+        assert_eq!(deleting.state.status, DeploymentStatus::DeleteFailed);
+        let stack_state = deleting
+            .state
+            .stack_state
+            .expect("delete failed state should keep stack state");
+        let resource = stack_state
+            .resources
+            .get("gateway")
+            .expect("daemon resource should remain in stack state");
+        assert_eq!(resource.status, ResourceStatus::DeleteFailed);
+        let error = resource
+            .error
+            .as_ref()
+            .expect("daemon delete failure should store resource error");
+        assert!(
+            error.message.contains("LocalWorkerManager"),
+            "expected LocalWorkerManager error, got {error:?}"
+        );
     }
 }

--- a/crates/alien-infra/src/worker/azure.rs
+++ b/crates/alien-infra/src/worker/azure.rs
@@ -1,3 +1,4 @@
+use alien_azure_clients::AzureClientConfig;
 use alien_azure_clients::container_apps::{
     ManagedEnvironmentCertificate, ManagedEnvironmentCertificateKeyVaultProperties,
     ManagedEnvironmentCertificateProperties,
@@ -10,14 +11,13 @@ use alien_azure_clients::models::container_apps::{
     IdentitySettingsLifecycle, IngressTransport, RegistryCredentials, Scale, Secret, Template,
     TrafficWeight,
 };
-use alien_azure_clients::AzureClientConfig;
 use alien_client_core::ErrorData as CloudClientErrorData;
 use alien_core::{
-    AzureContainerAppsWorkerHeartbeatData, CertificateStatus, DnsRecordStatus, HeartbeatBackend,
-    ObservedHealth, Platform, ProviderLifecycleState, RemoteStackManagement,
+    AzureContainerAppsWorkerHeartbeatData, CertificateStatus, DnsRecordStatus, ENV_AZURE_CLIENT_ID,
+    HeartbeatBackend, ObservedHealth, Platform, ProviderLifecycleState, RemoteStackManagement,
     RemoteStackManagementOutputs, ResourceHeartbeat, ResourceHeartbeatData, ResourceOutputs,
     ResourceRef, ResourceStatus, Worker, WorkerHeartbeatData, WorkerOutputs,
-    WorkloadHeartbeatStatus, ENV_AZURE_CLIENT_ID,
+    WorkloadHeartbeatStatus,
 };
 use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 use base64::Engine;
@@ -34,7 +34,7 @@ use crate::infra_requirements::azure_utils::{
     get_container_apps_environment_name, get_container_apps_environment_outputs,
     get_resource_group_name, is_azure_authorization_propagation_error,
 };
-use crate::worker::readiness_probe::{run_readiness_probe, READINESS_PROBE_MAX_ATTEMPTS};
+use crate::worker::readiness_probe::{READINESS_PROBE_MAX_ATTEMPTS, run_readiness_probe};
 use alien_macros::controller;
 
 /// Generates a deterministic Azure Container Apps name for a worker.
@@ -3226,14 +3226,14 @@ impl AzureWorkerController {
     fn build_outputs(&self) -> Option<ResourceOutputs> {
         self.resource_id.as_ref().map(|id| {
             // CNAME target = the ingress host; fall back to `url` when `container_app_url` is unset.
-            let load_balancer_endpoint = self
-                .container_app_url
-                .as_ref()
-                .or(self.url.as_ref())
-                .map(|host| alien_core::LoadBalancerEndpoint {
-                    dns_name: dns_name_from_url(host),
-                    hosted_zone_id: None,
-                });
+            let load_balancer_endpoint =
+                self.container_app_url
+                    .as_ref()
+                    .or(self.url.as_ref())
+                    .map(|host| alien_core::LoadBalancerEndpoint {
+                        dns_name: dns_name_from_url(host),
+                        hosted_zone_id: None,
+                    });
 
             ResourceOutputs::new(WorkerOutputs {
                 worker_name: self
@@ -4605,15 +4605,15 @@ mod tests {
     use httpmock::MockServer;
     use rstest::rstest;
 
-    use super::{current_unix_timestamp_secs, dns_name_from_url, AZURE_RBAC_WAIT_POLL_SECS};
-    use crate::core::{controller_test::SingleControllerExecutor, MockPlatformServiceProvider};
+    use super::{AZURE_RBAC_WAIT_POLL_SECS, current_unix_timestamp_secs, dns_name_from_url};
+    use crate::AzureWorkerState;
+    use crate::core::{MockPlatformServiceProvider, controller_test::SingleControllerExecutor};
     use crate::error::ErrorData;
     use crate::infra_requirements::azure_utils::is_azure_authorization_propagation_error;
     use crate::worker::{
-        fixtures::*, readiness_probe::test_utils::create_readiness_probe_mock,
-        AzureWorkerController,
+        AzureWorkerController, fixtures::*,
+        readiness_probe::test_utils::create_readiness_probe_mock,
     };
-    use crate::AzureWorkerState;
 
     #[test]
     fn strips_scheme_and_path_from_dns_endpoint_url() {
@@ -4667,14 +4667,18 @@ mod tests {
 
         let outputs = controller.build_outputs().unwrap();
         let worker_outputs = outputs.downcast_ref::<WorkerOutputs>().unwrap();
+        let endpoint = worker_outputs
+            .public_endpoints
+            .get("default")
+            .expect("default public endpoint");
 
         // Display URL stays the public FQDN.
         assert_eq!(
-            worker_outputs.url.as_deref(),
-            Some("https://test-worker.abc123.dev.vpc.direct")
+            endpoint.url.as_str(),
+            "https://test-worker.abc123.dev.vpc.direct"
         );
         // The CNAME target is the ingress host — and crucially NOT the record's own public FQDN.
-        let dns_name = worker_outputs
+        let dns_name = endpoint
             .load_balancer_endpoint
             .as_ref()
             .map(|endpoint| endpoint.dns_name.as_str());
@@ -4724,7 +4728,11 @@ mod tests {
         // …so build_outputs targets it, NOT the public display FQDN.
         let outputs = controller.build_outputs().unwrap();
         let worker_outputs = outputs.downcast_ref::<WorkerOutputs>().unwrap();
-        let dns_name = worker_outputs
+        let endpoint = worker_outputs
+            .public_endpoints
+            .get("default")
+            .expect("default public endpoint");
+        let dns_name = endpoint
             .load_balancer_endpoint
             .as_ref()
             .map(|endpoint| endpoint.dns_name.as_str());


### PR DESCRIPTION
## Summary
- persist local deployment metadata so destroy uses the same local agent state directory created by up
- wire local runtime deletion through the local bindings provider instead of ambient cloud credentials
- stop/uninstall the managed local agent service during successful destroy cleanup
- update stale Azure worker test assertions to the current `public_endpoints` output model so CI fast compiles all tests

## Branches
- Head: `codex/fix-local-destroy-cleanup`
- Base: `main`

## Linear
- ALIEN-209: https://linear.app/alienplatform/issue/ALIEN-209/fix-deploy-cli-local-destroy-cleanup

## Validation
- `pnpm generate`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm build`
- `git diff --check`
- `cargo fmt --check -p alien-deploy-cli -p alien-deployment`
- `cargo test -p alien-deploy-cli -- --nocapture`
- `cargo test -p alien-deployment local_daemon_runtime_delete_without_local_provider_fails_at_resource -- --nocapture`
- `cargo test --no-run --message-format human --workspace --exclude alien-aws-clients --exclude alien-gcp-clients --exclude alien-azure-clients --exclude alien-k8s-clients --exclude alien-bindings --exclude byocdb --exclude endpoint-agent --exclude alien-test-server`
- `cargo test -p alien-infra --features all-platforms dns_target_is_ingress_host_when_url_is_overridden_to_public_fqdn -- --nocapture`
- `cargo test -p alien-infra --features all-platforms imported_worker_heartbeat_rebuilds_ingress_host_for_dns -- --nocapture`