### PR TITLE
fix: withhold aws vault listing until namespace isolation lands (ALIEN-215)

### DIFF
--- a/crates/alien-bindings/src/providers/vault/aws_parameter_store.rs
+++ b/crates/alien-bindings/src/providers/vault/aws_parameter_store.rs
@@ -1,8 +1,5 @@
 use crate::error::{ErrorData, Result};
-use alien_aws_clients::ssm::{
-    DescribeParametersRequest, GetParameterRequest, ParameterStringFilter, PutParameterRequest,
-    SsmApi, SsmClient,
-};
+use alien_aws_clients::ssm::{GetParameterRequest, PutParameterRequest, SsmApi, SsmClient};
 use alien_error::Context;
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -108,49 +105,73 @@ impl crate::traits::Vault for AwsParameterStoreVault {
         Ok(())
     }
 
-    /// List secret names by enumerating SSM parameters whose name begins with
-    /// this vault's `{vault_prefix}-` and stripping that prefix back off, so
-    /// each returned name round-trips through [`Self::get_secret`].
+    /// Listing is withheld: SSM parameter names are flat (`{vault_prefix}-{name}`),
+    /// so a `BeginsWith` filter on `"{vault_prefix}-"` also matches every sibling
+    /// vault whose prefix extends this one (vault `"app"` would list vault
+    /// `"app-prod"`'s parameters too). There is no separator reserved between
+    /// the prefix and the secret name, so this is unfixable without a naming
+    /// scheme change. Returns `OperationNotSupported` until the naming scheme
+    /// gains unambiguous separation between `vault_prefix` and `secret_name`.
     async fn list_secrets(&self) -> Result<Vec<String>> {
-        let name_prefix = format!("{}-", self.vault_prefix);
-        let filter = ParameterStringFilter::builder()
-            .key("Name".to_string())
-            .option("BeginsWith".to_string())
-            .values(vec![name_prefix.clone()])
-            .build();
+        Err(alien_error::AlienError::new(
+            ErrorData::OperationNotSupported {
+                operation: "vault.list_secrets".to_string(),
+                reason: format!(
+                    "AWS Parameter Store names are flat ('{{vault_prefix}}-{{name}}'); a \
+                     BeginsWith filter on vault prefix '{}' would also match sibling vaults \
+                     whose prefix extends this one (e.g. '{}-prod'). Listing will return once \
+                     the naming scheme has unambiguous separation between vault prefix and \
+                     secret name.",
+                    self.vault_prefix, self.vault_prefix
+                ),
+            },
+        ))
+    }
+}
 
-        let mut names = Vec::new();
-        let mut next_token: Option<String> = None;
-        loop {
-            let request = DescribeParametersRequest::builder()
-                .parameter_filters(vec![filter.clone()])
-                .maybe_next_token(next_token.clone())
-                .build();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Vault as _;
+    use alien_aws_clients::AwsCredentialProvider;
+    use alien_core::{AwsClientConfig, AwsCredentials};
 
-            let response = self.client.describe_parameters(request).await.context(
-                ErrorData::CloudPlatformError {
-                    message: format!(
-                        "Failed to describe parameters for vault prefix '{}'",
-                        self.vault_prefix
-                    ),
-                    resource_id: None,
-                },
-            )?;
+    async fn test_vault() -> AwsParameterStoreVault {
+        let config = AwsClientConfig {
+            account_id: "000000000000".to_string(),
+            region: "us-east-1".to_string(),
+            credentials: AwsCredentials::AccessKeys {
+                access_key_id: "test".to_string(),
+                secret_access_key: "test".to_string(),
+                session_token: None,
+            },
+            service_overrides: None,
+        };
+        let credentials = AwsCredentialProvider::from_config(config)
+            .await
+            .expect("static access-key credentials never fail to construct");
+        let client = Arc::new(SsmClient::new(reqwest::Client::new(), credentials));
+        AwsParameterStoreVault::new(client, "app".to_string())
+    }
 
-            for parameter in response.parameters.unwrap_or_default() {
-                if let Some(name) = parameter.name {
-                    if let Some(secret_name) = name.strip_prefix(&name_prefix) {
-                        names.push(secret_name.to_string());
-                    }
-                }
-            }
+    /// Listing is withheld rather than implemented with a `BeginsWith` scan,
+    /// because a flat `{vault_prefix}-{name}` namespace lets sibling vault
+    /// prefixes alias one another (vault "app" would also match "app-prod").
+    /// This must not silently start scanning again; assert the typed error.
+    #[tokio::test]
+    async fn list_secrets_reports_not_supported() {
+        let vault = test_vault().await;
 
-            next_token = response.next_token;
-            if next_token.is_none() {
-                break;
-            }
-        }
+        let error = vault
+            .list_secrets()
+            .await
+            .expect_err("list_secrets must stay withheld until namespace isolation lands");
 
-        Ok(names)
+        assert_eq!(error.code, "OPERATION_NOT_SUPPORTED");
+        assert!(
+            error.to_string().contains("app"),
+            "message should name the vault prefix so operators can diagnose which vault hit \
+             this, got: {error}"
+        );
     }
 }

--- a/crates/alien-bindings/src/traits.rs
+++ b/crates/alien-bindings/src/traits.rs
@@ -402,6 +402,13 @@ pub trait Vault: Binding {
     /// Returned names are in the vault's own namespace (any provider-specific
     /// prefix is stripped), so each name can be passed straight back to
     /// [`Vault::get_secret`].
+    ///
+    /// Implementations backed by a flat namespace (a single string prefix
+    /// with no reserved separator, e.g. `"{vault_prefix}-{secret_name}"`)
+    /// cannot implement this safely with a prefix/`BeginsWith` scan: a vault
+    /// named `"app"` would also match a sibling vault named `"app-prod"`,
+    /// aliasing across vaults. Such providers should return
+    /// `OperationNotSupported` rather than list under this hazard.
     async fn list_secrets(&self) -> Result<Vec<String>>;
 }
 


### PR DESCRIPTION
Greptile flagged a P1 aliasing bug on the merged #110: AWS SSM Parameter Store's `list_secrets` used a `BeginsWith` filter on `{vault_prefix}-`, and since SSM names are a flat `{prefix}-{name}` namespace with no reserved separator, a vault named `app` would also match a sibling vault named `app-prod`, leaking that vault's secret names across the boundary. This reverts `AwsParameterStoreVault::list_secrets` to a typed `OperationNotSupported` (matching the existing GCP and Azure vault providers) until the naming scheme gains unambiguous separation between vault prefix and secret name, adds a doc comment on `Vault::list_secrets` calling out the aliasing hazard for flat-namespace providers, and adds a unit test asserting the typed error. Kubernetes is unaffected since it lists via an exact `vault-prefix` label match rather than a name-prefix scan.