### PR TITLE
fix(cli): format whoami output for humans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-agent"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -333,6 +333,7 @@ dependencies = [
  "hex",
  "hostname 0.4.2",
  "indexmap 2.14.0",
+ "insta",
  "keyring",
  "oauth2",
  "object_store",
@@ -365,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -379,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -397,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -416,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -431,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -465,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -480,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -511,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-agent",
  "alien-cli-common",
@@ -549,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -579,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -592,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -635,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -649,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -709,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -738,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -779,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -788,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -847,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-error",
  "chrono",
@@ -864,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -883,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-error",
  "chrono",
@@ -900,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -917,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -975,14 +976,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -997,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1043,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-cli/Cargo.toml
+++ b/crates/alien-cli/Cargo.toml
@@ -93,3 +93,4 @@ crossterm = { workspace = true }
 [dev-dependencies]
 snapbox = "0.6.0"
 predicates = "3.0.4"
+insta = { workspace = true }

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__dev_whoami_response.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__dev_whoami_response.snap
@@ -1,0 +1,10 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_dev_whoami(&response)
+---
+Signed in as sa_01HXYZ
+Account Type serviceAccount
+Role workspace.member
+Scope project (proj_9f3a)
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__dev_whoami_response_unknown_scope_type.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__dev_whoami_response_unknown_scope_type.snap
@@ -1,0 +1,10 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_dev_whoami(&response)
+---
+Signed in as sa_01HXYZ
+Account Type serviceAccount
+Role workspace.member
+Scope future-type
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_deployment_group_scope.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_deployment_group_scope.snap
@@ -1,0 +1,11 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_service_account_subject(&subject)
+---
+Signed in as service account
+Account ID sa_01HXYZ
+Account Type serviceAccount
+Role deployment-group.deployer
+Scope deployment-group (dg_3c4d, project proj_9f3a)
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_deployment_scope.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_deployment_scope.snap
@@ -1,0 +1,11 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_service_account_subject(&subject)
+---
+Signed in as service account
+Account ID sa_01HXYZ
+Account Type serviceAccount
+Role deployment.manager
+Scope deployment (dep_1a2b, project proj_9f3a)
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_manager_scope.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_manager_scope.snap
@@ -1,0 +1,11 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_service_account_subject(&subject)
+---
+Signed in as service account
+Account ID sa_01HXYZ
+Account Type serviceAccount
+Role manager.runtime
+Scope manager (mgr_5e6f)
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_project_scope.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_project_scope.snap
@@ -1,0 +1,11 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_service_account_subject(&subject)
+---
+Signed in as service account
+Account ID sa_01HXYZ
+Account Type serviceAccount
+Role project.developer
+Scope project (proj_9f3a)
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_workspace_scope.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__service_account_workspace_scope.snap
@@ -1,0 +1,11 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_service_account_subject(&subject)
+---
+Signed in as service account
+Account ID sa_01HXYZ
+Account Type serviceAccount
+Role workspace.member
+Scope workspace
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__user_subject_with_workspace_name.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__user_subject_with_workspace_name.snap
@@ -1,0 +1,10 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: "render_user_subject(&user_subject(Some(\"Acme Corp\")))"
+---
+Signed in as user@example.com
+Account ID usr_7k2m
+Account Type user
+Role workspace.admin
+Workspace ID ws_4b21
+Workspace Name Acme Corp

--- a/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__user_subject_without_workspace_name.snap
+++ b/crates/alien-cli/src/commands/snapshots/alien_cli__commands__whoami__tests__user_subject_without_workspace_name.snap
@@ -1,0 +1,9 @@
+---
+source: crates/alien-cli/src/commands/whoami.rs
+expression: render_user_subject(&user_subject(None))
+---
+Signed in as user@example.com
+Account ID usr_7k2m
+Account Type user
+Role workspace.admin
+Workspace ID ws_4b21

--- a/crates/alien-cli/src/commands/whoami.rs
+++ b/crates/alien-cli/src/commands/whoami.rs
@@ -1,8 +1,11 @@
 use crate::error::{ErrorData, Result};
 use crate::execution_context::ExecutionMode;
 use crate::output::print_json;
+use crate::ui::{contextual_heading, dim_label};
 use alien_error::Context;
+use alien_manager_api::types::{ScopeInfo, WhoamiResponse};
 use alien_manager_api::SdkResultExt as ManagerSdkResultExt;
+use alien_platform_api::types::{Role, ServiceAccountSubject, Subject, SubjectScope, UserSubject};
 use alien_platform_api::SdkResultExt;
 use clap::Parser;
 
@@ -48,7 +51,7 @@ pub async fn whoami_task(args: WhoamiArgs, ctx: ExecutionMode) -> Result<()> {
     if args.json {
         print_json(&response)?;
     } else {
-        println!("{:#?}", response);
+        println!("{}", render_subject(&response));
     }
 
     Ok(())
@@ -72,10 +75,277 @@ async fn whoami_task_dev(args: WhoamiArgs, port: u16) -> Result<()> {
     if args.json {
         print_json(&response)?;
     } else {
-        println!("Kind: {}", response.kind);
-        println!("ID: {}", response.id);
-        println!("Scope: {}", response.scope.type_);
+        println!("{}", render_dev_whoami(&response));
     }
 
     Ok(())
+}
+
+fn render_subject(subject: &Subject) -> String {
+    match subject {
+        Subject::UserSubject(user) => render_user_subject(user),
+        Subject::ServiceAccountSubject(service_account) => {
+            render_service_account_subject(service_account)
+        }
+    }
+}
+
+fn render_user_subject(user: &UserSubject) -> String {
+    let mut lines = vec![
+        contextual_heading("Signed in as", &user.email, &[]),
+        format!("{} {}", dim_label("Account ID"), user.id),
+        format!("{} {}", dim_label("Account Type"), user.kind),
+        format!("{} {}", dim_label("Role"), user.role),
+        format!("{} {}", dim_label("Workspace ID"), user.workspace_id),
+    ];
+    if let Some(workspace_name) = &user.workspace_name {
+        lines.push(format!("{} {}", dim_label("Workspace Name"), workspace_name));
+    }
+    lines.join("\n")
+}
+
+fn render_service_account_subject(service_account: &ServiceAccountSubject) -> String {
+    let mut lines = vec![
+        contextual_heading("Signed in as", "service account", &[]),
+        format!("{} {}", dim_label("Account ID"), service_account.id),
+        format!("{} {}", dim_label("Account Type"), service_account.kind),
+        format!(
+            "{} {}",
+            dim_label("Role"),
+            format_role(&service_account.role)
+        ),
+        format!(
+            "{} {}",
+            dim_label("Scope"),
+            format_scope(&service_account.scope)
+        ),
+        format!(
+            "{} {}",
+            dim_label("Workspace ID"),
+            service_account.workspace_id
+        ),
+    ];
+    if let Some(workspace_name) = &service_account.workspace_name {
+        lines.push(format!("{} {}", dim_label("Workspace Name"), workspace_name));
+    }
+    lines.join("\n")
+}
+
+// Role is an untagged wrapper with no generated Display of its own — each arm
+// delegates to the wrapped role type's Display instead.
+fn format_role(role: &Role) -> String {
+    match role {
+        Role::WorkspaceRole(role) => role.to_string(),
+        Role::ProjectRole(role) => role.to_string(),
+        Role::DeploymentRole(role) => role.to_string(),
+        Role::DeploymentGroupRole(role) => role.to_string(),
+        Role::ManagerRole(role) => role.to_string(),
+    }
+}
+
+fn format_scope(scope: &SubjectScope) -> String {
+    match scope {
+        SubjectScope::Workspace => "workspace".to_string(),
+        SubjectScope::Project { project_id } => format!("project ({project_id})"),
+        SubjectScope::Deployment {
+            deployment_id,
+            project_id,
+        } => format!("deployment ({deployment_id}, project {project_id})"),
+        SubjectScope::DeploymentGroup {
+            deployment_group_id,
+            project_id,
+        } => format!("deployment-group ({deployment_group_id}, project {project_id})"),
+        SubjectScope::Manager { manager_id } => format!("manager ({manager_id})"),
+    }
+}
+
+fn render_dev_whoami(response: &WhoamiResponse) -> String {
+    vec![
+        contextual_heading("Signed in as", &response.id, &[]),
+        format!("{} {}", dim_label("Account Type"), response.kind),
+        format!("{} {}", dim_label("Role"), response.role),
+        format!(
+            "{} {}",
+            dim_label("Scope"),
+            format_scope_info(&response.scope)
+        ),
+        format!("{} {}", dim_label("Workspace ID"), response.workspace_id),
+        format!(
+            "{} {}",
+            dim_label("Workspace Name"),
+            response.workspace_name
+        ),
+    ]
+    .join("\n")
+}
+
+// scope.type_ is a plain wire String from the manager's own OpenAPI spec, not a
+// compiler-checked enum like SubjectScope — the catch-all here is a deliberate
+// exception to this file's otherwise-exhaustive matches, not an oversight.
+fn format_scope_info(scope: &ScopeInfo) -> String {
+    match scope.type_.as_str() {
+        "workspace" => "workspace".to_string(),
+        "project" => format!("project ({})", scope.project_id.as_deref().unwrap_or("-")),
+        "deployment" => format!(
+            "deployment ({}, project {})",
+            scope.deployment_id.as_deref().unwrap_or("-"),
+            scope.project_id.as_deref().unwrap_or("-"),
+        ),
+        "deployment-group" => format!(
+            "deployment-group ({}, project {})",
+            scope.deployment_group_id.as_deref().unwrap_or("-"),
+            scope.project_id.as_deref().unwrap_or("-"),
+        ),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alien_platform_api::types::{
+        DeploymentGroupRole, DeploymentRole, ManagerRole, ProjectRole, ServiceAccountSubjectKind,
+        UserRole, UserSubjectKind, WorkspaceRole,
+    };
+
+    fn user_subject(workspace_name: Option<&str>) -> UserSubject {
+        UserSubject {
+            email: "user@example.com".to_string(),
+            id: "usr_7k2m".to_string(),
+            kind: UserSubjectKind::User,
+            role: UserRole::WorkspaceAdmin,
+            workspace_id: "ws_4b21".to_string(),
+            workspace_name: workspace_name.map(|name| name.to_string()),
+        }
+    }
+
+    fn service_account_subject(role: Role, scope: SubjectScope) -> ServiceAccountSubject {
+        ServiceAccountSubject {
+            id: "sa_01HXYZ".to_string(),
+            kind: ServiceAccountSubjectKind::ServiceAccount,
+            role,
+            scope,
+            workspace_id: "ws_4b21".to_string(),
+            workspace_name: Some("Acme Corp".to_string()),
+        }
+    }
+
+    #[test]
+    fn user_subject_with_workspace_name() {
+        insta::assert_snapshot!(render_user_subject(&user_subject(Some("Acme Corp"))));
+    }
+
+    #[test]
+    fn user_subject_without_workspace_name() {
+        insta::assert_snapshot!(render_user_subject(&user_subject(None)));
+    }
+
+    #[test]
+    fn service_account_workspace_scope() {
+        let subject = service_account_subject(
+            Role::WorkspaceRole(WorkspaceRole::WorkspaceMember),
+            SubjectScope::Workspace,
+        );
+        insta::assert_snapshot!(render_service_account_subject(&subject));
+    }
+
+    #[test]
+    fn service_account_project_scope() {
+        let subject = service_account_subject(
+            Role::ProjectRole(ProjectRole::ProjectDeveloper),
+            SubjectScope::Project {
+                project_id: "proj_9f3a".to_string(),
+            },
+        );
+        insta::assert_snapshot!(render_service_account_subject(&subject));
+    }
+
+    #[test]
+    fn service_account_deployment_scope() {
+        let subject = service_account_subject(
+            Role::DeploymentRole(DeploymentRole::DeploymentManager),
+            SubjectScope::Deployment {
+                deployment_id: "dep_1a2b".to_string(),
+                project_id: "proj_9f3a".to_string(),
+            },
+        );
+        insta::assert_snapshot!(render_service_account_subject(&subject));
+    }
+
+    #[test]
+    fn service_account_deployment_group_scope() {
+        let subject = service_account_subject(
+            Role::DeploymentGroupRole(DeploymentGroupRole::DeploymentGroupDeployer),
+            SubjectScope::DeploymentGroup {
+                deployment_group_id: "dg_3c4d".to_string(),
+                project_id: "proj_9f3a".to_string(),
+            },
+        );
+        insta::assert_snapshot!(render_service_account_subject(&subject));
+    }
+
+    #[test]
+    fn service_account_manager_scope() {
+        let subject = service_account_subject(
+            Role::ManagerRole(ManagerRole::ManagerRuntime),
+            SubjectScope::Manager {
+                manager_id: "mgr_5e6f".to_string(),
+            },
+        );
+        insta::assert_snapshot!(render_service_account_subject(&subject));
+    }
+
+    #[test]
+    fn dev_whoami_response() {
+        let response = WhoamiResponse {
+            id: "sa_01HXYZ".to_string(),
+            kind: "serviceAccount".to_string(),
+            role: "workspace.member".to_string(),
+            scope: ScopeInfo {
+                type_: "project".to_string(),
+                project_id: Some("proj_9f3a".to_string()),
+                deployment_id: None,
+                deployment_group_id: None,
+            },
+            workspace_id: "ws_4b21".to_string(),
+            workspace_name: "Acme Corp".to_string(),
+        };
+        insta::assert_snapshot!(render_dev_whoami(&response));
+    }
+
+    #[test]
+    fn dev_whoami_response_unknown_scope_type() {
+        // A scope type the manager doesn't recognize today still renders
+        // instead of panicking.
+        let response = WhoamiResponse {
+            id: "sa_01HXYZ".to_string(),
+            kind: "serviceAccount".to_string(),
+            role: "workspace.member".to_string(),
+            scope: ScopeInfo {
+                type_: "future-type".to_string(),
+                project_id: None,
+                deployment_id: None,
+                deployment_group_id: None,
+            },
+            workspace_id: "ws_4b21".to_string(),
+            workspace_name: "Acme Corp".to_string(),
+        };
+        insta::assert_snapshot!(render_dev_whoami(&response));
+    }
+
+    #[test]
+    fn render_subject_has_no_debug_wrapper_leakage() {
+        let subject = Subject::ServiceAccountSubject(service_account_subject(
+            Role::WorkspaceRole(WorkspaceRole::WorkspaceMember),
+            SubjectScope::Project {
+                project_id: "proj_9f3a".to_string(),
+            },
+        ));
+
+        let rendered = render_subject(&subject);
+
+        assert!(!rendered.contains("ServiceAccountSubject("));
+        assert!(!rendered.contains("WorkspaceRole("));
+        assert!(!rendered.contains("Some("));
+    }
 }


### PR DESCRIPTION
## Summary

`alien whoami`'s human-readable output printed Rust's raw debug format, leaking internal type names like `ServiceAccountSubject(...)` and `Some(...)`. This replaces it with plain labeled lines and brings `alien dev whoami` up to the same level of detail; `--json` is unchanged.

Step-by-step flow when you run `alien whoami` without `--json`:

1. The CLI fetches the caller's identity from the platform or local manager.
2. It picks a renderer based on whether the caller is a user or a service account. ← the fix lives here
3. It prints aligned `Label value` lines instead of the old debug dump.

This PR changes whoami's human output from a raw debug dump to plain labeled lines.

## What was broken

Running `alien whoami` printed Rust's struct-debug format directly — things like `ServiceAccountSubject(ServiceAccountSubject { role: WorkspaceRole(WorkspaceMember), ... })` instead of a readable summary. `alien dev whoami` was cleaner but incomplete — it dropped the role and workspace fields entirely.

## What I did

- Added render functions for both platform response shapes (user vs. service account) and for the separate local-manager response, each printing aligned label/value lines.
- Brought `alien dev whoami` up to the same fields as the main path (role, workspace ID, workspace name).
- Left the `--json` flag and its output exactly as they were.

## Files touched

- `crates/alien-cli/src/commands/whoami.rs` — new render functions, wired into both whoami paths, plus an inline test module.
- `crates/alien-cli/Cargo.toml` — added `insta` as a dev-dependency for snapshot testing.
- `Cargo.lock` — updated for the new dependency (also re-syncs pre-existing lockfile drift from the already-released v1.10.7 version bump).

## How I tested

- **Manually:** started a local manager (`alien dev server`) and ran `alien dev whoami` and `alien dev whoami --json` against it — human output shows clean labeled lines with no wrapper types, JSON output is byte-for-byte unchanged.
- **Unit tests:** 9 snapshot tests covering both response shapes and all scope variants, plus one test asserting the output never contains the old debug-wrapper text (fails on `main`, passes here).