### PR TITLE
feat: credential minting and resolution for direct bindings (ALIEN-218)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "alien-platform-api",
  "async-stream",
  "async-trait",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "chrono",

--- a/crates/alien-bindings/Cargo.toml
+++ b/crates/alien-bindings/Cargo.toml
@@ -70,6 +70,7 @@ k8s-openapi = { version = "0.25.0", features = ["v1_33"], optional = true }
 
 [dev-dependencies]
 alien-aws-clients = { workspace = true, features = ["test-utils"] }
+axum = { workspace = true, features = ["tokio", "http1", "json"] }
 dotenvy = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }

--- a/crates/alien-bindings/src/credential_source.rs
+++ b/crates/alien-bindings/src/credential_source.rs
@@ -1,0 +1,503 @@
+//! Minting-backed client credential resolution.
+//!
+//! This is the *only* client-side credential resolver: every language SDK
+//! inherits it through the napi addon, so it must stay runtime-agnostic (no
+//! background timers, no spawned refresh loops — refresh happens lazily, on the
+//! access path).
+//!
+//! When a deployed app process cannot resolve native/projected cloud
+//! credentials from its environment (see the selection order in
+//! [`crate::provider::LazyEnvBindingsProvider`]), it falls back to *minting*:
+//! it POSTs to `{ALIEN_MANAGER_URL}/v1/credentials/mint` with its deployment
+//! token and receives a short-lived [`ClientConfig`] plus a server-computed
+//! `expiresAt` refresh hint. The minted config is cached and re-minted on
+//! access once it passes the refresh threshold, with a single-flight guard so a
+//! burst of concurrent binding loads triggers at most one mint.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alien_core::{
+    ClientConfig, ENV_ALIEN_DEPLOYMENT_ID, ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT,
+    ENV_ALIEN_DEPLOYMENT_TOKEN, ENV_ALIEN_MANAGER_URL,
+};
+use alien_error::{AlienError, Context, IntoAlienError};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use serde::Deserialize;
+use tokio::sync::{Mutex, RwLock};
+use tracing::debug;
+
+use crate::error::{ErrorData, Result};
+use crate::provider::BindingsProvider;
+
+/// Re-mint credentials once they are within this many seconds of their
+/// server-declared expiry. Gives in-flight work a safety margin so it never
+/// races a hard expiry, and absorbs modest client/server clock skew.
+const REFRESH_SKEW_SECONDS: i64 = 300;
+
+/// Timeout for a single mint HTTP request. The mint endpoint impersonates a
+/// service account / calls STS, so it is not instant; this is generous enough
+/// for that round-trip while still bounding a hung manager.
+const MINT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The mint request inputs read from the process environment, plus the HTTP
+/// client used to reach the manager.
+///
+/// The manager injects these vars for deployed app processes (controller
+/// injection is an ALIEN-218 task-10/16 follow-up).
+pub(crate) struct MintingCredentialSource {
+    /// Base URL of the deployment's manager (`ALIEN_MANAGER_URL`).
+    manager_url: String,
+    /// Deployment bearer token (`ALIEN_DEPLOYMENT_TOKEN`). Secret material —
+    /// see the manual [`fmt::Debug`] impl, which must never print it.
+    token: String,
+    /// Deployment id (`ALIEN_DEPLOYMENT_ID`).
+    deployment_id: String,
+    /// Service-account binding to mint credentials for
+    /// (`ALIEN_DEPLOYMENT_SERVICE_ACCOUNT`).
+    binding_name: String,
+    http: reqwest::Client,
+}
+
+/// Manual `Debug`: `token` is a live bearer credential. Never let a `{:?}` of
+/// this source (log line, panic message, test failure output) print it.
+impl fmt::Debug for MintingCredentialSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MintingCredentialSource")
+            .field("manager_url", &self.manager_url)
+            .field("token", &"<redacted>")
+            .field("deployment_id", &self.deployment_id)
+            .field("binding_name", &self.binding_name)
+            .finish()
+    }
+}
+
+impl MintingCredentialSource {
+    /// Builds a source from the environment when the mint contract is present.
+    ///
+    /// Returns `Ok(None)` when the gate (`ALIEN_MANAGER_URL` +
+    /// `ALIEN_DEPLOYMENT_TOKEN`) is absent — the caller then keeps the existing
+    /// (non-minting) behaviour. When the gate *is* present but the rest of the
+    /// request contract (`ALIEN_DEPLOYMENT_ID`, `ALIEN_DEPLOYMENT_SERVICE_ACCOUNT`)
+    /// is missing, this fails fast: a half-injected mint environment is a
+    /// manager bug, not a reason to silently fall back to static resolution.
+    pub(crate) fn from_env(env: &HashMap<String, String>) -> Result<Option<Self>> {
+        let (Some(manager_url), Some(token)) = (
+            env.get(ENV_ALIEN_MANAGER_URL),
+            env.get(ENV_ALIEN_DEPLOYMENT_TOKEN),
+        ) else {
+            return Ok(None);
+        };
+
+        let deployment_id = env.get(ENV_ALIEN_DEPLOYMENT_ID).ok_or_else(|| {
+            AlienError::new(ErrorData::EnvironmentVariableMissing {
+                variable_name: ENV_ALIEN_DEPLOYMENT_ID.to_string(),
+            })
+        })?;
+        let binding_name = env
+            .get(ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT)
+            .ok_or_else(|| {
+                AlienError::new(ErrorData::EnvironmentVariableMissing {
+                    variable_name: ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT.to_string(),
+                })
+            })?;
+
+        let http = reqwest::Client::builder()
+            .timeout(MINT_TIMEOUT)
+            .build()
+            .into_alien_error()
+            .context(ErrorData::RemoteAccessFailed {
+                operation: "build minting HTTP client".to_string(),
+            })?;
+
+        Ok(Some(Self {
+            manager_url: manager_url.clone(),
+            token: token.clone(),
+            deployment_id: deployment_id.clone(),
+            binding_name: binding_name.clone(),
+            http,
+        }))
+    }
+
+    /// POST the mint request and parse the response. Errors surface typed via
+    /// `alien-error` with context; there are no panic paths.
+    async fn mint(&self) -> Result<MintedConfig> {
+        let url = format!(
+            "{}/v1/credentials/mint",
+            self.manager_url.trim_end_matches('/')
+        );
+
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token)
+            .json(&serde_json::json!({
+                "deploymentId": self.deployment_id,
+                "bindingName": self.binding_name,
+            }))
+            .send()
+            .await
+            .into_alien_error()
+            .context(ErrorData::RemoteAccessFailed {
+                operation: "mint credentials from manager".to_string(),
+            })?;
+
+        let response = response.error_for_status().into_alien_error().context(
+            ErrorData::RemoteAccessFailed {
+                operation: "mint credentials from manager (non-success status)".to_string(),
+            },
+        )?;
+
+        let minted: MintResponse =
+            response
+                .json()
+                .await
+                .into_alien_error()
+                .context(ErrorData::RemoteAccessFailed {
+                    operation: "parse mint response".to_string(),
+                })?;
+
+        // Audit trail: never logs the client_config (credential material) — only
+        // the non-secret principal and expiry.
+        debug!(
+            deployment_id = %self.deployment_id,
+            binding_name = %self.binding_name,
+            principal = %minted.principal,
+            expires_at = %minted.expires_at.to_rfc3339(),
+            "Minted client credentials"
+        );
+
+        Ok(MintedConfig {
+            client_config: minted.client_config,
+            expires_at: minted.expires_at,
+        })
+    }
+}
+
+/// Deserialised mint response. Mirrors the manager's `MintCredentialsResponse`
+/// (`crates/alien-manager/src/routes/credentials.rs`).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MintResponse {
+    client_config: ClientConfig,
+    /// Server-computed refresh hint (RFC3339). Treated as "re-mint at or before
+    /// this instant", not as proof the credential is valid to the last second.
+    expires_at: DateTime<Utc>,
+    /// Human-readable identity the credentials act as. Non-secret; logged only.
+    principal: String,
+}
+
+/// A minted config together with the server's expiry hint.
+struct MintedConfig {
+    client_config: ClientConfig,
+    expires_at: DateTime<Utc>,
+}
+
+/// A cached [`BindingsProvider`] built from minted credentials, plus the expiry
+/// that decides when it must be rebuilt.
+struct Cached {
+    provider: Arc<BindingsProvider>,
+    expires_at: DateTime<Utc>,
+}
+
+/// Resolves a [`BindingsProvider`] from minted credentials, caching it until it
+/// passes the refresh threshold and re-minting on access under a single-flight
+/// guard.
+pub(crate) struct MintingResolver {
+    source: MintingCredentialSource,
+    /// Binding JSON (`ALIEN_*_BINDING`), reused verbatim across re-mints — only
+    /// the credentials change, not the binding topology.
+    bindings: HashMap<String, serde_json::Value>,
+    /// Cached provider + expiry. `None` until the first mint.
+    cache: RwLock<Option<Cached>>,
+    /// Single-flight guard: a burst of concurrent stale/first loads collapses to
+    /// one mint. An async `Mutex` (not a timer) keeps this napi-runtime-agnostic.
+    refresh_lock: Mutex<()>,
+    /// Re-mint once within this many seconds of expiry. Field (not the bare
+    /// const) so tests can pin it.
+    refresh_skew_seconds: i64,
+}
+
+/// Manual `Debug`: the cached provider holds a live [`ClientConfig`] and the
+/// source holds a bearer token. Redact both; delegating to the source's own
+/// (already-redacting) `Debug` is safe.
+impl fmt::Debug for MintingResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MintingResolver")
+            .field("source", &self.source)
+            .field("bindings", &self.bindings.keys().collect::<Vec<_>>())
+            .field("cache", &"<redacted>")
+            .field("refresh_skew_seconds", &self.refresh_skew_seconds)
+            .finish()
+    }
+}
+
+impl MintingResolver {
+    pub(crate) fn new(
+        source: MintingCredentialSource,
+        bindings: HashMap<String, serde_json::Value>,
+    ) -> Self {
+        Self {
+            source,
+            bindings,
+            cache: RwLock::new(None),
+            refresh_lock: Mutex::new(()),
+            refresh_skew_seconds: REFRESH_SKEW_SECONDS,
+        }
+    }
+
+    /// Returns a provider backed by fresh-enough minted credentials, minting (or
+    /// re-minting) only when the cache is empty or stale.
+    pub(crate) async fn provider(&self) -> Result<Arc<BindingsProvider>> {
+        // Fast path: a fresh cached provider needs no lock contention and no mint.
+        if let Some(provider) = self.fresh_cached().await {
+            return Ok(provider);
+        }
+
+        // Slow path: single-flight the mint. Only one task refreshes per
+        // staleness window; the rest wait here and then observe the fresh cache.
+        let _flight = self.refresh_lock.lock().await;
+
+        // Double-check: a racing task may have refreshed while we waited for the
+        // lock. This is what makes concurrent first-loads collapse to one mint.
+        if let Some(provider) = self.fresh_cached().await {
+            return Ok(provider);
+        }
+
+        let minted = self.source.mint().await?;
+        let provider = Arc::new(BindingsProvider::new(
+            minted.client_config,
+            self.bindings.clone(),
+        )?);
+
+        let mut cache = self.cache.write().await;
+        *cache = Some(Cached {
+            provider: provider.clone(),
+            expires_at: minted.expires_at,
+        });
+        Ok(provider)
+    }
+
+    /// The cached provider if present and not yet within the refresh window.
+    async fn fresh_cached(&self) -> Option<Arc<BindingsProvider>> {
+        let cache = self.cache.read().await;
+        cache.as_ref().and_then(|cached| {
+            if self.is_stale(cached.expires_at) {
+                None
+            } else {
+                Some(cached.provider.clone())
+            }
+        })
+    }
+
+    fn is_stale(&self, expires_at: DateTime<Utc>) -> bool {
+        Utc::now() >= expires_at - ChronoDuration::seconds(self.refresh_skew_seconds)
+    }
+
+    /// Test-only: simulate elapsed time by pushing the cached expiry into the
+    /// past, so the next access observes the entry as stale and re-mints. Keeps
+    /// the re-mint test deterministic without a real sleep.
+    #[cfg(test)]
+    async fn force_stale(&self) {
+        if let Some(cached) = self.cache.write().await.as_mut() {
+            cached.expires_at = Utc::now() - ChronoDuration::seconds(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::{extract::State, routing::post, Json, Router};
+    use serde_json::json;
+
+    /// Shared state for the fake mint endpoint: counts requests and controls the
+    /// expiry it hands back.
+    #[derive(Clone)]
+    struct MintServerState {
+        calls: Arc<AtomicUsize>,
+        /// Seconds from now used for each response's `expiresAt`.
+        expiry_secs: i64,
+        /// Optional artificial delay to widen the single-flight race window.
+        delay: Option<Duration>,
+    }
+
+    async fn mint_handler(State(state): State<MintServerState>) -> Json<serde_json::Value> {
+        state.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(delay) = state.delay {
+            tokio::time::sleep(delay).await;
+        }
+        let expires_at = (Utc::now() + ChronoDuration::seconds(state.expiry_secs)).to_rfc3339();
+        // A `Local` client config deserialises without needing real cloud
+        // credentials, so binding loads against the minted provider stay offline.
+        Json(json!({
+            "clientConfig": { "platform": "local", "state_directory": "/tmp/alien-mint-test" },
+            "expiresAt": expires_at,
+            "principal": "local:mint-test",
+        }))
+    }
+
+    /// Spawn a fake mint server; returns its base URL and the call counter.
+    async fn spawn_mint_server(
+        expiry_secs: i64,
+        delay: Option<Duration>,
+    ) -> (String, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let state = MintServerState {
+            calls: calls.clone(),
+            expiry_secs,
+            delay,
+        };
+        let app = Router::new()
+            .route("/v1/credentials/mint", post(mint_handler))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .expect("bind fake mint server");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        (format!("http://{addr}"), calls)
+    }
+
+    fn source(manager_url: &str) -> MintingCredentialSource {
+        let env = HashMap::from([
+            (ENV_ALIEN_MANAGER_URL.to_string(), manager_url.to_string()),
+            (
+                ENV_ALIEN_DEPLOYMENT_TOKEN.to_string(),
+                "ax_deploy_SECRET_TOKEN".to_string(),
+            ),
+            (ENV_ALIEN_DEPLOYMENT_ID.to_string(), "dep_123".to_string()),
+            (
+                ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT.to_string(),
+                "management".to_string(),
+            ),
+        ]);
+        MintingCredentialSource::from_env(&env)
+            .expect("source builds")
+            .expect("mint contract present")
+    }
+
+    #[tokio::test]
+    async fn from_env_returns_none_without_gate() {
+        // No manager URL / token -> not a minting environment.
+        let env = HashMap::from([(ENV_ALIEN_DEPLOYMENT_ID.to_string(), "dep_1".to_string())]);
+        assert!(MintingCredentialSource::from_env(&env)
+            .expect("no error")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn from_env_fails_fast_when_gate_present_but_contract_incomplete() {
+        // Manager URL + token present, but deployment id / SA binding missing:
+        // a half-injected mint environment must error, not silently fall back.
+        let env = HashMap::from([
+            (
+                ENV_ALIEN_MANAGER_URL.to_string(),
+                "http://localhost".to_string(),
+            ),
+            (ENV_ALIEN_DEPLOYMENT_TOKEN.to_string(), "tok".to_string()),
+        ]);
+        let error = MintingCredentialSource::from_env(&env)
+            .expect_err("incomplete contract should fail fast");
+        assert_eq!(error.code, "ENVIRONMENT_VARIABLE_MISSING");
+    }
+
+    #[tokio::test]
+    async fn first_use_mints_then_caches_then_re_mints_when_stale() {
+        let (base_url, calls) = spawn_mint_server(3600, None).await;
+        let resolver = MintingResolver::new(source(&base_url), HashMap::new());
+
+        // First access mints.
+        resolver.provider().await.expect("first mint");
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "first access mints once");
+
+        // Second access is served from the fresh cache: no new mint.
+        resolver.provider().await.expect("cached");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "fresh cache must not re-hit the manager"
+        );
+
+        // Once stale, the next access re-mints.
+        resolver.force_stale().await;
+        resolver.provider().await.expect("re-mint");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "stale credentials must trigger a re-mint on access"
+        );
+    }
+
+    #[tokio::test]
+    async fn near_expiry_config_is_treated_as_stale() {
+        // Server hands back an expiry inside the refresh skew window, so the
+        // very next access re-mints — the credential is never handed out cutting
+        // it close to the hard expiry.
+        let (base_url, calls) = spawn_mint_server(60, None).await;
+        let resolver = MintingResolver::new(source(&base_url), HashMap::new());
+
+        resolver.provider().await.expect("first mint");
+        resolver.provider().await.expect("second mint");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "an expiry within the 300s skew window is stale on the next access"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_loads_mint_exactly_once() {
+        // Two tasks race the empty cache; the single-flight guard must collapse
+        // them to one mint. A server delay widens the window to make the race real.
+        let (base_url, calls) = spawn_mint_server(3600, Some(Duration::from_millis(100))).await;
+        let resolver = Arc::new(MintingResolver::new(source(&base_url), HashMap::new()));
+
+        let a = {
+            let resolver = resolver.clone();
+            tokio::spawn(async move { resolver.provider().await.map(|_| ()) })
+        };
+        let b = {
+            let resolver = resolver.clone();
+            tokio::spawn(async move { resolver.provider().await.map(|_| ()) })
+        };
+        a.await.expect("join a").expect("mint a");
+        b.await.expect("join b").expect("mint b");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "single-flight must collapse concurrent first-loads to one mint"
+        );
+    }
+
+    #[tokio::test]
+    async fn debug_never_leaks_token_or_credentials() {
+        let (base_url, _calls) = spawn_mint_server(3600, None).await;
+        let resolver = MintingResolver::new(source(&base_url), HashMap::new());
+        resolver.provider().await.expect("mint");
+
+        let rendered = format!("{resolver:?}");
+        assert!(
+            !rendered.contains("ax_deploy_SECRET_TOKEN"),
+            "resolver Debug leaked the deployment token: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "resolver Debug should mark redacted fields: {rendered}"
+        );
+
+        // The source alone must also redact its token.
+        let source_rendered = format!("{:?}", source(&base_url));
+        assert!(!source_rendered.contains("ax_deploy_SECRET_TOKEN"));
+    }
+}

--- a/crates/alien-bindings/src/credential_source.rs
+++ b/crates/alien-bindings/src/credential_source.rs
@@ -13,6 +13,75 @@
 //! `expiresAt` refresh hint. The minted config is cached and re-minted on
 //! access once it passes the refresh threshold, with a single-flight guard so a
 //! burst of concurrent binding loads triggers at most one mint.
+//!
+//! # Bootstrapping an external app
+//!
+//! An externally-deployed app process (Container/Daemon) never receives a
+//! native cloud identity of its own — it has no IAM role, no metadata service,
+//! nothing [`crate::provider::LazyEnvBindingsProvider`]'s native path can read.
+//! What it does get, injected by the manager at deploy time, is a *deployment
+//! token*: proof of which deployment it is, good for asking the manager to
+//! mint short-lived credentials on its behalf. That handoff is carried by
+//! three env vars, all required together (see [`MintingCredentialSource::from_env`]):
+//!
+//! - `ALIEN_MANAGER_URL` — base URL of the deployment's manager; the mint
+//!   endpoint is `{ALIEN_MANAGER_URL}/v1/credentials/mint`.
+//! - `ALIEN_DEPLOYMENT_TOKEN` — bearer token scoped to this deployment (or its
+//!   deployment group). Sent as `Authorization: Bearer …`; never logged.
+//! - `ALIEN_DEPLOYMENT_SERVICE_ACCOUNT` — the service-account binding to mint
+//!   credentials for (`bindingName` in the request body).
+//!
+//! `ALIEN_DEPLOYMENT_ID` (`deploymentId` in the request body) is reused from
+//! the existing deployment-identity contract rather than duplicated.
+//!
+//! Controller injection of these three vars for Container/Daemon processes is
+//! a follow-up (ALIEN-218 tasks 10/16); until it lands, the gate below is
+//! simply absent and every process falls through to whatever error its native
+//! resolution already produced.
+//!
+//! # Selection order
+//!
+//! [`crate::provider::LazyEnvBindingsProvider`] decides its strategy once, on
+//! first binding use, in a fixed order:
+//!
+//! 1. **Native/projected identity** — `ClientConfig::from_env` succeeds (an
+//!    IAM role, workload identity, metadata service, or explicit static
+//!    credentials in the environment). Used as-is; minting is never attempted.
+//! 2. **Mint** — native resolution failed, but the mint gate
+//!    (`ALIEN_MANAGER_URL` + `ALIEN_DEPLOYMENT_TOKEN`) is present. Falls back
+//!    to this module.
+//! 3. **Original error** — native resolution failed and no mint gate is
+//!    present. The original `from_env` error is surfaced unchanged; there is
+//!    nothing left to fall back to.
+//!
+//! # Refresh semantics
+//!
+//! A minted [`ClientConfig`] is cached under its server-declared `expiresAt`
+//! and treated as stale once `now >= expiresAt - 300s`
+//! ([`REFRESH_SKEW_SECONDS`]) — the credential is re-minted *before* it would
+//! actually expire, not after. Re-minting happens lazily, only on access
+//! ([`MintingResolver::provider`]); there is no background timer.
+//!
+//! Two properties make this safe under concurrency and manager failures:
+//!
+//! - **Single-flight**: concurrent callers that observe a stale/empty cache
+//!   contend on one lock; only the first re-mints, the rest observe the
+//!   now-fresh cache after it releases. A burst of concurrent binding loads
+//!   never produces a burst of mint calls.
+//! - **Fail-closed**: if a mint call errors, that error propagates to the
+//!   caller instead of serving the stale provider. Availability suffers (a
+//!   manager blip can break every binding load), but no caller is ever handed
+//!   credentials past their declared expiry.
+//!
+//! # Static/local mode
+//!
+//! Tests and local development don't need any of this: when
+//! `ClientConfig::from_env` resolves directly (e.g. `ALIEN_DEPLOYMENT_TYPE=local`
+//! with a `state_directory`), selection stops at step 1 above and this module
+//! is never touched. The fake-mint-server tests in this file, and the
+//! `mints_when_native_config_unavailable` / `native_config_wins_and_never_mints`
+//! tests in `crate::provider`, exercise both sides of that boundary without
+//! needing a real manager or real cloud credentials.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -35,6 +104,14 @@ use crate::provider::BindingsProvider;
 /// Re-mint credentials once they are within this many seconds of their
 /// server-declared expiry. Gives in-flight work a safety margin so it never
 /// races a hard expiry, and absorbs modest client/server clock skew.
+///
+/// This margin is only safe from a per-call "mint storm" (re-minting on every
+/// access instead of every refresh window) because the manager clamps minted
+/// lifetimes to `[900, 3600]` seconds (`MIN_DURATION_SECONDS` /
+/// `MAX_DURATION_SECONDS` in `crates/alien-manager/src/routes/credentials.rs`).
+/// A 900s floor minus this 300s skew still leaves a 600s window of cache
+/// hits between mints; if the server ever granted shorter-lived credentials
+/// than the skew, every access would re-mint.
 const REFRESH_SKEW_SECONDS: i64 = 300;
 
 /// Timeout for a single mint HTTP request. The mint endpoint impersonates a
@@ -266,6 +343,10 @@ impl MintingResolver {
             return Ok(provider);
         }
 
+        // Fail closed: if the mint call errors, this returns the error to the
+        // caller rather than serving a stale/expired provider. That trades
+        // availability (a manager blip can break every binding load) for never
+        // handing out credentials past their declared expiry.
         let minted = self.source.mint().await?;
         let provider = Arc::new(BindingsProvider::new(
             minted.client_config,

--- a/crates/alien-bindings/src/lib.rs
+++ b/crates/alien-bindings/src/lib.rs
@@ -28,6 +28,7 @@ pub mod presigned {
     pub use alien_core::presigned::*;
 }
 pub mod alien_context;
+mod credential_source;
 pub mod http_client;
 pub mod provider;
 

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -47,11 +47,19 @@ pub struct BindingsProvider {
 /// otherwise the original `from_env` error is surfaced unchanged.
 pub struct LazyEnvBindingsProvider {
     env: HashMap<String, String>,
+    /// Deployment platform parsed at construction on the runtime path
+    /// ([`BindingsProvider::from_env_lazy`] validates it eagerly and `select`
+    /// reuses it instead of re-parsing `env` on first use). `None` on the
+    /// app-facing deferred path ([`BindingsProvider::from_env_deferred`]),
+    /// which must construct with zero environment; `select` then resolves the
+    /// platform on first use of a configured binding.
+    platform: Option<Platform>,
     /// Binding names present in `env`, parsed at construction. Kept separately
     /// from the fully-resolved [`BindingsProvider`] so the app-facing kinds can
     /// answer "is this binding configured?" without first resolving the platform
     /// or cloud client config. Parsing here also makes malformed binding JSON
-    /// fail fast at construction.
+    /// fail fast at construction, and `select` reuses the parse instead of
+    /// re-parsing `env` on first use.
     bindings: HashMap<String, serde_json::Value>,
     /// The credential resolution strategy, decided once on first use.
     resolver: OnceCell<CredentialResolver>,
@@ -160,11 +168,12 @@ impl BindingsProvider {
     pub fn from_env_lazy(env: HashMap<String, String>) -> Result<LazyEnvBindingsProvider> {
         // Runtime path: validate the deployment platform eagerly so a
         // misconfigured worker fails at startup, not on first binding use.
-        crate::get_platform_from_env(&env)?;
+        let platform = crate::get_platform_from_env(&env)?;
         let bindings = Self::parse_bindings_from_env(&env)?;
 
         Ok(LazyEnvBindingsProvider {
             env,
+            platform: Some(platform),
             bindings,
             resolver: OnceCell::new(),
         })
@@ -190,6 +199,9 @@ impl BindingsProvider {
 
         Ok(LazyEnvBindingsProvider {
             env,
+            // Deferred contract: platform resolution happens on first use of a
+            // configured binding, never at construction.
+            platform: None,
             bindings,
             resolver: OnceCell::new(),
         })
@@ -478,18 +490,25 @@ impl LazyEnvBindingsProvider {
     ///    `ALIEN_DEPLOYMENT_TOKEN`) is present → mint.
     /// 3. Else → surface the original `from_env` error unchanged.
     async fn select(&self) -> Result<CredentialResolver> {
-        let platform = crate::get_platform_from_env(&self.env)?;
-        let bindings = BindingsProvider::parse_bindings_from_env(&self.env)?;
-
+        // Binding JSON (and, on the `from_env_lazy` path, the platform) was
+        // already parsed and validated at construction; `env` cannot have
+        // changed since, so re-parsing would just repeat that work for the
+        // same result. On the `from_env_deferred` path the platform was
+        // deliberately not resolved at construction, so resolve it now.
+        let platform = match self.platform {
+            Some(platform) => platform,
+            None => crate::get_platform_from_env(&self.env)?,
+        };
         match BindingsProvider::client_config_from_env(platform, &self.env).await {
             Ok(client_config) => Ok(CredentialResolver::Static(Arc::new(BindingsProvider::new(
                 client_config,
-                bindings,
+                self.bindings.clone(),
             )?))),
             Err(from_env_error) => match MintingCredentialSource::from_env(&self.env)? {
-                Some(source) => Ok(CredentialResolver::Minting(Box::new(
-                    MintingResolver::new(source, bindings),
-                ))),
+                Some(source) => Ok(CredentialResolver::Minting(Box::new(MintingResolver::new(
+                    source,
+                    self.bindings.clone(),
+                )))),
                 // No mint contract: the environment simply couldn't produce
                 // credentials. Preserve the exact original error.
                 None => Err(from_env_error),

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 
+use crate::credential_source::{MintingCredentialSource, MintingResolver};
 use alien_client_config::ClientConfigExt;
 use alien_core::bindings::PostgresBinding;
 use alien_core::{ClientConfig, Platform, StackState, ENV_OPERATOR_BASE_PLATFORM};
@@ -39,7 +40,11 @@ pub struct BindingsProvider {
 /// Long-running HTTP daemons can be wrapped by alien-runtime only for commands,
 /// logs, or future binding access. They should still start when no startup
 /// secret needs loading, even if cloud metadata is temporarily unavailable.
-#[derive(Debug)]
+///
+/// On first binding use it resolves credentials in a fixed order (see
+/// [`LazyEnvBindingsProvider::select`]): native/projected `ClientConfig::from_env`
+/// first, then minting-backed resolution if the mint env contract is present,
+/// otherwise the original `from_env` error is surfaced unchanged.
 pub struct LazyEnvBindingsProvider {
     env: HashMap<String, String>,
     /// Binding names present in `env`, parsed at construction. Kept separately
@@ -48,7 +53,44 @@ pub struct LazyEnvBindingsProvider {
     /// or cloud client config. Parsing here also makes malformed binding JSON
     /// fail fast at construction.
     bindings: HashMap<String, serde_json::Value>,
-    provider: OnceCell<BindingsProvider>,
+    /// The credential resolution strategy, decided once on first use.
+    resolver: OnceCell<CredentialResolver>,
+}
+
+/// Manual `Debug`: `env` may hold live credential material (cloud secret keys,
+/// the deployment token). Print only the env var *names*, never their values.
+impl std::fmt::Debug for LazyEnvBindingsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyEnvBindingsProvider")
+            .field("env_keys", &self.env.keys().collect::<Vec<_>>())
+            .field("resolver", &self.resolver.get())
+            .finish()
+    }
+}
+
+/// How a [`LazyEnvBindingsProvider`] obtains its [`BindingsProvider`], chosen
+/// once at first binding use.
+enum CredentialResolver {
+    /// Native/projected credentials resolved from the environment. The provider
+    /// (and its `ClientConfig`) never changes for the process lifetime.
+    Static(Arc<BindingsProvider>),
+    /// Minting-backed credentials fetched from the manager. The backing provider
+    /// is rebuilt on each re-mint; see [`MintingResolver`]. Boxed so this variant
+    /// doesn't bloat the common `Static` one.
+    Minting(Box<MintingResolver>),
+}
+
+/// Manual `Debug`: the `Static` provider embeds a live `ClientConfig` and the
+/// `Minting` resolver a bearer token / minted config. Never render either.
+impl std::fmt::Debug for CredentialResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CredentialResolver::Static(_) => f.write_str("Static(<redacted>)"),
+            CredentialResolver::Minting(resolver) => {
+                f.debug_tuple("Minting").field(resolver).finish()
+            }
+        }
+    }
 }
 
 impl BindingsProvider {
@@ -124,7 +166,7 @@ impl BindingsProvider {
         Ok(LazyEnvBindingsProvider {
             env,
             bindings,
-            provider: OnceCell::new(),
+            resolver: OnceCell::new(),
         })
     }
 
@@ -149,7 +191,7 @@ impl BindingsProvider {
         Ok(LazyEnvBindingsProvider {
             env,
             bindings,
-            provider: OnceCell::new(),
+            resolver: OnceCell::new(),
         })
     }
 
@@ -411,10 +453,48 @@ impl BindingsProvider {
 }
 
 impl LazyEnvBindingsProvider {
-    async fn provider(&self) -> Result<&BindingsProvider> {
-        self.provider
-            .get_or_try_init(|| async { BindingsProvider::from_env(self.env.clone()).await })
-            .await
+    /// Resolve (once) which credential strategy to use, then return a provider
+    /// backed by fresh-enough credentials.
+    ///
+    /// The strategy selection happens exactly once (via `OnceCell`); on the
+    /// minting path each call additionally checks credential freshness and
+    /// re-mints on access if stale.
+    async fn provider(&self) -> Result<Arc<BindingsProvider>> {
+        let resolver = self
+            .resolver
+            .get_or_try_init(|| async { self.select().await })
+            .await?;
+
+        match resolver {
+            CredentialResolver::Static(provider) => Ok(provider.clone()),
+            CredentialResolver::Minting(minting) => minting.provider().await,
+        }
+    }
+
+    /// Decide the credential strategy at first use, in a fixed order:
+    ///
+    /// 1. Native/projected `ClientConfig::from_env` succeeds → use it, never mint.
+    /// 2. Else if the mint env contract (`ALIEN_MANAGER_URL` +
+    ///    `ALIEN_DEPLOYMENT_TOKEN`) is present → mint.
+    /// 3. Else → surface the original `from_env` error unchanged.
+    async fn select(&self) -> Result<CredentialResolver> {
+        let platform = crate::get_platform_from_env(&self.env)?;
+        let bindings = BindingsProvider::parse_bindings_from_env(&self.env)?;
+
+        match BindingsProvider::client_config_from_env(platform, &self.env).await {
+            Ok(client_config) => Ok(CredentialResolver::Static(Arc::new(BindingsProvider::new(
+                client_config,
+                bindings,
+            )?))),
+            Err(from_env_error) => match MintingCredentialSource::from_env(&self.env)? {
+                Some(source) => Ok(CredentialResolver::Minting(Box::new(
+                    MintingResolver::new(source, bindings),
+                ))),
+                // No mint contract: the environment simply couldn't produce
+                // credentials. Preserve the exact original error.
+                None => Err(from_env_error),
+            },
+        }
     }
 
     /// Fail fast with [`ErrorData::BindingNotConfigured`] when `binding_name`
@@ -1903,6 +1983,167 @@ mod tests {
             error.to_string().contains("ALIEN_CACHE_BINDING"),
             "message should name the env var, got: {error}"
         );
+    }
+
+    // --- Selection order on the lazy path (native-vs-mint) ---
+
+    mod selection {
+        use super::*;
+        use crate::traits::BindingsProviderApi;
+        use alien_core::{
+            ENV_ALIEN_DEPLOYMENT_ID, ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT,
+            ENV_ALIEN_DEPLOYMENT_TOKEN, ENV_ALIEN_MANAGER_URL,
+        };
+        use axum::{extract::State, routing::post, Json, Router};
+        use std::net::SocketAddr;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tempfile::TempDir;
+
+        /// Fake mint endpoint that counts requests and returns a `Local` config.
+        async fn mint_handler(State(calls): State<Arc<AtomicUsize>>) -> Json<serde_json::Value> {
+            calls.fetch_add(1, Ordering::SeqCst);
+            let expires_at = (chrono::Utc::now() + chrono::Duration::seconds(3600)).to_rfc3339();
+            Json(serde_json::json!({
+                "clientConfig": { "platform": "local", "state_directory": "/tmp/alien-sel-test" },
+                "expiresAt": expires_at,
+                "principal": "local:mint-test",
+            }))
+        }
+
+        async fn spawn_mint_server() -> (String, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let app = Router::new()
+                .route("/v1/credentials/mint", post(mint_handler))
+                .with_state(calls.clone());
+            let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .expect("bind");
+            let addr = listener.local_addr().expect("addr");
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.expect("serve");
+            });
+            (format!("http://{addr}"), calls)
+        }
+
+        fn local_storage_binding(dir: &TempDir) -> String {
+            format!(
+                r#"{{"service":"local-storage","storagePath":"{}"}}"#,
+                dir.path().display()
+            )
+        }
+
+        /// Full mint env contract pointing at `manager_url`.
+        fn mint_env(manager_url: &str) -> HashMap<String, String> {
+            HashMap::from([
+                (ENV_ALIEN_MANAGER_URL.to_string(), manager_url.to_string()),
+                (
+                    ENV_ALIEN_DEPLOYMENT_TOKEN.to_string(),
+                    "ax_deploy_tok".to_string(),
+                ),
+                (ENV_ALIEN_DEPLOYMENT_ID.to_string(), "dep_1".to_string()),
+                (
+                    ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT.to_string(),
+                    "management".to_string(),
+                ),
+            ])
+        }
+
+        #[tokio::test]
+        async fn native_config_wins_and_never_mints() {
+            // Local platform resolves `ClientConfig::from_env` successfully, so
+            // even with a full mint contract present the resolver must pick the
+            // native path and never call the manager.
+            let (base_url, calls) = spawn_mint_server().await;
+            let dir = TempDir::new().expect("tempdir");
+
+            let mut env = mint_env(&base_url);
+            env.insert(
+                ENV_ALIEN_DEPLOYMENT_TYPE.to_string(),
+                Platform::Local.as_str().to_string(),
+            );
+            env.insert(
+                "ALIEN_FILES_BINDING".to_string(),
+                local_storage_binding(&dir),
+            );
+
+            let provider = BindingsProvider::from_env_lazy(env).expect("lazy construct");
+            provider
+                .load_storage("files")
+                .await
+                .expect("native local storage should load");
+
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                0,
+                "native credentials must never trigger a mint"
+            );
+        }
+
+        #[tokio::test]
+        async fn mints_when_native_config_unavailable() {
+            // AWS platform with no usable credentials makes `from_env` fail; with
+            // the mint contract present the resolver falls through to minting and
+            // resolves the (Local) minted config, which then serves the binding.
+            let (base_url, calls) = spawn_mint_server().await;
+            let dir = TempDir::new().expect("tempdir");
+
+            let mut env = mint_env(&base_url);
+            env.insert(
+                ENV_ALIEN_DEPLOYMENT_TYPE.to_string(),
+                Platform::Aws.as_str().to_string(),
+            );
+            env.insert("AWS_EC2_METADATA_DISABLED".to_string(), "true".to_string());
+            env.insert(
+                "AWS_PROFILE".to_string(),
+                "__alien_missing_test_profile__".to_string(),
+            );
+            env.insert(
+                "ALIEN_FILES_BINDING".to_string(),
+                local_storage_binding(&dir),
+            );
+
+            let provider = BindingsProvider::from_env_lazy(env).expect("lazy construct");
+            provider
+                .load_storage("files")
+                .await
+                .expect("mint path should resolve a usable config");
+
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "unavailable native credentials must trigger exactly one mint"
+            );
+        }
+
+        #[tokio::test]
+        async fn no_mint_contract_preserves_original_from_env_error() {
+            // AWS platform, no usable creds, and no mint contract: the resolver
+            // must surface the original `from_env` error unchanged (path 3).
+            let dir = TempDir::new().expect("tempdir");
+            let env = HashMap::from([
+                (
+                    ENV_ALIEN_DEPLOYMENT_TYPE.to_string(),
+                    Platform::Aws.as_str().to_string(),
+                ),
+                ("AWS_EC2_METADATA_DISABLED".to_string(), "true".to_string()),
+                (
+                    "AWS_PROFILE".to_string(),
+                    "__alien_missing_test_profile__".to_string(),
+                ),
+                (
+                    "ALIEN_FILES_BINDING".to_string(),
+                    local_storage_binding(&dir),
+                ),
+            ]);
+
+            let provider = BindingsProvider::from_env_lazy(env).expect("lazy construct");
+            let error = provider
+                .load_storage("files")
+                .await
+                .expect_err("no creds and no mint contract must error");
+
+            assert_eq!(error.code, "CLIENT_CONFIG_INVALID");
+        }
     }
 }
 

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -1909,6 +1909,28 @@ mod tests {
         assert_eq!(error.code, "CLIENT_CONFIG_INVALID");
     }
 
+    /// The construction-time binding-JSON parse is load-bearing: `select`
+    /// reuses it instead of re-parsing `env` on first use, so malformed JSON
+    /// must fail at construction — for BOTH lazy constructors.
+    #[test]
+    fn malformed_binding_json_fails_at_construction_for_both_lazy_constructors() {
+        let env = HashMap::from([
+            (
+                ENV_ALIEN_DEPLOYMENT_TYPE.to_string(),
+                Platform::Aws.as_str().to_string(),
+            ),
+            ("ALIEN_FILES_BINDING".to_string(), "not-json".to_string()),
+        ]);
+
+        let error = BindingsProvider::from_env_lazy(env.clone())
+            .expect_err("from_env_lazy must reject malformed binding JSON at construction");
+        assert_eq!(error.code, "BINDING_CONFIG_INVALID");
+
+        let error = BindingsProvider::from_env_deferred(env)
+            .expect_err("from_env_deferred must reject malformed binding JSON at construction");
+        assert_eq!(error.code, "BINDING_CONFIG_INVALID");
+    }
+
     // Building the KubernetesCloud client config requires kubernetes support
     // to be compiled in; without the feature, `from_env` rejects the config.
     #[cfg(feature = "kubernetes")]

--- a/crates/alien-core/src/runtime_environment.rs
+++ b/crates/alien-core/src/runtime_environment.rs
@@ -23,6 +23,22 @@ pub const ENV_ALIEN_COMMANDS_TOKEN: &str = "ALIEN_COMMANDS_TOKEN";
 /// by runtime polling in a later ALIEN-219 task; declared here so it's
 /// reserved from day one.
 pub const ENV_ALIEN_COMMANDS_TARGET_RESOURCE_ID: &str = "ALIEN_COMMANDS_TARGET_RESOURCE_ID";
+/// Base URL of the deployment's manager. The client-side minting-backed
+/// credential resolver ([`alien-bindings`]) posts to `{ALIEN_MANAGER_URL}/v1/credentials/mint`
+/// when native cloud credentials are not available in the environment.
+/// Injected for deployed app processes by the manager (controller injection is
+/// tracked as an ALIEN-218 task-10/16 follow-up).
+pub const ENV_ALIEN_MANAGER_URL: &str = "ALIEN_MANAGER_URL";
+/// Deployment bearer token the minting resolver presents to the manager. Carries
+/// the deployment's token value; kept distinct from [`ENV_ALIEN_COMMANDS_TOKEN`]
+/// (which is worker-command-polling scoped and only injected for command-enabled
+/// workers) so the Container/Daemon lazy-bindings path has a deployment-wide
+/// credential of its own.
+pub const ENV_ALIEN_DEPLOYMENT_TOKEN: &str = "ALIEN_DEPLOYMENT_TOKEN";
+/// Service-account binding name the minting resolver asks the manager to mint
+/// credentials for (the deployment's own managed identity). Required by the mint
+/// request contract; the manager selects and injects it (task-10/16 follow-up).
+pub const ENV_ALIEN_DEPLOYMENT_SA_BINDING: &str = "ALIEN_DEPLOYMENT_SA_BINDING";
 pub const ENV_ALIEN_BINDINGS_ADDRESS: &str = "ALIEN_BINDINGS_ADDRESS";
 pub const ENV_ALIEN_BINDINGS_GRPC_ADDRESS: &str = "ALIEN_BINDINGS_GRPC_ADDRESS";
 pub const ENV_ALIEN_BINDINGS_MODE: &str = "ALIEN_BINDINGS_MODE";
@@ -418,6 +434,9 @@ pub fn is_reserved_runtime_environment_name(name: &str) -> bool {
                 | ENV_ALIEN_COMMANDS_TARGET_RESOURCE_ID
                 | ENV_ALIEN_DEPLOYMENT_ID
                 | ENV_ALIEN_DEPLOYMENT_NAME
+                | ENV_ALIEN_DEPLOYMENT_SA_BINDING
+                | ENV_ALIEN_DEPLOYMENT_TOKEN
+                | ENV_ALIEN_MANAGER_URL
                 | ENV_ALIEN_PUBLIC_ENDPOINTS_JSON
                 | ENV_ALIEN_RUNTIME_SECRETS
                 | ENV_ALIEN_SECRETS
@@ -494,6 +513,20 @@ mod tests {
             "ALIEN_BINDING_STORAGE_URL"
         ));
         assert!(!is_reserved_runtime_environment_name("USER_DEFINED"));
+    }
+
+    #[test]
+    fn reserves_minting_credential_resolver_names() {
+        assert!(is_reserved_runtime_environment_name(ENV_ALIEN_MANAGER_URL));
+        assert!(is_reserved_runtime_environment_name(
+            ENV_ALIEN_DEPLOYMENT_TOKEN
+        ));
+        assert!(is_reserved_runtime_environment_name(
+            ENV_ALIEN_DEPLOYMENT_SA_BINDING
+        ));
+        assert_eq!(ENV_ALIEN_MANAGER_URL, "ALIEN_MANAGER_URL");
+        assert_eq!(ENV_ALIEN_DEPLOYMENT_TOKEN, "ALIEN_DEPLOYMENT_TOKEN");
+        assert_eq!(ENV_ALIEN_DEPLOYMENT_SA_BINDING, "ALIEN_DEPLOYMENT_SA_BINDING");
     }
 
     #[test]

--- a/crates/alien-core/src/runtime_environment.rs
+++ b/crates/alien-core/src/runtime_environment.rs
@@ -38,7 +38,10 @@ pub const ENV_ALIEN_DEPLOYMENT_TOKEN: &str = "ALIEN_DEPLOYMENT_TOKEN";
 /// Service-account binding name the minting resolver asks the manager to mint
 /// credentials for (the deployment's own managed identity). Required by the mint
 /// request contract; the manager selects and injects it (task-10/16 follow-up).
-pub const ENV_ALIEN_DEPLOYMENT_SA_BINDING: &str = "ALIEN_DEPLOYMENT_SA_BINDING";
+///
+/// Deliberately does **not** end in `_BINDING`: names matching `ALIEN_*_BINDING`
+/// are parsed as resource-binding JSON by the provider, which this is not.
+pub const ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT: &str = "ALIEN_DEPLOYMENT_SERVICE_ACCOUNT";
 pub const ENV_ALIEN_BINDINGS_ADDRESS: &str = "ALIEN_BINDINGS_ADDRESS";
 pub const ENV_ALIEN_BINDINGS_GRPC_ADDRESS: &str = "ALIEN_BINDINGS_GRPC_ADDRESS";
 pub const ENV_ALIEN_BINDINGS_MODE: &str = "ALIEN_BINDINGS_MODE";
@@ -434,7 +437,7 @@ pub fn is_reserved_runtime_environment_name(name: &str) -> bool {
                 | ENV_ALIEN_COMMANDS_TARGET_RESOURCE_ID
                 | ENV_ALIEN_DEPLOYMENT_ID
                 | ENV_ALIEN_DEPLOYMENT_NAME
-                | ENV_ALIEN_DEPLOYMENT_SA_BINDING
+                | ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT
                 | ENV_ALIEN_DEPLOYMENT_TOKEN
                 | ENV_ALIEN_MANAGER_URL
                 | ENV_ALIEN_PUBLIC_ENDPOINTS_JSON
@@ -522,11 +525,17 @@ mod tests {
             ENV_ALIEN_DEPLOYMENT_TOKEN
         ));
         assert!(is_reserved_runtime_environment_name(
-            ENV_ALIEN_DEPLOYMENT_SA_BINDING
+            ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT
         ));
         assert_eq!(ENV_ALIEN_MANAGER_URL, "ALIEN_MANAGER_URL");
         assert_eq!(ENV_ALIEN_DEPLOYMENT_TOKEN, "ALIEN_DEPLOYMENT_TOKEN");
-        assert_eq!(ENV_ALIEN_DEPLOYMENT_SA_BINDING, "ALIEN_DEPLOYMENT_SA_BINDING");
+        assert_eq!(
+            ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT,
+            "ALIEN_DEPLOYMENT_SERVICE_ACCOUNT"
+        );
+        // Must not match the `ALIEN_*_BINDING` resource-binding pattern, or the
+        // provider would try to parse its value as binding JSON.
+        assert!(!ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT.ends_with("_BINDING"));
     }
 
     #[test]

--- a/crates/alien-manager/src/routes/credentials.rs
+++ b/crates/alien-manager/src/routes/credentials.rs
@@ -3,6 +3,7 @@
 use alien_bindings::traits::ImpersonationRequest;
 use alien_bindings::ServiceAccountInfo;
 use alien_core::ClientConfig;
+use alien_error::ContextError;
 use axum::{
     extract::{Json, State},
     http::HeaderMap,
@@ -14,8 +15,10 @@ use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
+use crate::auth::Subject;
 use crate::error::ErrorData;
 use crate::ids::sha256_hash;
+use crate::traits::DeploymentRecord;
 
 use super::{auth, AppState};
 
@@ -40,11 +43,23 @@ pub struct ResolveCredentialsRequest {
     pub deployment_id: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveCredentialsResponse {
-    pub client_config: serde_json::Value,
+    pub client_config: ClientConfig,
+}
+
+/// Manual `Debug`: `ClientConfig` carries live credentials. Never let a
+/// `{:?}` of this response (log line, panic message, test failure output)
+/// print them — even indirectly through `serde_json::Value`, which has no
+/// redaction of its own once the typed config is serialized.
+impl std::fmt::Debug for ResolveCredentialsResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolveCredentialsResponse")
+            .field("client_config", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Request body for `POST /v1/credentials/mint`.
@@ -73,17 +88,36 @@ pub struct MintCredentialsRequest {
 }
 
 /// Response body for `POST /v1/credentials/mint`.
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct MintCredentialsResponse {
     /// Minted platform client configuration (carries the short-lived creds).
-    pub client_config: serde_json::Value,
+    pub client_config: ClientConfig,
     /// Credential expiry as an RFC3339 timestamp (now + clamped duration).
+    ///
+    /// This is server-computed (`now + clamped duration`), not read back from
+    /// the provider — for lazily-resolved configs (e.g. GCP, where the
+    /// resolver doesn't always round-trip an authoritative expiry) it is
+    /// nominal rather than provider truth. Treat it as a refresh hint: fetch
+    /// new credentials at or before this time, don't rely on it to prove the
+    /// underlying credential is still valid at that exact instant.
     pub expires_at: String,
     /// Human-readable identity the credentials act as (role ARN, SA email,
     /// managed-identity client id, or `platform:account` for the local path).
     pub principal: String,
+}
+
+/// Manual `Debug`: see [`ResolveCredentialsResponse`]'s impl — same reasoning,
+/// same secret-bearing field.
+impl std::fmt::Debug for MintCredentialsResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MintCredentialsResponse")
+            .field("client_config", &"<redacted>")
+            .field("expires_at", &self.expires_at)
+            .field("principal", &self.principal)
+            .finish()
+    }
 }
 
 // --- Router ---
@@ -113,38 +147,66 @@ async fn resolve_credentials(
     headers: HeaderMap,
     Json(req): Json<ResolveCredentialsRequest>,
 ) -> Response {
-    let subject = match auth::require_auth(&state, &headers).await {
-        Ok(s) => s,
-        Err(e) => return e.into_response(),
-    };
-    // Get the deployment, then authorize on the loaded entity (Pattern 2 of
-    // authorization-guidelines.md).
-    let deployment = match state
-        .deployment_store
-        .get_deployment(&subject, &req.deployment_id)
-        .await
+    let (_subject, deployment) = match authorize_deployment(
+        &state,
+        &headers,
+        &req.deployment_id,
+        "resolve credentials for",
+    )
+    .await
     {
-        Ok(Some(d)) => d,
-        Ok(None) => return ErrorData::not_found_deployment(&req.deployment_id).into_response(),
-        Err(e) => return e.into_response(),
+        Ok(pair) => pair,
+        Err(response) => return response,
     };
-
-    if !state.authz.can_act_on_deployment(&subject, &deployment) {
-        return ErrorData::forbidden("Cannot resolve credentials for this deployment")
-            .into_response();
-    }
 
     // Resolve credentials
     match state.credential_resolver.resolve(&deployment).await {
-        Ok(client_config) => {
-            let config_value = serde_json::to_value(&client_config).unwrap_or_default();
-            Json(ResolveCredentialsResponse {
-                client_config: config_value,
-            })
-            .into_response()
-        }
+        Ok(client_config) => Json(ResolveCredentialsResponse { client_config }).into_response(),
         Err(e) => e.into_response(),
     }
+}
+
+// --- Shared auth/load plumbing ---
+
+/// Load the deployment and authorize the subject on it. Shared by
+/// `resolve_credentials` and `mint_credentials`, which both need "valid
+/// bearer, deployment exists, subject can act on it" before doing anything
+/// endpoint-specific. `action` only affects the forbidden-response wording
+/// (e.g. `"mint credentials for"`).
+///
+/// `can_act_on_deployment` is `can_read_deployment` under the hood: a
+/// Workspace/Project-scoped token passes unconditionally, a
+/// DeploymentGroup-scoped token passes for any deployment in its group, and a
+/// Deployment-scoped token passes only for its own deployment. So a
+/// deployment-group token can mint/resolve for every deployment in its group
+/// — an inherited grant, not a bug (see the DG-token matrix test).
+async fn authorize_deployment(
+    state: &AppState,
+    headers: &HeaderMap,
+    deployment_id: &str,
+    action: &str,
+) -> std::result::Result<(Subject, DeploymentRecord), Response> {
+    let subject = auth::require_auth(state, headers)
+        .await
+        .map_err(|e| e.into_response())?;
+
+    let deployment = match state
+        .deployment_store
+        .get_deployment(&subject, deployment_id)
+        .await
+    {
+        Ok(Some(d)) => d,
+        Ok(None) => return Err(ErrorData::not_found_deployment(deployment_id).into_response()),
+        Err(e) => return Err(e.into_response()),
+    };
+
+    if !state.authz.can_act_on_deployment(&subject, &deployment) {
+        return Err(
+            ErrorData::forbidden(format!("Cannot {action} this deployment")).into_response(),
+        );
+    }
+
+    Ok((subject, deployment))
 }
 
 // --- Mint handler ---
@@ -166,27 +228,25 @@ async fn mint_credentials(
     headers: HeaderMap,
     Json(req): Json<MintCredentialsRequest>,
 ) -> Response {
-    // Auth: valid bearer required (401 otherwise).
-    let subject = match auth::require_auth(&state, &headers).await {
-        Ok(s) => s,
-        Err(e) => return e.into_response(),
-    };
+    // Auth + load + authorize (401 / 404 / 403). See `authorize_deployment`
+    // for the scope semantics — notably that DeploymentGroup/Project/Workspace
+    // scoped tokens all inherit mint access, not just the deployment's own
+    // token.
+    let (_subject, deployment) =
+        match authorize_deployment(&state, &headers, &req.deployment_id, "mint credentials for")
+            .await
+        {
+            Ok(pair) => pair,
+            Err(response) => return response,
+        };
 
-    // Load the deployment, then authorize on the loaded entity. A deployment
-    // token whose scope doesn't match this deployment fails `can_act_on_...`
-    // (403); a workspace-admin token passes.
-    let deployment = match state
-        .deployment_store
-        .get_deployment(&subject, &req.deployment_id)
-        .await
-    {
-        Ok(Some(d)) => d,
-        Ok(None) => return ErrorData::not_found_deployment(&req.deployment_id).into_response(),
-        Err(e) => return e.into_response(),
-    };
-
-    if !state.authz.can_act_on_deployment(&subject, &deployment) {
-        return ErrorData::forbidden("Cannot mint credentials for this deployment").into_response();
+    if let Some(response) = validate_sts_session_component("bindingName", &req.binding_name) {
+        return response;
+    }
+    if let Some(resource_id) = req.resource_id.as_deref() {
+        if let Some(response) = validate_sts_session_component("resourceId", resource_id) {
+            return response;
+        }
     }
 
     let platform = deployment.platform;
@@ -215,9 +275,22 @@ async fn mint_credentials(
                 }
             };
 
+            // `.context(...)` preserves the source error's code/retryable/
+            // http_status_code/chain instead of flattening it into a bare
+            // "internal error: {message}" string — same idiom the local
+            // (resolver) path gets for free via `e.into_response()`.
             let info = match service_account.get_info().await {
                 Ok(info) => info,
-                Err(e) => return ErrorData::internal(e.message).into_response(),
+                Err(e) => {
+                    return e
+                        .context(ErrorData::InternalError {
+                            message: format!(
+                                "Failed to get service-account info for binding '{}'",
+                                req.binding_name
+                            ),
+                        })
+                        .into_response()
+                }
             };
 
             let impersonated = match service_account
@@ -229,7 +302,16 @@ async fn mint_credentials(
                 .await
             {
                 Ok(config) => config,
-                Err(e) => return ErrorData::internal(e.message).into_response(),
+                Err(e) => {
+                    return e
+                        .context(ErrorData::InternalError {
+                            message: format!(
+                                "Failed to impersonate service-account binding '{}'",
+                                req.binding_name
+                            ),
+                        })
+                        .into_response()
+                }
             };
 
             (impersonated, principal_from_info(&info), "impersonation")
@@ -242,14 +324,6 @@ async fn mint_credentials(
                 Err(e) => return e.into_response(),
             }
         };
-
-    let config_value = match serde_json::to_value(&client_config) {
-        Ok(value) => value,
-        Err(e) => {
-            return ErrorData::internal(format!("Failed to serialize client config: {e}"))
-                .into_response()
-        }
-    };
 
     let expires_at = (Utc::now() + chrono::Duration::seconds(duration_seconds as i64))
         .to_rfc3339_opts(SecondsFormat::Secs, true);
@@ -268,7 +342,7 @@ async fn mint_credentials(
     );
 
     Json(MintCredentialsResponse {
-        client_config: config_value,
+        client_config,
         expires_at,
         principal,
     })
@@ -300,9 +374,15 @@ fn mint_session_name(deployment_id: &str, resource_id: Option<&str>) -> String {
 
 /// Truncate a session name to [`MAX_SESSION_NAME_LEN`] with a hash suffix.
 ///
-/// Inputs are ASCII (`alien-mint-`, deployment/resource ids), so byte slicing
-/// is safe. The suffix is the first 8 hex chars of the SHA-256 of the full raw
-/// name, keeping the result deterministic and collision-resistant.
+/// The suffix is the first 8 hex chars of the SHA-256 of the full raw name,
+/// keeping the result deterministic and collision-resistant.
+///
+/// Callers today only pass STS-safe-charset (hence ASCII) input — see
+/// [`validate_sts_session_component`] — but this walks the cut point back to
+/// the nearest `char` boundary regardless, as defense in depth against any
+/// future caller that isn't validated the same way. Byte-slicing a
+/// multi-byte-straddling index panics; there is no excuse to let that surface
+/// here again.
 fn truncate_session_name(raw: &str) -> String {
     if raw.len() <= MAX_SESSION_NAME_LEN {
         return raw.to_string();
@@ -310,8 +390,37 @@ fn truncate_session_name(raw: &str) -> String {
     let suffix = sha256_hash(raw);
     let suffix = &suffix[..8];
     // prefix + '-' + 8-char suffix == MAX_SESSION_NAME_LEN
-    let prefix_len = MAX_SESSION_NAME_LEN - 1 - suffix.len();
+    let mut prefix_len = MAX_SESSION_NAME_LEN - 1 - suffix.len();
+    while prefix_len > 0 && !raw.is_char_boundary(prefix_len) {
+        prefix_len -= 1;
+    }
     format!("{}-{}", &raw[..prefix_len], suffix)
+}
+
+/// STS `RoleSessionName` safe charset: `[A-Za-z0-9_+=,.@-]`. AWS STS rejects
+/// anything outside this set, and folding caller-controlled text into the
+/// session name without checking it first is how [`truncate_session_name`]
+/// used to panic on non-ASCII input. Validating up front turns that into a
+/// clean 400 and forecloses weird strings from ever reaching the audit log.
+///
+/// Returns `Some(response)` (a 400) when `value` is invalid, `None` when it's
+/// fine — an `Option` rather than `Result<(), Response>` because the `Ok`
+/// side carries no data and clippy (rightly) flags a `Result` whose only
+/// payload is a fat `Response` in the `Err` arm.
+fn validate_sts_session_component(field: &str, value: &str) -> Option<Response> {
+    let is_safe = value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '+' | '=' | ',' | '.' | '@' | '-'));
+    if is_safe {
+        None
+    } else {
+        Some(
+            ErrorData::bad_request(format!(
+                "{field} contains characters outside the STS session-name charset (allowed: A-Z a-z 0-9 _ + = , . @ -)"
+            ))
+            .into_response(),
+        )
+    }
 }
 
 /// Derive a principal string from an impersonated service account's identity.
@@ -337,7 +446,8 @@ fn principal_from_client_config(config: &ClientConfig) -> String {
 mod tests {
     use super::{
         clamp_duration, mint_session_name, principal_from_client_config, principal_from_info,
-        truncate_session_name, MAX_SESSION_NAME_LEN,
+        truncate_session_name, MintCredentialsResponse, ResolveCredentialsResponse,
+        MAX_SESSION_NAME_LEN,
     };
     use alien_bindings::ServiceAccountInfo;
     use alien_bindings::{
@@ -409,6 +519,22 @@ mod tests {
     }
 
     #[test]
+    fn truncate_session_name_multibyte_input_does_not_panic_on_boundary() {
+        // 'é' is 2 bytes in UTF-8. 40 repetitions is an 80-byte string whose
+        // deterministic prefix cut (byte 55, per MAX_SESSION_NAME_LEN) lands
+        // mid-character. This must not panic regardless of what upstream
+        // validation does — defense in depth for future callers of this
+        // helper.
+        let raw = "é".repeat(40);
+        let truncated = truncate_session_name(&raw);
+        assert!(
+            truncated.len() <= MAX_SESSION_NAME_LEN,
+            "got {} bytes: {truncated}",
+            truncated.len()
+        );
+    }
+
+    #[test]
     fn principal_from_info_extracts_platform_identity() {
         assert_eq!(
             principal_from_info(&ServiceAccountInfo::Aws(AwsServiceAccountInfo {
@@ -432,6 +558,44 @@ mod tests {
             })),
             "client-abc"
         );
+    }
+
+    #[test]
+    fn mint_response_debug_redacts_client_config() {
+        let secret_config = ClientConfig::Aws(Box::new(AwsClientConfig {
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            credentials: AwsCredentials::AccessKeys {
+                access_key_id: "AKIA_SECRET".to_string(),
+                secret_access_key: "TOP_SECRET_KEY_MATERIAL".to_string(),
+                session_token: Some("TOP_SECRET_SESSION_TOKEN".to_string()),
+            },
+            service_overrides: None,
+        }));
+
+        let mint_response = MintCredentialsResponse {
+            client_config: secret_config.clone(),
+            expires_at: "2026-01-01T00:00:00Z".to_string(),
+            principal: "arn:aws:iam::123:role/r".to_string(),
+        };
+        let mint_debug = format!("{:?}", mint_response);
+        assert!(
+            mint_debug.contains("<redacted>"),
+            "expected redaction marker: {mint_debug}"
+        );
+        assert!(!mint_debug.contains("TOP_SECRET_KEY_MATERIAL"));
+        assert!(!mint_debug.contains("TOP_SECRET_SESSION_TOKEN"));
+
+        let resolve_response = ResolveCredentialsResponse {
+            client_config: secret_config,
+        };
+        let resolve_debug = format!("{:?}", resolve_response);
+        assert!(
+            resolve_debug.contains("<redacted>"),
+            "expected redaction marker: {resolve_debug}"
+        );
+        assert!(!resolve_debug.contains("TOP_SECRET_KEY_MATERIAL"));
+        assert!(!resolve_debug.contains("TOP_SECRET_SESSION_TOKEN"));
     }
 
     #[test]

--- a/crates/alien-manager/src/routes/credentials.rs
+++ b/crates/alien-manager/src/routes/credentials.rs
@@ -1,5 +1,8 @@
-//! Credential resolution endpoint.
+//! Credential resolution and minting endpoints.
 
+use alien_bindings::traits::ImpersonationRequest;
+use alien_bindings::ServiceAccountInfo;
+use alien_core::ClientConfig;
 use axum::{
     extract::{Json, State},
     http::HeaderMap,
@@ -7,11 +10,26 @@ use axum::{
     routing::post,
     Router,
 };
+use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::error::ErrorData;
+use crate::ids::sha256_hash;
 
 use super::{auth, AppState};
+
+// --- Mint constants ---
+
+/// Minimum session duration the mint endpoint will grant, in seconds.
+const MIN_DURATION_SECONDS: i32 = 900;
+/// Maximum session duration the mint endpoint will grant, in seconds.
+const MAX_DURATION_SECONDS: i32 = 3600;
+/// Default session duration when the caller omits `durationSeconds`.
+const DEFAULT_DURATION_SECONDS: i32 = 3600;
+/// Maximum length of an STS `RoleSessionName`. Session names longer than this
+/// are hash-suffix truncated (see [`mint_session_name`]).
+const MAX_SESSION_NAME_LEN: usize = 64;
 
 // --- Request / Response types ---
 
@@ -29,10 +47,51 @@ pub struct ResolveCredentialsResponse {
     pub client_config: serde_json::Value,
 }
 
+/// Request body for `POST /v1/credentials/mint`.
+///
+/// `deny_unknown_fields` so clients cannot smuggle in resolver internals
+/// (platform, stack state, etc.) — the server derives everything from the
+/// authenticated deployment.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MintCredentialsRequest {
+    /// Deployment to mint credentials for. The caller's bearer token must be
+    /// this deployment's token (or a workspace-admin token).
+    pub deployment_id: String,
+    /// Optional target resource the credentials are scoped to. Only affects the
+    /// impersonation session name.
+    #[serde(default)]
+    pub resource_id: Option<String>,
+    /// Service-account binding to impersonate on the target platform.
+    pub binding_name: String,
+    /// Requested lifetime in seconds. Clamped to
+    /// `[MIN_DURATION_SECONDS, MAX_DURATION_SECONDS]`; defaults to
+    /// `DEFAULT_DURATION_SECONDS` when omitted.
+    #[serde(default)]
+    pub duration_seconds: Option<i32>,
+}
+
+/// Response body for `POST /v1/credentials/mint`.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct MintCredentialsResponse {
+    /// Minted platform client configuration (carries the short-lived creds).
+    pub client_config: serde_json::Value,
+    /// Credential expiry as an RFC3339 timestamp (now + clamped duration).
+    pub expires_at: String,
+    /// Human-readable identity the credentials act as (role ARN, SA email,
+    /// managed-identity client id, or `platform:account` for the local path).
+    pub principal: String,
+}
+
 // --- Router ---
 
 pub fn router() -> Router<AppState> {
-    Router::new().route("/v1/resolve-credentials", post(resolve_credentials))
+    Router::new()
+        .route("/v1/resolve-credentials", post(resolve_credentials))
+        .route("/v1/credentials/mint", post(mint_credentials))
 }
 
 // --- Handler ---
@@ -85,5 +144,308 @@ async fn resolve_credentials(
             .into_response()
         }
         Err(e) => e.into_response(),
+    }
+}
+
+// --- Mint handler ---
+
+#[cfg_attr(feature = "openapi", utoipa::path(
+    post,
+    path = "/v1/credentials/mint",
+    tag = "credentials",
+    request_body = MintCredentialsRequest,
+    responses(
+        (status = 200, description = "Credentials minted successfully", body = MintCredentialsResponse)
+    ),
+    security(
+        ("bearer" = [])
+    )
+))]
+async fn mint_credentials(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<MintCredentialsRequest>,
+) -> Response {
+    // Auth: valid bearer required (401 otherwise).
+    let subject = match auth::require_auth(&state, &headers).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    // Load the deployment, then authorize on the loaded entity. A deployment
+    // token whose scope doesn't match this deployment fails `can_act_on_...`
+    // (403); a workspace-admin token passes.
+    let deployment = match state
+        .deployment_store
+        .get_deployment(&subject, &req.deployment_id)
+        .await
+    {
+        Ok(Some(d)) => d,
+        Ok(None) => return ErrorData::not_found_deployment(&req.deployment_id).into_response(),
+        Err(e) => return e.into_response(),
+    };
+
+    if !state.authz.can_act_on_deployment(&subject, &deployment) {
+        return ErrorData::forbidden("Cannot mint credentials for this deployment").into_response();
+    }
+
+    let platform = deployment.platform;
+    let duration_seconds = clamp_duration(req.duration_seconds);
+    let session_name = mint_session_name(&req.deployment_id, req.resource_id.as_deref());
+
+    // Prefer per-target impersonation: if a target bindings provider is
+    // configured for this platform (managed / cross-account mode), impersonate
+    // the requested service-account binding to obtain short-lived credentials.
+    // Otherwise fall back to the deployment-level credential resolver
+    // (single-account / local mode). The branch — not a config flag — is what
+    // distinguishes managed impersonation from local resolution.
+    let (client_config, principal, provider) =
+        if let Some(target_provider) = state.target_bindings_providers.get(&platform) {
+            let service_account = match target_provider
+                .load_service_account(&req.binding_name)
+                .await
+            {
+                Ok(sa) => sa,
+                Err(e) => {
+                    return ErrorData::bad_request(format!(
+                        "Service-account binding '{}' not available for {}: {}",
+                        req.binding_name, platform, e.message
+                    ))
+                    .into_response()
+                }
+            };
+
+            let info = match service_account.get_info().await {
+                Ok(info) => info,
+                Err(e) => return ErrorData::internal(e.message).into_response(),
+            };
+
+            let impersonated = match service_account
+                .impersonate(ImpersonationRequest {
+                    session_name: Some(session_name),
+                    duration_seconds: Some(duration_seconds),
+                    scopes: None,
+                })
+                .await
+            {
+                Ok(config) => config,
+                Err(e) => return ErrorData::internal(e.message).into_response(),
+            };
+
+            (impersonated, principal_from_info(&info), "impersonation")
+        } else {
+            match state.credential_resolver.resolve(&deployment).await {
+                Ok(config) => {
+                    let principal = principal_from_client_config(&config);
+                    (config, principal, "resolver")
+                }
+                Err(e) => return e.into_response(),
+            }
+        };
+
+    let config_value = match serde_json::to_value(&client_config) {
+        Ok(value) => value,
+        Err(e) => {
+            return ErrorData::internal(format!("Failed to serialize client config: {e}"))
+                .into_response()
+        }
+    };
+
+    let expires_at = (Utc::now() + chrono::Duration::seconds(duration_seconds as i64))
+        .to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    // Structured audit trail. NEVER logs credential material — only the
+    // request shape, the resolved provider/principal, and the expiry.
+    info!(
+        deployment_id = %req.deployment_id,
+        resource_id = req.resource_id.as_deref().unwrap_or("-"),
+        binding_name = %req.binding_name,
+        provider = %provider,
+        principal = %principal,
+        expires_at = %expires_at,
+        duration_seconds = duration_seconds,
+        "Minted deployment credentials"
+    );
+
+    Json(MintCredentialsResponse {
+        client_config: config_value,
+        expires_at,
+        principal,
+    })
+    .into_response()
+}
+
+// --- Mint helpers ---
+
+/// Clamp a requested duration into the allowed window, defaulting when absent.
+fn clamp_duration(requested: Option<i32>) -> i32 {
+    requested
+        .unwrap_or(DEFAULT_DURATION_SECONDS)
+        .clamp(MIN_DURATION_SECONDS, MAX_DURATION_SECONDS)
+}
+
+/// Build the impersonation session name `alien-mint-{deploymentId}-{resourceId}`,
+/// truncated to fit STS's `RoleSessionName` limit ([`MAX_SESSION_NAME_LEN`]).
+///
+/// When the raw name is too long, it is replaced by a stable
+/// `{prefix}-{hash8}` form so distinct inputs keep distinct (and reproducible)
+/// session names while staying within the limit.
+fn mint_session_name(deployment_id: &str, resource_id: Option<&str>) -> String {
+    let raw = match resource_id {
+        Some(resource_id) => format!("alien-mint-{deployment_id}-{resource_id}"),
+        None => format!("alien-mint-{deployment_id}"),
+    };
+    truncate_session_name(&raw)
+}
+
+/// Truncate a session name to [`MAX_SESSION_NAME_LEN`] with a hash suffix.
+///
+/// Inputs are ASCII (`alien-mint-`, deployment/resource ids), so byte slicing
+/// is safe. The suffix is the first 8 hex chars of the SHA-256 of the full raw
+/// name, keeping the result deterministic and collision-resistant.
+fn truncate_session_name(raw: &str) -> String {
+    if raw.len() <= MAX_SESSION_NAME_LEN {
+        return raw.to_string();
+    }
+    let suffix = sha256_hash(raw);
+    let suffix = &suffix[..8];
+    // prefix + '-' + 8-char suffix == MAX_SESSION_NAME_LEN
+    let prefix_len = MAX_SESSION_NAME_LEN - 1 - suffix.len();
+    format!("{}-{}", &raw[..prefix_len], suffix)
+}
+
+/// Derive a principal string from an impersonated service account's identity.
+fn principal_from_info(info: &ServiceAccountInfo) -> String {
+    match info {
+        ServiceAccountInfo::Aws(aws) => aws.role_arn.clone(),
+        ServiceAccountInfo::Gcp(gcp) => gcp.email.clone(),
+        ServiceAccountInfo::Azure(azure) => azure.client_id.clone(),
+    }
+}
+
+/// Derive a principal string from resolved (non-impersonated) credentials.
+fn principal_from_client_config(config: &ClientConfig) -> String {
+    match config {
+        ClientConfig::Aws(aws) => format!("aws:{}", aws.account_id),
+        ClientConfig::Gcp(gcp) => format!("gcp:{}", gcp.project_id),
+        ClientConfig::Azure(azure) => format!("azure:{}", azure.subscription_id),
+        other => other.platform().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        clamp_duration, mint_session_name, principal_from_client_config, principal_from_info,
+        truncate_session_name, MAX_SESSION_NAME_LEN,
+    };
+    use alien_bindings::ServiceAccountInfo;
+    use alien_bindings::{
+        traits::AwsServiceAccountInfo, traits::AzureServiceAccountInfo,
+        traits::GcpServiceAccountInfo,
+    };
+    use alien_core::{AwsClientConfig, AwsCredentials, ClientConfig};
+
+    #[test]
+    fn clamp_duration_defaults_when_absent() {
+        assert_eq!(clamp_duration(None), 3600);
+    }
+
+    #[test]
+    fn clamp_duration_clamps_below_minimum() {
+        assert_eq!(clamp_duration(Some(10)), 900);
+        assert_eq!(clamp_duration(Some(-5)), 900);
+    }
+
+    #[test]
+    fn clamp_duration_clamps_above_maximum() {
+        assert_eq!(clamp_duration(Some(100_000)), 3600);
+    }
+
+    #[test]
+    fn clamp_duration_passes_through_in_range() {
+        assert_eq!(clamp_duration(Some(1800)), 1800);
+        assert_eq!(clamp_duration(Some(900)), 900);
+        assert_eq!(clamp_duration(Some(3600)), 3600);
+    }
+
+    #[test]
+    fn session_name_short_is_unchanged() {
+        assert_eq!(
+            mint_session_name("dep_123", Some("api")),
+            "alien-mint-dep_123-api"
+        );
+        assert_eq!(mint_session_name("dep_123", None), "alien-mint-dep_123");
+    }
+
+    #[test]
+    fn session_name_truncates_long_input_within_limit() {
+        let long_deployment = "d".repeat(80);
+        let name = mint_session_name(&long_deployment, Some("some-long-resource-name"));
+        assert!(
+            name.len() <= MAX_SESSION_NAME_LEN,
+            "session name must fit the STS limit, got {} chars: {name}",
+            name.len()
+        );
+        assert!(name.starts_with("alien-mint-"));
+    }
+
+    #[test]
+    fn session_name_truncation_is_deterministic_and_distinct() {
+        let base = "e".repeat(80);
+        let a = mint_session_name(&base, Some("resource-a"));
+        let b = mint_session_name(&base, Some("resource-b"));
+        // Same input -> same output.
+        assert_eq!(a, mint_session_name(&base, Some("resource-a")));
+        // Different input -> different output (hash suffix disambiguates).
+        assert_ne!(a, b);
+        assert!(a.len() <= MAX_SESSION_NAME_LEN && b.len() <= MAX_SESSION_NAME_LEN);
+    }
+
+    #[test]
+    fn truncate_session_name_exactly_at_limit_is_unchanged() {
+        let exact = "x".repeat(MAX_SESSION_NAME_LEN);
+        assert_eq!(truncate_session_name(&exact), exact);
+    }
+
+    #[test]
+    fn principal_from_info_extracts_platform_identity() {
+        assert_eq!(
+            principal_from_info(&ServiceAccountInfo::Aws(AwsServiceAccountInfo {
+                role_name: "r".to_string(),
+                role_arn: "arn:aws:iam::123:role/r".to_string(),
+            })),
+            "arn:aws:iam::123:role/r"
+        );
+        assert_eq!(
+            principal_from_info(&ServiceAccountInfo::Gcp(GcpServiceAccountInfo {
+                email: "sa@project.iam.gserviceaccount.com".to_string(),
+                unique_id: "1".to_string(),
+            })),
+            "sa@project.iam.gserviceaccount.com"
+        );
+        assert_eq!(
+            principal_from_info(&ServiceAccountInfo::Azure(AzureServiceAccountInfo {
+                client_id: "client-abc".to_string(),
+                resource_id: "/id".to_string(),
+                principal_id: "p".to_string(),
+            })),
+            "client-abc"
+        );
+    }
+
+    #[test]
+    fn principal_from_client_config_uses_account_scope() {
+        let config = ClientConfig::Aws(Box::new(AwsClientConfig {
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            credentials: AwsCredentials::AccessKeys {
+                access_key_id: "AKIA".to_string(),
+                secret_access_key: "secret".to_string(),
+                session_token: None,
+            },
+            service_overrides: None,
+        }));
+        assert_eq!(principal_from_client_config(&config), "aws:123456789012");
     }
 }

--- a/crates/alien-manager/tests/credentials_mint.rs
+++ b/crates/alien-manager/tests/credentials_mint.rs
@@ -28,8 +28,8 @@ use alien_bindings::error::{ErrorData as BindingErrorData, Result as BindingResu
 use alien_bindings::traits::{
     AwsServiceAccountInfo, Binding, ImpersonationRequest, ServiceAccount, ServiceAccountInfo,
 };
-use alien_bindings::{providers::kv::local::LocalKv, providers::storage::local::LocalStorage};
 use alien_bindings::BindingsProviderApi;
+use alien_bindings::{providers::kv::local::LocalKv, providers::storage::local::LocalStorage};
 use alien_commands::dispatchers::NullCommandDispatcher;
 use alien_commands::server::{CommandDispatcher, CommandRegistry, CommandServer};
 use alien_commands::InMemoryCommandRegistry;
@@ -234,6 +234,10 @@ struct Fixture {
     /// cross-deployment access is denied.
     token_b: String,
     admin_token: String,
+    /// A deployment-group token scoped to the group both deployments belong
+    /// to. Documents that group scope inherits mint access for every
+    /// deployment in the group, not just one.
+    group_token: String,
     /// The last impersonation request the fake service account received
     /// (only populated on the managed path).
     captured: Arc<Mutex<Option<ImpersonationRequest>>>,
@@ -314,6 +318,15 @@ async fn build(
     let (_deployment_b, token_b) =
         create_deployment(&deployment_store, &token_store, &dg.id, "deploy-b").await;
 
+    let group_token = mint_token(
+        &token_store,
+        TokenType::DeploymentGroup,
+        "ax_dg_",
+        Some(dg.id.clone()),
+        None,
+    )
+    .await;
+
     let auth_validator: Arc<dyn AuthValidator> = Arc::new(
         alien_manager::providers::token_db_validator::TokenDbValidator::new(token_store.clone()),
     );
@@ -363,6 +376,7 @@ async fn build(
         token_a,
         token_b,
         admin_token,
+        group_token,
         captured,
     }
 }
@@ -442,8 +456,7 @@ async fn post_mint(
     bearer: Option<&str>,
     body: serde_json::Value,
 ) -> (StatusCode, serde_json::Value) {
-    let router =
-        alien_manager::routes::credentials::router().with_state(fixture.state.clone());
+    let router = alien_manager::routes::credentials::router().with_state(fixture.state.clone());
 
     let mut req = Request::builder()
         .method("POST")
@@ -454,7 +467,9 @@ async fn post_mint(
         req = req.header(header::AUTHORIZATION, format!("Bearer {}", token));
     }
 
-    let request = req.body(Body::from(serde_json::to_vec(&body).unwrap())).unwrap();
+    let request = req
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
     let response = router.oneshot(request).await.unwrap();
     let status = response.status();
     let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
@@ -495,8 +510,7 @@ async fn deployment_token_for_its_deployment_mints_200() {
         "principal is the impersonated role"
     );
     let expires_at = json["expiresAt"].as_str().expect("expiresAt is a string");
-    chrono::DateTime::parse_from_rfc3339(expires_at)
-        .expect("expiresAt must be RFC3339");
+    chrono::DateTime::parse_from_rfc3339(expires_at).expect("expiresAt must be RFC3339");
 }
 
 #[tokio::test]
@@ -533,6 +547,23 @@ async fn garbage_bearer_is_unauthorized() {
 }
 
 #[tokio::test]
+async fn deployment_group_token_can_mint_for_deployment_in_its_group() {
+    // Documents the inherited grant: a deployment-group-scoped (`ax_dg_`)
+    // token is not pinned to one deployment id like a deployment token is —
+    // `can_act_on_deployment` (== `can_read_deployment`) passes for any
+    // deployment whose deployment_group_id matches the token's scope.
+    let fixture = impersonation_fixture().await;
+    let (status, json) = post_mint(
+        &fixture,
+        Some(&fixture.group_token),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body = {json:#}");
+    assert!(json["clientConfig"].is_object());
+}
+
+#[tokio::test]
 async fn admin_token_mints_200() {
     let fixture = impersonation_fixture().await;
     let (status, json) = post_mint(
@@ -557,8 +588,17 @@ async fn duration_is_clamped_to_the_allowed_window() {
     body["durationSeconds"] = serde_json::json!(10);
     let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
     assert_eq!(status, StatusCode::OK);
-    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
-    assert_eq!(captured.duration_seconds, Some(900), "clamped up to the floor");
+    let captured = fixture
+        .captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("impersonated");
+    assert_eq!(
+        captured.duration_seconds,
+        Some(900),
+        "clamped up to the floor"
+    );
 
     // Above the ceiling -> 3600.
     let fixture = impersonation_fixture().await;
@@ -566,7 +606,12 @@ async fn duration_is_clamped_to_the_allowed_window() {
     body["durationSeconds"] = serde_json::json!(999_999);
     let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
     assert_eq!(status, StatusCode::OK);
-    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    let captured = fixture
+        .captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("impersonated");
     assert_eq!(
         captured.duration_seconds,
         Some(3600),
@@ -582,7 +627,12 @@ async fn duration_is_clamped_to_the_allowed_window() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    let captured = fixture
+        .captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("impersonated");
     assert_eq!(captured.duration_seconds, Some(3600), "default duration");
 }
 
@@ -594,7 +644,12 @@ async fn session_name_is_scoped_to_deployment_and_resource() {
     let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
     assert_eq!(status, StatusCode::OK);
 
-    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    let captured = fixture
+        .captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("impersonated");
     assert_eq!(
         captured.session_name,
         Some(format!("alien-mint-{}-api", fixture.deployment_a)),
@@ -649,6 +704,19 @@ async fn unknown_binding_returns_400() {
         "deploymentId": fixture.deployment_a,
         "bindingName": "does-not-exist",
     });
+    let (status, json) = post_mint(&fixture, Some(&fixture.token_a), body).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body = {json:#}");
+}
+
+#[tokio::test]
+async fn non_ascii_resource_id_is_rejected_with_400_not_panic() {
+    // Reproduces the reviewer's finding: a resourceId straddling a
+    // multi-byte UTF-8 boundary at the truncation cut point used to panic
+    // inside `truncate_session_name`'s byte slicing. STS would reject this
+    // charset anyway, so it must come back as a clean 400.
+    let fixture = impersonation_fixture().await;
+    let mut body = mint_body(&fixture.deployment_a);
+    body["resourceId"] = serde_json::json!("é".repeat(10));
     let (status, json) = post_mint(&fixture, Some(&fixture.token_a), body).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "body = {json:#}");
 }

--- a/crates/alien-manager/tests/credentials_mint.rs
+++ b/crates/alien-manager/tests/credentials_mint.rs
@@ -1,0 +1,731 @@
+//! Integration tests for `POST /v1/credentials/mint`.
+//!
+//! Drives the manager's credential-minting handler through a manually-assembled
+//! [`alien_manager::routes::AppState`] and `tower::ServiceExt::oneshot`, mirroring
+//! `tests/stack_import.rs`. The focus is the auth matrix (deployment token vs.
+//! admin vs. wrong-deployment vs. missing) plus mint behaviour: duration
+//! clamping, session-name wiring, short-lived-only managed credentials, response
+//! shape, and the guarantee that the audit log never carries credential material.
+//!
+//! Two credential paths are exercised explicitly rather than faked into one:
+//!   * **managed / impersonation** — a target bindings provider is configured
+//!     for the platform, so the handler impersonates a service-account binding
+//!     and returns session-token credentials.
+//!   * **local / resolver** — no target provider, so the handler falls back to
+//!     the deployment-level credential resolver, which returns static keys.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use http::header;
+use sha2::{Digest, Sha256};
+use tower::ServiceExt;
+
+use alien_bindings::error::{ErrorData as BindingErrorData, Result as BindingResult};
+use alien_bindings::traits::{
+    AwsServiceAccountInfo, Binding, ImpersonationRequest, ServiceAccount, ServiceAccountInfo,
+};
+use alien_bindings::{providers::kv::local::LocalKv, providers::storage::local::LocalStorage};
+use alien_bindings::BindingsProviderApi;
+use alien_commands::dispatchers::NullCommandDispatcher;
+use alien_commands::server::{CommandDispatcher, CommandRegistry, CommandServer};
+use alien_commands::InMemoryCommandRegistry;
+use alien_core::{
+    AwsClientConfig, AwsCredentials, ClientConfig, Platform, StackSettings,
+    CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+};
+use alien_error::AlienError;
+use alien_manager::auth::{Authz, Subject};
+use alien_manager::config::ManagerConfig;
+use alien_manager::providers::{NullTelemetryBackend, OssAuthz};
+use alien_manager::routes::registry_proxy::{
+    CredentialCache, PullValidationCache, RegistryRoutingTable,
+};
+use alien_manager::routes::AppState;
+use alien_manager::stores::sqlite::{
+    SqliteDatabase, SqliteDeploymentStore, SqliteReleaseStore, SqliteTokenStore,
+};
+use alien_manager::traits::{
+    AuthValidator, CreateDeploymentGroupParams, CreateDeploymentParams, CreateTokenParams,
+    CredentialResolver, DeploymentRecord, DeploymentStore, ReleaseStore, TelemetryBackend,
+    TokenStore, TokenType,
+};
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+const FAKE_SECRET: &str = "TOP_SECRET_ACCESS_KEY_material_must_never_be_logged";
+const FAKE_SESSION_TOKEN: &str = "TOP_SECRET_SESSION_TOKEN_material_must_never_be_logged";
+
+fn missing_binding(binding_name: &str) -> AlienError<BindingErrorData> {
+    AlienError::new(BindingErrorData::BindingConfigInvalid {
+        binding_name: binding_name.to_string(),
+        env_var: alien_core::bindings::binding_env_var_name(binding_name),
+        reason: "not found".to_string(),
+    })
+}
+
+/// Managed short-lived credentials, modelling what STS AssumeRole returns:
+/// access keys *with* a session token.
+fn managed_aws_config() -> ClientConfig {
+    ClientConfig::Aws(Box::new(AwsClientConfig {
+        account_id: "210987654321".to_string(),
+        region: "us-east-1".to_string(),
+        credentials: AwsCredentials::AccessKeys {
+            access_key_id: "ASIAEXAMPLE".to_string(),
+            secret_access_key: FAKE_SECRET.to_string(),
+            session_token: Some(FAKE_SESSION_TOKEN.to_string()),
+        },
+        service_overrides: None,
+    }))
+}
+
+/// Local static credentials: access keys with *no* session token.
+fn static_aws_config() -> ClientConfig {
+    ClientConfig::Aws(Box::new(AwsClientConfig {
+        account_id: "123456789012".to_string(),
+        region: "us-east-1".to_string(),
+        credentials: AwsCredentials::AccessKeys {
+            access_key_id: "AKIAEXAMPLE".to_string(),
+            secret_access_key: FAKE_SECRET.to_string(),
+            session_token: None,
+        },
+        service_overrides: None,
+    }))
+}
+
+/// Fake service account that records the impersonation request it received and
+/// returns preset short-lived credentials.
+#[derive(Debug)]
+struct FakeServiceAccount {
+    info: ServiceAccountInfo,
+    minted: ClientConfig,
+    captured: Arc<Mutex<Option<ImpersonationRequest>>>,
+}
+
+impl Binding for FakeServiceAccount {}
+
+#[async_trait]
+impl ServiceAccount for FakeServiceAccount {
+    async fn get_info(&self) -> BindingResult<ServiceAccountInfo> {
+        Ok(self.info.clone())
+    }
+
+    async fn impersonate(&self, request: ImpersonationRequest) -> BindingResult<ClientConfig> {
+        *self.captured.lock().unwrap() = Some(request);
+        Ok(self.minted.clone())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Bindings provider that only serves a single service-account binding.
+#[derive(Debug)]
+struct FakeServiceAccountProvider {
+    binding_name: String,
+    service_account: Arc<FakeServiceAccount>,
+}
+
+#[async_trait]
+impl BindingsProviderApi for FakeServiceAccountProvider {
+    async fn load_service_account(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn ServiceAccount>> {
+        if binding_name == self.binding_name {
+            Ok(self.service_account.clone())
+        } else {
+            Err(missing_binding(binding_name))
+        }
+    }
+
+    async fn load_storage(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Storage>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_build(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Build>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_artifact_registry(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::ArtifactRegistry>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_vault(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Vault>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_kv(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Kv>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_postgres(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Postgres>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_queue(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Queue>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_worker(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Worker>> {
+        Err(missing_binding(binding_name))
+    }
+
+    async fn load_container(
+        &self,
+        binding_name: &str,
+    ) -> BindingResult<Arc<dyn alien_bindings::traits::Container>> {
+        Err(missing_binding(binding_name))
+    }
+}
+
+/// Credential resolver that always returns a preset config (the local path).
+struct StaticCredentialResolver {
+    config: ClientConfig,
+}
+
+#[async_trait]
+impl CredentialResolver for StaticCredentialResolver {
+    async fn resolve(&self, _deployment: &DeploymentRecord) -> Result<ClientConfig, AlienError> {
+        Ok(self.config.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    state: AppState,
+    /// Deployment the caller's token is scoped to.
+    deployment_a: String,
+    token_a: String,
+    /// A deployment token scoped to a *different* deployment, used to prove
+    /// cross-deployment access is denied.
+    token_b: String,
+    admin_token: String,
+    /// The last impersonation request the fake service account received
+    /// (only populated on the managed path).
+    captured: Arc<Mutex<Option<ImpersonationRequest>>>,
+}
+
+const BINDING_NAME: &str = "management";
+
+/// Build a fixture wired for the managed / impersonation path: a target bindings
+/// provider for AWS that impersonates `BINDING_NAME`.
+async fn impersonation_fixture() -> Fixture {
+    let captured = Arc::new(Mutex::new(None));
+    let service_account = Arc::new(FakeServiceAccount {
+        info: ServiceAccountInfo::Aws(AwsServiceAccountInfo {
+            role_name: "AlienManaged".to_string(),
+            role_arn: "arn:aws:iam::210987654321:role/AlienManaged".to_string(),
+        }),
+        minted: managed_aws_config(),
+        captured: captured.clone(),
+    });
+    let provider: Arc<dyn BindingsProviderApi> = Arc::new(FakeServiceAccountProvider {
+        binding_name: BINDING_NAME.to_string(),
+        service_account,
+    });
+    let target_providers = HashMap::from([(Platform::Aws, provider)]);
+
+    // Resolver present but should never be hit on the impersonation path; give
+    // it a config distinct from the managed one so a wrong branch is visible.
+    let resolver: Arc<dyn CredentialResolver> = Arc::new(StaticCredentialResolver {
+        config: static_aws_config(),
+    });
+
+    build(target_providers, resolver, captured).await
+}
+
+/// Build a fixture wired for the local / resolver path: no target providers, so
+/// the handler falls back to the credential resolver.
+async fn resolver_fixture() -> Fixture {
+    let resolver: Arc<dyn CredentialResolver> = Arc::new(StaticCredentialResolver {
+        config: static_aws_config(),
+    });
+    build(HashMap::new(), resolver, Arc::new(Mutex::new(None))).await
+}
+
+async fn build(
+    target_bindings_providers: HashMap<Platform, Arc<dyn BindingsProviderApi>>,
+    credential_resolver: Arc<dyn CredentialResolver>,
+    captured: Arc<Mutex<Option<ImpersonationRequest>>>,
+) -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("test.db");
+    std::mem::forget(tmp);
+
+    let db = Arc::new(
+        SqliteDatabase::new(&db_path.to_string_lossy())
+            .await
+            .unwrap(),
+    );
+    let deployment_store: Arc<dyn DeploymentStore> =
+        Arc::new(SqliteDeploymentStore::new(db.clone()));
+    let release_store: Arc<dyn ReleaseStore> = Arc::new(SqliteReleaseStore::new(db.clone()));
+    let token_store: Arc<dyn TokenStore> = Arc::new(SqliteTokenStore::new(db.clone()));
+
+    let admin_token = mint_token(&token_store, TokenType::Admin, "ax_admin_", None, None).await;
+
+    let dg = deployment_store
+        .create_deployment_group(
+            &Subject::system(),
+            CreateDeploymentGroupParams {
+                name: "mint-group".to_string(),
+                max_deployments: 100,
+            },
+        )
+        .await
+        .unwrap();
+
+    let (deployment_a, token_a) =
+        create_deployment(&deployment_store, &token_store, &dg.id, "deploy-a").await;
+    let (_deployment_b, token_b) =
+        create_deployment(&deployment_store, &token_store, &dg.id, "deploy-b").await;
+
+    let auth_validator: Arc<dyn AuthValidator> = Arc::new(
+        alien_manager::providers::token_db_validator::TokenDbValidator::new(token_store.clone()),
+    );
+    let authz: Arc<dyn Authz> = Arc::new(OssAuthz);
+    let telemetry_backend: Arc<dyn TelemetryBackend> = Arc::new(NullTelemetryBackend);
+
+    let kv_dir = db_path.parent().unwrap().join("kv");
+    let storage_dir = db_path.parent().unwrap().join("storage");
+    let kv: Arc<dyn alien_bindings::traits::Kv> =
+        Arc::new(LocalKv::new(kv_dir.clone()).await.unwrap());
+    let command_storage: Arc<dyn alien_bindings::traits::Storage> =
+        Arc::new(LocalStorage::new(storage_dir.to_string_lossy().to_string()).unwrap());
+    let command_dispatcher: Arc<dyn CommandDispatcher> = Arc::new(NullCommandDispatcher);
+    let command_registry: Arc<dyn CommandRegistry> = Arc::new(InMemoryCommandRegistry::default());
+    let command_server = Arc::new(CommandServer::new(
+        kv.clone(),
+        command_storage,
+        command_dispatcher,
+        command_registry,
+        "http://localhost:0/v1".to_string(),
+        b"test-signing-key".to_vec(),
+    ));
+
+    let state = AppState {
+        deployment_store: deployment_store.clone(),
+        release_store,
+        token_store: token_store.clone(),
+        auth_validator,
+        authz,
+        telemetry_backend,
+        credential_resolver,
+        command_server,
+        config: Arc::new(ManagerConfig::default()),
+        bindings_provider: None,
+        target_bindings_providers,
+        kv,
+        http_client: reqwest::Client::new(),
+        credential_cache: Arc::new(CredentialCache::new()),
+        pull_validation_cache: Arc::new(PullValidationCache::new()),
+        registry_routing_table: Arc::new(RegistryRoutingTable::new(vec![])),
+        import_registry: Arc::new(alien_infra::ImporterRegistry::built_in()),
+    };
+
+    Fixture {
+        state,
+        deployment_a,
+        token_a,
+        token_b,
+        admin_token,
+        captured,
+    }
+}
+
+/// Create an AWS deployment and a deployment token scoped to it. Returns
+/// `(deployment_id, raw_token)`.
+async fn create_deployment(
+    deployment_store: &Arc<dyn DeploymentStore>,
+    token_store: &Arc<dyn TokenStore>,
+    deployment_group_id: &str,
+    name: &str,
+) -> (String, String) {
+    let record = deployment_store
+        .create_deployment(
+            &Subject::system(),
+            CreateDeploymentParams {
+                deployment_protocol_version: CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+                name: name.to_string(),
+                deployment_group_id: deployment_group_id.to_string(),
+                platform: Platform::Aws,
+                base_platform: None,
+                stack_settings: StackSettings::default(),
+                stack_state: None,
+                environment_variables: None,
+                input_values: Default::default(),
+                deployment_token: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let token = mint_token(
+        token_store,
+        TokenType::Deployment,
+        "ax_deploy_",
+        Some(deployment_group_id.to_string()),
+        Some(record.id.clone()),
+    )
+    .await;
+
+    (record.id, token)
+}
+
+async fn mint_token(
+    token_store: &Arc<dyn TokenStore>,
+    token_type: TokenType,
+    prefix: &str,
+    deployment_group_id: Option<String>,
+    deployment_id: Option<String>,
+) -> String {
+    let raw = format!("{}{}", prefix, uuid::Uuid::new_v4().simple());
+    let key_prefix = raw[..12.min(raw.len())].to_string();
+    let key_hash = {
+        let mut h = Sha256::new();
+        h.update(raw.as_bytes());
+        format!("{:x}", h.finalize())
+    };
+    token_store
+        .create_token(CreateTokenParams {
+            token_type,
+            key_prefix,
+            key_hash,
+            deployment_group_id,
+            deployment_id,
+        })
+        .await
+        .unwrap();
+    raw
+}
+
+// ---------------------------------------------------------------------------
+// Request helper
+// ---------------------------------------------------------------------------
+
+async fn post_mint(
+    fixture: &Fixture,
+    bearer: Option<&str>,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let router =
+        alien_manager::routes::credentials::router().with_state(fixture.state.clone());
+
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/mint")
+        .header(header::CONTENT_TYPE, "application/json");
+
+    if let Some(token) = bearer {
+        req = req.header(header::AUTHORIZATION, format!("Bearer {}", token));
+    }
+
+    let request = req.body(Body::from(serde_json::to_vec(&body).unwrap())).unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+fn mint_body(deployment_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "deploymentId": deployment_id,
+        "bindingName": BINDING_NAME,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Auth matrix
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn deployment_token_for_its_deployment_mints_200() {
+    let fixture = impersonation_fixture().await;
+    let (status, json) = post_mint(
+        &fixture,
+        Some(&fixture.token_a),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body = {json:#}");
+    // Response shape.
+    assert!(json["clientConfig"].is_object(), "clientConfig present");
+    assert_eq!(
+        json["principal"], "arn:aws:iam::210987654321:role/AlienManaged",
+        "principal is the impersonated role"
+    );
+    let expires_at = json["expiresAt"].as_str().expect("expiresAt is a string");
+    chrono::DateTime::parse_from_rfc3339(expires_at)
+        .expect("expiresAt must be RFC3339");
+}
+
+#[tokio::test]
+async fn deployment_token_for_other_deployment_is_forbidden() {
+    let fixture = impersonation_fixture().await;
+    // token_b is scoped to deployment_b; ask for deployment_a.
+    let (status, json) = post_mint(
+        &fixture,
+        Some(&fixture.token_b),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN, "body = {json:#}");
+}
+
+#[tokio::test]
+async fn missing_bearer_is_unauthorized() {
+    let fixture = impersonation_fixture().await;
+    let (status, _) = post_mint(&fixture, None, mint_body(&fixture.deployment_a)).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn garbage_bearer_is_unauthorized() {
+    let fixture = impersonation_fixture().await;
+    let (status, _) = post_mint(
+        &fixture,
+        Some("ax_deploy_not-a-real-token"),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_token_mints_200() {
+    let fixture = impersonation_fixture().await;
+    let (status, json) = post_mint(
+        &fixture,
+        Some(&fixture.admin_token),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body = {json:#}");
+    assert!(json["clientConfig"].is_object());
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn duration_is_clamped_to_the_allowed_window() {
+    // Below the floor -> 900.
+    let fixture = impersonation_fixture().await;
+    let mut body = mint_body(&fixture.deployment_a);
+    body["durationSeconds"] = serde_json::json!(10);
+    let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
+    assert_eq!(status, StatusCode::OK);
+    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    assert_eq!(captured.duration_seconds, Some(900), "clamped up to the floor");
+
+    // Above the ceiling -> 3600.
+    let fixture = impersonation_fixture().await;
+    let mut body = mint_body(&fixture.deployment_a);
+    body["durationSeconds"] = serde_json::json!(999_999);
+    let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
+    assert_eq!(status, StatusCode::OK);
+    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    assert_eq!(
+        captured.duration_seconds,
+        Some(3600),
+        "clamped down to the ceiling"
+    );
+
+    // Default when omitted -> 3600.
+    let fixture = impersonation_fixture().await;
+    let (status, _) = post_mint(
+        &fixture,
+        Some(&fixture.token_a),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    assert_eq!(captured.duration_seconds, Some(3600), "default duration");
+}
+
+#[tokio::test]
+async fn session_name_is_scoped_to_deployment_and_resource() {
+    let fixture = impersonation_fixture().await;
+    let mut body = mint_body(&fixture.deployment_a);
+    body["resourceId"] = serde_json::json!("api");
+    let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let captured = fixture.captured.lock().unwrap().clone().expect("impersonated");
+    assert_eq!(
+        captured.session_name,
+        Some(format!("alien-mint-{}-api", fixture.deployment_a)),
+        "session name embeds deployment and resource"
+    );
+}
+
+#[tokio::test]
+async fn managed_path_returns_session_token_credentials() {
+    let fixture = impersonation_fixture().await;
+    let (status, json) = post_mint(
+        &fixture,
+        Some(&fixture.token_a),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body = {json:#}");
+
+    let credentials = &json["clientConfig"]["credentials"];
+    assert_eq!(credentials["type"], "accessKeys");
+    assert!(
+        credentials["session_token"].is_string(),
+        "managed impersonation must return short-lived session-token creds: {credentials:#}"
+    );
+}
+
+#[tokio::test]
+async fn local_path_returns_static_credentials_without_session_token() {
+    let fixture = resolver_fixture().await;
+    let (status, json) = post_mint(
+        &fixture,
+        Some(&fixture.token_a),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body = {json:#}");
+
+    // No target provider -> resolver fallback -> principal derived from config.
+    assert_eq!(json["principal"], "aws:123456789012");
+    let credentials = &json["clientConfig"]["credentials"];
+    assert_eq!(credentials["type"], "accessKeys");
+    assert!(
+        credentials["session_token"].is_null(),
+        "local static credentials carry no session token: {credentials:#}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_binding_returns_400() {
+    let fixture = impersonation_fixture().await;
+    let body = serde_json::json!({
+        "deploymentId": fixture.deployment_a,
+        "bindingName": "does-not-exist",
+    });
+    let (status, json) = post_mint(&fixture, Some(&fixture.token_a), body).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body = {json:#}");
+}
+
+#[tokio::test]
+async fn unknown_field_is_rejected() {
+    let fixture = impersonation_fixture().await;
+    let body = serde_json::json!({
+        "deploymentId": fixture.deployment_a,
+        "bindingName": BINDING_NAME,
+        "platform": "aws",
+    });
+    let (status, _) = post_mint(&fixture, Some(&fixture.token_a), body).await;
+    assert!(
+        status.is_client_error(),
+        "deny_unknown_fields must reject smuggled resolver internals, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn audit_log_never_contains_credential_material() {
+    use std::io::Write;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+    impl Write for BufWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> MakeWriter<'a> for BufWriter {
+        type Writer = BufWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    let fixture = impersonation_fixture().await;
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(BufWriter(buf.clone()))
+        .with_ansi(false)
+        .finish();
+
+    // `#[tokio::test]` uses a current-thread runtime, so the awaited handler
+    // work stays on this thread and the thread-local default subscriber
+    // captures its audit event.
+    let guard = tracing::subscriber::set_default(subscriber);
+    let (status, _) = post_mint(
+        &fixture,
+        Some(&fixture.token_a),
+        mint_body(&fixture.deployment_a),
+    )
+    .await;
+    drop(guard);
+    assert_eq!(status, StatusCode::OK);
+
+    let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(
+        logs.contains("Minted deployment credentials"),
+        "audit event must be emitted; captured logs: {logs}"
+    );
+    assert!(
+        logs.contains(&fixture.deployment_a) && logs.contains("AlienManaged"),
+        "audit event must carry the deployment id and principal; captured logs: {logs}"
+    );
+    assert!(
+        !logs.contains(FAKE_SECRET),
+        "audit log leaked the secret access key: {logs}"
+    );
+    assert!(
+        !logs.contains(FAKE_SESSION_TOKEN),
+        "audit log leaked the session token: {logs}"
+    );
+}

--- a/crates/alien-manager/tests/credentials_mint_bootstrap.rs
+++ b/crates/alien-manager/tests/credentials_mint_bootstrap.rs
@@ -1,0 +1,428 @@
+//! Integration test: external-app credential bootstrap through the *real*
+//! manager mint route.
+//!
+//! `crates/alien-manager/tests/credentials_mint.rs` drives the mint handler
+//! through `tower::ServiceExt::oneshot` — no real network involved. This file
+//! instead spins the real manager `AppState`/router on a real TCP listener
+//! (`axum::serve`) and points `alien_bindings::provider::BindingsProvider::
+//! from_env_lazy` — the actual entry point a deployed app process uses — at
+//! it over real HTTP, with a real deployment token minted by a real
+//! `TokenStore`. That proves the client (`alien-bindings`'s minting resolver)
+//! and server (`alien-manager`'s mint route) round-trip correctly end-to-end,
+//! not just that each side unit-tests cleanly against a fake counterpart.
+//!
+//! Two scenarios, matching the two things that must never go wrong for a
+//! bootstrapping external app:
+//!
+//!   * authorized — a real deployment token mints a working `ClientConfig`
+//!     (the manager's local/resolver path, `ClientConfig::Local`) and a KV
+//!     binding load through it actually works (a put/get round trip, not
+//!     just "the load call returned Ok").
+//!   * unauthorized — a token scoped to a *different* deployment surfaces a
+//!     typed `REMOTE_ACCESS_FAILED` error through the resolver, bounded by a
+//!     timeout so a regression that hangs instead of erroring fails loudly.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+use tracing_subscriber::fmt::MakeWriter;
+
+use alien_bindings::providers::kv::local::LocalKv;
+use alien_bindings::providers::storage::local::LocalStorage;
+use alien_bindings::traits::BindingsProviderApi;
+use alien_bindings::BindingsProvider;
+use alien_commands::dispatchers::NullCommandDispatcher;
+use alien_commands::server::{CommandDispatcher, CommandRegistry, CommandServer};
+use alien_commands::InMemoryCommandRegistry;
+use alien_core::{
+    Platform, StackSettings, CURRENT_DEPLOYMENT_PROTOCOL_VERSION, ENV_ALIEN_DEPLOYMENT_ID,
+    ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT, ENV_ALIEN_DEPLOYMENT_TOKEN, ENV_ALIEN_DEPLOYMENT_TYPE,
+    ENV_ALIEN_MANAGER_URL,
+};
+use alien_manager::auth::Subject;
+use alien_manager::config::ManagerConfig;
+use alien_manager::providers::local_credentials::LocalCredentialResolver;
+use alien_manager::providers::token_db_validator::TokenDbValidator;
+use alien_manager::providers::{NullTelemetryBackend, OssAuthz};
+use alien_manager::routes::registry_proxy::{
+    CredentialCache, PullValidationCache, RegistryRoutingTable,
+};
+use alien_manager::routes::AppState;
+use alien_manager::stores::sqlite::{
+    SqliteDatabase, SqliteDeploymentStore, SqliteReleaseStore, SqliteTokenStore,
+};
+use alien_manager::traits::{
+    AuthValidator, CreateDeploymentGroupParams, CreateDeploymentParams, CreateTokenParams,
+    CredentialResolver, DeploymentStore, ReleaseStore, TelemetryBackend, TokenStore, TokenType,
+};
+
+const BINDING_NAME: &str = "management";
+
+/// Bound every mint round trip in these tests: a regression that hangs
+/// instead of erroring must fail the test quickly, not stall CI.
+const ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ---------------------------------------------------------------------------
+// Fixture: a real manager AppState wired to the local/resolver credential
+// path (`ClientConfig::Local`), so the happy-path binding load never needs
+// real cloud credentials.
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    state: AppState,
+    /// Deployment the caller's real deployment token is scoped to.
+    deployment_a: String,
+    token_a: String,
+    /// A deployment token scoped to a *different* deployment — used to prove
+    /// the manager rejects a cross-deployment mint request.
+    token_b: String,
+}
+
+async fn build() -> Fixture {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let local_state_dir = tmp.path().join("local-state");
+    // Leak the tempdir so it survives until the test process exits (turso's
+    // WAL mode needs a real file path for the duration of the test).
+    std::mem::forget(tmp);
+
+    let db = Arc::new(
+        SqliteDatabase::new(&db_path.to_string_lossy())
+            .await
+            .unwrap(),
+    );
+    let deployment_store: Arc<dyn DeploymentStore> =
+        Arc::new(SqliteDeploymentStore::new(db.clone()));
+    let release_store: Arc<dyn ReleaseStore> = Arc::new(SqliteReleaseStore::new(db.clone()));
+    let token_store: Arc<dyn TokenStore> = Arc::new(SqliteTokenStore::new(db.clone()));
+
+    let dg = deployment_store
+        .create_deployment_group(
+            &Subject::system(),
+            CreateDeploymentGroupParams {
+                name: "bootstrap-group".to_string(),
+                max_deployments: 100,
+            },
+        )
+        .await
+        .unwrap();
+
+    let (deployment_a, token_a) =
+        create_deployment(&deployment_store, &token_store, &dg.id, "app-a").await;
+    let (_deployment_b, token_b) =
+        create_deployment(&deployment_store, &token_store, &dg.id, "app-b").await;
+
+    let auth_validator: Arc<dyn AuthValidator> =
+        Arc::new(TokenDbValidator::new(token_store.clone()));
+    let authz: Arc<dyn alien_manager::auth::Authz> = Arc::new(OssAuthz);
+    let telemetry_backend: Arc<dyn TelemetryBackend> = Arc::new(NullTelemetryBackend);
+    // The real single-account/local-mode resolver: it's what a Local-platform
+    // deployment resolves to in production, giving this test a real
+    // production type on the credential-resolution side, not a test double.
+    let credential_resolver: Arc<dyn CredentialResolver> =
+        Arc::new(LocalCredentialResolver::new(local_state_dir));
+
+    let kv_dir = db_path.parent().unwrap().join("kv");
+    let storage_dir = db_path.parent().unwrap().join("storage");
+    let kv: Arc<dyn alien_bindings::traits::Kv> =
+        Arc::new(LocalKv::new(kv_dir.clone()).await.unwrap());
+    let command_storage: Arc<dyn alien_bindings::traits::Storage> =
+        Arc::new(LocalStorage::new(storage_dir.to_string_lossy().to_string()).unwrap());
+    let command_dispatcher: Arc<dyn CommandDispatcher> = Arc::new(NullCommandDispatcher);
+    let command_registry: Arc<dyn CommandRegistry> = Arc::new(InMemoryCommandRegistry::default());
+    let command_server = Arc::new(CommandServer::new(
+        kv.clone(),
+        command_storage,
+        command_dispatcher,
+        command_registry,
+        "http://localhost:0/v1".to_string(),
+        b"test-signing-key".to_vec(),
+    ));
+
+    let state = AppState {
+        deployment_store: deployment_store.clone(),
+        release_store,
+        token_store: token_store.clone(),
+        auth_validator,
+        authz,
+        telemetry_backend,
+        credential_resolver,
+        command_server,
+        config: Arc::new(ManagerConfig::default()),
+        bindings_provider: None,
+        target_bindings_providers: HashMap::new(),
+        kv,
+        http_client: reqwest::Client::new(),
+        credential_cache: Arc::new(CredentialCache::new()),
+        pull_validation_cache: Arc::new(PullValidationCache::new()),
+        registry_routing_table: Arc::new(RegistryRoutingTable::new(vec![])),
+        import_registry: Arc::new(alien_infra::ImporterRegistry::built_in()),
+    };
+
+    Fixture {
+        state,
+        deployment_a,
+        token_a,
+        token_b,
+    }
+}
+
+async fn create_deployment(
+    deployment_store: &Arc<dyn DeploymentStore>,
+    token_store: &Arc<dyn TokenStore>,
+    deployment_group_id: &str,
+    name: &str,
+) -> (String, String) {
+    let record = deployment_store
+        .create_deployment(
+            &Subject::system(),
+            CreateDeploymentParams {
+                deployment_protocol_version: CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+                name: name.to_string(),
+                deployment_group_id: deployment_group_id.to_string(),
+                platform: Platform::Local,
+                base_platform: None,
+                stack_settings: StackSettings::default(),
+                stack_state: None,
+                environment_variables: None,
+                input_values: Default::default(),
+                deployment_token: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let token = mint_token(
+        token_store,
+        TokenType::Deployment,
+        "ax_deploy_",
+        Some(deployment_group_id.to_string()),
+        Some(record.id.clone()),
+    )
+    .await;
+
+    (record.id, token)
+}
+
+async fn mint_token(
+    token_store: &Arc<dyn TokenStore>,
+    token_type: TokenType,
+    prefix: &str,
+    deployment_group_id: Option<String>,
+    deployment_id: Option<String>,
+) -> String {
+    let raw = format!("{}{}", prefix, uuid::Uuid::new_v4().simple());
+    let key_prefix = raw[..12.min(raw.len())].to_string();
+    let key_hash = {
+        let mut h = Sha256::new();
+        h.update(raw.as_bytes());
+        format!("{:x}", h.finalize())
+    };
+    token_store
+        .create_token(CreateTokenParams {
+            token_type,
+            key_prefix,
+            key_hash,
+            deployment_group_id,
+            deployment_id,
+        })
+        .await
+        .unwrap();
+    raw
+}
+
+/// Serve the manager's real credentials router on a real TCP listener; returns
+/// its base URL. The server task runs for the lifetime of the test process
+/// (single-threaded `#[tokio::test]` runtime cooperatively schedules it
+/// alongside the test body — see the tracing-capture comment below).
+async fn spawn_manager(state: AppState) -> String {
+    let router = alien_manager::routes::credentials::router().with_state(state);
+    let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind real manager listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve manager");
+    });
+    format!("http://{addr}")
+}
+
+/// Env that forces `ClientConfig::from_env` to fail for a platform-agnostic
+/// reason (no metadata service, no profile), so `LazyEnvBindingsProvider`
+/// falls through to minting. Mirrors `mints_when_native_config_unavailable`
+/// in `crate::provider`'s own selection tests.
+fn base_env(
+    manager_url: &str,
+    deployment_token: &str,
+    deployment_id: &str,
+) -> HashMap<String, String> {
+    HashMap::from([
+        (
+            ENV_ALIEN_DEPLOYMENT_TYPE.to_string(),
+            Platform::Aws.as_str().to_string(),
+        ),
+        ("AWS_EC2_METADATA_DISABLED".to_string(), "true".to_string()),
+        (
+            "AWS_PROFILE".to_string(),
+            "__alien_missing_test_profile__".to_string(),
+        ),
+        (ENV_ALIEN_MANAGER_URL.to_string(), manager_url.to_string()),
+        (
+            ENV_ALIEN_DEPLOYMENT_TOKEN.to_string(),
+            deployment_token.to_string(),
+        ),
+        (
+            ENV_ALIEN_DEPLOYMENT_ID.to_string(),
+            deployment_id.to_string(),
+        ),
+        (
+            ENV_ALIEN_DEPLOYMENT_SERVICE_ACCOUNT.to_string(),
+            BINDING_NAME.to_string(),
+        ),
+    ])
+}
+
+fn local_kv_binding(data_dir: &Path) -> String {
+    serde_json::json!({
+        "service": "local-kv",
+        "dataDir": data_dir.display().to_string(),
+    })
+    .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// tracing capture (same pattern as `credentials_mint.rs`'s
+// `audit_log_never_contains_credential_material`).
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for BufWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for BufWriter {
+    type Writer = BufWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn authorized_bootstrap_mints_via_real_manager_and_loads_a_working_binding() {
+    let fixture = build().await;
+    let manager_url = spawn_manager(fixture.state.clone()).await;
+    let data_dir = tempfile::tempdir().expect("tempdir");
+
+    let mut env = base_env(&manager_url, &fixture.token_a, &fixture.deployment_a);
+    env.insert(
+        "ALIEN_CACHE_BINDING".to_string(),
+        local_kv_binding(data_dir.path()),
+    );
+
+    // Capture tracing across the whole round trip. `#[tokio::test]` defaults
+    // to a current-thread runtime, so the `axum::serve`-spawned server task
+    // (and its per-request handler) is cooperatively scheduled on this same
+    // OS thread — the thread-local default subscriber set here also captures
+    // the manager's own audit event, not just anything logged by the client.
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(BufWriter(buf.clone()))
+        .with_ansi(false)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+
+    let provider = BindingsProvider::from_env_lazy(env).expect("lazy construct");
+    let kv = tokio::time::timeout(ROUND_TRIP_TIMEOUT, provider.load_kv("cache"))
+        .await
+        .expect("mint round trip must not hang")
+        .expect("mint path should resolve a usable kv binding");
+
+    // Prove the minted credentials actually work end-to-end, not just that
+    // `load_kv` returned `Ok` — a put/get round trip through the resulting
+    // binding.
+    kv.put("hello", b"world".to_vec(), None)
+        .await
+        .expect("put through the minted binding");
+    let value = kv
+        .get("hello")
+        .await
+        .expect("get through the minted binding");
+
+    drop(guard);
+
+    assert_eq!(
+        value,
+        Some(b"world".to_vec()),
+        "a binding loaded through minted credentials must actually read/write, not just construct"
+    );
+
+    let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(
+        logs.contains("Minted deployment credentials"),
+        "audit event must be emitted; captured logs: {logs}"
+    );
+    assert!(
+        logs.contains(&fixture.deployment_a),
+        "audit event must carry deploymentId; captured logs: {logs}"
+    );
+    assert!(
+        logs.contains(BINDING_NAME),
+        "audit event must carry bindingName; captured logs: {logs}"
+    );
+    assert!(
+        logs.contains("principal"),
+        "audit event must carry the principal field; captured logs: {logs}"
+    );
+    assert!(
+        logs.contains("expires_at"),
+        "audit event must carry the expiry field; captured logs: {logs}"
+    );
+    assert!(
+        !logs.contains(&fixture.token_a),
+        "audit log must never contain the deployment token: {logs}"
+    );
+}
+
+#[tokio::test]
+async fn wrong_deployment_token_surfaces_a_typed_error_not_a_panic_or_hang() {
+    let fixture = build().await;
+    let manager_url = spawn_manager(fixture.state.clone()).await;
+    let data_dir = tempfile::tempdir().expect("tempdir");
+
+    // token_b is scoped to a different deployment than deployment_a: the real
+    // manager must reject this with 403, and the resolver must turn that into
+    // a typed error rather than panicking or hanging.
+    let mut env = base_env(&manager_url, &fixture.token_b, &fixture.deployment_a);
+    env.insert(
+        "ALIEN_CACHE_BINDING".to_string(),
+        local_kv_binding(data_dir.path()),
+    );
+
+    let provider = BindingsProvider::from_env_lazy(env).expect("lazy construct");
+    let result = tokio::time::timeout(ROUND_TRIP_TIMEOUT, provider.load_kv("cache"))
+        .await
+        .expect("a rejected mint must fail fast, not hang");
+
+    let error = result.expect_err("a token scoped to a different deployment must not mint");
+    assert_eq!(
+        error.code, "REMOTE_ACCESS_FAILED",
+        "wrong-deployment rejection must surface as a typed error, got: {error}"
+    );
+}


### PR DESCRIPTION
Direct bindings authenticate without a runtime process: prefer projected identity; otherwise mint short-lived credentials from the manager, cached and refreshed by the single client-side resolver in `alien-bindings` (every language inherits it through the napi addon — no TypeScript resolver, by design).

## What changed

- **Manager `POST /v1/credentials/mint`** (contract pinned on the Linear ticket before coding): deployment-token or admin auth via the real TokenStore chain, deployment identity enforced server-side (cross-deployment → 403), duration clamped [900,3600], response `{clientConfig, expiresAt, principal}` with short-lived material only; STS-safe session names (`alien-mint-{dep}-{res}`, charset-validated 400 + char-boundary-safe truncation); structured audit tracing (ids/binding/provider/principal/expiry — proven credential-free by a capturing subscriber test); both credential responses now hold typed `ClientConfig` to the JSON boundary with redacted `Debug` (also fixed the same latent gap on the pre-existing resolve route, plus its silent-empty-config serialize bug).
- **Resolver in `alien-bindings`**: selection at first use on the lazy path — (1) projected/native `ClientConfig::from_env` wins, never mints (proven 0-mint); (2) else mint when `ALIEN_MANAGER_URL` + `ALIEN_DEPLOYMENT_TOKEN` are present (new reserved env vars; `ALIEN_DEPLOYMENT_SERVICE_ACCOUNT` names the SA binding); (3) else the original error, unchanged. Refresh-on-access at `expiresAt − 300s`, fail-closed, single-flight (proven by request-counting under a racing load); no background timers (napi-runtime-agnostic); redacted Debug end to end.
- **Bootstrap proof**: real-TCP integration tests — the actual resolver minting from the actual route with real tokens (happy path + wrong-deployment rejection), audit fields captured. Module rustdoc documents bootstrap (deployment token from deploy time), selection order, and refresh semantics.

## Security rules (ticket) — all audited in final review

Never log creds ✓ (2 audit-only sites, negative assertions) · no creds in non-secret state ✓ · authenticated minting ✓ (401/403/200 matrix) · deployment identity proof ✓ · static mode local-only ✓ · bootstrap documented ✓.

## Dormant until wired

Nothing activates until controllers inject the new env vars — that wiring is task 10/16 and recorded there. Platform-mode equivalent (alien-managerx) is a follow-on private-repo PR. The TS-side refresh test lands with whichever of this and the ALIEN-215 branch merges second (napi addon lives there).

## Merge note

This branch and ALIEN-215 both modify `crates/alien-bindings` (lazy provider path). Merge-second reconciliation map is prepared; key rule: `LazyEnvBindingsProvider`'s manual redacted `Debug` must survive the merge.

Blocks: ALIEN-222 (10), ALIEN-228 (16) consume the env-var injection follow-up.