### PR TITLE
feat: typescript package layout contracts and fixtures (ALIEN-213)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -111,6 +111,9 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
         run: pnpm test:ts
 
+      - name: Validate package layout
+        run: pnpm validate:package-layout
+
       - name: Rust fast tests (non-cloud)
         env:
           AXIOM_OTLP_ENDPOINT: https://api.axiom.co/v1/logs
@@ -136,7 +139,7 @@ jobs:
         if: steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
-        run: pnpm build
+        run: pnpm build && pnpm -C packages/package-layout check
 
       - name: Run examples
         if: steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "changeset": "changeset",
     "version:npm": "changeset version",
     "test:ts": "turbo test:ts --concurrency 15",
+    "validate:package-layout": "turbo run validate:package-layout",
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write"
   },

--- a/packages/bindings/PACKAGE_LAYOUT.md
+++ b/packages/bindings/PACKAGE_LAYOUT.md
@@ -1,0 +1,115 @@
+# `@alienplatform/bindings` — package layout contract
+
+> Contract document. The names, subpaths, error codes, and dependency rules below
+> are binding for the tasks that implement and enforce them. Implementers may not
+> rename anything pinned here. Items whose owner is a later task are marked
+> **OPEN (task NN)** and must not be decided in this file.
+
+## Purpose
+
+`@alienplatform/bindings` is the public, direct bindings package for TypeScript: a
+thin wrapper over a napi-rs native addon. The Rust crate `alien-bindings` is the
+single provider implementation (S3/GCS/Blob, DynamoDB/Firestore/Table Storage,
+SQS/Pub-Sub/Service Bus, the vaults, the local providers, and their credential
+chains). The TypeScript layer carries only types, the binding factories, and error
+mapping; every storage/kv/queue/vault operation runs the Rust provider in-process.
+
+The package exposes exactly the four app-facing binding kinds — **storage**, **kv**,
+**queue**, **vault**. It has no JS cloud SDK dependencies and no provider logic of
+its own.
+
+## Public surface — all exports from `"."`
+
+| Export | Kind | Signature sketch | Notes |
+|---|---|---|---|
+| `storage` | function | `storage(name: string): Storage` | Factory. Resolves the `name` binding from the environment. |
+| `kv` | function | `kv(name: string): Kv` | Factory. |
+| `queue` | function | `queue(name: string): Queue` | Factory. |
+| `vault` | function | `vault(name: string): Vault` | Factory. |
+| `Storage` | type | resource handle | Instance type returned by `storage()`. Operation method signatures OPEN (task 04) — mirror the Rust `alien-bindings` storage handle. |
+| `Kv` | type | resource handle | Instance type returned by `kv()`. Method signatures OPEN (task 04). |
+| `Queue` | type | resource handle | Instance type returned by `queue()`. Method signatures OPEN (task 04). |
+| `Vault` | type | resource handle | Instance type returned by `vault()`. Method signatures OPEN (task 04). |
+| `BindingNotConfiguredError` | error | `defineError({ code: "BINDING_NOT_CONFIGURED", context: { binding, envVar } })` | Thrown on the first operation against an unconfigured binding. `binding` is the binding name; `envVar` is `ALIEN_<NAME>_BINDING`. |
+| shared error primitives | re-export | `AlienError`, `defineError` (from `@alienplatform/core`) | Re-exported so consumers handle bindings errors without a direct `@alienplatform/core` import. |
+
+### Intentionally not exposed
+
+The non-app binding kinds are deliberately absent from this package and must not be
+added:
+
+- worker invoke
+- container
+- build
+- artifact-registry
+- service-account
+
+These live only on the Rust `BindingsProvider` (manager, controllers, tooling,
+remote bindings) and are never part of an app-facing surface.
+
+## Exports map
+
+Only two entry points. Every condition carries `types`. No deep imports.
+
+```jsonc
+{
+  ".": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js"
+  },
+  "./native": {
+    "types": "./dist/native.d.ts",
+    "import": "./dist/native.js"
+  }
+}
+```
+
+- `"."` — the factories, instance types, and errors above.
+- `./native` — static-embed entry for `bun build --compile`. It imports the
+  platform `.node` addon through a statically analyzable specifier so the compiler
+  can stage it. The subpath name `./native` is pinned here; it is consumed by
+  task 13's compile staging and produced by task 04's addon.
+
+## Manifest requirements
+
+- `"type": "module"` (ESM-first).
+- `"sideEffects": false`.
+- `"exports"` and per-condition `"types"` exactly as above; `"types"` top-level for
+  legacy resolvers; declarations shipped.
+- `optionalDependencies` — the per-platform prebuild packages
+  `@alienplatform/bindings-<platform>`. Initial set: `@alienplatform/bindings-darwin-arm64`,
+  `@alienplatform/bindings-linux-x64-gnu`, `@alienplatform/bindings-linux-arm64-gnu`.
+  The final platform list is OPEN (task 04a).
+- `description` and `keywords`.
+- Support note: Bun ≥ 1.0.23 and Node ≥ 18 (Node-API / napi-rs addon).
+- `dependencies`: `@alienplatform/core` (errors) only.
+
+## Dependency boundaries
+
+MUST NOT depend on, import, or reference:
+
+- Cloud SDKs — `@aws-sdk/*`, `@google-cloud/*`, `@azure/*`.
+- gRPC packages — `@grpc/grpc-js`, `nice-grpc`.
+- Generated binding proto clients.
+- The env vars `ALIEN_BINDINGS_GRPC_ADDRESS` or `ALIEN_BINDINGS_MODE`.
+- Worker protocol files.
+- `@alienplatform/sdk` or [`@alienplatform/commands`](../commands/PACKAGE_LAYOUT.md).
+
+MAY depend on:
+
+- `@alienplatform/core` (error definitions).
+
+## Behavior contract
+
+- Importing the package and constructing any factory (`storage("x")`, `kv("y")`, …)
+  requires no deployment and no cloud credentials. Construction never performs I/O.
+- The first operation against a binding that has no `ALIEN_<NAME>_BINDING` in the
+  environment throws `BindingNotConfiguredError` (code `BINDING_NOT_CONFIGURED`),
+  and the error names the missing env var `ALIEN_<NAME>_BINDING` in its context.
+
+## Status
+
+- Package implemented in task 04 (TypeScript wrapper + napi-rs addon over
+  `alien-bindings`).
+- Per-platform prebuilds and the final `optionalDependencies` list in task 04a.
+- This file is the contract; it defines no runtime code.

--- a/packages/commands/PACKAGE_LAYOUT.md
+++ b/packages/commands/PACKAGE_LAYOUT.md
@@ -1,0 +1,95 @@
+# `@alienplatform/commands` — package layout contract
+
+> Contract document. The names, subpaths, error codes, and dependency rules below
+> are binding for the tasks that implement and enforce them. Implementers may not
+> rename anything pinned here. Items whose owner is a later task are marked
+> **OPEN (task NN)** and must not be decided in this file.
+
+## Purpose
+
+`@alienplatform/commands` is the public command package for TypeScript: the command
+**sender** and the non-Worker (pull) **receiver**. It is pure TypeScript over
+`fetch` — protocol types and HTTP only. It carries no native code and no provider
+logic. Large payloads are exchanged as storage-backed presigned HTTP transfers, so
+the package never links `@alienplatform/bindings`.
+
+The Rust crate `alien-commands` is the protocol twin (base protocol types plus
+server and receiver roles); this package is the TypeScript sender + receiver over
+the same wire protocol.
+
+## Public surface — all exports from `"."`
+
+| Export | Kind | Signature sketch | Notes |
+|---|---|---|---|
+| `CommandsClient` | class | `new CommandsClient({ managerUrl, deploymentId, token })` | Sender. Constructor options `{ managerUrl: string; deploymentId: string; token: string }`. |
+| `CommandsClient#target` | method | `.target(name: string)` | Scopes the client to a target command-capable resource. Return type OPEN (task 08). |
+| `CommandsClient#invoke` | method | `.invoke(name: string, input, options?)` | Invokes a command and resolves to its response. `input`/`options`/response types OPEN (task 08). |
+| `createCommandReceiver` | function | `createCommandReceiver(): CommandReceiver` | Constructs the pull receiver from environment configuration. |
+| `CommandReceiver` | type | receiver handle | `.handle(name: string, handler)` registers a handler; `.run(): Promise<void>` leases and dispatches. Handler context `{ input, signal, deadline, commandId, attempt }`. Concrete field types OPEN (task 08). |
+| `CommandReceiverConfigInvalidError` | error | `defineError({ code: "COMMAND_RECEIVER_CONFIG_INVALID", context: { … } })` | Thrown when receiver env config is empty/invalid. Context names `ALIEN_COMMANDS_URL`. |
+| sender error types | error | migrated from the current `@alienplatform/sdk/commands` error set | The final exported sender-error set is OPEN (task 08); migration source is the existing `@alienplatform/sdk/commands` errors. |
+| shared error primitives | re-export | `AlienError`, `defineError` (from `@alienplatform/core`) | Re-exported for consumer error handling. |
+
+### Receiver environment contract
+
+- `ALIEN_COMMANDS_URL` — location of the command server. **Pinned now.** An empty
+  or invalid receiver environment fails with `COMMAND_RECEIVER_CONFIG_INVALID`,
+  which names `ALIEN_COMMANDS_URL`.
+- The receiver also reads a token variable and a target-resource variable. Their
+  final env-var names are OPEN (task 08) and will be pinned in this file when
+  task 08 lands; their roles are: the outbound-HTTPS auth token, and the target
+  command-capable resource the receiver leases for.
+
+## Exports map
+
+Single entry point. Every condition carries `types`. No deep imports.
+
+```jsonc
+{
+  ".": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js"
+  }
+}
+```
+
+## Manifest requirements
+
+- `"type": "module"` (ESM-first).
+- `"sideEffects": false`.
+- `"exports"` and per-condition `"types"` exactly as above; `"types"` top-level for
+  legacy resolvers; declarations shipped.
+- `description` and `keywords`.
+- Zero runtime dependencies beyond `@alienplatform/core` (the transport is the
+  platform `fetch`).
+- Support note: Bun and Node ≥ 18 (global `fetch`).
+
+## Dependency boundaries
+
+MUST NOT depend on, import, or reference:
+
+- Worker app protocol files.
+- gRPC packages — `@grpc/grpc-js`, `nice-grpc`.
+- [`@alienplatform/bindings`](../bindings/PACKAGE_LAYOUT.md) (large payloads use
+  presigned HTTP, not the bindings addon).
+
+MAY depend on:
+
+- `@alienplatform/core` (error definitions).
+
+## Behavior contract
+
+- Importing the package and constructing `CommandsClient` requires no deployment and
+  no cloud credentials.
+- `createCommandReceiver()` reads `ALIEN_COMMANDS_URL` from the environment. An
+  empty/invalid receiver environment throws `CommandReceiverConfigInvalidError`
+  (code `COMMAND_RECEIVER_CONFIG_INVALID`) naming `ALIEN_COMMANDS_URL`.
+- The receiver leases only commands addressed to its own target resource, over
+  outbound HTTPS; it never sees another target's commands.
+
+## Status
+
+- Package implemented in task 08 (TypeScript — pure protocol sender + pull
+  receiver).
+- Rust twin `alien-commands` in task 09.
+- This file is the contract; it defines no runtime code.

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,0 +1,2 @@
+.turbo/
+*.tsbuildinfo

--- a/packages/package-layout/.gitignore
+++ b/packages/package-layout/.gitignore
@@ -1,0 +1,8 @@
+# Packed tarballs produced by `run.ts` (pnpm pack) — regenerated every run.
+.tarballs/
+
+# The consumer app is installed by npm at run time; nothing under it is committed
+# except the source that run.ts does not rewrite.
+fixture/node_modules/
+fixture/package-lock.json
+fixture/.compiled/

--- a/packages/package-layout/README.md
+++ b/packages/package-layout/README.md
@@ -1,0 +1,105 @@
+# `@alienplatform/package-layout`
+
+Executable fixture that proves the packed publishable packages install and import
+correctly on Bun and Node, honoring the surfaces pinned in
+[`packages/sdk`](../sdk/PACKAGE_LAYOUT.md),
+[`packages/bindings`](../bindings/PACKAGE_LAYOUT.md), and
+[`packages/commands`](../commands/PACKAGE_LAYOUT.md).
+
+It is not a unit test. It packs the real tarballs (`pnpm pack`), installs them into
+a throwaway consumer with **npm** (a real downstream consumer, not the pnpm
+workspace), and then imports, typechecks, and — for the binding native embed —
+`bun build --compile`s them. This catches packaging bugs (`exports` maps, shipped
+declarations, `file:`/override resolution, tarball contents) that never show up
+when everything is a workspace symlink.
+
+## Run it
+
+```sh
+# From the workspace (the invocation the ticket specifies):
+pnpm --filter @alienplatform/package-layout run check
+
+# Bun-first, from packages/package-layout:
+bun run.ts
+
+# Node (what the `check` script runs under):
+node --experimental-strip-types run.ts
+```
+
+The orchestrator (`run.ts`) runs under either Node or Bun. Whichever drives it, it
+then exercises the installed consumer under **both** runtimes: `bun src/imports.ts`
+and `node --experimental-strip-types src/imports.ts`. The Node import check
+deliberately runs `node --experimental-strip-types` against the **raw `.ts`
+fixture source** (no build step) — the same runner decision as the validator in
+`packages/scripts`; the shipped-declaration surface is covered separately by the
+`typecheck` step. If `bun` is not on `PATH`, the Bun-only steps print
+`[env-skip]` and are dropped from reconciliation (CI provides Bun via
+`setup-bun`).
+
+Requires: Node ≥ 22 (native `--experimental-strip-types`), Bun ≥ 1.0, and network
+access to the npm registry for the non-`@alienplatform` transitive dependencies.
+Every transitive `@alienplatform/*` package is pinned to a packed tarball via
+`overrides`, so those never come from the registry.
+
+## Expected-failure semantics
+
+Most of the pinned surface is not implemented yet: `@alienplatform/bindings`
+(task 04), its per-platform prebuilds (task 04a), `@alienplatform/commands`
+(task 08), and the sdk `./worker-runtime` subpath (task 03). The fixture is
+**designed to run today** and fail only on those not-yet-landed pieces.
+
+- Each discrete check reports `PASS`, `[expected]`, or `FAIL` with an evidence
+  line.
+- Every failure that is expected right now is listed in
+  [`expected-failures.json`](./expected-failures.json) with the owning task, using
+  the same `{ check, package, reason, owningTask }` shape as the static validator
+  in [`packages/scripts`](../scripts/expected-failures.json).
+- The run exits `0` **only** when the actual failure set matches that list exactly
+  — zero unexpected failures **and** zero stale expectations (an expectation that
+  no longer occurs fails the run too, so the list cannot silently rot). This reuses
+  the validator's `applyExpectedFailures` + `exitCodeFor`.
+- When a task lands its package, its checks flip from `[expected]` to `PASS` and
+  the owning task **must delete** the now-stale entries from `expected-failures.json`
+  (the run will fail loudly until it does).
+
+## What each step proves
+
+| Step | Proves |
+|---|---|
+| `pack` | Each publishable package (`sdk`, `core`) produces a tarball; `bindings`/`commands` are `[expected]` absent (04/08). |
+| `write-manifest` | The consumer manifest is rewritten to `file:` the packed tarballs with `overrides` pinning every transitive `@alienplatform/*`. |
+| `install` / `install-resolution` | `npm install` succeeds and `@alienplatform/{sdk,core}` resolve to the **tarballs**, not the registry. |
+| `import` (bun + node) | The pinned surfaces import under both runtimes, including each contract's pinned error re-exports (`AlienError`/`defineError`; `BindingNotConfiguredError`; `CommandReceiverConfigInvalidError`). The sdk facade's error re-exports (03), `./worker-runtime` (03), `@alienplatform/bindings` (04), and `@alienplatform/commands` (08) are `[expected]` missing. |
+| `error-code` (bun + node) | `BINDING_NOT_CONFIGURED` / `COMMAND_RECEIVER_CONFIG_INVALID` are asserted by their `code` field once the packages exist; `[expected]` until 04/08. |
+| `typecheck` | The consumer typechecks under NodeNext/strict against the shipped declarations; only the not-yet-landed module specifiers are `[expected]` unresolved. |
+| `packed-contents` | Each tarball's file list matches an **exact** expected set — see the note below. Required artifacts (`dist/*.js`, `package.json`, `PACKAGE_LAYOUT.md` for the contract packages) must be present, and any file outside the set fails the run. The per-platform prebuild's exact `.node`+manifest shape is `[expected]` until 04a. |
+| `compile` | `bun build --compile` of the pinned `./native` embed entry produces a runnable single-file binary; `[expected]` to fail until 04/04a. |
+| `validator` | The static layout validator in `packages/scripts` still passes. |
+
+### Note on the `packed-contents` expected set
+
+The expected file set per package is: `package.json`, `README*`, `LICENSE*`,
+`PACKAGE_LAYOUT.md` (when the package owns one), and `dist/**`. When a manifest
+carries a `files` allowlist, the set is derived from that field instead (plus the
+files npm always includes). Because no publishable manifest carries `files` today,
+sdk/core also ship a handful of source/config files; those are **explicitly
+enumerated** in `EXTRA_SHIPPED_TODAY` in `run.ts` (no wildcard allowance) with the
+tightening owned by the package-restructure tasks (03/17). Any file outside the
+union fails the run — adding an unexpected file to a published tarball is a
+contract violation this fixture catches.
+
+## Files
+
+- `run.ts` — orchestrator (pack → rewrite manifest → npm install → import/typecheck/
+  contents/compile → validator), reconciled against `expected-failures.json`.
+- `expected-failures.json` — the task-owned failures allowed today.
+- `fixture/package.json` — the npm consumer. `run.ts` rewrites `dependencies` and
+  `overrides` on every run to point at the freshly packed tarballs; every other
+  field is committed and preserved.
+- `fixture/tsconfig.json` — self-contained NodeNext/strict config (the consumer is
+  installed by npm, so it cannot extend the workspace tsconfig).
+- `fixture/src/imports.ts` — per-package dynamic imports + error-code assertions.
+- `fixture/src/compile-entry.ts` — static `./native` import for `bun build --compile`.
+
+`.tarballs/`, `fixture/node_modules/`, `fixture/package-lock.json`, and
+`fixture/.compiled/` are generated per run and git-ignored.

--- a/packages/package-layout/expected-failures.json
+++ b/packages/package-layout/expected-failures.json
@@ -1,0 +1,86 @@
+[
+  {
+    "check": "pack",
+    "package": "bindings",
+    "reason": "publishable package not present (nothing to pack)",
+    "owningTask": "04"
+  },
+  {
+    "check": "pack",
+    "package": "commands",
+    "reason": "publishable package not present (nothing to pack)",
+    "owningTask": "08"
+  },
+  {
+    "check": "import",
+    "package": "sdk",
+    "reason": "facade root is missing pinned error re-exports",
+    "owningTask": "03"
+  },
+  {
+    "check": "import",
+    "package": "sdk",
+    "reason": "subpath ./worker-runtime is not exported",
+    "owningTask": "03"
+  },
+  {
+    "check": "import",
+    "package": "bindings",
+    "reason": "cannot import @alienplatform/bindings (package not installed)",
+    "owningTask": "04"
+  },
+  {
+    "check": "import",
+    "package": "commands",
+    "reason": "cannot import @alienplatform/commands (package not installed)",
+    "owningTask": "08"
+  },
+  {
+    "check": "error-code",
+    "package": "bindings",
+    "reason": "cannot assert BINDING_NOT_CONFIGURED (bindings package not installed)",
+    "owningTask": "04"
+  },
+  {
+    "check": "error-code",
+    "package": "commands",
+    "reason": "cannot assert COMMAND_RECEIVER_CONFIG_INVALID (commands package not installed)",
+    "owningTask": "08"
+  },
+  {
+    "check": "typecheck",
+    "package": "sdk",
+    "reason": "cannot find module '@alienplatform/sdk/worker-runtime'",
+    "owningTask": "03"
+  },
+  {
+    "check": "typecheck",
+    "package": "bindings",
+    "reason": "cannot find module '@alienplatform/bindings'",
+    "owningTask": "04"
+  },
+  {
+    "check": "typecheck",
+    "package": "bindings",
+    "reason": "cannot find module '@alienplatform/bindings/native'",
+    "owningTask": "04"
+  },
+  {
+    "check": "typecheck",
+    "package": "commands",
+    "reason": "cannot find module '@alienplatform/commands'",
+    "owningTask": "08"
+  },
+  {
+    "check": "packed-contents",
+    "package": "@alienplatform/bindings-darwin-arm64",
+    "reason": "per-platform prebuild package not present (expected one .node addon + manifest)",
+    "owningTask": "04a"
+  },
+  {
+    "check": "compile",
+    "package": "bindings",
+    "reason": "bun build --compile of ./native entry fails (bindings package not installed)",
+    "owningTask": "04/04a"
+  }
+]

--- a/packages/package-layout/expected-failures.json
+++ b/packages/package-layout/expected-failures.json
@@ -12,13 +12,13 @@
     "owningTask": "08"
   },
   {
-    "check": "import",
+    "check": "import-error-reexports",
     "package": "sdk",
     "reason": "facade root is missing pinned error re-exports",
     "owningTask": "03"
   },
   {
-    "check": "import",
+    "check": "import-worker-runtime",
     "package": "sdk",
     "reason": "subpath ./worker-runtime is not exported",
     "owningTask": "03"

--- a/packages/package-layout/fixture/package.json
+++ b/packages/package-layout/fixture/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "package-layout-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Real npm consumer of the packed @alienplatform tarballs. run.ts rewrites `dependencies` and `overrides` on every run to point at the freshly packed tarballs in ../.tarballs; every other field here is committed and preserved.",
+  "devDependencies": {
+    "@types/node": "24.10.4",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
+    "@alienplatform/sdk": "file:../.tarballs/alienplatform-sdk-1.10.7.tgz"
+  },
+  "overrides": {
+    "@alienplatform/core": "file:../.tarballs/alienplatform-core-1.10.7.tgz",
+    "@alienplatform/sdk": "file:../.tarballs/alienplatform-sdk-1.10.7.tgz"
+  }
+}

--- a/packages/package-layout/fixture/src/compile-entry.ts
+++ b/packages/package-layout/fixture/src/compile-entry.ts
@@ -1,0 +1,25 @@
+/**
+ * Static-embed entry point for the `bun build --compile` check in `run.ts`.
+ *
+ * It imports `@alienplatform/bindings` through the pinned `./native` subpath —
+ * the statically analyzable specifier that lets the Bun compiler stage the
+ * platform `.node` addon into a single-file binary (bindings PACKAGE_LAYOUT.md,
+ * "Exports map"). Unlike `imports.ts`, this uses a STATIC import on purpose:
+ * `bun build --compile` only follows statically analyzable imports.
+ *
+ * Until task 04 ships `@alienplatform/bindings` and task 04a ships the
+ * per-platform `.node` prebuilds, this specifier does not resolve, so both the
+ * fixture typecheck and the `bun build --compile` step fail — `run.ts` marks
+ * those `[expected]`.
+ */
+
+import { storage } from "@alienplatform/bindings/native"
+
+// Reference the import so the compiler must stage the native addon, then exit 0
+// so a successfully compiled binary is observably runnable.
+const factory: unknown = storage
+if (typeof factory !== "function") {
+  throw new Error("expected the ./native storage factory to be a function")
+}
+
+console.log("compile-entry: native binding factory embedded")

--- a/packages/package-layout/fixture/src/imports.ts
+++ b/packages/package-layout/fixture/src/imports.ts
@@ -1,0 +1,299 @@
+/**
+ * Fixture import + behavior checks for the pinned package surfaces.
+ *
+ * This file is executed by `run.ts` under BOTH Bun (`bun src/imports.ts`) and
+ * Node (`node --experimental-strip-types src/imports.ts`). It imports each of
+ * the three packages' pinned surfaces from
+ * `packages/{sdk,bindings,commands}/PACKAGE_LAYOUT.md` and, where the surface is
+ * present, asserts the pinned error codes by their `code` field.
+ *
+ * Every package is loaded with its OWN dynamic `import()` inside a `try/catch`
+ * so a not-yet-published package fails only its own checks — the file never dies
+ * on the first missing package. Each check prints one machine-readable
+ * `##CHECK##` line; `run.ts` reconciles the failing ones against
+ * `expected-failures.json`. This file always exits 0: a crash with no output is
+ * how `run.ts` detects an unexpected, un-reported failure.
+ *
+ * Today only `@alienplatform/sdk` (+ its transitive `@alienplatform/core`) is
+ * installed, so the `@alienplatform/bindings` (task 04), `@alienplatform/commands`
+ * (task 08), and `./worker-runtime` (task 03) checks report `fail` and `run.ts`
+ * marks them `[expected]`.
+ */
+
+interface CheckLine {
+  check: string
+  package: string
+  status: "pass" | "fail"
+  reason: string
+  evidence: string
+}
+
+function report(line: CheckLine): void {
+  console.log(`##CHECK## ${JSON.stringify(line)}`)
+}
+
+function firstLine(value: unknown): string {
+  const text = value instanceof Error ? `${value.name}: ${value.message}` : String(value)
+  return text.split("\n")[0] ?? text
+}
+
+/** Names that must be present on a namespace object; returns the missing ones. */
+function missingExports(mod: object, names: readonly string[]): string[] {
+  return names.filter(name => !(name in mod))
+}
+
+// --- @alienplatform/sdk (facade root) — installed today, must PASS ----------
+const SDK_FACADE_EXPORTS = [
+  "command",
+  "onStorageEvent",
+  "onCronEvent",
+  "onQueueMessage",
+  "waitUntil",
+  "storage",
+  "kv",
+  "queue",
+  "vault",
+] as const
+
+// The sdk contract's "error re-exports" row: BindingNotConfiguredError (from
+// @alienplatform/bindings) and AlienError (from @alienplatform/core). These
+// arrive with task 03's facade re-export of the bindings package, so today
+// they are a separate [expected] check rather than part of the main surface.
+const SDK_FACADE_ERROR_REEXPORTS = ["BindingNotConfiguredError", "AlienError"] as const
+
+async function checkSdk(): Promise<void> {
+  let mod: object
+  try {
+    mod = await import("@alienplatform/sdk")
+  } catch (err) {
+    report({
+      check: "import",
+      package: "sdk",
+      status: "fail",
+      reason: "cannot import @alienplatform/sdk",
+      evidence: firstLine(err),
+    })
+    return
+  }
+
+  const missing = missingExports(mod, SDK_FACADE_EXPORTS)
+  report({
+    check: "import",
+    package: "sdk",
+    status: missing.length === 0 ? "pass" : "fail",
+    reason: missing.length === 0 ? "ok" : "facade root is missing pinned exports",
+    evidence:
+      missing.length === 0
+        ? `resolved ${SDK_FACADE_EXPORTS.length}/${SDK_FACADE_EXPORTS.length} pinned facade exports`
+        : `missing: ${missing.join(", ")}`,
+  })
+
+  const missingErrors = missingExports(mod, SDK_FACADE_ERROR_REEXPORTS)
+  report({
+    check: "import",
+    package: "sdk",
+    status: missingErrors.length === 0 ? "pass" : "fail",
+    reason: missingErrors.length === 0 ? "ok" : "facade root is missing pinned error re-exports",
+    evidence:
+      missingErrors.length === 0
+        ? "resolved BindingNotConfiguredError + AlienError re-exports"
+        : `missing: ${missingErrors.join(", ")}`,
+  })
+}
+
+// --- @alienplatform/sdk/worker-runtime — subpath OPEN until task 03 ----------
+async function checkSdkWorkerRuntime(): Promise<void> {
+  try {
+    const mod = await import("@alienplatform/sdk/worker-runtime")
+    const missing = missingExports(mod, ["runWorker"])
+    if (missing.length > 0) {
+      report({
+        check: "import",
+        package: "sdk",
+        status: "fail",
+        reason: "worker-runtime subpath is missing pinned export runWorker",
+        evidence: `missing: ${missing.join(", ")}`,
+      })
+      return
+    }
+    report({
+      check: "import",
+      package: "sdk",
+      status: "pass",
+      reason: "ok",
+      evidence: "resolved ./worker-runtime runWorker",
+    })
+  } catch (err) {
+    report({
+      check: "import",
+      package: "sdk",
+      status: "fail",
+      reason: "subpath ./worker-runtime is not exported",
+      evidence: firstLine(err),
+    })
+  }
+}
+
+// --- @alienplatform/bindings — package OPEN until task 04 --------------------
+// Public surface table + the shared error primitives re-export (AlienError,
+// defineError from @alienplatform/core) pinned by the bindings contract.
+const BINDINGS_EXPORTS = [
+  "storage",
+  "kv",
+  "queue",
+  "vault",
+  "BindingNotConfiguredError",
+  "AlienError",
+  "defineError",
+] as const
+
+function errorCode(err: unknown): string | undefined {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code: unknown }).code
+    return typeof code === "string" ? code : undefined
+  }
+  return undefined
+}
+
+async function checkBindings(): Promise<void> {
+  let mod: Record<string, unknown>
+  try {
+    mod = (await import("@alienplatform/bindings")) as Record<string, unknown>
+  } catch (err) {
+    report({
+      check: "import",
+      package: "bindings",
+      status: "fail",
+      reason: "cannot import @alienplatform/bindings (package not installed)",
+      evidence: firstLine(err),
+    })
+    report({
+      check: "error-code",
+      package: "bindings",
+      status: "fail",
+      reason: "cannot assert BINDING_NOT_CONFIGURED (bindings package not installed)",
+      evidence: "bindings import failed; see the import check above",
+    })
+    return
+  }
+
+  const missing = missingExports(mod, BINDINGS_EXPORTS)
+  report({
+    check: "import",
+    package: "bindings",
+    status: missing.length === 0 ? "pass" : "fail",
+    reason: missing.length === 0 ? "ok" : "missing pinned exports",
+    evidence: missing.length === 0 ? "resolved storage/kv/queue/vault + error" : missing.join(", "),
+  })
+
+  // The first operation against an unconfigured binding must throw
+  // BINDING_NOT_CONFIGURED naming ALIEN_<NAME>_BINDING (bindings behavior
+  // contract). The concrete first-operation name is OPEN (task 04); task 04
+  // fills the real operation call here when the addon lands.
+  try {
+    const storageFactory = mod.storage as (name: string) => Record<string, unknown>
+    const handle = storageFactory("layout-fixture-probe")
+    // TODO(task 04): replace with the pinned first storage operation.
+    const firstOp = handle.get as ((key: string) => Promise<unknown>) | undefined
+    if (typeof firstOp !== "function") {
+      throw new Error("no first operation available to trigger BINDING_NOT_CONFIGURED yet")
+    }
+    await firstOp("probe")
+    report({
+      check: "error-code",
+      package: "bindings",
+      status: "fail",
+      reason: "expected BINDING_NOT_CONFIGURED but no error was thrown",
+      evidence: "unconfigured storage operation did not throw",
+    })
+  } catch (err) {
+    const code = errorCode(err)
+    report({
+      check: "error-code",
+      package: "bindings",
+      status: code === "BINDING_NOT_CONFIGURED" ? "pass" : "fail",
+      reason:
+        code === "BINDING_NOT_CONFIGURED" ? "ok" : "expected error code BINDING_NOT_CONFIGURED",
+      evidence: `code=${code ?? "<none>"}: ${firstLine(err)}`,
+    })
+  }
+}
+
+// --- @alienplatform/commands — package OPEN until task 08 -------------------
+const COMMANDS_EXPORTS = [
+  "CommandsClient",
+  "createCommandReceiver",
+  "CommandReceiverConfigInvalidError",
+  // Shared error primitives re-export (AlienError, defineError from
+  // @alienplatform/core) pinned by the commands contract.
+  "AlienError",
+  "defineError",
+] as const
+
+async function checkCommands(): Promise<void> {
+  let mod: Record<string, unknown>
+  try {
+    mod = (await import("@alienplatform/commands")) as Record<string, unknown>
+  } catch (err) {
+    report({
+      check: "import",
+      package: "commands",
+      status: "fail",
+      reason: "cannot import @alienplatform/commands (package not installed)",
+      evidence: firstLine(err),
+    })
+    report({
+      check: "error-code",
+      package: "commands",
+      status: "fail",
+      reason: "cannot assert COMMAND_RECEIVER_CONFIG_INVALID (commands package not installed)",
+      evidence: "commands import failed; see the import check above",
+    })
+    return
+  }
+
+  const missing = missingExports(mod, COMMANDS_EXPORTS)
+  report({
+    check: "import",
+    package: "commands",
+    status: missing.length === 0 ? "pass" : "fail",
+    reason: missing.length === 0 ? "ok" : "missing pinned exports",
+    evidence:
+      missing.length === 0
+        ? "resolved CommandsClient/createCommandReceiver + error"
+        : missing.join(", "),
+  })
+
+  // An empty/invalid receiver environment must throw
+  // COMMAND_RECEIVER_CONFIG_INVALID naming ALIEN_COMMANDS_URL (commands behavior
+  // contract). Force an empty value so the call must fail regardless of ambient env.
+  process.env.ALIEN_COMMANDS_URL = ""
+  try {
+    const createReceiver = mod.createCommandReceiver as () => unknown
+    createReceiver()
+    report({
+      check: "error-code",
+      package: "commands",
+      status: "fail",
+      reason: "expected COMMAND_RECEIVER_CONFIG_INVALID but no error was thrown",
+      evidence: "createCommandReceiver() with empty env did not throw",
+    })
+  } catch (err) {
+    const code = errorCode(err)
+    report({
+      check: "error-code",
+      package: "commands",
+      status: code === "COMMAND_RECEIVER_CONFIG_INVALID" ? "pass" : "fail",
+      reason:
+        code === "COMMAND_RECEIVER_CONFIG_INVALID"
+          ? "ok"
+          : "expected error code COMMAND_RECEIVER_CONFIG_INVALID",
+      evidence: `code=${code ?? "<none>"}: ${firstLine(err)}`,
+    })
+  }
+}
+
+await checkSdk()
+await checkSdkWorkerRuntime()
+await checkBindings()
+await checkCommands()

--- a/packages/package-layout/fixture/src/imports.ts
+++ b/packages/package-layout/fixture/src/imports.ts
@@ -90,7 +90,7 @@ async function checkSdk(): Promise<void> {
 
   const missingErrors = missingExports(mod, SDK_FACADE_ERROR_REEXPORTS)
   report({
-    check: "import",
+    check: "import-error-reexports",
     package: "sdk",
     status: missingErrors.length === 0 ? "pass" : "fail",
     reason: missingErrors.length === 0 ? "ok" : "facade root is missing pinned error re-exports",
@@ -102,13 +102,18 @@ async function checkSdk(): Promise<void> {
 }
 
 // --- @alienplatform/sdk/worker-runtime — subpath OPEN until task 03 ----------
+// Uses its own `check` name (distinct from the facade's "import"/"import-error-
+// reexports") so per-package results stay one-assertion-per-key: run.ts's
+// runtime-divergence check groups by check+package to compare Bun vs Node, and
+// a shared name across unrelated assertions would let two different checks
+// masquerade as "the same assertion, different runtime".
 async function checkSdkWorkerRuntime(): Promise<void> {
   try {
     const mod = await import("@alienplatform/sdk/worker-runtime")
     const missing = missingExports(mod, ["runWorker"])
     if (missing.length > 0) {
       report({
-        check: "import",
+        check: "import-worker-runtime",
         package: "sdk",
         status: "fail",
         reason: "worker-runtime subpath is missing pinned export runWorker",
@@ -117,7 +122,7 @@ async function checkSdkWorkerRuntime(): Promise<void> {
       return
     }
     report({
-      check: "import",
+      check: "import-worker-runtime",
       package: "sdk",
       status: "pass",
       reason: "ok",
@@ -125,7 +130,7 @@ async function checkSdkWorkerRuntime(): Promise<void> {
     })
   } catch (err) {
     report({
-      check: "import",
+      check: "import-worker-runtime",
       package: "sdk",
       status: "fail",
       reason: "subpath ./worker-runtime is not exported",

--- a/packages/package-layout/fixture/tsconfig.json
+++ b/packages/package-layout/fixture/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "//": "Self-contained: this consumer is installed with npm (not the pnpm workspace), so it cannot extend @alienplatform/typescript-config. The compilerOptions below mirror @alienplatform/typescript-config/base.json (NodeNext, strict, noUncheckedIndexedAccess) so the fixture typechecks under the same rules a published-package consumer gets.",
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/package-layout/package.json
+++ b/packages/package-layout/package.json
@@ -14,6 +14,11 @@
     "directory": "packages/package-layout"
   },
   "scripts": {
-    "check": "node --experimental-strip-types run.ts"
+    "check": "node --experimental-strip-types run.ts",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.15",
+    "vitest": "^3.1.4"
   }
 }

--- a/packages/package-layout/package.json
+++ b/packages/package-layout/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@alienplatform/package-layout",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Executable fixture that packs the publishable packages, installs them into a real npm consumer, and asserts the pinned surfaces in packages/{sdk,bindings,commands}/PACKAGE_LAYOUT.md import and typecheck on Bun and Node",
+  "keywords": ["alien", "internal", "fixture", "package-layout"],
+  "author": "Alien Software, Inc. <hi@alien.dev>",
+  "license": "FSL-1.1-Apache-2.0",
+  "homepage": "https://alien.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alienplatform/alien.git",
+    "directory": "packages/package-layout"
+  },
+  "scripts": {
+    "check": "node --experimental-strip-types run.ts"
+  }
+}

--- a/packages/package-layout/run.test.ts
+++ b/packages/package-layout/run.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest"
+
+import { detectRuntimeDivergence } from "./run.ts"
+
+describe("detectRuntimeDivergence", () => {
+  it("reports nothing when both runtimes agree (both pass)", () => {
+    const violations = detectRuntimeDivergence([
+      {
+        check: "import",
+        package: "sdk",
+        status: "pass",
+        reason: "ok",
+        evidence: "a",
+        runtime: "bun",
+      },
+      {
+        check: "import",
+        package: "sdk",
+        status: "pass",
+        reason: "ok",
+        evidence: "b",
+        runtime: "node",
+      },
+    ])
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("reports nothing when both runtimes agree (both fail)", () => {
+    const violations = detectRuntimeDivergence([
+      {
+        check: "import",
+        package: "bindings",
+        status: "fail",
+        reason: "cannot import @alienplatform/bindings (package not installed)",
+        evidence: "bun evidence",
+        runtime: "bun",
+      },
+      {
+        check: "import",
+        package: "bindings",
+        status: "fail",
+        reason: "cannot import @alienplatform/bindings (package not installed)",
+        evidence: "node evidence",
+        runtime: "node",
+      },
+    ])
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("flags a check that passes on bun but fails on node — the exact false-green this guards against", () => {
+    // This is the scenario the shared applyExpectedFailures cannot see on its
+    // own: a still-registered expected-failure entry for "bindings not
+    // installed" would keep matching the Node failure by check::package::reason
+    // alone, silently hiding that Bun has already started passing.
+    const violations = detectRuntimeDivergence([
+      {
+        check: "import",
+        package: "bindings",
+        status: "pass",
+        reason: "ok",
+        evidence: "resolved",
+        runtime: "bun",
+      },
+      {
+        check: "import",
+        package: "bindings",
+        status: "fail",
+        reason: "cannot import @alienplatform/bindings (package not installed)",
+        evidence: "still throws",
+        runtime: "node",
+      },
+    ])
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ check: "runtime-divergence", package: "bindings" })
+    expect(violations[0]?.reason).toBe("import passes on bun but fails on node")
+    expect(violations[0]?.evidence).toBe("bun: resolved | node: still throws")
+  })
+
+  it("flags a check that passes on node but fails on bun (the other direction)", () => {
+    const violations = detectRuntimeDivergence([
+      {
+        check: "import",
+        package: "commands",
+        status: "fail",
+        reason: "boom",
+        evidence: "bun fail",
+        runtime: "bun",
+      },
+      {
+        check: "import",
+        package: "commands",
+        status: "pass",
+        reason: "ok",
+        evidence: "node ok",
+        runtime: "node",
+      },
+    ])
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.reason).toBe("import passes on node but fails on bun")
+  })
+
+  it("ignores results with no runtime tag (single-run checks like pack/install/typecheck)", () => {
+    const violations = detectRuntimeDivergence([
+      { check: "pack", package: "sdk", status: "pass", reason: "ok", evidence: "tarball" },
+      {
+        check: "install",
+        package: "fixture",
+        status: "fail",
+        reason: "npm install failed",
+        evidence: "exit 1",
+      },
+    ])
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("does not false-positive when only one runtime ran a check (e.g. bun unavailable)", () => {
+    const violations = detectRuntimeDivergence([
+      {
+        check: "import",
+        package: "sdk",
+        status: "fail",
+        reason: "boom",
+        evidence: "node only",
+        runtime: "node",
+      },
+    ])
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("keeps distinct check names for the same package independent (no cross-assertion bleed)", () => {
+    // sdk reports three distinct import-family checks (import, import-error-
+    // reexports, import-worker-runtime); a shared "import" name across all
+    // three would let an unrelated pass/fail pairing masquerade as divergence.
+    const violations = detectRuntimeDivergence([
+      {
+        check: "import",
+        package: "sdk",
+        status: "pass",
+        reason: "ok",
+        evidence: "a",
+        runtime: "bun",
+      },
+      {
+        check: "import",
+        package: "sdk",
+        status: "pass",
+        reason: "ok",
+        evidence: "b",
+        runtime: "node",
+      },
+      {
+        check: "import-worker-runtime",
+        package: "sdk",
+        status: "fail",
+        reason: "subpath ./worker-runtime is not exported",
+        evidence: "c",
+        runtime: "bun",
+      },
+      {
+        check: "import-worker-runtime",
+        package: "sdk",
+        status: "fail",
+        reason: "subpath ./worker-runtime is not exported",
+        evidence: "d",
+        runtime: "node",
+      },
+    ])
+
+    expect(violations).toHaveLength(0)
+  })
+})

--- a/packages/package-layout/run.ts
+++ b/packages/package-layout/run.ts
@@ -349,6 +349,15 @@ function tarEntries(tarball: string): string[] {
     .filter(line => line.length > 0)
 }
 
+// Hard denylist: never allowed in a packed tarball, regardless of `files` or
+// EXTRA_SHIPPED_TODAY. Catches regressions even if an .npmignore is deleted.
+const HARD_DENYLIST_PATTERNS: RegExp[] = [
+  /(^|\/)node_modules\//,
+  /(^|\/)\.env$/,
+  /\.tgz$/,
+  /(^|\/)\.turbo\//,
+]
+
 // Intended publish set for every publishable package: manifest, docs, license,
 // contract file, and built output. When a manifest carries a `files` allowlist,
 // that allowlist (plus the files npm always includes) is the source of truth.
@@ -411,14 +420,27 @@ for (const name of ["sdk", "core"]) {
   const requiresContract = existsSync(join(packagesDir, name, "PACKAGE_LAYOUT.md"))
   const hasContract = entries.includes("PACKAGE_LAYOUT.md")
 
-  // …and nothing outside the exact allowlist may ship.
+  // …and nothing outside the exact allowlist may ship. Hard-denylisted entries
+  // are reported separately (and always), so exclude them from `unexpected` to
+  // avoid reporting the same file twice.
+  const denylisted = entries.filter(entry =>
+    HARD_DENYLIST_PATTERNS.some(pattern => pattern.test(entry)),
+  )
   const allowed = allowedPatternsFor(name)
-  const unexpected = entries.filter(entry => !allowed.some(pattern => pattern.test(entry)))
+  const unexpected = entries.filter(
+    entry => !denylisted.includes(entry) && !allowed.some(pattern => pattern.test(entry)),
+  )
 
   const problems: string[] = []
   if (!hasManifest) problems.push("missing package.json")
   if (!hasDist) problems.push("missing dist/*.js")
   if (requiresContract && !hasContract) problems.push("missing PACKAGE_LAYOUT.md")
+  if (denylisted.length > 0) {
+    const shown = denylisted.slice(0, 5).join(", ")
+    problems.push(
+      `ships ${denylisted.length} hard-denylisted file(s): ${shown}${denylisted.length > 5 ? ", …" : ""}`,
+    )
+  }
   if (unexpected.length > 0) {
     const shown = unexpected.slice(0, 5).join(", ")
     problems.push(

--- a/packages/package-layout/run.ts
+++ b/packages/package-layout/run.ts
@@ -1,0 +1,578 @@
+/**
+ * Package-layout fixture orchestrator.
+ *
+ * Runs the executable proof that the packed publishable packages install and
+ * import correctly on Bun and Node, honoring the pinned surfaces in
+ * packages/{sdk,bindings,commands}/PACKAGE_LAYOUT.md. Discrete steps:
+ *
+ *   1. pnpm pack each existing publishable package (sdk, core; bindings/commands
+ *      when they land) into .tarballs/.
+ *   2. Rewrite the consumer's `dependencies` + `overrides` to file: those tarballs
+ *      (every transitive @alienplatform/* pinned to a tarball, never npm).
+ *   3. npm install the consumer (npm, not pnpm — a real consumer) and assert the
+ *      @alienplatform/* packages resolved to the tarballs.
+ *   4/5. Import check under Bun and Node (src/imports.ts) — pinned surfaces +
+ *      BINDING_NOT_CONFIGURED / COMMAND_RECEIVER_CONFIG_INVALID by `code`.
+ *   6. tsc typecheck of the consumer.
+ *   7. packed-contents check (tar -tzf) of each tarball.
+ *   8. bun build --compile of src/compile-entry.ts (the ./native embed) + run it.
+ *   9. Invoke the static validator (packages/scripts/validate-package-layout.ts).
+ *
+ * Every step is individually reported (name, PASS/[expected]/FAIL, evidence).
+ * Failing checks are reconciled against expected-failures.json exactly like the
+ * validator does — the run exits 0 only when there are zero unexpected failures
+ * and zero stale expectations (reused applyExpectedFailures + exitCodeFor).
+ */
+
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  type ExpectedFailureEntry,
+  type Violation,
+  applyExpectedFailures,
+  exitCodeFor,
+} from "../scripts/validate-package-layout.ts"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packagesDir = join(scriptDir, "..")
+const tarballsDir = join(scriptDir, ".tarballs")
+const fixtureDir = join(scriptDir, "fixture")
+const validatorPath = join(packagesDir, "scripts", "validate-package-layout.ts")
+
+/** One reported check. Failing ones are reconciled against expected-failures.json. */
+interface CheckResult {
+  check: string
+  package: string
+  status: "pass" | "fail"
+  reason: string
+  evidence: string
+}
+
+const results: CheckResult[] = []
+function record(result: CheckResult): void {
+  results.push(result)
+}
+
+interface RunOutput {
+  status: number | null
+  stdout: string
+  stderr: string
+}
+
+function run(command: string, args: string[], cwd: string): RunOutput {
+  const proc = spawnSync(command, args, { cwd, encoding: "utf8" })
+  if (proc.error) {
+    return { status: null, stdout: proc.stdout ?? "", stderr: String(proc.error) }
+  }
+  return { status: proc.status, stdout: proc.stdout ?? "", stderr: proc.stderr ?? "" }
+}
+
+function lastLine(text: string): string {
+  const lines = text
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+  return lines.at(-1) ?? ""
+}
+
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+const bunAvailable = run("bun", ["--version"], scriptDir).status === 0
+if (!bunAvailable) {
+  console.log(
+    "[env-skip] bun is not on PATH — the Bun import and `bun build --compile` steps are " +
+      "skipped in this environment. CI provides bun via setup-bun.",
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — pack the publishable packages
+// ---------------------------------------------------------------------------
+
+rmSync(tarballsDir, { recursive: true, force: true })
+mkdirSync(tarballsDir, { recursive: true })
+
+/** name -> absolute tarball path, for packages that packed successfully. */
+const tarballs = new Map<string, string>()
+
+const PACK_TARGETS: { name: string; owningReason: string }[] = [
+  { name: "sdk", owningReason: "" },
+  { name: "core", owningReason: "" },
+  { name: "bindings", owningReason: "publishable package not present (nothing to pack)" },
+  { name: "commands", owningReason: "publishable package not present (nothing to pack)" },
+]
+
+function findTarball(name: string): string | undefined {
+  const prefix = `alienplatform-${name}-`
+  const file = readdirSync(tarballsDir).find(
+    entry => entry.startsWith(prefix) && entry.endsWith(".tgz"),
+  )
+  return file ? join(tarballsDir, file) : undefined
+}
+
+for (const target of PACK_TARGETS) {
+  const pkgDir = join(packagesDir, target.name)
+  if (!existsSync(join(pkgDir, "package.json"))) {
+    record({
+      check: "pack",
+      package: target.name,
+      status: "fail",
+      reason: target.owningReason || "publishable package not present (nothing to pack)",
+      evidence: pkgDir,
+    })
+    continue
+  }
+
+  const packed = run("pnpm", ["pack", "--pack-destination", tarballsDir], pkgDir)
+  const tarball = findTarball(target.name)
+  if (packed.status !== 0 || !tarball) {
+    record({
+      check: "pack",
+      package: target.name,
+      status: "fail",
+      reason: "pnpm pack failed",
+      evidence: lastLine(packed.stderr) || lastLine(packed.stdout) || `exit ${packed.status}`,
+    })
+    continue
+  }
+  tarballs.set(target.name, tarball)
+  record({
+    check: "pack",
+    package: target.name,
+    status: "pass",
+    reason: "ok",
+    evidence: relative(scriptDir, tarball),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — rewrite the consumer manifest to file: the tarballs
+// ---------------------------------------------------------------------------
+
+// Direct dependencies the consumer imports; overrides pin every transitive
+// @alienplatform/* to a packed tarball so npm never reaches the registry for one.
+const DIRECT_DEP_PACKAGES = ["sdk", "bindings", "commands"] as const
+const OVERRIDE_PACKAGES = ["core", "sdk", "bindings", "commands"] as const
+
+function fileSpec(tarball: string): string {
+  return `file:${relative(fixtureDir, tarball).split("\\").join("/")}`
+}
+
+const fixtureManifestPath = join(fixtureDir, "package.json")
+const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, "utf8")) as Record<
+  string,
+  unknown
+>
+
+const dependencies: Record<string, string> = {}
+for (const name of DIRECT_DEP_PACKAGES) {
+  const tarball = tarballs.get(name)
+  if (tarball) dependencies[`@alienplatform/${name}`] = fileSpec(tarball)
+}
+const overrides: Record<string, string> = {}
+for (const name of OVERRIDE_PACKAGES) {
+  const tarball = tarballs.get(name)
+  if (tarball) overrides[`@alienplatform/${name}`] = fileSpec(tarball)
+}
+
+fixtureManifest.dependencies = dependencies
+fixtureManifest.overrides = overrides
+writeFileSync(fixtureManifestPath, `${JSON.stringify(fixtureManifest, null, 2)}\n`)
+record({
+  check: "write-manifest",
+  package: "fixture",
+  status: "pass",
+  reason: "ok",
+  evidence: `deps=[${Object.keys(dependencies).join(", ")}] overrides=[${Object.keys(overrides).join(", ")}]`,
+})
+
+// ---------------------------------------------------------------------------
+// Step 3 — npm install the consumer, assert tarball resolution
+// ---------------------------------------------------------------------------
+
+// Force a clean resolution against the freshly rewritten manifest.
+rmSync(join(fixtureDir, "node_modules"), { recursive: true, force: true })
+rmSync(join(fixtureDir, "package-lock.json"), { force: true })
+
+const install = run("npm", ["install", "--no-audit", "--no-fund"], fixtureDir)
+if (install.status !== 0) {
+  record({
+    check: "install",
+    package: "fixture",
+    status: "fail",
+    reason: "npm install failed",
+    evidence: lastLine(install.stderr) || lastLine(install.stdout) || `exit ${install.status}`,
+  })
+} else {
+  record({
+    check: "install",
+    package: "fixture",
+    status: "pass",
+    reason: "ok",
+    evidence: lastLine(install.stdout),
+  })
+
+  const lockPath = join(fixtureDir, "package-lock.json")
+  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
+    packages?: Record<string, { resolved?: string }>
+  }
+  const lockPackages = lock.packages ?? {}
+  for (const name of ["sdk", "core"]) {
+    if (!tarballs.has(name)) continue
+    const entry = lockPackages[`node_modules/@alienplatform/${name}`]
+    const resolved = entry?.resolved ?? "<not installed>"
+    record({
+      check: "install-resolution",
+      package: name,
+      status: resolved.startsWith("file:") ? "pass" : "fail",
+      reason: resolved.startsWith("file:")
+        ? "ok"
+        : "transitive @alienplatform package did not resolve to the packed tarball",
+      evidence: `node_modules/@alienplatform/${name} -> ${resolved}`,
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Steps 4/5 — import check under Bun and Node
+// ---------------------------------------------------------------------------
+
+const IMPORTS_ENTRY = join("src", "imports.ts")
+
+function runImportCheck(runtime: "bun" | "node"): void {
+  const output =
+    runtime === "bun"
+      ? run("bun", [IMPORTS_ENTRY], fixtureDir)
+      : run("node", ["--experimental-strip-types", IMPORTS_ENTRY], fixtureDir)
+
+  const lines = output.stdout.split("\n").filter(line => line.startsWith("##CHECK## "))
+  if (lines.length === 0) {
+    record({
+      check: `${runtime}-imports`,
+      package: "fixture",
+      status: "fail",
+      reason: "import check produced no results (crashed before reporting)",
+      evidence: lastLine(output.stderr) || lastLine(output.stdout) || `exit ${output.status}`,
+    })
+    return
+  }
+
+  for (const line of lines) {
+    const parsed = JSON.parse(line.slice("##CHECK## ".length)) as CheckResult
+    record({
+      check: parsed.check,
+      package: parsed.package,
+      status: parsed.status,
+      reason: parsed.reason,
+      evidence: `[${runtime}] ${parsed.evidence}`,
+    })
+  }
+}
+
+if (bunAvailable) runImportCheck("bun")
+runImportCheck("node")
+
+// ---------------------------------------------------------------------------
+// Step 6 — tsc typecheck of the consumer
+// ---------------------------------------------------------------------------
+
+// Modules that are legitimately unresolvable today, with the task that lands them.
+const EXPECTED_MISSING_MODULES: Record<string, { package: string }> = {
+  "@alienplatform/bindings": { package: "bindings" },
+  "@alienplatform/bindings/native": { package: "bindings" },
+  "@alienplatform/commands": { package: "commands" },
+  "@alienplatform/sdk/worker-runtime": { package: "sdk" },
+}
+
+const tscBin = join(fixtureDir, "node_modules", "typescript", "bin", "tsc")
+if (!existsSync(tscBin)) {
+  record({
+    check: "typecheck",
+    package: "fixture",
+    status: "fail",
+    reason: "typescript is not installed in the consumer (install step failed?)",
+    evidence: tscBin,
+  })
+} else {
+  const tsc = run("node", [tscBin, "--noEmit", "-p", "tsconfig.json"], fixtureDir)
+  if (tsc.status === 0) {
+    record({
+      check: "typecheck",
+      package: "fixture",
+      status: "pass",
+      reason: "ok",
+      evidence: "tsc --noEmit reported no errors",
+    })
+  } else {
+    const errorLines = tsc.stdout.split("\n").filter(line => /error TS\d+/.test(line))
+    const seenMissing = new Set<string>()
+    for (const line of errorLines) {
+      const missing = line.match(/Cannot find module '([^']+)'/)
+      const moduleName = missing?.[1]
+      const known = moduleName ? EXPECTED_MISSING_MODULES[moduleName] : undefined
+      if (moduleName && known) {
+        if (seenMissing.has(moduleName)) continue
+        seenMissing.add(moduleName)
+        record({
+          check: "typecheck",
+          package: known.package,
+          status: "fail",
+          reason: `cannot find module '${moduleName}'`,
+          evidence: line.trim(),
+        })
+      } else {
+        record({
+          check: "typecheck",
+          package: "fixture",
+          status: "fail",
+          reason: "unexpected typecheck error",
+          evidence: line.trim(),
+        })
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 7 — packed-contents check
+// ---------------------------------------------------------------------------
+
+function tarEntries(tarball: string): string[] {
+  const listed = run("tar", ["-tzf", tarball], scriptDir)
+  return listed.stdout
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+}
+
+// Intended publish set for every publishable package: manifest, docs, license,
+// contract file, and built output. When a manifest carries a `files` allowlist,
+// that allowlist (plus the files npm always includes) is the source of truth.
+const DEFAULT_ALLOWED_PATTERNS: RegExp[] = [
+  /^package\.json$/,
+  /^README(\.|$)/i,
+  /^LICENSE(\.|$)/i,
+  /^PACKAGE_LAYOUT\.md$/,
+  /^dist\//,
+]
+
+// Files OUTSIDE the intended publish set that sdk/core ship TODAY, because no
+// publishable manifest carries a `files` allowlist yet. Listed explicitly — not
+// a silent allowance: anything not named here fails the run. Tightening the
+// manifests (adding `files` and dropping these entries) is owned by tasks 03/17.
+const EXTRA_SHIPPED_TODAY: Record<string, RegExp[]> = {
+  sdk: [/^AGENTS\.md$/, /^scripts\//, /^src\//, /^tsconfig\.json$/, /^tsdown\.config\.ts$/],
+  core: [
+    /^AGENTS\.md$/,
+    /^kubb\.config\.ts$/,
+    /^src\//,
+    /^tsconfig\.json$/,
+    /^tsdown\.config\.ts$/,
+  ],
+}
+
+/** Escapes a string for literal use inside a RegExp. */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/** The exact-contents allowlist for one packed package. */
+function allowedPatternsFor(name: string): RegExp[] {
+  const manifest = JSON.parse(readFileSync(join(packagesDir, name, "package.json"), "utf8")) as {
+    files?: string[]
+  }
+
+  if (manifest.files && manifest.files.length > 0) {
+    // npm always includes package.json, README, and LICENSE regardless of `files`.
+    const always = [/^package\.json$/, /^README(\.|$)/i, /^LICENSE(\.|$)/i]
+    const fromFiles = manifest.files.map(entry => {
+      const cleaned = entry.replace(/^\.\//, "").replace(/\/$/, "")
+      return new RegExp(`^${escapeRegExp(cleaned)}(/|$)`)
+    })
+    return [...always, ...fromFiles]
+  }
+
+  return [...DEFAULT_ALLOWED_PATTERNS, ...(EXTRA_SHIPPED_TODAY[name] ?? [])]
+}
+
+for (const name of ["sdk", "core"]) {
+  const tarball = tarballs.get(name)
+  if (!tarball) continue
+  const entries = tarEntries(tarball).map(entry => entry.replace(/^package\//, ""))
+
+  // Required artifacts must be present…
+  const hasManifest = entries.includes("package.json")
+  const hasDist = entries.some(entry => /^dist\/.+\.js$/.test(entry))
+  // Only the three contract packages ship a PACKAGE_LAYOUT.md; core does not.
+  const requiresContract = existsSync(join(packagesDir, name, "PACKAGE_LAYOUT.md"))
+  const hasContract = entries.includes("PACKAGE_LAYOUT.md")
+
+  // …and nothing outside the exact allowlist may ship.
+  const allowed = allowedPatternsFor(name)
+  const unexpected = entries.filter(entry => !allowed.some(pattern => pattern.test(entry)))
+
+  const problems: string[] = []
+  if (!hasManifest) problems.push("missing package.json")
+  if (!hasDist) problems.push("missing dist/*.js")
+  if (requiresContract && !hasContract) problems.push("missing PACKAGE_LAYOUT.md")
+  if (unexpected.length > 0) {
+    const shown = unexpected.slice(0, 5).join(", ")
+    problems.push(
+      `ships ${unexpected.length} file(s) outside the expected set: ${shown}${unexpected.length > 5 ? ", …" : ""}`,
+    )
+  }
+
+  record({
+    check: "packed-contents",
+    package: name,
+    status: problems.length === 0 ? "pass" : "fail",
+    reason: problems.length === 0 ? "ok" : problems.join("; "),
+    evidence:
+      problems.length === 0
+        ? `${entries.length} entries, all within the expected file set${requiresContract ? " (incl. PACKAGE_LAYOUT.md)" : ""}`
+        : `${entries.length} entries in ${relative(scriptDir, tarball)}`,
+  })
+}
+
+// Per-platform prebuild package (@alienplatform/bindings-<platform>): not built
+// until task 04a. Its packed shape (exactly one .node addon + manifest) cannot be
+// asserted yet.
+record({
+  check: "packed-contents",
+  package: "@alienplatform/bindings-darwin-arm64",
+  status: "fail",
+  reason: "per-platform prebuild package not present (expected one .node addon + manifest)",
+  evidence: "no @alienplatform/bindings-darwin-arm64 tarball to inspect",
+})
+
+// ---------------------------------------------------------------------------
+// Step 8 — bun build --compile of the ./native embed entry
+// ---------------------------------------------------------------------------
+
+if (bunAvailable) {
+  const compiledDir = join(fixtureDir, ".compiled")
+  mkdirSync(compiledDir, { recursive: true })
+  const outFile = join(compiledDir, "compile-entry-bin")
+  const built = run(
+    "bun",
+    ["build", "--compile", join("src", "compile-entry.ts"), "--outfile", outFile],
+    fixtureDir,
+  )
+  if (built.status !== 0) {
+    record({
+      check: "compile",
+      package: "bindings",
+      status: "fail",
+      reason: "bun build --compile of ./native entry fails (bindings package not installed)",
+      evidence: lastLine(built.stderr) || lastLine(built.stdout) || `exit ${built.status}`,
+    })
+  } else {
+    const ran = run(outFile, [], fixtureDir)
+    record({
+      check: "compile",
+      package: "bindings",
+      status: ran.status === 0 ? "pass" : "fail",
+      reason: ran.status === 0 ? "ok" : "compiled binary exited non-zero",
+      evidence: ran.status === 0 ? lastLine(ran.stdout) : lastLine(ran.stderr),
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 9 — invoke the static validator
+// ---------------------------------------------------------------------------
+
+const validator = run("node", ["--experimental-strip-types", validatorPath], scriptDir)
+record({
+  check: "validator",
+  package: "layout",
+  status: validator.status === 0 ? "pass" : "fail",
+  reason:
+    validator.status === 0
+      ? "ok"
+      : "packages/scripts validator reported unexpected failures or stale expectations",
+  evidence: lastLine(validator.stdout) || lastLine(validator.stderr) || `exit ${validator.status}`,
+})
+
+// ---------------------------------------------------------------------------
+// Reconcile against expected-failures.json and report
+// ---------------------------------------------------------------------------
+
+const expectedFailures = JSON.parse(
+  readFileSync(join(scriptDir, "expected-failures.json"), "utf8"),
+) as ExpectedFailureEntry[]
+
+// The `bun build --compile` failure is only produced when bun runs. If bun is
+// unavailable in this environment, drop that expectation so it is not counted
+// stale (CI always has bun, so the committed list stays complete there).
+const activeExpectations = bunAvailable
+  ? expectedFailures
+  : expectedFailures.filter(entry => !(entry.check === "compile" && entry.package === "bindings"))
+
+const violations: Violation[] = results
+  .filter(result => result.status === "fail")
+  .map(result => ({
+    check: result.check,
+    package: result.package,
+    reason: result.reason,
+    evidence: result.evidence,
+  }))
+
+const filtered = applyExpectedFailures(violations, activeExpectations)
+
+function expectationKey(entry: { check: string; package: string; reason: string }): string {
+  return `${entry.check}::${entry.package}::${entry.reason}`
+}
+const expectedKeys = new Map(activeExpectations.map(entry => [expectationKey(entry), entry]))
+
+console.log("")
+console.log("package-layout fixture — step results")
+console.log("=====================================")
+
+let passCount = 0
+let expectedCount = 0
+let fatalCount = 0
+for (const result of results) {
+  if (result.status === "pass") {
+    passCount += 1
+    console.log(`  PASS       ${result.check} package=${result.package} — ${result.evidence}`)
+    continue
+  }
+  const entry = expectedKeys.get(expectationKey(result))
+  if (entry) {
+    expectedCount += 1
+    console.log(
+      `  [expected] ${result.check} package=${result.package} (task ${entry.owningTask}): ${result.reason}`,
+    )
+    console.log(`             evidence: ${result.evidence}`)
+  } else {
+    fatalCount += 1
+    console.error(`  FAIL       ${result.check} package=${result.package}: ${result.reason}`)
+    console.error(`             evidence: ${result.evidence}`)
+  }
+}
+
+for (const staleEntry of filtered.stale) {
+  console.error(
+    `  STALE      ${staleEntry.check} package=${staleEntry.package}: "${staleEntry.reason}" ` +
+      `(task ${staleEntry.owningTask}) is listed in expected-failures.json but never occurred — remove it or fix the check.`,
+  )
+}
+
+console.log("")
+const exitCode = exitCodeFor(filtered)
+if (exitCode === 0) {
+  console.log(
+    `OK: ${passCount} passed, ${expectedCount} expected failure(s), 0 unexpected, 0 stale.`,
+  )
+} else {
+  console.log(
+    `FAILED: ${passCount} passed, ${fatalCount} unexpected failure(s), ${filtered.stale.length} stale expectation(s).`,
+  )
+}
+
+process.exit(exitCode)

--- a/packages/package-layout/run.ts
+++ b/packages/package-layout/run.ts
@@ -21,7 +21,14 @@
  * Every step is individually reported (name, PASS/[expected]/FAIL, evidence).
  * Failing checks are reconciled against expected-failures.json exactly like the
  * validator does — the run exits 0 only when there are zero unexpected failures
- * and zero stale expectations (reused applyExpectedFailures + exitCodeFor).
+ * and zero stale expectations (reused applyExpectedFailures + exitCodeFor), and
+ * zero cross-runtime divergences (see `detectRuntimeDivergence` below).
+ *
+ * Only pure, side-effect-free declarations run at module load (types, helper
+ * functions, `detectRuntimeDivergence`). Everything that touches the filesystem
+ * or spawns a process lives in `main()`, invoked only when this file is the
+ * program entry point — so importing this module (e.g. from a unit test) never
+ * triggers pack/install/import/compile or calls `process.exit`.
  */
 
 import { spawnSync } from "node:child_process"
@@ -35,12 +42,6 @@ import {
   exitCodeFor,
 } from "../scripts/validate-package-layout.ts"
 
-const scriptDir = dirname(fileURLToPath(import.meta.url))
-const packagesDir = join(scriptDir, "..")
-const tarballsDir = join(scriptDir, ".tarballs")
-const fixtureDir = join(scriptDir, "fixture")
-const validatorPath = join(packagesDir, "scripts", "validate-package-layout.ts")
-
 /** One reported check. Failing ones are reconciled against expected-failures.json. */
 interface CheckResult {
   check: string
@@ -48,11 +49,60 @@ interface CheckResult {
   status: "pass" | "fail"
   reason: string
   evidence: string
+  /**
+   * Set only for checks run once per JS runtime (the `import`/`error-code`
+   * family from src/imports.ts, executed under both Bun and Node). Used by
+   * `detectRuntimeDivergence` to compare the same assertion across runtimes;
+   * absent for checks that run exactly once regardless of runtime (pack,
+   * install, typecheck, packed-contents, compile, validator).
+   */
+  runtime?: "bun" | "node"
 }
 
-const results: CheckResult[] = []
-function record(result: CheckResult): void {
-  results.push(result)
+/**
+ * Flags a check+package pair that passes on one JS runtime and fails on the
+ * other. This is the one case `applyExpectedFailures` cannot see on its own:
+ * that function's key is `check::package::reason`, and a runtime is only
+ * recorded in `evidence` — so if Bun and Node happen to report the same
+ * check/package/reason (e.g. because a still-registered expected-failure
+ * entry describes "not implemented yet" text that both runtimes emit while
+ * the underlying package doesn't exist), a fix landing on only one runtime
+ * would still fully satisfy that shared expectation and the run would exit 0.
+ * Divergence violations always use the `runtime-divergence` check name, which
+ * never appears in expected-failures.json, so `applyExpectedFailures` can
+ * never classify one as expected — it is unconditionally fatal.
+ *
+ * Pure function (no I/O) so it can be unit-tested directly against crafted
+ * result lists instead of only through the full pack/install/import pipeline.
+ */
+export function detectRuntimeDivergence(results: readonly CheckResult[]): Violation[] {
+  const byKey = new Map<string, Map<"bun" | "node", CheckResult>>()
+
+  for (const result of results) {
+    if (!result.runtime) continue
+    const key = `${result.check}::${result.package}`
+    const byRuntime = byKey.get(key) ?? new Map<"bun" | "node", CheckResult>()
+    byRuntime.set(result.runtime, result)
+    byKey.set(key, byRuntime)
+  }
+
+  const violations: Violation[] = []
+  for (const byRuntime of byKey.values()) {
+    const bun = byRuntime.get("bun")
+    const node = byRuntime.get("node")
+    if (!bun || !node || bun.status === node.status) continue
+
+    const passing = bun.status === "pass" ? bun : node
+    const failing = bun.status === "pass" ? node : bun
+    violations.push({
+      check: "runtime-divergence",
+      package: passing.package,
+      reason: `${passing.check} passes on ${passing.runtime} but fails on ${failing.runtime}`,
+      evidence: `${passing.runtime}: ${passing.evidence} | ${failing.runtime}: ${failing.evidence}`,
+    })
+  }
+
+  return violations
 }
 
 interface RunOutput {
@@ -77,524 +127,571 @@ function lastLine(text: string): string {
   return lines.at(-1) ?? ""
 }
 
-// ---------------------------------------------------------------------------
-// Environment
-// ---------------------------------------------------------------------------
-
-const bunAvailable = run("bun", ["--version"], scriptDir).status === 0
-if (!bunAvailable) {
-  console.log(
-    "[env-skip] bun is not on PATH — the Bun import and `bun build --compile` steps are " +
-      "skipped in this environment. CI provides bun via setup-bun.",
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Step 1 — pack the publishable packages
-// ---------------------------------------------------------------------------
-
-rmSync(tarballsDir, { recursive: true, force: true })
-mkdirSync(tarballsDir, { recursive: true })
-
-/** name -> absolute tarball path, for packages that packed successfully. */
-const tarballs = new Map<string, string>()
-
-const PACK_TARGETS: { name: string; owningReason: string }[] = [
-  { name: "sdk", owningReason: "" },
-  { name: "core", owningReason: "" },
-  { name: "bindings", owningReason: "publishable package not present (nothing to pack)" },
-  { name: "commands", owningReason: "publishable package not present (nothing to pack)" },
-]
-
-function findTarball(name: string): string | undefined {
-  const prefix = `alienplatform-${name}-`
-  const file = readdirSync(tarballsDir).find(
-    entry => entry.startsWith(prefix) && entry.endsWith(".tgz"),
-  )
-  return file ? join(tarballsDir, file) : undefined
-}
-
-for (const target of PACK_TARGETS) {
-  const pkgDir = join(packagesDir, target.name)
-  if (!existsSync(join(pkgDir, "package.json"))) {
-    record({
-      check: "pack",
-      package: target.name,
-      status: "fail",
-      reason: target.owningReason || "publishable package not present (nothing to pack)",
-      evidence: pkgDir,
-    })
-    continue
-  }
-
-  const packed = run("pnpm", ["pack", "--pack-destination", tarballsDir], pkgDir)
-  const tarball = findTarball(target.name)
-  if (packed.status !== 0 || !tarball) {
-    record({
-      check: "pack",
-      package: target.name,
-      status: "fail",
-      reason: "pnpm pack failed",
-      evidence: lastLine(packed.stderr) || lastLine(packed.stdout) || `exit ${packed.status}`,
-    })
-    continue
-  }
-  tarballs.set(target.name, tarball)
-  record({
-    check: "pack",
-    package: target.name,
-    status: "pass",
-    reason: "ok",
-    evidence: relative(scriptDir, tarball),
-  })
-}
-
-// ---------------------------------------------------------------------------
-// Step 2 — rewrite the consumer manifest to file: the tarballs
-// ---------------------------------------------------------------------------
-
-// Direct dependencies the consumer imports; overrides pin every transitive
-// @alienplatform/* to a packed tarball so npm never reaches the registry for one.
-const DIRECT_DEP_PACKAGES = ["sdk", "bindings", "commands"] as const
-const OVERRIDE_PACKAGES = ["core", "sdk", "bindings", "commands"] as const
-
-function fileSpec(tarball: string): string {
-  return `file:${relative(fixtureDir, tarball).split("\\").join("/")}`
-}
-
-const fixtureManifestPath = join(fixtureDir, "package.json")
-const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, "utf8")) as Record<
-  string,
-  unknown
->
-
-const dependencies: Record<string, string> = {}
-for (const name of DIRECT_DEP_PACKAGES) {
-  const tarball = tarballs.get(name)
-  if (tarball) dependencies[`@alienplatform/${name}`] = fileSpec(tarball)
-}
-const overrides: Record<string, string> = {}
-for (const name of OVERRIDE_PACKAGES) {
-  const tarball = tarballs.get(name)
-  if (tarball) overrides[`@alienplatform/${name}`] = fileSpec(tarball)
-}
-
-fixtureManifest.dependencies = dependencies
-fixtureManifest.overrides = overrides
-writeFileSync(fixtureManifestPath, `${JSON.stringify(fixtureManifest, null, 2)}\n`)
-record({
-  check: "write-manifest",
-  package: "fixture",
-  status: "pass",
-  reason: "ok",
-  evidence: `deps=[${Object.keys(dependencies).join(", ")}] overrides=[${Object.keys(overrides).join(", ")}]`,
-})
-
-// ---------------------------------------------------------------------------
-// Step 3 — npm install the consumer, assert tarball resolution
-// ---------------------------------------------------------------------------
-
-// Force a clean resolution against the freshly rewritten manifest.
-rmSync(join(fixtureDir, "node_modules"), { recursive: true, force: true })
-rmSync(join(fixtureDir, "package-lock.json"), { force: true })
-
-const install = run("npm", ["install", "--no-audit", "--no-fund"], fixtureDir)
-if (install.status !== 0) {
-  record({
-    check: "install",
-    package: "fixture",
-    status: "fail",
-    reason: "npm install failed",
-    evidence: lastLine(install.stderr) || lastLine(install.stdout) || `exit ${install.status}`,
-  })
-} else {
-  record({
-    check: "install",
-    package: "fixture",
-    status: "pass",
-    reason: "ok",
-    evidence: lastLine(install.stdout),
-  })
-
-  const lockPath = join(fixtureDir, "package-lock.json")
-  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
-    packages?: Record<string, { resolved?: string }>
-  }
-  const lockPackages = lock.packages ?? {}
-  for (const name of ["sdk", "core"]) {
-    if (!tarballs.has(name)) continue
-    const entry = lockPackages[`node_modules/@alienplatform/${name}`]
-    const resolved = entry?.resolved ?? "<not installed>"
-    record({
-      check: "install-resolution",
-      package: name,
-      status: resolved.startsWith("file:") ? "pass" : "fail",
-      reason: resolved.startsWith("file:")
-        ? "ok"
-        : "transitive @alienplatform package did not resolve to the packed tarball",
-      evidence: `node_modules/@alienplatform/${name} -> ${resolved}`,
-    })
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Steps 4/5 — import check under Bun and Node
-// ---------------------------------------------------------------------------
-
-const IMPORTS_ENTRY = join("src", "imports.ts")
-
-function runImportCheck(runtime: "bun" | "node"): void {
-  const output =
-    runtime === "bun"
-      ? run("bun", [IMPORTS_ENTRY], fixtureDir)
-      : run("node", ["--experimental-strip-types", IMPORTS_ENTRY], fixtureDir)
-
-  const lines = output.stdout.split("\n").filter(line => line.startsWith("##CHECK## "))
-  if (lines.length === 0) {
-    record({
-      check: `${runtime}-imports`,
-      package: "fixture",
-      status: "fail",
-      reason: "import check produced no results (crashed before reporting)",
-      evidence: lastLine(output.stderr) || lastLine(output.stdout) || `exit ${output.status}`,
-    })
-    return
-  }
-
-  for (const line of lines) {
-    const parsed = JSON.parse(line.slice("##CHECK## ".length)) as CheckResult
-    record({
-      check: parsed.check,
-      package: parsed.package,
-      status: parsed.status,
-      reason: parsed.reason,
-      evidence: `[${runtime}] ${parsed.evidence}`,
-    })
-  }
-}
-
-if (bunAvailable) runImportCheck("bun")
-runImportCheck("node")
-
-// ---------------------------------------------------------------------------
-// Step 6 — tsc typecheck of the consumer
-// ---------------------------------------------------------------------------
-
-// Modules that are legitimately unresolvable today, with the task that lands them.
-const EXPECTED_MISSING_MODULES: Record<string, { package: string }> = {
-  "@alienplatform/bindings": { package: "bindings" },
-  "@alienplatform/bindings/native": { package: "bindings" },
-  "@alienplatform/commands": { package: "commands" },
-  "@alienplatform/sdk/worker-runtime": { package: "sdk" },
-}
-
-const tscBin = join(fixtureDir, "node_modules", "typescript", "bin", "tsc")
-if (!existsSync(tscBin)) {
-  record({
-    check: "typecheck",
-    package: "fixture",
-    status: "fail",
-    reason: "typescript is not installed in the consumer (install step failed?)",
-    evidence: tscBin,
-  })
-} else {
-  const tsc = run("node", [tscBin, "--noEmit", "-p", "tsconfig.json"], fixtureDir)
-  if (tsc.status === 0) {
-    record({
-      check: "typecheck",
-      package: "fixture",
-      status: "pass",
-      reason: "ok",
-      evidence: "tsc --noEmit reported no errors",
-    })
-  } else {
-    const errorLines = tsc.stdout.split("\n").filter(line => /error TS\d+/.test(line))
-    const seenMissing = new Set<string>()
-    for (const line of errorLines) {
-      const missing = line.match(/Cannot find module '([^']+)'/)
-      const moduleName = missing?.[1]
-      const known = moduleName ? EXPECTED_MISSING_MODULES[moduleName] : undefined
-      if (moduleName && known) {
-        if (seenMissing.has(moduleName)) continue
-        seenMissing.add(moduleName)
-        record({
-          check: "typecheck",
-          package: known.package,
-          status: "fail",
-          reason: `cannot find module '${moduleName}'`,
-          evidence: line.trim(),
-        })
-      } else {
-        record({
-          check: "typecheck",
-          package: "fixture",
-          status: "fail",
-          reason: "unexpected typecheck error",
-          evidence: line.trim(),
-        })
-      }
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Step 7 — packed-contents check
-// ---------------------------------------------------------------------------
-
-function tarEntries(tarball: string): string[] {
-  const listed = run("tar", ["-tzf", tarball], scriptDir)
-  return listed.stdout
-    .split("\n")
-    .map(line => line.trim())
-    .filter(line => line.length > 0)
-}
-
-// Hard denylist: never allowed in a packed tarball, regardless of `files` or
-// EXTRA_SHIPPED_TODAY. Catches regressions even if an .npmignore is deleted.
-const HARD_DENYLIST_PATTERNS: RegExp[] = [
-  /(^|\/)node_modules\//,
-  /(^|\/)\.env$/,
-  /\.tgz$/,
-  /(^|\/)\.turbo\//,
-]
-
-// Intended publish set for every publishable package: manifest, docs, license,
-// contract file, and built output. When a manifest carries a `files` allowlist,
-// that allowlist (plus the files npm always includes) is the source of truth.
-const DEFAULT_ALLOWED_PATTERNS: RegExp[] = [
-  /^package\.json$/,
-  /^README(\.|$)/i,
-  /^LICENSE(\.|$)/i,
-  /^PACKAGE_LAYOUT\.md$/,
-  /^dist\//,
-]
-
-// Files OUTSIDE the intended publish set that sdk/core ship TODAY, because no
-// publishable manifest carries a `files` allowlist yet. Listed explicitly — not
-// a silent allowance: anything not named here fails the run. Tightening the
-// manifests (adding `files` and dropping these entries) is owned by tasks 03/17.
-const EXTRA_SHIPPED_TODAY: Record<string, RegExp[]> = {
-  sdk: [/^AGENTS\.md$/, /^scripts\//, /^src\//, /^tsconfig\.json$/, /^tsdown\.config\.ts$/],
-  core: [
-    /^AGENTS\.md$/,
-    /^kubb\.config\.ts$/,
-    /^src\//,
-    /^tsconfig\.json$/,
-    /^tsdown\.config\.ts$/,
-  ],
-}
-
 /** Escapes a string for literal use inside a RegExp. */
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
-/** The exact-contents allowlist for one packed package. */
-function allowedPatternsFor(name: string): RegExp[] {
-  const manifest = JSON.parse(readFileSync(join(packagesDir, name, "package.json"), "utf8")) as {
-    files?: string[]
-  }
-
-  if (manifest.files && manifest.files.length > 0) {
-    // npm always includes package.json, README, and LICENSE regardless of `files`.
-    const always = [/^package\.json$/, /^README(\.|$)/i, /^LICENSE(\.|$)/i]
-    const fromFiles = manifest.files.map(entry => {
-      const cleaned = entry.replace(/^\.\//, "").replace(/\/$/, "")
-      return new RegExp(`^${escapeRegExp(cleaned)}(/|$)`)
-    })
-    return [...always, ...fromFiles]
-  }
-
-  return [...DEFAULT_ALLOWED_PATTERNS, ...(EXTRA_SHIPPED_TODAY[name] ?? [])]
+function isMainModule(): boolean {
+  return typeof process.argv[1] === "string" && import.meta.url === `file://${process.argv[1]}`
 }
 
-for (const name of ["sdk", "core"]) {
-  const tarball = tarballs.get(name)
-  if (!tarball) continue
-  const entries = tarEntries(tarball).map(entry => entry.replace(/^package\//, ""))
+// ---------------------------------------------------------------------------
+// Everything below is imperative: filesystem I/O, subprocess spawning, and
+// process.exit. Gated behind main() so importing this module is side-effect
+// free (see the file-level doc comment above).
+// ---------------------------------------------------------------------------
 
-  // Required artifacts must be present…
-  const hasManifest = entries.includes("package.json")
-  const hasDist = entries.some(entry => /^dist\/.+\.js$/.test(entry))
-  // Only the three contract packages ship a PACKAGE_LAYOUT.md; core does not.
-  const requiresContract = existsSync(join(packagesDir, name, "PACKAGE_LAYOUT.md"))
-  const hasContract = entries.includes("PACKAGE_LAYOUT.md")
+function main(): void {
+  const scriptDir = dirname(fileURLToPath(import.meta.url))
+  const packagesDir = join(scriptDir, "..")
+  const tarballsDir = join(scriptDir, ".tarballs")
+  const fixtureDir = join(scriptDir, "fixture")
+  const validatorPath = join(packagesDir, "scripts", "validate-package-layout.ts")
 
-  // …and nothing outside the exact allowlist may ship. Hard-denylisted entries
-  // are reported separately (and always), so exclude them from `unexpected` to
-  // avoid reporting the same file twice.
-  const denylisted = entries.filter(entry =>
-    HARD_DENYLIST_PATTERNS.some(pattern => pattern.test(entry)),
-  )
-  const allowed = allowedPatternsFor(name)
-  const unexpected = entries.filter(
-    entry => !denylisted.includes(entry) && !allowed.some(pattern => pattern.test(entry)),
-  )
-
-  const problems: string[] = []
-  if (!hasManifest) problems.push("missing package.json")
-  if (!hasDist) problems.push("missing dist/*.js")
-  if (requiresContract && !hasContract) problems.push("missing PACKAGE_LAYOUT.md")
-  if (denylisted.length > 0) {
-    const shown = denylisted.slice(0, 5).join(", ")
-    problems.push(
-      `ships ${denylisted.length} hard-denylisted file(s): ${shown}${denylisted.length > 5 ? ", …" : ""}`,
-    )
+  const results: CheckResult[] = []
+  function record(result: CheckResult): void {
+    results.push(result)
   }
-  if (unexpected.length > 0) {
-    const shown = unexpected.slice(0, 5).join(", ")
-    problems.push(
-      `ships ${unexpected.length} file(s) outside the expected set: ${shown}${unexpected.length > 5 ? ", …" : ""}`,
+
+  // -------------------------------------------------------------------------
+  // Environment
+  // -------------------------------------------------------------------------
+
+  const bunAvailable = run("bun", ["--version"], scriptDir).status === 0
+  if (!bunAvailable) {
+    console.log(
+      "[env-skip] bun is not on PATH — the Bun import and `bun build --compile` steps are " +
+        "skipped in this environment. CI provides bun via setup-bun.",
     )
   }
 
+  // -------------------------------------------------------------------------
+  // Step 1 — pack the publishable packages
+  // -------------------------------------------------------------------------
+
+  rmSync(tarballsDir, { recursive: true, force: true })
+  mkdirSync(tarballsDir, { recursive: true })
+
+  /** name -> absolute tarball path, for packages that packed successfully. */
+  const tarballs = new Map<string, string>()
+
+  const PACK_TARGETS: { name: string; owningReason: string }[] = [
+    { name: "sdk", owningReason: "" },
+    { name: "core", owningReason: "" },
+    { name: "bindings", owningReason: "publishable package not present (nothing to pack)" },
+    { name: "commands", owningReason: "publishable package not present (nothing to pack)" },
+  ]
+
+  function findTarball(name: string): string | undefined {
+    const prefix = `alienplatform-${name}-`
+    const file = readdirSync(tarballsDir).find(
+      entry => entry.startsWith(prefix) && entry.endsWith(".tgz"),
+    )
+    return file ? join(tarballsDir, file) : undefined
+  }
+
+  for (const target of PACK_TARGETS) {
+    const pkgDir = join(packagesDir, target.name)
+    if (!existsSync(join(pkgDir, "package.json"))) {
+      record({
+        check: "pack",
+        package: target.name,
+        status: "fail",
+        reason: target.owningReason || "publishable package not present (nothing to pack)",
+        evidence: pkgDir,
+      })
+      continue
+    }
+
+    const packed = run("pnpm", ["pack", "--pack-destination", tarballsDir], pkgDir)
+    const tarball = findTarball(target.name)
+    if (packed.status !== 0 || !tarball) {
+      record({
+        check: "pack",
+        package: target.name,
+        status: "fail",
+        reason: "pnpm pack failed",
+        evidence: lastLine(packed.stderr) || lastLine(packed.stdout) || `exit ${packed.status}`,
+      })
+      continue
+    }
+    tarballs.set(target.name, tarball)
+    record({
+      check: "pack",
+      package: target.name,
+      status: "pass",
+      reason: "ok",
+      evidence: relative(scriptDir, tarball),
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2 — rewrite the consumer manifest to file: the tarballs
+  // -------------------------------------------------------------------------
+
+  // Direct dependencies the consumer imports; overrides pin every transitive
+  // @alienplatform/* to a packed tarball so npm never reaches the registry for one.
+  const DIRECT_DEP_PACKAGES = ["sdk", "bindings", "commands"] as const
+  const OVERRIDE_PACKAGES = ["core", "sdk", "bindings", "commands"] as const
+
+  function fileSpec(tarball: string): string {
+    return `file:${relative(fixtureDir, tarball).split("\\").join("/")}`
+  }
+
+  const fixtureManifestPath = join(fixtureDir, "package.json")
+  const fixtureManifest = JSON.parse(readFileSync(fixtureManifestPath, "utf8")) as Record<
+    string,
+    unknown
+  >
+
+  const dependencies: Record<string, string> = {}
+  for (const name of DIRECT_DEP_PACKAGES) {
+    const tarball = tarballs.get(name)
+    if (tarball) dependencies[`@alienplatform/${name}`] = fileSpec(tarball)
+  }
+  const overrides: Record<string, string> = {}
+  for (const name of OVERRIDE_PACKAGES) {
+    const tarball = tarballs.get(name)
+    if (tarball) overrides[`@alienplatform/${name}`] = fileSpec(tarball)
+  }
+
+  fixtureManifest.dependencies = dependencies
+  fixtureManifest.overrides = overrides
+  writeFileSync(fixtureManifestPath, `${JSON.stringify(fixtureManifest, null, 2)}\n`)
+  record({
+    check: "write-manifest",
+    package: "fixture",
+    status: "pass",
+    reason: "ok",
+    evidence: `deps=[${Object.keys(dependencies).join(", ")}] overrides=[${Object.keys(overrides).join(", ")}]`,
+  })
+
+  // -------------------------------------------------------------------------
+  // Step 3 — npm install the consumer, assert tarball resolution
+  // -------------------------------------------------------------------------
+
+  // Force a clean resolution against the freshly rewritten manifest.
+  rmSync(join(fixtureDir, "node_modules"), { recursive: true, force: true })
+  rmSync(join(fixtureDir, "package-lock.json"), { force: true })
+
+  const install = run("npm", ["install", "--no-audit", "--no-fund"], fixtureDir)
+  if (install.status !== 0) {
+    record({
+      check: "install",
+      package: "fixture",
+      status: "fail",
+      reason: "npm install failed",
+      evidence: lastLine(install.stderr) || lastLine(install.stdout) || `exit ${install.status}`,
+    })
+  } else {
+    record({
+      check: "install",
+      package: "fixture",
+      status: "pass",
+      reason: "ok",
+      evidence: lastLine(install.stdout),
+    })
+
+    const lockPath = join(fixtureDir, "package-lock.json")
+    const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
+      packages?: Record<string, { resolved?: string }>
+    }
+    const lockPackages = lock.packages ?? {}
+    for (const name of ["sdk", "core"]) {
+      if (!tarballs.has(name)) continue
+      const entry = lockPackages[`node_modules/@alienplatform/${name}`]
+      const resolved = entry?.resolved ?? "<not installed>"
+      record({
+        check: "install-resolution",
+        package: name,
+        status: resolved.startsWith("file:") ? "pass" : "fail",
+        reason: resolved.startsWith("file:")
+          ? "ok"
+          : "transitive @alienplatform package did not resolve to the packed tarball",
+        evidence: `node_modules/@alienplatform/${name} -> ${resolved}`,
+      })
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Steps 4/5 — import check under Bun and Node
+  // -------------------------------------------------------------------------
+
+  const IMPORTS_ENTRY = join("src", "imports.ts")
+
+  function runImportCheck(runtime: "bun" | "node"): void {
+    const output =
+      runtime === "bun"
+        ? run("bun", [IMPORTS_ENTRY], fixtureDir)
+        : run("node", ["--experimental-strip-types", IMPORTS_ENTRY], fixtureDir)
+
+    const lines = output.stdout.split("\n").filter(line => line.startsWith("##CHECK## "))
+    if (lines.length === 0) {
+      record({
+        check: `${runtime}-imports`,
+        package: "fixture",
+        status: "fail",
+        reason: "import check produced no results (crashed before reporting)",
+        evidence: lastLine(output.stderr) || lastLine(output.stdout) || `exit ${output.status}`,
+        runtime,
+      })
+      return
+    }
+
+    for (const line of lines) {
+      const parsed = JSON.parse(line.slice("##CHECK## ".length)) as CheckResult
+      record({
+        check: parsed.check,
+        package: parsed.package,
+        status: parsed.status,
+        reason: parsed.reason,
+        evidence: `[${runtime}] ${parsed.evidence}`,
+        runtime,
+      })
+    }
+  }
+
+  if (bunAvailable) runImportCheck("bun")
+  runImportCheck("node")
+
+  // -------------------------------------------------------------------------
+  // Step 6 — tsc typecheck of the consumer
+  // -------------------------------------------------------------------------
+
+  // Modules that are legitimately unresolvable today, with the task that lands them.
+  const EXPECTED_MISSING_MODULES: Record<string, { package: string }> = {
+    "@alienplatform/bindings": { package: "bindings" },
+    "@alienplatform/bindings/native": { package: "bindings" },
+    "@alienplatform/commands": { package: "commands" },
+    "@alienplatform/sdk/worker-runtime": { package: "sdk" },
+  }
+
+  const tscBin = join(fixtureDir, "node_modules", "typescript", "bin", "tsc")
+  if (!existsSync(tscBin)) {
+    record({
+      check: "typecheck",
+      package: "fixture",
+      status: "fail",
+      reason: "typescript is not installed in the consumer (install step failed?)",
+      evidence: tscBin,
+    })
+  } else {
+    const tsc = run("node", [tscBin, "--noEmit", "-p", "tsconfig.json"], fixtureDir)
+    if (tsc.status === 0) {
+      record({
+        check: "typecheck",
+        package: "fixture",
+        status: "pass",
+        reason: "ok",
+        evidence: "tsc --noEmit reported no errors",
+      })
+    } else {
+      const errorLines = tsc.stdout.split("\n").filter(line => /error TS\d+/.test(line))
+      const seenMissing = new Set<string>()
+      for (const line of errorLines) {
+        const missing = line.match(/Cannot find module '([^']+)'/)
+        const moduleName = missing?.[1]
+        const known = moduleName ? EXPECTED_MISSING_MODULES[moduleName] : undefined
+        if (moduleName && known) {
+          if (seenMissing.has(moduleName)) continue
+          seenMissing.add(moduleName)
+          record({
+            check: "typecheck",
+            package: known.package,
+            status: "fail",
+            reason: `cannot find module '${moduleName}'`,
+            evidence: line.trim(),
+          })
+        } else {
+          record({
+            check: "typecheck",
+            package: "fixture",
+            status: "fail",
+            reason: "unexpected typecheck error",
+            evidence: line.trim(),
+          })
+        }
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 7 — packed-contents check
+  // -------------------------------------------------------------------------
+
+  function tarEntries(tarball: string): string[] {
+    const listed = run("tar", ["-tzf", tarball], scriptDir)
+    return listed.stdout
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.length > 0)
+  }
+
+  // Hard denylist: never allowed in a packed tarball, regardless of `files` or
+  // EXTRA_SHIPPED_TODAY. Catches regressions even if an .npmignore is deleted.
+  const HARD_DENYLIST_PATTERNS: RegExp[] = [
+    /(^|\/)node_modules\//,
+    /(^|\/)\.env$/,
+    /\.tgz$/,
+    /(^|\/)\.turbo\//,
+  ]
+
+  // Intended publish set for every publishable package: manifest, docs, license,
+  // contract file, and built output. When a manifest carries a `files` allowlist,
+  // that allowlist (plus the files npm always includes) is the source of truth.
+  const DEFAULT_ALLOWED_PATTERNS: RegExp[] = [
+    /^package\.json$/,
+    /^README(\.|$)/i,
+    /^LICENSE(\.|$)/i,
+    /^PACKAGE_LAYOUT\.md$/,
+    /^dist\//,
+  ]
+
+  // Files OUTSIDE the intended publish set that sdk/core ship TODAY, because no
+  // publishable manifest carries a `files` allowlist yet. Listed explicitly — not
+  // a silent allowance: anything not named here fails the run. Tightening the
+  // manifests (adding `files` and dropping these entries) is owned by tasks 03/17.
+  const EXTRA_SHIPPED_TODAY: Record<string, RegExp[]> = {
+    sdk: [/^AGENTS\.md$/, /^scripts\//, /^src\//, /^tsconfig\.json$/, /^tsdown\.config\.ts$/],
+    core: [
+      /^AGENTS\.md$/,
+      /^kubb\.config\.ts$/,
+      /^src\//,
+      /^tsconfig\.json$/,
+      /^tsdown\.config\.ts$/,
+    ],
+  }
+
+  /** The exact-contents allowlist for one packed package. */
+  function allowedPatternsFor(name: string): RegExp[] {
+    const manifest = JSON.parse(readFileSync(join(packagesDir, name, "package.json"), "utf8")) as {
+      files?: string[]
+    }
+
+    if (manifest.files && manifest.files.length > 0) {
+      // npm always includes package.json, README, and LICENSE regardless of `files`.
+      const always = [/^package\.json$/, /^README(\.|$)/i, /^LICENSE(\.|$)/i]
+      const fromFiles = manifest.files.map(entry => {
+        const cleaned = entry.replace(/^\.\//, "").replace(/\/$/, "")
+        return new RegExp(`^${escapeRegExp(cleaned)}(/|$)`)
+      })
+      return [...always, ...fromFiles]
+    }
+
+    return [...DEFAULT_ALLOWED_PATTERNS, ...(EXTRA_SHIPPED_TODAY[name] ?? [])]
+  }
+
+  for (const name of ["sdk", "core"]) {
+    const tarball = tarballs.get(name)
+    if (!tarball) continue
+    const entries = tarEntries(tarball).map(entry => entry.replace(/^package\//, ""))
+
+    // Required artifacts must be present…
+    const hasManifest = entries.includes("package.json")
+    const hasDist = entries.some(entry => /^dist\/.+\.js$/.test(entry))
+    // Only the three contract packages ship a PACKAGE_LAYOUT.md; core does not.
+    const requiresContract = existsSync(join(packagesDir, name, "PACKAGE_LAYOUT.md"))
+    const hasContract = entries.includes("PACKAGE_LAYOUT.md")
+
+    // …and nothing outside the exact allowlist may ship. Hard-denylisted entries
+    // are reported separately (and always), so exclude them from `unexpected` to
+    // avoid reporting the same file twice.
+    const denylisted = entries.filter(entry =>
+      HARD_DENYLIST_PATTERNS.some(pattern => pattern.test(entry)),
+    )
+    const allowed = allowedPatternsFor(name)
+    const unexpected = entries.filter(
+      entry => !denylisted.includes(entry) && !allowed.some(pattern => pattern.test(entry)),
+    )
+
+    const problems: string[] = []
+    if (!hasManifest) problems.push("missing package.json")
+    if (!hasDist) problems.push("missing dist/*.js")
+    if (requiresContract && !hasContract) problems.push("missing PACKAGE_LAYOUT.md")
+    if (denylisted.length > 0) {
+      const shown = denylisted.slice(0, 5).join(", ")
+      problems.push(
+        `ships ${denylisted.length} hard-denylisted file(s): ${shown}${denylisted.length > 5 ? ", …" : ""}`,
+      )
+    }
+    if (unexpected.length > 0) {
+      const shown = unexpected.slice(0, 5).join(", ")
+      problems.push(
+        `ships ${unexpected.length} file(s) outside the expected set: ${shown}${unexpected.length > 5 ? ", …" : ""}`,
+      )
+    }
+
+    record({
+      check: "packed-contents",
+      package: name,
+      status: problems.length === 0 ? "pass" : "fail",
+      reason: problems.length === 0 ? "ok" : problems.join("; "),
+      evidence:
+        problems.length === 0
+          ? `${entries.length} entries, all within the expected file set${requiresContract ? " (incl. PACKAGE_LAYOUT.md)" : ""}`
+          : `${entries.length} entries in ${relative(scriptDir, tarball)}`,
+    })
+  }
+
+  // Per-platform prebuild package (@alienplatform/bindings-<platform>): not built
+  // until task 04a. Its packed shape (exactly one .node addon + manifest) cannot be
+  // asserted yet.
   record({
     check: "packed-contents",
-    package: name,
-    status: problems.length === 0 ? "pass" : "fail",
-    reason: problems.length === 0 ? "ok" : problems.join("; "),
-    evidence:
-      problems.length === 0
-        ? `${entries.length} entries, all within the expected file set${requiresContract ? " (incl. PACKAGE_LAYOUT.md)" : ""}`
-        : `${entries.length} entries in ${relative(scriptDir, tarball)}`,
+    package: "@alienplatform/bindings-darwin-arm64",
+    status: "fail",
+    reason: "per-platform prebuild package not present (expected one .node addon + manifest)",
+    evidence: "no @alienplatform/bindings-darwin-arm64 tarball to inspect",
   })
-}
 
-// Per-platform prebuild package (@alienplatform/bindings-<platform>): not built
-// until task 04a. Its packed shape (exactly one .node addon + manifest) cannot be
-// asserted yet.
-record({
-  check: "packed-contents",
-  package: "@alienplatform/bindings-darwin-arm64",
-  status: "fail",
-  reason: "per-platform prebuild package not present (expected one .node addon + manifest)",
-  evidence: "no @alienplatform/bindings-darwin-arm64 tarball to inspect",
-})
+  // -------------------------------------------------------------------------
+  // Step 8 — bun build --compile of the ./native embed entry
+  // -------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// Step 8 — bun build --compile of the ./native embed entry
-// ---------------------------------------------------------------------------
-
-if (bunAvailable) {
-  const compiledDir = join(fixtureDir, ".compiled")
-  mkdirSync(compiledDir, { recursive: true })
-  const outFile = join(compiledDir, "compile-entry-bin")
-  const built = run(
-    "bun",
-    ["build", "--compile", join("src", "compile-entry.ts"), "--outfile", outFile],
-    fixtureDir,
-  )
-  if (built.status !== 0) {
-    record({
-      check: "compile",
-      package: "bindings",
-      status: "fail",
-      reason: "bun build --compile of ./native entry fails (bindings package not installed)",
-      evidence: lastLine(built.stderr) || lastLine(built.stdout) || `exit ${built.status}`,
-    })
-  } else {
-    const ran = run(outFile, [], fixtureDir)
-    record({
-      check: "compile",
-      package: "bindings",
-      status: ran.status === 0 ? "pass" : "fail",
-      reason: ran.status === 0 ? "ok" : "compiled binary exited non-zero",
-      evidence: ran.status === 0 ? lastLine(ran.stdout) : lastLine(ran.stderr),
-    })
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Step 9 — invoke the static validator
-// ---------------------------------------------------------------------------
-
-const validator = run("node", ["--experimental-strip-types", validatorPath], scriptDir)
-record({
-  check: "validator",
-  package: "layout",
-  status: validator.status === 0 ? "pass" : "fail",
-  reason:
-    validator.status === 0
-      ? "ok"
-      : "packages/scripts validator reported unexpected failures or stale expectations",
-  evidence: lastLine(validator.stdout) || lastLine(validator.stderr) || `exit ${validator.status}`,
-})
-
-// ---------------------------------------------------------------------------
-// Reconcile against expected-failures.json and report
-// ---------------------------------------------------------------------------
-
-const expectedFailures = JSON.parse(
-  readFileSync(join(scriptDir, "expected-failures.json"), "utf8"),
-) as ExpectedFailureEntry[]
-
-// The `bun build --compile` failure is only produced when bun runs. If bun is
-// unavailable in this environment, drop that expectation so it is not counted
-// stale (CI always has bun, so the committed list stays complete there).
-const activeExpectations = bunAvailable
-  ? expectedFailures
-  : expectedFailures.filter(entry => !(entry.check === "compile" && entry.package === "bindings"))
-
-const violations: Violation[] = results
-  .filter(result => result.status === "fail")
-  .map(result => ({
-    check: result.check,
-    package: result.package,
-    reason: result.reason,
-    evidence: result.evidence,
-  }))
-
-const filtered = applyExpectedFailures(violations, activeExpectations)
-
-function expectationKey(entry: { check: string; package: string; reason: string }): string {
-  return `${entry.check}::${entry.package}::${entry.reason}`
-}
-const expectedKeys = new Map(activeExpectations.map(entry => [expectationKey(entry), entry]))
-
-console.log("")
-console.log("package-layout fixture — step results")
-console.log("=====================================")
-
-let passCount = 0
-let expectedCount = 0
-let fatalCount = 0
-for (const result of results) {
-  if (result.status === "pass") {
-    passCount += 1
-    console.log(`  PASS       ${result.check} package=${result.package} — ${result.evidence}`)
-    continue
-  }
-  const entry = expectedKeys.get(expectationKey(result))
-  if (entry) {
-    expectedCount += 1
-    console.log(
-      `  [expected] ${result.check} package=${result.package} (task ${entry.owningTask}): ${result.reason}`,
+  if (bunAvailable) {
+    const compiledDir = join(fixtureDir, ".compiled")
+    mkdirSync(compiledDir, { recursive: true })
+    const outFile = join(compiledDir, "compile-entry-bin")
+    const built = run(
+      "bun",
+      ["build", "--compile", join("src", "compile-entry.ts"), "--outfile", outFile],
+      fixtureDir,
     )
-    console.log(`             evidence: ${result.evidence}`)
-  } else {
-    fatalCount += 1
-    console.error(`  FAIL       ${result.check} package=${result.package}: ${result.reason}`)
-    console.error(`             evidence: ${result.evidence}`)
+    if (built.status !== 0) {
+      record({
+        check: "compile",
+        package: "bindings",
+        status: "fail",
+        reason: "bun build --compile of ./native entry fails (bindings package not installed)",
+        evidence: lastLine(built.stderr) || lastLine(built.stdout) || `exit ${built.status}`,
+      })
+    } else {
+      const ran = run(outFile, [], fixtureDir)
+      record({
+        check: "compile",
+        package: "bindings",
+        status: ran.status === 0 ? "pass" : "fail",
+        reason: ran.status === 0 ? "ok" : "compiled binary exited non-zero",
+        evidence: ran.status === 0 ? lastLine(ran.stdout) : lastLine(ran.stderr),
+      })
+    }
   }
+
+  // -------------------------------------------------------------------------
+  // Step 9 — invoke the static validator
+  // -------------------------------------------------------------------------
+
+  const validator = run("node", ["--experimental-strip-types", validatorPath], scriptDir)
+  record({
+    check: "validator",
+    package: "layout",
+    status: validator.status === 0 ? "pass" : "fail",
+    reason:
+      validator.status === 0
+        ? "ok"
+        : "packages/scripts validator reported unexpected failures or stale expectations",
+    evidence:
+      lastLine(validator.stdout) || lastLine(validator.stderr) || `exit ${validator.status}`,
+  })
+
+  // -------------------------------------------------------------------------
+  // Reconcile against expected-failures.json and report
+  // -------------------------------------------------------------------------
+
+  const expectedFailures = JSON.parse(
+    readFileSync(join(scriptDir, "expected-failures.json"), "utf8"),
+  ) as ExpectedFailureEntry[]
+
+  // The `bun build --compile` failure is only produced when bun runs. If bun is
+  // unavailable in this environment, drop that expectation so it is not counted
+  // stale (CI always has bun, so the committed list stays complete there).
+  const activeExpectations = bunAvailable
+    ? expectedFailures
+    : expectedFailures.filter(entry => !(entry.check === "compile" && entry.package === "bindings"))
+
+  // Computed from ALL results (pass and fail) — a divergence is defined by one
+  // runtime passing while the other fails, so passes must stay in view.
+  const divergences = detectRuntimeDivergence(results)
+
+  const violations: Violation[] = [
+    ...results
+      .filter(result => result.status === "fail")
+      .map(result => ({
+        check: result.check,
+        package: result.package,
+        reason: result.reason,
+        evidence: result.evidence,
+      })),
+    // Always fatal: "runtime-divergence" is never a key in expected-failures.json,
+    // so applyExpectedFailures can only ever bucket these as unexpected.
+    ...divergences,
+  ]
+
+  const filtered = applyExpectedFailures(violations, activeExpectations)
+
+  function expectationKey(entry: { check: string; package: string; reason: string }): string {
+    return `${entry.check}::${entry.package}::${entry.reason}`
+  }
+  const expectedKeys = new Map(activeExpectations.map(entry => [expectationKey(entry), entry]))
+
+  console.log("")
+  console.log("package-layout fixture — step results")
+  console.log("=====================================")
+
+  let passCount = 0
+  let expectedCount = 0
+  let fatalCount = 0
+  for (const result of results) {
+    if (result.status === "pass") {
+      passCount += 1
+      console.log(`  PASS       ${result.check} package=${result.package} — ${result.evidence}`)
+      continue
+    }
+    const entry = expectedKeys.get(expectationKey(result))
+    if (entry) {
+      expectedCount += 1
+      console.log(
+        `  [expected] ${result.check} package=${result.package} (task ${entry.owningTask}): ${result.reason}`,
+      )
+      console.log(`             evidence: ${result.evidence}`)
+    } else {
+      fatalCount += 1
+      console.error(`  FAIL       ${result.check} package=${result.package}: ${result.reason}`)
+      console.error(`             evidence: ${result.evidence}`)
+    }
+  }
+
+  for (const divergence of divergences) {
+    fatalCount += 1
+    console.error(
+      `  FAIL       ${divergence.check} package=${divergence.package}: ${divergence.reason}`,
+    )
+    console.error(`             evidence: ${divergence.evidence}`)
+  }
+
+  for (const staleEntry of filtered.stale) {
+    console.error(
+      `  STALE      ${staleEntry.check} package=${staleEntry.package}: "${staleEntry.reason}" ` +
+        `(task ${staleEntry.owningTask}) is listed in expected-failures.json but never occurred — remove it or fix the check.`,
+    )
+  }
+
+  console.log("")
+  const exitCode = exitCodeFor(filtered)
+  if (exitCode === 0) {
+    console.log(
+      `OK: ${passCount} passed, ${expectedCount} expected failure(s), 0 unexpected, 0 stale.`,
+    )
+  } else {
+    console.log(
+      `FAILED: ${passCount} passed, ${fatalCount} unexpected failure(s), ${filtered.stale.length} stale expectation(s).`,
+    )
+  }
+
+  process.exit(exitCode)
 }
 
-for (const staleEntry of filtered.stale) {
-  console.error(
-    `  STALE      ${staleEntry.check} package=${staleEntry.package}: "${staleEntry.reason}" ` +
-      `(task ${staleEntry.owningTask}) is listed in expected-failures.json but never occurred — remove it or fix the check.`,
-  )
+if (isMainModule()) {
+  main()
 }
-
-console.log("")
-const exitCode = exitCodeFor(filtered)
-if (exitCode === 0) {
-  console.log(
-    `OK: ${passCount} passed, ${expectedCount} expected failure(s), 0 unexpected, 0 stale.`,
-  )
-} else {
-  console.log(
-    `FAILED: ${passCount} passed, ${fatalCount} unexpected failure(s), ${filtered.stale.length} stale expectation(s).`,
-  )
-}
-
-process.exit(exitCode)

--- a/packages/scripts/expected-failures.json
+++ b/packages/scripts/expected-failures.json
@@ -1,0 +1,44 @@
+[
+  {
+    "check": "no-commands-subpath",
+    "package": "sdk",
+    "reason": "exports map still contains ./commands",
+    "owningTask": "03"
+  },
+  {
+    "check": "sdk-subpath-containment",
+    "package": "sdk",
+    "reason": "gRPC import (nice-grpc) outside ./worker-runtime source directory",
+    "owningTask": "03"
+  },
+  {
+    "check": "sdk-subpath-containment",
+    "package": "sdk",
+    "reason": "gRPC import (nice-grpc-common) outside ./worker-runtime source directory",
+    "owningTask": "03"
+  },
+  {
+    "check": "sdk-subpath-containment",
+    "package": "sdk",
+    "reason": "gRPC import (@grpc/grpc-js) outside ./worker-runtime source directory",
+    "owningTask": "03"
+  },
+  {
+    "check": "sdk-subpath-containment",
+    "package": "sdk",
+    "reason": "generated binding-service proto client shipped in the package",
+    "owningTask": "03/17"
+  },
+  {
+    "check": "package-not-implemented",
+    "package": "bindings",
+    "reason": "package not yet implemented (only PACKAGE_LAYOUT.md present)",
+    "owningTask": "04"
+  },
+  {
+    "check": "package-not-implemented",
+    "package": "commands",
+    "reason": "package not yet implemented (only PACKAGE_LAYOUT.md present)",
+    "owningTask": "08"
+  }
+]

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@alienplatform/scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Internal validation scripts enforcing the TypeScript package layout contracts (PACKAGE_LAYOUT.md)",
+  "keywords": ["alien", "internal", "validation"],
+  "author": "Alien Software, Inc. <hi@alien.dev>",
+  "license": "FSL-1.1-Apache-2.0",
+  "homepage": "https://alien.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alienplatform/alien.git",
+    "directory": "packages/scripts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ts": "tsc --noEmit",
+    "validate:package-layout": "node --experimental-strip-types validate-package-layout.ts",
+    "format-and-lint": "biome check .",
+    "format-and-lint:fix": "biome check . --write"
+  },
+  "dependencies": {
+    "ts-pattern": "^5.7.1"
+  },
+  "devDependencies": {
+    "@alienplatform/typescript-config": "workspace:^",
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^24.0.15",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
+  }
+}

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@alienplatform/typescript-config/base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/scripts/validate-package-layout.test.ts
+++ b/packages/scripts/validate-package-layout.test.ts
@@ -1,0 +1,303 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  applyExpectedFailures,
+  checkExportsTypes,
+  checkForbiddenDeps,
+  checkForbiddenSources,
+  checkNoCommandsSubpath,
+  checkSdkSubpathContainment,
+  exitCodeFor,
+} from "./validate-package-layout.js"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "package-layout-test-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe("checkForbiddenDeps", () => {
+  it("flags a forbidden cloud SDK dependency in a bindings-like manifest", () => {
+    const violations = checkForbiddenDeps(
+      join(tempDir, "package.json"),
+      { dependencies: { "@aws-sdk/client-s3": "^3.0.0" } },
+      "bindings",
+      "bindings",
+    )
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      check: "forbidden-deps",
+      package: "bindings",
+    })
+    expect(violations[0]?.reason).toMatch(/AWS SDK/)
+  })
+
+  it("passes a clean bindings-like manifest", () => {
+    const violations = checkForbiddenDeps(
+      join(tempDir, "package.json"),
+      { dependencies: { "@alienplatform/core": "workspace:*" } },
+      "bindings",
+      "bindings",
+    )
+
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe("checkForbiddenSources", () => {
+  it("flags a nice-grpc import under a bindings-like source dir", () => {
+    writeFileSync(
+      join(tempDir, "storage.ts"),
+      'import { createChannel } from "nice-grpc"\n\nexport const noop = () => createChannel\n',
+    )
+
+    const violations = checkForbiddenSources(tempDir, "bindings", "bindings")
+
+    expect(violations.some(v => v.reason.includes("nice-grpc"))).toBe(true)
+  })
+
+  it("flags a reference to the forbidden ALIEN_BINDINGS_GRPC_ADDRESS env var", () => {
+    writeFileSync(
+      join(tempDir, "config.ts"),
+      "export const address = process.env.ALIEN_BINDINGS_GRPC_ADDRESS\n",
+    )
+
+    const violations = checkForbiddenSources(tempDir, "bindings", "bindings")
+
+    expect(violations.some(v => v.reason.includes("ALIEN_BINDINGS_GRPC_ADDRESS"))).toBe(true)
+  })
+
+  it("passes clean bindings sources", () => {
+    writeFileSync(join(tempDir, "storage.ts"), "export const noop = () => 1\n")
+
+    const violations = checkForbiddenSources(tempDir, "bindings", "bindings")
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("flags a nice-grpc-common import with its own explicit reason", () => {
+    writeFileSync(
+      join(tempDir, "types.ts"),
+      'import type { CallContext } from "nice-grpc-common"\n',
+    )
+
+    const violations = checkForbiddenSources(tempDir, "bindings", "bindings")
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.reason).toContain("nice-grpc-common")
+  })
+
+  it("flags an @alienplatform/sdk import (any subpath) under a commands-like source dir", () => {
+    writeFileSync(
+      join(tempDir, "receiver.ts"),
+      'import { runWorker } from "@alienplatform/sdk/worker-runtime"\n',
+    )
+
+    const violations = checkForbiddenSources(tempDir, "commands", "commands")
+
+    expect(violations.some(v => v.reason.includes("@alienplatform/sdk"))).toBe(true)
+  })
+
+  it("flags a generated Worker-protocol module import under a commands-like source dir", () => {
+    writeFileSync(
+      join(tempDir, "client.ts"),
+      'import { ControlServiceDefinition } from "./generated/control.js"\n',
+    )
+
+    const violations = checkForbiddenSources(tempDir, "commands", "commands")
+
+    expect(violations.some(v => v.reason.includes("Worker protocol"))).toBe(true)
+  })
+
+  it("passes clean commands sources (plain fetch, core imports)", () => {
+    writeFileSync(
+      join(tempDir, "client.ts"),
+      'import { defineError } from "@alienplatform/core"\n\nexport const send = () => fetch("https://example.com")\n',
+    )
+
+    const violations = checkForbiddenSources(tempDir, "commands", "commands")
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("returns no violations for a nonexistent source dir (ENOENT is not an error)", () => {
+    const violations = checkForbiddenSources(
+      join(tempDir, "does-not-exist"),
+      "commands",
+      "commands",
+    )
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("propagates non-ENOENT filesystem errors instead of swallowing them", () => {
+    // Point the walker at a regular file: readdirSync raises ENOTDIR, which must
+    // NOT be treated as "no sources" — only ENOENT may mean that.
+    const filePath = join(tempDir, "not-a-dir.ts")
+    writeFileSync(filePath, "export const x = 1\n")
+
+    expect(() => checkForbiddenSources(filePath, "commands", "commands")).toThrow(/ENOTDIR/)
+  })
+})
+
+describe("checkSdkSubpathContainment", () => {
+  it("flags a gRPC import in packages/sdk/src OUTSIDE the worker-runtime dir", () => {
+    writeFileSync(join(tempDir, "channel.ts"), 'import { createChannel } from "nice-grpc"\n')
+
+    const violations = checkSdkSubpathContainment(tempDir, "sdk")
+
+    expect(violations.some(v => v.reason.includes("nice-grpc"))).toBe(true)
+  })
+
+  it("passes the same gRPC import INSIDE the worker-runtime dir", () => {
+    mkdirSync(join(tempDir, "worker-runtime"))
+    writeFileSync(
+      join(tempDir, "worker-runtime", "channel.ts"),
+      'import { createChannel } from "nice-grpc"\n',
+    )
+
+    const violations = checkSdkSubpathContainment(tempDir, "sdk")
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it("flags a generated binding-service proto client anywhere in the package", () => {
+    mkdirSync(join(tempDir, "generated"))
+    writeFileSync(join(tempDir, "generated", "storage.ts"), "export const x = 1\n")
+
+    const violations = checkSdkSubpathContainment(tempDir, "sdk")
+
+    expect(violations.some(v => v.reason.includes("generated binding-service proto client"))).toBe(
+      true,
+    )
+  })
+})
+
+describe("checkNoCommandsSubpath", () => {
+  it("flags an exports map containing ./commands", () => {
+    const violations = checkNoCommandsSubpath("package.json", { ".": {}, "./commands": {} }, "sdk")
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ check: "no-commands-subpath", package: "sdk" })
+  })
+
+  it("passes an exports map without ./commands", () => {
+    const violations = checkNoCommandsSubpath("package.json", { ".": {} }, "sdk")
+
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe("checkExportsTypes", () => {
+  it("flags a subpath condition missing types", () => {
+    const violations = checkExportsTypes(
+      "package.json",
+      { ".": { import: "./dist/index.js" } },
+      "sdk",
+    )
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ check: "exports-types", package: "sdk" })
+  })
+
+  it("passes when every condition carries types", () => {
+    const violations = checkExportsTypes(
+      "package.json",
+      { ".": { types: "./dist/index.d.ts", import: "./dist/index.js" } },
+      "sdk",
+    )
+
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe("applyExpectedFailures", () => {
+  it("turns a listed failure into an expected (non-fatal) warning", () => {
+    const result = applyExpectedFailures(
+      [
+        {
+          check: "no-commands-subpath",
+          package: "sdk",
+          reason: "exports ./commands",
+          evidence: "x",
+        },
+      ],
+      [
+        {
+          check: "no-commands-subpath",
+          package: "sdk",
+          reason: "exports ./commands",
+          owningTask: "03",
+        },
+      ],
+    )
+
+    expect(result.expected).toHaveLength(1)
+    expect(result.fatal).toHaveLength(0)
+    expect(result.stale).toHaveLength(0)
+  })
+
+  it("leaves an unlisted failure fatal", () => {
+    const result = applyExpectedFailures(
+      [{ check: "forbidden-deps", package: "bindings", reason: "AWS SDK", evidence: "x" }],
+      [],
+    )
+
+    expect(result.fatal).toHaveLength(1)
+    expect(result.expected).toHaveLength(0)
+    expect(result.stale).toHaveLength(0)
+  })
+
+  it("reports an expected entry with no matching violation as stale (fatal to the run)", () => {
+    const result = applyExpectedFailures(
+      [],
+      [
+        {
+          check: "no-commands-subpath",
+          package: "sdk",
+          reason: "exports ./commands",
+          owningTask: "03",
+        },
+      ],
+    )
+
+    expect(result.stale).toHaveLength(1)
+    expect(result.fatal).toHaveLength(0)
+    expect(result.expected).toHaveLength(0)
+  })
+})
+
+describe("exitCodeFor", () => {
+  const violation = {
+    check: "forbidden-deps",
+    package: "bindings",
+    reason: "AWS SDK",
+    evidence: "x",
+  }
+  const staleEntry = {
+    check: "no-commands-subpath",
+    package: "sdk",
+    reason: "exports ./commands",
+    owningTask: "03",
+  }
+
+  it("returns 0 when there are no fatal violations and no stale expectations", () => {
+    expect(exitCodeFor({ expected: [violation], fatal: [], stale: [] })).toBe(0)
+  })
+
+  it("returns 1 when any unexpected (fatal) violation exists", () => {
+    expect(exitCodeFor({ expected: [], fatal: [violation], stale: [] })).toBe(1)
+  })
+
+  it("returns 1 when any stale expectation exists, even with zero violations", () => {
+    expect(exitCodeFor({ expected: [], fatal: [], stale: [staleEntry] })).toBe(1)
+  })
+})

--- a/packages/scripts/validate-package-layout.ts
+++ b/packages/scripts/validate-package-layout.ts
@@ -1,0 +1,535 @@
+/**
+ * Static validator enforcing the TypeScript package layout boundaries pinned in
+ * packages/{sdk,bindings,commands}/PACKAGE_LAYOUT.md.
+ *
+ * Runs today against the real tree: bindings/commands don't exist yet, and the
+ * sdk package still has several PACKAGE_LAYOUT.md violations on purpose (the
+ * split is executed by later tasks). Every failure that is expected right now
+ * is listed in expected-failures.json with the owning task; the run exits 0
+ * only when the actual failure set matches that list exactly (no unexpected
+ * failures, no stale expectations).
+ */
+
+import { type Dirent, existsSync, readFileSync, readdirSync } from "node:fs"
+import { basename, dirname, extname, join, relative, sep } from "node:path"
+import { match } from "ts-pattern"
+
+export interface Violation {
+  check: string
+  package: string
+  reason: string
+  evidence: string
+}
+
+export interface ExpectedFailureEntry {
+  check: string
+  package: string
+  reason: string
+  owningTask: string
+}
+
+export interface FilterResult {
+  expected: Violation[]
+  fatal: Violation[]
+  stale: ExpectedFailureEntry[]
+}
+
+/** Loose shape of a package.json — only the fields the checks below read. */
+export interface PackageJsonLike {
+  name?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  exports?: Record<string, unknown>
+}
+
+export type DependencyPackageKind = "bindings" | "commands"
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const
+
+interface ForbiddenPattern {
+  pattern: RegExp
+  label: string
+}
+
+const FORBIDDEN_DEP_PATTERNS: Record<DependencyPackageKind, ForbiddenPattern[]> = {
+  bindings: [
+    { pattern: /^@aws-sdk\//, label: "forbidden dependency: AWS SDK" },
+    { pattern: /^@google-cloud\//, label: "forbidden dependency: Google Cloud SDK" },
+    { pattern: /^@azure\//, label: "forbidden dependency: Azure SDK" },
+    { pattern: /^@grpc\/grpc-js$/, label: "forbidden dependency: gRPC (@grpc/grpc-js)" },
+    { pattern: /^nice-grpc/, label: "forbidden dependency: nice-grpc" },
+    { pattern: /^@alienplatform\/sdk$/, label: "forbidden dependency: @alienplatform/sdk" },
+    {
+      pattern: /^@alienplatform\/commands$/,
+      label: "forbidden dependency: @alienplatform/commands",
+    },
+  ],
+  commands: [
+    { pattern: /^@grpc\/grpc-js$/, label: "forbidden dependency: gRPC (@grpc/grpc-js)" },
+    { pattern: /^nice-grpc/, label: "forbidden dependency: nice-grpc" },
+    {
+      pattern: /^@alienplatform\/bindings$/,
+      label: "forbidden dependency: @alienplatform/bindings",
+    },
+  ],
+}
+
+/**
+ * Flags forbidden runtime/dev/peer/optional dependencies in a package.json for
+ * a bindings-like or commands-like package (PACKAGE_LAYOUT.md "Dependency
+ * boundaries" sections).
+ */
+export function checkForbiddenDeps(
+  packageJsonPath: string,
+  packageJson: PackageJsonLike,
+  packageName: string,
+  kind: DependencyPackageKind,
+): Violation[] {
+  const violations: Violation[] = []
+  const rules = FORBIDDEN_DEP_PATTERNS[kind]
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const deps = packageJson[section]
+    if (!deps) continue
+
+    for (const depName of Object.keys(deps)) {
+      for (const rule of rules) {
+        if (rule.pattern.test(depName)) {
+          violations.push({
+            check: "forbidden-deps",
+            package: packageName,
+            reason: rule.label,
+            evidence: `${packageJsonPath} (${section}.${depName})`,
+          })
+        }
+      }
+    }
+  }
+
+  return violations
+}
+
+// `nice-grpc` and `nice-grpc-common` are matched by two separate, explicit
+// patterns (rather than one `nice-grpc` prefix match that happens to cover
+// both) so that tightening either regex later cannot silently drop coverage
+// of the other package. The `["'/]` terminator keeps `nice-grpc` from
+// matching `nice-grpc-common` while still catching subpath imports.
+const NICE_GRPC_IMPORT = /from\s+["']nice-grpc["'/]/
+const NICE_GRPC_COMMON_IMPORT = /from\s+["']nice-grpc-common["'/]/
+const GRPC_JS_IMPORT = /from\s+["']@grpc\/grpc-js/
+// Generated Worker-protocol proto clients pulled in via a `generated/` path
+// (e.g. `./generated/control.js`). Forbidden wholesale in bindings/commands —
+// only the sdk's ./worker-runtime subpath may carry Worker protocol code.
+const GENERATED_WORKER_PROTOCOL_IMPORT =
+  /from\s+["'][^"']*generated\/(control|wait_until|worker)(\.js)?["']/
+
+const FORBIDDEN_SOURCE_PATTERNS: Record<DependencyPackageKind, ForbiddenPattern[]> = {
+  bindings: [
+    { pattern: NICE_GRPC_IMPORT, label: "forbidden gRPC import (nice-grpc)" },
+    { pattern: NICE_GRPC_COMMON_IMPORT, label: "forbidden gRPC import (nice-grpc-common)" },
+    { pattern: GRPC_JS_IMPORT, label: "forbidden gRPC import (@grpc/grpc-js)" },
+    { pattern: /from\s+["']@aws-sdk\//, label: "forbidden AWS SDK import" },
+    { pattern: /from\s+["']@google-cloud\//, label: "forbidden Google Cloud SDK import" },
+    { pattern: /from\s+["']@azure\//, label: "forbidden Azure SDK import" },
+    {
+      pattern: /from\s+["']@alienplatform\/sdk/,
+      label: "forbidden import of @alienplatform/sdk (Worker protocol)",
+    },
+    {
+      pattern: GENERATED_WORKER_PROTOCOL_IMPORT,
+      label: "forbidden Worker protocol import (generated proto client)",
+    },
+    {
+      pattern: /ALIEN_BINDINGS_GRPC_ADDRESS/,
+      label: "forbidden env var reference: ALIEN_BINDINGS_GRPC_ADDRESS",
+    },
+    { pattern: /ALIEN_BINDINGS_MODE/, label: "forbidden env var reference: ALIEN_BINDINGS_MODE" },
+  ],
+  commands: [
+    { pattern: NICE_GRPC_IMPORT, label: "forbidden gRPC import (nice-grpc)" },
+    { pattern: NICE_GRPC_COMMON_IMPORT, label: "forbidden gRPC import (nice-grpc-common)" },
+    { pattern: GRPC_JS_IMPORT, label: "forbidden gRPC import (@grpc/grpc-js)" },
+    {
+      pattern: /from\s+["']@alienplatform\/bindings/,
+      label: "forbidden import of @alienplatform/bindings",
+    },
+    {
+      // Any subpath of the sdk, including /worker-runtime — the commands
+      // package is pure fetch and may not touch Worker app protocol at all.
+      pattern: /from\s+["']@alienplatform\/sdk/,
+      label: "forbidden import of @alienplatform/sdk (Worker protocol)",
+    },
+    {
+      pattern: GENERATED_WORKER_PROTOCOL_IMPORT,
+      label: "forbidden Worker protocol import (generated proto client)",
+    },
+  ],
+}
+
+const SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", ".turbo"])
+
+function isEnoent(error: unknown): boolean {
+  return error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT"
+}
+
+/**
+ * Recursively collects `.ts`/`.tsx` source file paths under `dir`.
+ *
+ * A missing directory (ENOENT) yields no results — "no src/ yet" is a valid
+ * state for a package this validator inspects. Every other filesystem error
+ * (EACCES, ENOTDIR, I/O, …) propagates: silently treating those as "no
+ * sources" would let the validator pass without having looked.
+ *
+ * Note: symlinks are not resolved — `Dirent.isDirectory()`/`isFile()` are
+ * false for symlinks, so symlinked dirs/files are skipped, not followed.
+ */
+function walkSourceFiles(dir: string): string[] {
+  const results: string[] = []
+  let entries: Dirent<string>[]
+
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch (error) {
+    if (isEnoent(error)) return results
+    throw error
+  }
+
+  for (const entry of entries) {
+    if (SKIPPED_DIR_NAMES.has(entry.name) || entry.name.startsWith(".")) continue
+
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...walkSourceFiles(fullPath))
+    } else if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+      results.push(fullPath)
+    }
+  }
+
+  return results
+}
+
+/**
+ * Flags forbidden imports and forbidden env-var references anywhere under a
+ * bindings-like or commands-like package's source directory.
+ */
+export function checkForbiddenSources(
+  dirPath: string,
+  packageName: string,
+  kind: DependencyPackageKind,
+): Violation[] {
+  const violations: Violation[] = []
+  const rules = FORBIDDEN_SOURCE_PATTERNS[kind]
+
+  for (const filePath of walkSourceFiles(dirPath)) {
+    const lines = readFileSync(filePath, "utf8").split("\n")
+
+    lines.forEach((line, index) => {
+      for (const rule of rules) {
+        if (rule.pattern.test(line)) {
+          violations.push({
+            check: "forbidden-sources",
+            package: packageName,
+            reason: rule.label,
+            evidence: `${filePath}:${index + 1}`,
+          })
+        }
+      }
+    })
+  }
+
+  return violations
+}
+
+const WORKER_RUNTIME_DIRNAME = "worker-runtime"
+
+const SDK_GRPC_IMPORT_PATTERNS: ForbiddenPattern[] = [
+  {
+    pattern: NICE_GRPC_IMPORT,
+    label: "gRPC import (nice-grpc) outside ./worker-runtime source directory",
+  },
+  {
+    pattern: NICE_GRPC_COMMON_IMPORT,
+    label: "gRPC import (nice-grpc-common) outside ./worker-runtime source directory",
+  },
+  {
+    pattern: GRPC_JS_IMPORT,
+    label: "gRPC import (@grpc/grpc-js) outside ./worker-runtime source directory",
+  },
+]
+
+/**
+ * Generated ts-proto client basenames that back binding-service RPCs
+ * (storage/kv/queue/vault + the deleted non-app kinds). Worker's own protocol
+ * (control, wait_until) is intentionally excluded — that proto is permitted,
+ * but only under ./worker-runtime.
+ */
+const BINDING_SERVICE_PROTO_BASENAMES = new Set([
+  "artifact_registry",
+  "build",
+  "container",
+  "kv",
+  "queue",
+  "service_account",
+  "storage",
+  "vault",
+  "worker",
+])
+
+/**
+ * Enforces the sdk package's `./worker-runtime` containment rule: gRPC /
+ * Worker-protocol imports are forbidden outside `./worker-runtime`, and no
+ * generated binding-service proto client may ship anywhere in the package.
+ */
+export function checkSdkSubpathContainment(srcDir: string, packageName = "sdk"): Violation[] {
+  const violations: Violation[] = []
+
+  for (const filePath of walkSourceFiles(srcDir)) {
+    const relPath = relative(srcDir, filePath)
+    const insideWorkerRuntime = relPath.split(sep)[0] === WORKER_RUNTIME_DIRNAME
+
+    if (!insideWorkerRuntime) {
+      const lines = readFileSync(filePath, "utf8").split("\n")
+      lines.forEach((line, index) => {
+        for (const rule of SDK_GRPC_IMPORT_PATTERNS) {
+          if (rule.pattern.test(line)) {
+            violations.push({
+              check: "sdk-subpath-containment",
+              package: packageName,
+              reason: rule.label,
+              evidence: `${filePath}:${index + 1}`,
+            })
+          }
+        }
+      })
+    }
+
+    const base = basename(filePath, extname(filePath))
+    const parentDirName = basename(dirname(filePath))
+    // Assumes generated proto clients sit as DIRECT children of a `generated/`
+    // dir (the ts-proto layout in use today); clients nested one level deeper
+    // (e.g. generated/foo/storage.ts) would not match this basename check.
+    if (parentDirName === "generated" && BINDING_SERVICE_PROTO_BASENAMES.has(base)) {
+      violations.push({
+        check: "sdk-subpath-containment",
+        package: packageName,
+        reason: "generated binding-service proto client shipped in the package",
+        evidence: filePath,
+      })
+    }
+  }
+
+  return violations
+}
+
+/** Flags a `package.json` `exports` map that still contains the deleted `./commands` subpath. */
+export function checkNoCommandsSubpath(
+  packageJsonPath: string,
+  exportsMap: Record<string, unknown> | undefined,
+  packageName: string,
+): Violation[] {
+  if (!exportsMap || !Object.hasOwn(exportsMap, "./commands")) return []
+
+  return [
+    {
+      check: "no-commands-subpath",
+      package: packageName,
+      reason: "exports map still contains ./commands",
+      evidence: `${packageJsonPath} exports["./commands"]`,
+    },
+  ]
+}
+
+/** Flags any `exports` subpath condition object missing a `types` entry. */
+export function checkExportsTypes(
+  packageJsonPath: string,
+  exportsMap: Record<string, unknown> | undefined,
+  packageName: string,
+): Violation[] {
+  if (!exportsMap) return []
+
+  const violations: Violation[] = []
+
+  for (const [subpath, condition] of Object.entries(exportsMap)) {
+    const hasTypes =
+      typeof condition === "object" && condition !== null && Object.hasOwn(condition, "types")
+
+    if (!hasTypes) {
+      violations.push({
+        check: "exports-types",
+        package: packageName,
+        reason: `exports["${subpath}"] is missing a "types" condition`,
+        evidence: `${packageJsonPath} exports["${subpath}"]`,
+      })
+    }
+  }
+
+  return violations
+}
+
+function expectedFailureKey(entry: {
+  check: string
+  package: string
+  reason: string
+}): string {
+  return `${entry.check}::${entry.package}::${entry.reason}`
+}
+
+/**
+ * Splits actual violations into `expected` (matches an entry in
+ * expected-failures.json) and `fatal` (does not). Any expected-failures.json
+ * entry that matched nothing real is returned as `stale` — a stale entry
+ * fails the run too, so the list can't silently rot.
+ */
+export function applyExpectedFailures(
+  violations: Violation[],
+  expectedFailures: ExpectedFailureEntry[],
+): FilterResult {
+  const matchedKeys = new Set<string>()
+  const expected: Violation[] = []
+  const fatal: Violation[] = []
+
+  for (const violation of violations) {
+    const key = expectedFailureKey(violation)
+    const isExpected = expectedFailures.some(entry => expectedFailureKey(entry) === key)
+
+    if (isExpected) {
+      matchedKeys.add(key)
+      expected.push(violation)
+    } else {
+      fatal.push(violation)
+    }
+  }
+
+  const stale = expectedFailures.filter(entry => !matchedKeys.has(expectedFailureKey(entry)))
+
+  return { expected, fatal, stale }
+}
+
+/**
+ * The run passes (exit 0) only when there are zero unexpected (fatal)
+ * violations AND zero stale expectations. Expected violations never fail
+ * the run; a stale expectation always does.
+ */
+export function exitCodeFor(result: FilterResult): 0 | 1 {
+  return result.fatal.length === 0 && result.stale.length === 0 ? 0 : 1
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function readPackageJson(packageJsonPath: string): PackageJsonLike {
+  return JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJsonLike
+}
+
+/**
+ * Runs every check against the real packages/{sdk,bindings,commands} tree.
+ * bindings/commands currently contain only PACKAGE_LAYOUT.md — that is
+ * recorded as its own violation (`package-not-implemented`) rather than
+ * silently skipped, so expected-failures.json has to name it explicitly.
+ */
+function collectViolations(packagesDir: string): Violation[] {
+  const violations: Violation[] = []
+
+  const sdkDir = join(packagesDir, "sdk")
+  if (existsSync(join(sdkDir, "package.json"))) {
+    const packageJsonPath = join(sdkDir, "package.json")
+    const packageJson = readPackageJson(packageJsonPath)
+    violations.push(...checkNoCommandsSubpath(packageJsonPath, packageJson.exports, "sdk"))
+    violations.push(...checkExportsTypes(packageJsonPath, packageJson.exports, "sdk"))
+    violations.push(...checkSdkSubpathContainment(join(sdkDir, "src"), "sdk"))
+  }
+
+  for (const [packageName, kind] of [
+    ["bindings", "bindings"],
+    ["commands", "commands"],
+  ] as const) {
+    const packageDir = join(packagesDir, packageName)
+    const packageJsonPath = join(packageDir, "package.json")
+
+    if (!existsSync(packageJsonPath)) {
+      violations.push({
+        check: "package-not-implemented",
+        package: packageName,
+        reason: "package not yet implemented (only PACKAGE_LAYOUT.md present)",
+        evidence: packageDir,
+      })
+      continue
+    }
+
+    const packageJson = readPackageJson(packageJsonPath)
+    violations.push(...checkForbiddenDeps(packageJsonPath, packageJson, packageName, kind))
+    violations.push(...checkForbiddenSources(join(packageDir, "src"), packageName, kind))
+    violations.push(...checkExportsTypes(packageJsonPath, packageJson.exports, packageName))
+  }
+
+  return violations
+}
+
+function loadExpectedFailures(expectedFailuresPath: string): ExpectedFailureEntry[] {
+  return JSON.parse(readFileSync(expectedFailuresPath, "utf8")) as ExpectedFailureEntry[]
+}
+
+function printReport(result: FilterResult): void {
+  for (const violation of result.expected) {
+    console.log(`[expected] ${violation.check} package=${violation.package}: ${violation.reason}`)
+    console.log(`           evidence: ${violation.evidence}`)
+  }
+
+  for (const violation of result.fatal) {
+    console.error(`[FAIL] ${violation.check} package=${violation.package}: ${violation.reason}`)
+    console.error(`       evidence: ${violation.evidence}`)
+  }
+
+  for (const staleEntry of result.stale) {
+    console.error(
+      `[STALE EXPECTATION] ${staleEntry.check} package=${staleEntry.package}: "${staleEntry.reason}" ` +
+        `(owningTask ${staleEntry.owningTask}) is listed in expected-failures.json but no longer occurs — remove it or fix the check.`,
+    )
+  }
+
+  const summary = match(result)
+    .with(
+      { fatal: [], stale: [] },
+      () => `OK: ${result.expected.length} expected failure(s), 0 unexpected, 0 stale.`,
+    )
+    .otherwise(
+      () =>
+        `FAILED: ${result.fatal.length} unexpected failure(s), ${result.stale.length} stale expectation(s).`,
+    )
+  console.log(summary)
+}
+
+function main(): void {
+  // packages/scripts -> packages
+  const packagesDir = join(import.meta.dirname, "..")
+  const expectedFailuresPath = join(import.meta.dirname, "expected-failures.json")
+
+  if (!existsSync(packagesDir)) {
+    console.error(`Cannot find packages directory at ${packagesDir}`)
+    process.exit(1)
+  }
+
+  const violations = collectViolations(packagesDir)
+  const expectedFailures = loadExpectedFailures(expectedFailuresPath)
+  const result = applyExpectedFailures(violations, expectedFailures)
+
+  printReport(result)
+
+  process.exit(exitCodeFor(result))
+}
+
+function isMainModule(): boolean {
+  return typeof process.argv[1] === "string" && import.meta.url === `file://${process.argv[1]}`
+}
+
+if (isMainModule()) {
+  main()
+}

--- a/packages/sdk/.npmignore
+++ b/packages/sdk/.npmignore
@@ -1,0 +1,2 @@
+.turbo/
+*.tsbuildinfo

--- a/packages/sdk/PACKAGE_LAYOUT.md
+++ b/packages/sdk/PACKAGE_LAYOUT.md
@@ -1,0 +1,126 @@
+# `@alienplatform/sdk` — package layout contract
+
+> Contract document. The names, subpaths, error codes, and dependency rules below
+> are binding for the tasks that implement and enforce them. Implementers may not
+> rename anything pinned here. Items whose owner is a later task are marked
+> **OPEN (task NN)** and must not be decided in this file.
+
+## Purpose
+
+`@alienplatform/sdk` stays published as the ergonomic facade for Worker apps. It
+provides the Worker handler APIs and re-exports the app-facing binding factories
+from [`@alienplatform/bindings`](../bindings/PACKAGE_LAYOUT.md), so a Worker author
+installs one package. Worker protocol dependencies (nice-grpc, generated Worker
+protocol clients) are confined to the `./worker-runtime` subpath.
+
+The direct command surface moves out of this package: `CommandsClient` lives in
+[`@alienplatform/commands`](../commands/PACKAGE_LAYOUT.md), and direct bindings live
+in [`@alienplatform/bindings`](../bindings/PACKAGE_LAYOUT.md).
+
+### Current state (truthful baseline)
+
+- Current `exports` are `.` and `./commands`.
+- Worker/gRPC protocol code lives in `src/{channel,events,commands,wait-until,grpc-utils}.ts`,
+  `src/bindings/*`, and `src/generated/*`.
+- `src/commands/` (the `CommandsClient`) is already pure `fetch` + HTTP.
+
+## Public surface — from `"."` (facade)
+
+| Export | Kind | Signature sketch | Notes |
+|---|---|---|---|
+| `command` | function | `command(name, handler): void` | Register a Worker command handler. |
+| `onStorageEvent` | function | Worker storage-event handler registrar | Signature owned by task 03. |
+| `onCronEvent` | function | Worker cron-event handler registrar | Signature owned by task 03. |
+| `onQueueMessage` | function | Worker queue-message handler registrar | Signature owned by task 03. |
+| `waitUntil` | function | `waitUntil(promise): void` | Extend Worker task lifetime past the response. |
+| handler types | type | `StorageEvent`, `StorageEventType`, `CronEvent`, `QueueMessage`, `QueueMessageEvent`, `ScheduledEvent` | The event/handler types for the APIs above. |
+| `storage`, `kv`, `queue`, `vault` | function | re-export from `@alienplatform/bindings` | Facade re-export of the binding factories. |
+| `Storage`, `Kv`, `Queue`, `Vault` | type | re-export from `@alienplatform/bindings` | Facade re-export of the instance types. |
+| error re-exports | error | from `@alienplatform/bindings` and `@alienplatform/core` | Includes `BindingNotConfiguredError`; `AlienError`. |
+
+### Deleted from the current root surface
+
+Recorded here as contract; execution is tasks 03/17. These names must be gone from
+`"."` after the split:
+
+- `worker()`, `build()`, `artifactRegistry()`, `serviceAccount()` — non-app binding
+  factories.
+- `AlienContext` and its `AlienContext.fromEnv()` binding-gRPC entry.
+- Binding classes for non-app kinds: `Build`, `ArtifactRegistry`, `WorkerBinding`,
+  `ServiceAccount`.
+- gRPC-era binding errors that the direct bindings package replaces:
+  `GrpcConnectionError`, `GrpcCallError`, `BindingNotFoundError` (superseded by
+  `BINDING_NOT_CONFIGURED` in `@alienplatform/bindings`).
+- `getPostgresConnection` / `PostgresConnection` — destination is **OPEN (task 03)**;
+  this file does not decide where Postgres connection resolution moves.
+
+## Subpaths
+
+### `./worker-runtime`
+
+The **only** location for `nice-grpc` and the generated Worker protocol clients. It
+exports:
+
+- `runWorker` — the Worker bootstrap contract. The name `runWorker` is pinned here;
+  its signature is owned by task 03.
+- Worker protocol client internals consumed by generated Worker bootstraps.
+
+Generated Worker bootstraps import this exact subpath (tasks 03/13 depend on it).
+
+### `./commands` — DELETED
+
+The old `./commands` subpath is removed. Its `CommandsClient` functionality moves to
+[`@alienplatform/commands`](../commands/PACKAGE_LAYOUT.md) (task 08). The package
+must not continue to export `./commands`.
+
+## Exports map
+
+`"."` and `./worker-runtime` only. Every condition carries `types`. No deep imports.
+
+```jsonc
+{
+  ".": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js"
+  },
+  "./worker-runtime": {
+    "types": "./dist/worker-runtime/index.d.ts",
+    "import": "./dist/worker-runtime/index.js"
+  }
+}
+```
+
+## Manifest requirements
+
+- `"type": "module"` (ESM-first).
+- `"sideEffects": false`.
+- `"exports"` and per-condition `"types"` exactly as above; `"types"` top-level for
+  legacy resolvers; declarations shipped.
+- `description` and `keywords` (updated to drop the standalone-commands framing).
+- Support note: Bun and Node ≥ 18.
+- `dependencies`: `@alienplatform/bindings` and `@alienplatform/core`.
+
+## Dependency boundaries
+
+- gRPC and Worker-protocol imports are forbidden anywhere outside the
+  `./worker-runtime` source directory.
+- No generated binding-service proto clients anywhere in the package. Only Worker
+  protocol proto is permitted, and only under `./worker-runtime`.
+- MUST NOT still export `./commands`.
+- MUST NOT still ship generated binding-service proto clients.
+- Depends on [`@alienplatform/bindings`](../bindings/PACKAGE_LAYOUT.md) and
+  `@alienplatform/core`.
+
+## Behavior contract
+
+- The facade re-exports binding factories from `@alienplatform/bindings`; importing
+  and constructing them requires no deployment and no credentials (see the
+  [bindings contract](../bindings/PACKAGE_LAYOUT.md#behavior-contract)).
+- Worker handler registration (`command`, `onStorageEvent`, `onCronEvent`,
+  `onQueueMessage`, `waitUntil`) is protocol-only at the facade; the Worker runtime
+  wiring lives behind `./worker-runtime`.
+
+## Status
+
+- The split is executed in task 03 (with cleanup of deleted names in task 17).
+- This file is the contract; it defines no runtime code.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,28 @@ importers:
         specifier: ^3.1.4
         version: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.4)(typescript@5.8.3))(tsx@4.21.0)
 
+  packages/scripts:
+    dependencies:
+      ts-pattern:
+        specifier: ^5.7.1
+        version: 5.9.0
+    devDependencies:
+      '@alienplatform/typescript-config':
+        specifier: link:../config-typescript
+        version: link:../config-typescript
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^24.0.15
+        version: 24.10.4
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.1.4
+        version: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.4)(typescript@5.8.3))(tsx@4.21.0)
+
   packages/sdk:
     dependencies:
       '@alienplatform/core':
@@ -685,11 +707,11 @@ packages:
   '@clack/prompts@1.1.0':
     resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
 
-  '@emnapi/core@1.11.0':
-    resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.11.0':
-    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1060,8 +1082,8 @@ packages:
     resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
     engines: {node: '>=18'}
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1097,8 +1119,8 @@ packages:
     peerDependencies:
       openapi-types: '*'
 
-  '@oxc-project/types@0.135.0':
-    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1166,91 +1188,91 @@ packages:
     resolution: {integrity: sha512-sb3QYpqJZq4U31x6LRuYXgaA4byNFoTMGVLCvq8o8Om1GGv6O0/oMu6EpPZoDAYDxIsTRDPC04Lu6MLVU6D/ag==}
     engines: {node: '>=22.12.0 || >=20.19.0 <21.0.0', npm: '>=10'}
 
-  '@rolldown/binding-android-arm64@1.1.1':
-    resolution: {integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==}
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.1':
-    resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.1':
-    resolution: {integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==}
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.1':
-    resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
-    resolution: {integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.1':
-    resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.1':
-    resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
-    resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.1':
-    resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.1':
-    resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.1.1':
-    resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.1.1':
-    resolution: {integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==}
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.1':
-    resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.1':
-    resolution: {integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.1':
-    resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1587,8 +1609,8 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
@@ -3047,8 +3069,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.1.1:
-    resolution: {integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==}
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4552,13 +4574,13 @@ snapshots:
       '@clack/core': 1.1.0
       sisteransi: 1.0.5
 
-  '@emnapi/core@1.11.0':
+  '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.0':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4920,11 +4942,11 @@ snapshots:
       strict-event-emitter: 0.5.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.11.0
-      '@emnapi/runtime': 1.11.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@nodable/entities@2.2.0': {}
@@ -4962,7 +4984,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/json-schema'
 
-  '@oxc-project/types@0.135.0': {}
+  '@oxc-project/types@0.138.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -5048,53 +5070,53 @@ snapshots:
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
 
-  '@rolldown/binding-android-arm64@1.1.1':
+  '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.1':
+  '@rolldown/binding-darwin-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.1':
+  '@rolldown/binding-darwin-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.1':
+  '@rolldown/binding-freebsd-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.1':
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.1':
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.1':
+  '@rolldown/binding-linux-x64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.1':
+  '@rolldown/binding-openharmony-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.1':
+  '@rolldown/binding-wasm32-wasi@1.1.4':
     dependencies:
-      '@emnapi/core': 1.11.0
-      '@emnapi/runtime': 1.11.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.1':
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -5497,7 +5519,7 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6948,7 +6970,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.19.13
+      '@types/node': 24.10.4
       long: 5.3.2
 
   punycode@2.3.1: {}
@@ -7014,7 +7036,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.15.10(rolldown@1.1.1)(typescript@5.8.3):
+  rolldown-plugin-dts@0.15.10(rolldown@1.1.4)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -7024,33 +7046,33 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.3
       get-tsconfig: 4.13.0
-      rolldown: 1.1.1
+      rolldown: 1.1.4
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.1.1:
+  rolldown@1.1.4:
     dependencies:
-      '@oxc-project/types': 0.135.0
+      '@oxc-project/types': 0.138.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.1
-      '@rolldown/binding-darwin-arm64': 1.1.1
-      '@rolldown/binding-darwin-x64': 1.1.1
-      '@rolldown/binding-freebsd-x64': 1.1.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
-      '@rolldown/binding-linux-arm64-gnu': 1.1.1
-      '@rolldown/binding-linux-arm64-musl': 1.1.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.1
-      '@rolldown/binding-linux-s390x-gnu': 1.1.1
-      '@rolldown/binding-linux-x64-gnu': 1.1.1
-      '@rolldown/binding-linux-x64-musl': 1.1.1
-      '@rolldown/binding-openharmony-arm64': 1.1.1
-      '@rolldown/binding-wasm32-wasi': 1.1.1
-      '@rolldown/binding-win32-arm64-msvc': 1.1.1
-      '@rolldown/binding-win32-x64-msvc': 1.1.1
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
 
   rollup@4.54.0:
     dependencies:
@@ -7320,8 +7342,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.1.1
-      rolldown-plugin-dts: 0.15.10(rolldown@1.1.1)(typescript@5.8.3)
+      rolldown: 1.1.4
+      rolldown-plugin-dts: 0.15.10(rolldown@1.1.4)(typescript@5.8.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,15 @@ importers:
         specifier: ^3.1.4
         version: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.4)(typescript@5.8.3))(tsx@4.21.0)
 
+  packages/package-layout:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.15
+        version: 24.10.4
+      vitest:
+        specifier: ^3.1.4
+        version: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(tsx@4.21.0)
+
   packages/scripts:
     dependencies:
       ts-pattern:
@@ -5677,6 +5686,15 @@ snapshots:
       msw: 2.12.7(@types/node@24.10.4)(typescript@5.8.3)
       vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@24.10.4)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -6758,6 +6776,32 @@ snapshots:
       - '@types/node'
     optional: true
 
+  msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@24.10.4)
+      '@mswjs/interceptors': 0.40.0
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.3.1
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   mustache@4.2.0: {}
 
   mute-stream@2.0.0:
@@ -7514,6 +7558,47 @@ snapshots:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
       '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@24.10.4)(typescript@5.8.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.4
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,9 @@
       "dependsOn": ["^build", "build"],
       "cache": false
     },
+    "validate:package-layout": {
+      "cache": false
+    },
     "//#format-and-lint": {},
     "//#format-and-lint:fix": {
       "cache": false


### PR DESCRIPTION
Pins the TypeScript package boundaries for the runtime-less refactor as contract files plus executable enforcement, so tasks 03/04/04a/08/13 never choose package names, public imports, or error codes.

## What's pinned

- `@alienplatform/sdk`: facade; Worker protocol code confined to the `./worker-runtime` subpath; `./commands` subpath deleted (contract — execution in task 03)
- `@alienplatform/bindings`: thin wrapper over the napi-rs addon; surface exactly `storage`/`kv`/`queue`/`vault`; per-platform prebuilds as `optionalDependencies`; `./native` static-embed entry for `bun build --compile` (named by this task — flagging for review since the ticket implied but didn't spell the name)
- `@alienplatform/commands`: pure fetch, protocol-only; `CommandsClient` + `createCommandReceiver`
- Error contract: `BINDING_NOT_CONFIGURED` (names `ALIEN_<NAME>_BINDING`), `COMMAND_RECEIVER_CONFIG_INVALID` (names `ALIEN_COMMANDS_URL`)

## How to run

- Static validator: `pnpm validate:package-layout` (wired into ci-fast after typecheck)
- Full fixture: `pnpm --filter @alienplatform/package-layout run check` (packs sdk+core, npm-installs the tarballs as a real consumer, runs Bun+Node import checks, typecheck, exact packed-contents check, `bun build --compile` probe, then the validator; chained onto the gated build step in CI)

Both run TODAY: current state yields 38 validator / 20 fixture expected failures, each tracked in `expected-failures.json` with its owning task (03/04/04a/08/17). Unexpected failure or stale entry → exit 1, so entries must be deleted as tasks land.

## Notes for later tasks

- The validator forbids any `@alienplatform/sdk` import from `commands` — slightly stricter than the commands contract's written boundary list; task 08 should either align the contract wording or relax the rule deliberately.
- `EXTRA_SHIPPED_TODAY` in the packed-contents check enumerates files sdk/core currently ship beyond the default set; task 03/17 owns tightening it via manifest `files` fields.

Blocks: ALIEN-214 (03), ALIEN-215 (04), ALIEN-216 (04a), ALIEN-220 (08), ALIEN-225 (13) — they implement to these contracts.
