### PR TITLE
feat: package native addon prebuilds (ALIEN-216)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,21 +297,25 @@ jobs:
             target: aarch64-apple-darwin
             triple: darwin-arm64
             smoke: true
+            expect_arch: arm64
           - runner: depot-macos-15
             os: macos
             target: x86_64-apple-darwin
             triple: darwin-x64
             smoke: false
+            expect_arch: x86_64
           - runner: depot-ubuntu-24.04-16
             os: linux
             target: x86_64-unknown-linux-gnu
             triple: linux-x64-gnu
             smoke: true
+            expect_arch: x86-64
           - runner: depot-ubuntu-24.04-arm-16
             os: linux
             target: aarch64-unknown-linux-gnu
             triple: linux-arm64-gnu
             smoke: false
+            expect_arch: aarch64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     env:
@@ -321,9 +325,10 @@ jobs:
         with:
           ref: ${{ inputs.dry_run && github.sha || format('v{0}', needs.prepare.outputs.version) }}
 
-      # Rust toolchain: Linux via the shared composite; macOS mirrors the native
-      # darwin binary job (dtolnay + depot + sccache + brew protoc). The addon
-      # depends on alien-bindings, whose build.rs needs protoc.
+      # Rust toolchain: Linux via the shared composite; macOS uses dtolnay +
+      # brew protoc directly (plain `napi build`, not `depot cargo`, so no
+      # Depot/sccache setup here). The addon depends on alien-bindings, whose
+      # build.rs needs protoc.
       - name: Setup Rust (linux)
         if: matrix.os == 'linux'
         uses: ./.github/actions/setup-rust
@@ -338,14 +343,6 @@ jobs:
       - name: Configure git credentials for cargo (macos)
         if: matrix.os == 'macos'
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
-
-      - name: Setup Depot (macos)
-        if: matrix.os == 'macos'
-        uses: depot/setup-action@v1
-
-      - name: Install sccache (macos)
-        if: matrix.os == 'macos'
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Install protoc (macos)
         if: matrix.os == 'macos'
@@ -382,6 +379,10 @@ jobs:
         run: |
           cp "crates/alien-bindings-node/alien-bindings-node.${{ matrix.triple }}.node" \
             "packages/bindings/npm/${{ matrix.triple }}/alien-bindings-node.${{ matrix.triple }}.node"
+
+      # Closes the wrong-arch hole on the two legs the smoke step doesn't cover.
+      - name: Assert staged binary architecture
+        run: file "packages/bindings/npm/${{ matrix.triple }}/alien-bindings-node.${{ matrix.triple }}.node" | grep -q "${{ matrix.expect_arch }}"
 
       # Smoke (ticket requirement): a published-shape install with NO build
       # toolchain must load the prebuilt .node and run a real local op. darwin-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,7 +400,13 @@ jobs:
           path: packages/bindings/npm/${{ matrix.triple }}/alien-bindings-node.${{ matrix.triple }}.node
 
   publish-bindings:
-    needs: [prepare, build-addon]
+    needs: [prepare, build-addon, publish-npm]
+    # publish-npm skips on dry_run, so a bare `needs` would cascade-skip the
+    # dry-run path this job deliberately supports. On a real release, wait for
+    # publish-npm to succeed: the wrapper's package.json pins
+    # `@alienplatform/core: ^<release>`, so publishing it while core's publish
+    # failed leaves every `npm install @alienplatform/bindings` ETARGET-broken.
+    if: always() && needs.build-addon.result == 'success' && (inputs.dry_run || needs.publish-npm.result == 'success')
     runs-on: depot-ubuntu-24.04-arm-4
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,15 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
-          for pkg in packages/core packages/sdk packages/testing client-sdks/platform/typescript client-sdks/manager/typescript; do
+          # The bindings addon ships as a wrapper + per-platform prebuild packages
+          # (crate manifest, wrapper, and each npm/<triple> skeleton) that must all
+          # carry the release version BEFORE the native build on the runners, so the
+          # loader embeds it and publish injects matching optionalDependencies.
+          for pkg in packages/core packages/sdk packages/testing \
+            client-sdks/platform/typescript client-sdks/manager/typescript \
+            packages/bindings crates/alien-bindings-node \
+            packages/bindings/npm/darwin-arm64 packages/bindings/npm/darwin-x64 \
+            packages/bindings/npm/linux-x64-gnu packages/bindings/npm/linux-arm64-gnu; do
             node -e "
               const fs = require('fs');
               const path = '${pkg}/package.json';
@@ -93,7 +101,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml packages/core/package.json packages/sdk/package.json packages/testing/package.json \
-            client-sdks/platform/typescript/package.json client-sdks/manager/typescript/package.json
+            client-sdks/platform/typescript/package.json client-sdks/manager/typescript/package.json \
+            packages/bindings/package.json crates/alien-bindings-node/package.json \
+            packages/bindings/npm/darwin-arm64/package.json packages/bindings/npm/darwin-x64/package.json \
+            packages/bindings/npm/linux-x64-gnu/package.json packages/bindings/npm/linux-arm64-gnu/package.json
           git commit -m "chore: release v${VERSION}"
           git tag "v${VERSION}"
           git push
@@ -262,6 +273,200 @@ jobs:
           npm install
           npm run build
           npm publish --access public
+
+  # ─── Native addon prebuilds (@alienplatform/bindings) ──────────────
+  #
+  # The bindings addon publishes as a thin wrapper plus per-platform prebuild
+  # packages (`@alienplatform/bindings-<triple>`) that carry a compiled `.node`,
+  # so `npm install @alienplatform/bindings` needs no Rust toolchain. Each triple
+  # builds on its native runner (darwin-x64 cross-builds on the arm mac — same
+  # toolchain via `--target`). Unlike the other build/publish jobs, build-addon
+  # and publish-bindings also run on dry_run (checking out the untagged HEAD and
+  # publishing with `--dry-run`) so a maintainer can validate the whole
+  # build → smoke → publish path — including the linux halves that can't run
+  # pre-merge — without cutting a real release.
+
+  build-addon:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: depot-macos-15
+            os: macos
+            target: aarch64-apple-darwin
+            triple: darwin-arm64
+            smoke: true
+          - runner: depot-macos-15
+            os: macos
+            target: x86_64-apple-darwin
+            triple: darwin-x64
+            smoke: false
+          - runner: depot-ubuntu-24.04-16
+            os: linux
+            target: x86_64-unknown-linux-gnu
+            triple: linux-x64-gnu
+            smoke: true
+          - runner: depot-ubuntu-24.04-arm-16
+            os: linux
+            target: aarch64-unknown-linux-gnu
+            triple: linux-arm64-gnu
+            smoke: false
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.dry_run && github.sha || format('v{0}', needs.prepare.outputs.version) }}
+
+      # Rust toolchain: Linux via the shared composite; macOS mirrors the native
+      # darwin binary job (dtolnay + depot + sccache + brew protoc). The addon
+      # depends on alien-bindings, whose build.rs needs protoc.
+      - name: Setup Rust (linux)
+        if: matrix.os == 'linux'
+        uses: ./.github/actions/setup-rust
+        with:
+          depot-project-id: ${{ vars.DEPOT_PROJECT_ID }}
+          repo-access-token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          install-protoc: "true"
+
+      - uses: dtolnay/rust-toolchain@nightly
+        if: matrix.os == 'macos'
+
+      - name: Configure git credentials for cargo (macos)
+        if: matrix.os == 'macos'
+        run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Setup Depot (macos)
+        if: matrix.os == 'macos'
+        uses: depot/setup-action@v1
+
+      - name: Install sccache (macos)
+        if: matrix.os == 'macos'
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Install protoc (macos)
+        if: matrix.os == 'macos'
+        run: brew install protobuf
+
+      - name: Add cross target (darwin-x64)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: rustup target add x86_64-apple-darwin
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+        if: matrix.smoke
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build addon (${{ matrix.triple }})
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          pnpm --filter @alienplatform/bindings exec napi build \
+            --platform --release --target ${{ matrix.target }} \
+            --cwd "$GITHUB_WORKSPACE/crates/alien-bindings-node"
+
+      - name: Stage addon into platform package
+        run: |
+          cp "crates/alien-bindings-node/alien-bindings-node.${{ matrix.triple }}.node" \
+            "packages/bindings/npm/${{ matrix.triple }}/alien-bindings-node.${{ matrix.triple }}.node"
+
+      # Smoke (ticket requirement): a published-shape install with NO build
+      # toolchain must load the prebuilt .node and run a real local op. darwin-x64
+      # can't execute on the arm mac, and linux-arm64 has no darwin/linux-x64
+      # host here, so the two natively-executable halves are smoked.
+      - name: Smoke prebuild (no toolchain)
+        if: matrix.smoke
+        run: bash scripts/smoke-addon-prebuild.sh "${{ matrix.triple }}"
+
+      - name: Upload addon artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: addon-${{ matrix.triple }}
+          retention-days: 1
+          path: packages/bindings/npm/${{ matrix.triple }}/alien-bindings-node.${{ matrix.triple }}.node
+
+  publish-bindings:
+    needs: [prepare, build-addon]
+    runs-on: depot-ubuntu-24.04-arm-4
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.dry_run && github.sha || format('v{0}', needs.prepare.outputs.version) }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Validate npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download addon artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: addon-*
+          path: ./addons
+          merge-multiple: false
+
+      - name: Stage addons into platform packages
+        run: |
+          for triple in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu; do
+            cp "./addons/addon-${triple}/alien-bindings-node.${triple}.node" \
+              "packages/bindings/npm/${triple}/alien-bindings-node.${triple}.node"
+          done
+
+      - name: Build wrapper
+        run: pnpm --filter @alienplatform/bindings build
+
+      # Platform packages publish FIRST so an install of the wrapper can never
+      # race ahead of the optionalDependencies it pins.
+      - name: Publish platform prebuild packages (first)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          DRY=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY="--dry-run"; fi
+          for triple in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu; do
+            echo "Publishing @alienplatform/bindings-${triple}..."
+            ( cd "packages/bindings/npm/${triple}" && npm publish --access public $DRY )
+          done
+
+      # Inject exact-version optionalDependencies explicitly (see the script) —
+      # more deterministic and reviewable than `napi prepublish`.
+      - name: Inject optionalDependencies into the wrapper
+        run: node packages/bindings/scripts/inject-optional-deps.mjs
+
+      - name: Publish wrapper (last)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          DRY=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY="--dry-run"; fi
+          pnpm --filter @alienplatform/bindings publish --access public --no-git-checks $DRY
 
   # ─── Binary builds (4 targets, all parallel) ───────────────────────
 

--- a/crates/alien-bindings-node/index.js
+++ b/crates/alien-bindings-node/index.js
@@ -75,8 +75,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-android-arm64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-android-arm64/package.json').version
+        const binding = require('@alienplatform/bindings-android-arm64')
+        const bindingPackageVersion = require('@alienplatform/bindings-android-arm64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +91,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-android-arm-eabi')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-android-arm-eabi/package.json').version
+        const binding = require('@alienplatform/bindings-android-arm-eabi')
+        const bindingPackageVersion = require('@alienplatform/bindings-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +112,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-win32-x64-gnu')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-win32-x64-gnu/package.json').version
+        const binding = require('@alienplatform/bindings-win32-x64-gnu')
+        const bindingPackageVersion = require('@alienplatform/bindings-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +128,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-win32-x64-msvc')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-win32-x64-msvc/package.json').version
+        const binding = require('@alienplatform/bindings-win32-x64-msvc')
+        const bindingPackageVersion = require('@alienplatform/bindings-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +145,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-win32-ia32-msvc')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-win32-ia32-msvc/package.json').version
+        const binding = require('@alienplatform/bindings-win32-ia32-msvc')
+        const bindingPackageVersion = require('@alienplatform/bindings-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +161,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-win32-arm64-msvc')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-win32-arm64-msvc/package.json').version
+        const binding = require('@alienplatform/bindings-win32-arm64-msvc')
+        const bindingPackageVersion = require('@alienplatform/bindings-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +180,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('@alienplatform/bindings-node-darwin-universal')
-      const bindingPackageVersion = require('@alienplatform/bindings-node-darwin-universal/package.json').version
+      const binding = require('@alienplatform/bindings-darwin-universal')
+      const bindingPackageVersion = require('@alienplatform/bindings-darwin-universal/package.json').version
       if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +196,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-darwin-x64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-darwin-x64/package.json').version
+        const binding = require('@alienplatform/bindings-darwin-x64')
+        const bindingPackageVersion = require('@alienplatform/bindings-darwin-x64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +212,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-darwin-arm64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-darwin-arm64/package.json').version
+        const binding = require('@alienplatform/bindings-darwin-arm64')
+        const bindingPackageVersion = require('@alienplatform/bindings-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +232,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-freebsd-x64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-freebsd-x64/package.json').version
+        const binding = require('@alienplatform/bindings-freebsd-x64')
+        const bindingPackageVersion = require('@alienplatform/bindings-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +248,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-freebsd-arm64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-freebsd-arm64/package.json').version
+        const binding = require('@alienplatform/bindings-freebsd-arm64')
+        const bindingPackageVersion = require('@alienplatform/bindings-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +269,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-x64-musl')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-x64-musl/package.json').version
+          const binding = require('@alienplatform/bindings-linux-x64-musl')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +285,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-x64-gnu')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-x64-gnu/package.json').version
+          const binding = require('@alienplatform/bindings-linux-x64-gnu')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +303,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-arm64-musl')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-arm64-musl/package.json').version
+          const binding = require('@alienplatform/bindings-linux-arm64-musl')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +319,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-arm64-gnu')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-arm64-gnu/package.json').version
+          const binding = require('@alienplatform/bindings-linux-arm64-gnu')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +337,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-arm-musleabihf')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-arm-musleabihf/package.json').version
+          const binding = require('@alienplatform/bindings-linux-arm-musleabihf')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +353,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-arm-gnueabihf/package.json').version
+          const binding = require('@alienplatform/bindings-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +371,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-loong64-musl')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-loong64-musl/package.json').version
+          const binding = require('@alienplatform/bindings-linux-loong64-musl')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +387,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-loong64-gnu')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-loong64-gnu/package.json').version
+          const binding = require('@alienplatform/bindings-linux-loong64-gnu')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +405,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-riscv64-musl')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-riscv64-musl/package.json').version
+          const binding = require('@alienplatform/bindings-linux-riscv64-musl')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +421,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('@alienplatform/bindings-node-linux-riscv64-gnu')
-          const bindingPackageVersion = require('@alienplatform/bindings-node-linux-riscv64-gnu/package.json').version
+          const binding = require('@alienplatform/bindings-linux-riscv64-gnu')
+          const bindingPackageVersion = require('@alienplatform/bindings-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +438,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-linux-ppc64-gnu')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-linux-ppc64-gnu/package.json').version
+        const binding = require('@alienplatform/bindings-linux-ppc64-gnu')
+        const bindingPackageVersion = require('@alienplatform/bindings-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +454,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-linux-s390x-gnu')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-linux-s390x-gnu/package.json').version
+        const binding = require('@alienplatform/bindings-linux-s390x-gnu')
+        const bindingPackageVersion = require('@alienplatform/bindings-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +474,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-openharmony-arm64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-openharmony-arm64/package.json').version
+        const binding = require('@alienplatform/bindings-openharmony-arm64')
+        const bindingPackageVersion = require('@alienplatform/bindings-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +490,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-openharmony-x64')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-openharmony-x64/package.json').version
+        const binding = require('@alienplatform/bindings-openharmony-x64')
+        const bindingPackageVersion = require('@alienplatform/bindings-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +506,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@alienplatform/bindings-node-openharmony-arm')
-        const bindingPackageVersion = require('@alienplatform/bindings-node-openharmony-arm/package.json').version
+        const binding = require('@alienplatform/bindings-openharmony-arm')
+        const bindingPackageVersion = require('@alienplatform/bindings-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '0.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -548,7 +548,7 @@ if (!nativeBinding || forceWasi) {
   }
   if (!nativeBinding || forceWasi) {
     try {
-      wasiBinding = require('@alienplatform/bindings-node-wasm32-wasi')
+      wasiBinding = require('@alienplatform/bindings-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
       if (forceWasi) {

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -4,17 +4,14 @@
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {
-    "name": "alien-bindings-node",
-    "package": {
-      "name": "@alienplatform/bindings"
-    },
-    "triples": {
-      "additional": [
-        "aarch64-apple-darwin",
-        "x86_64-unknown-linux-gnu",
-        "aarch64-unknown-linux-gnu"
-      ]
-    }
+    "binaryName": "alien-bindings-node",
+    "packageName": "@alienplatform/bindings",
+    "targets": [
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu"
+    ]
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/packages/bindings/PACKAGE_LAYOUT.md
+++ b/packages/bindings/PACKAGE_LAYOUT.md
@@ -77,16 +77,18 @@ Only two entry points. Every condition carries `types`. No deep imports.
 - `"exports"` and per-condition `"types"` exactly as above; `"types"` top-level for
   legacy resolvers; declarations shipped.
 - `optionalDependencies` — the per-platform prebuild packages
-  `@alienplatform/bindings-<platform>`. Initial set: `@alienplatform/bindings-darwin-arm64`,
+  `@alienplatform/bindings-<platform>`. Shipped set: `@alienplatform/bindings-darwin-arm64`,
   `@alienplatform/bindings-darwin-x64`, `@alienplatform/bindings-linux-x64-gnu`,
   `@alienplatform/bindings-linux-arm64-gnu`. This entry describes the **published**
-  manifest only: `napi prepublish` injects it at publish time (task 04a) from the
-  `napi.targets` config in `crates/alien-bindings-node/package.json`,
-  which is the source of truth for the platform list. The workspace source manifest
-  (`packages/bindings/package.json`) carries no `optionalDependencies` — adding the
-  per-platform packages there would pin unpublished versions and break `pnpm install
-  --frozen-lockfile` before task 04a publishes them. The final platform list is OPEN
-  (task 04a).
+  manifest only: `scripts/inject-optional-deps.mjs` injects it at publish time,
+  pinning each entry to the wrapper's own release version, from its own `TRIPLES`
+  const — chosen over `napi prepublish`, which rewrites/regenerates more than
+  needed. `TRIPLES` must mirror the `napi.targets` config in
+  `crates/alien-bindings-node/package.json`, which is the source of truth for the
+  release build matrix (the per-triple legs in the release workflow). The
+  workspace source manifest (`packages/bindings/package.json`) carries no
+  `optionalDependencies` — adding the per-platform packages there would pin
+  unpublished versions and break `pnpm install --frozen-lockfile` before release.
 - `description` and `keywords`.
 - Support note: Bun ≥ 1.0.23 and Node ≥ 18 (Node-API / napi-rs addon).
 - `dependencies`: `@alienplatform/core` (errors) only.

--- a/packages/bindings/PACKAGE_LAYOUT.md
+++ b/packages/bindings/PACKAGE_LAYOUT.md
@@ -78,9 +78,10 @@ Only two entry points. Every condition carries `types`. No deep imports.
   legacy resolvers; declarations shipped.
 - `optionalDependencies` — the per-platform prebuild packages
   `@alienplatform/bindings-<platform>`. Initial set: `@alienplatform/bindings-darwin-arm64`,
-  `@alienplatform/bindings-linux-x64-gnu`, `@alienplatform/bindings-linux-arm64-gnu`. This
-  entry describes the **published** manifest only: `napi prepublish` injects it at publish
-  time (task 04a) from the `napi.triples` config in `crates/alien-bindings-node/package.json`,
+  `@alienplatform/bindings-darwin-x64`, `@alienplatform/bindings-linux-x64-gnu`,
+  `@alienplatform/bindings-linux-arm64-gnu`. This entry describes the **published**
+  manifest only: `napi prepublish` injects it at publish time (task 04a) from the
+  `napi.targets` config in `crates/alien-bindings-node/package.json`,
   which is the source of truth for the platform list. The workspace source manifest
   (`packages/bindings/package.json`) carries no `optionalDependencies` — adding the
   per-platform packages there would pin unpublished versions and break `pnpm install

--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -35,6 +35,10 @@ bun run build:addon   # or: pnpm -C packages/bindings run build:addon
 `crates/alien-bindings-node` and drops the `.node` next to the crate, where the
 loader's dev fallback (step 3 above) finds it. Rebuild after changing any Rust
 in `alien-bindings` or `alien-bindings-node`. The built `.node` is gitignored.
+`build:addon` only builds for the host triple; on a Mac, cross-building the
+other mac triple (e.g. `darwin-x64` from an `arm64` host) needs an explicit
+`napi build --release --target x86_64-apple-darwin --cwd
+../../crates/alien-bindings-node`.
 
 To point the loader at an addon somewhere else, set `ALIEN_BINDINGS_ADDON_PATH`
 to its path (step 1).

--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -1,0 +1,55 @@
+# `@alienplatform/bindings`
+
+Direct TypeScript bindings for Alien storage, kv, queue, and vault over an
+in-process [napi-rs](https://napi.rs) addon. The addon itself lives in the Rust
+crate `crates/alien-bindings-node`; this package is the published JavaScript
+wrapper that loads it.
+
+## Native addon resolution
+
+The addon is loaded lazily on the first binding operation (never at import — the
+package is `sideEffects: false`). `src/loader.ts` resolves it in order:
+
+1. `ALIEN_BINDINGS_ADDON_PATH` — an explicit path to a `.node` file. A dev/test
+   escape hatch only; never set in a published install.
+2. The per-platform prebuild package `@alienplatform/bindings-<triple>`, pulled
+   in as an `optionalDependency`. This is how end users get the addon: `npm`/`bun`
+   installs only the package matching the host `os`/`cpu`/`libc`. The
+   `optionalDependencies` block exists **only in the published manifest** — it is
+   injected at publish time by the release pipeline, so a workspace checkout
+   carries none.
+3. Dev fallback: a locally-built addon at
+   `crates/alien-bindings-node/alien-bindings-node.<triple>.node`, found by
+   walking up from the installed package. Loaded only if its `version()` matches
+   this package's version (a stale build is warned about and rejected).
+
+## Local development
+
+Build the addon for your host once, then run anything that imports the package:
+
+```sh
+bun run build:addon   # or: pnpm -C packages/bindings run build:addon
+```
+
+`build:addon` runs `napi build --platform --release` against
+`crates/alien-bindings-node` and drops the `.node` next to the crate, where the
+loader's dev fallback (step 3 above) finds it. Rebuild after changing any Rust
+in `alien-bindings` or `alien-bindings-node`. The built `.node` is gitignored.
+
+To point the loader at an addon somewhere else, set `ALIEN_BINDINGS_ADDON_PATH`
+to its path (step 1).
+
+## Prebuild packages (`npm/`)
+
+`npm/<triple>/` holds the skeleton for each published per-platform package
+(`darwin-arm64`, `darwin-x64`, `linux-x64-gnu`, `linux-arm64-gnu`). Each carries
+a `package.json` (`name`/`os`/`cpu`/`libc`/`main`/`files`) and a README; the
+`.node` is staged in at build time and is never committed. There is no musl
+target: the deployment base images are glibc (chainguard/wolfi-base), not Alpine.
+
+The release pipeline builds each addon on its native runner, stages it into the
+matching `npm/<triple>/` dir, rewrites the placeholder `0.0.0` versions to the
+release version, injects the exact-version `optionalDependencies` into this
+package's published manifest, and publishes the platform packages before the
+wrapper. Pinning the exact version is what guarantees a published wrapper only
+ever loads the matching-version platform addon.

--- a/packages/bindings/npm/.gitignore
+++ b/packages/bindings/npm/.gitignore
@@ -1,4 +1,5 @@
 # Per-platform prebuild skeletons: only the manifest + README are committed.
 # The .node addon is staged into each dir at build/publish time (locally by
-# `bun run build:addon`, in CI by `napi artifacts`) and must never be committed.
+# `bun run build:addon`, in CI by `cp` in the build-addon/publish-bindings
+# jobs) and must never be committed.
 */*.node

--- a/packages/bindings/npm/.gitignore
+++ b/packages/bindings/npm/.gitignore
@@ -1,0 +1,4 @@
+# Per-platform prebuild skeletons: only the manifest + README are committed.
+# The .node addon is staged into each dir at build/publish time (locally by
+# `bun run build:addon`, in CI by `napi artifacts`) and must never be committed.
+*/*.node

--- a/packages/bindings/npm/darwin-arm64/README.md
+++ b/packages/bindings/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `@alienplatform/bindings-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `@alienplatform/bindings`

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@alienplatform/bindings-darwin-arm64",
+  "version": "0.0.0",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "alien-bindings-node.darwin-arm64.node",
+  "files": [
+    "alien-bindings-node.darwin-arm64.node"
+  ],
+  "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
+  "os": [
+    "darwin"
+  ]
+}

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,15 +1,9 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
   "version": "0.0.0",
-  "cpu": [
-    "arm64"
-  ],
+  "cpu": ["arm64"],
   "main": "alien-bindings-node.darwin-arm64.node",
-  "files": [
-    "alien-bindings-node.darwin-arm64.node"
-  ],
+  "files": ["alien-bindings-node.darwin-arm64.node"],
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
-  "os": [
-    "darwin"
-  ]
+  "os": ["darwin"]
 }

--- a/packages/bindings/npm/darwin-x64/README.md
+++ b/packages/bindings/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@alienplatform/bindings-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `@alienplatform/bindings`

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,15 +1,9 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
   "version": "0.0.0",
-  "cpu": [
-    "x64"
-  ],
+  "cpu": ["x64"],
   "main": "alien-bindings-node.darwin-x64.node",
-  "files": [
-    "alien-bindings-node.darwin-x64.node"
-  ],
+  "files": ["alien-bindings-node.darwin-x64.node"],
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
-  "os": [
-    "darwin"
-  ]
+  "os": ["darwin"]
 }

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@alienplatform/bindings-darwin-x64",
+  "version": "0.0.0",
+  "cpu": [
+    "x64"
+  ],
+  "main": "alien-bindings-node.darwin-x64.node",
+  "files": [
+    "alien-bindings-node.darwin-x64.node"
+  ],
+  "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
+  "os": [
+    "darwin"
+  ]
+}

--- a/packages/bindings/npm/linux-arm64-gnu/README.md
+++ b/packages/bindings/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@alienplatform/bindings-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@alienplatform/bindings`

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@alienplatform/bindings-linux-arm64-gnu",
+  "version": "0.0.0",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "alien-bindings-node.linux-arm64-gnu.node",
+  "files": [
+    "alien-bindings-node.linux-arm64-gnu.node"
+  ],
+  "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,18 +1,10 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
   "version": "0.0.0",
-  "cpu": [
-    "arm64"
-  ],
+  "cpu": ["arm64"],
   "main": "alien-bindings-node.linux-arm64-gnu.node",
-  "files": [
-    "alien-bindings-node.linux-arm64-gnu.node"
-  ],
+  "files": ["alien-bindings-node.linux-arm64-gnu.node"],
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
-  "os": [
-    "linux"
-  ],
-  "libc": [
-    "glibc"
-  ]
+  "os": ["linux"],
+  "libc": ["glibc"]
 }

--- a/packages/bindings/npm/linux-x64-gnu/README.md
+++ b/packages/bindings/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@alienplatform/bindings-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `@alienplatform/bindings`

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@alienplatform/bindings-linux-x64-gnu",
+  "version": "0.0.0",
+  "cpu": [
+    "x64"
+  ],
+  "main": "alien-bindings-node.linux-x64-gnu.node",
+  "files": [
+    "alien-bindings-node.linux-x64-gnu.node"
+  ],
+  "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,18 +1,10 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
   "version": "0.0.0",
-  "cpu": [
-    "x64"
-  ],
+  "cpu": ["x64"],
   "main": "alien-bindings-node.linux-x64-gnu.node",
-  "files": [
-    "alien-bindings-node.linux-x64-gnu.node"
-  ],
+  "files": ["alien-bindings-node.linux-x64-gnu.node"],
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
-  "os": [
-    "linux"
-  ],
-  "libc": [
-    "glibc"
-  ]
+  "os": ["linux"],
+  "libc": ["glibc"]
 }

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "tsdown && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build:addon": "napi build --platform --release --cwd ../../crates/alien-bindings-node",
     "prepare": "npm run build",
     "test": "vitest run",
     "test:bun": "BUN_EXPECTED=1 bun test",
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@alienplatform/typescript-config": "workspace:^",
     "@biomejs/biome": "^1.9.4",
+    "@napi-rs/cli": "^3.0.0",
     "@types/node": "^24.0.15",
     "tsdown": "^0.13.0",
     "typescript": "^5.8.3",

--- a/packages/bindings/scripts/compile-smoke.ts
+++ b/packages/bindings/scripts/compile-smoke.ts
@@ -49,18 +49,10 @@ import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { platformTriple } from "../src/loader.ts"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageDir = dirname(scriptDir)
-
-/** Map `process.platform`/`process.arch` to the napi triple (mirrors `src/loader.ts`). */
-function platformTriple(): string {
-  const { platform, arch } = process
-  if (platform === "darwin" && arch === "arm64") return "darwin-arm64"
-  if (platform === "linux" && arch === "x64") return "linux-x64-gnu"
-  if (platform === "linux" && arch === "arm64") return "linux-arm64-gnu"
-  throw new Error(`compile-smoke has no native addon for platform '${platform}' arch '${arch}'.`)
-}
 
 /** Walk up from `packageDir` looking for the locally-built dev addon (mirrors `src/loader.ts`). */
 function findLocalAddon(triple: string): string {

--- a/packages/bindings/scripts/inject-optional-deps.mjs
+++ b/packages/bindings/scripts/inject-optional-deps.mjs
@@ -1,0 +1,32 @@
+/**
+ * Inject the per-platform prebuild packages as exact-version
+ * `optionalDependencies` of the `@alienplatform/bindings` wrapper, pinned to the
+ * wrapper's own version.
+ *
+ * Run by the release pipeline (publish-bindings) after the wrapper's version has
+ * been rewritten to the release version and before the wrapper is published.
+ * Chosen over `napi prepublish`, which rewrites/regenerates more than we need —
+ * an explicit, exact pin is deterministic and reviewable, and guarantees a
+ * published wrapper can only ever resolve the matching-version platform addon.
+ *
+ * Idempotent: rewrites `optionalDependencies` wholesale from the fixed triple
+ * list, so re-running never accumulates stale entries.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const TRIPLES = ["darwin-arm64", "darwin-x64", "linux-x64-gnu", "linux-arm64-gnu"]
+
+const wrapperManifest = fileURLToPath(new URL("../package.json", import.meta.url))
+const pkg = JSON.parse(readFileSync(wrapperManifest, "utf8"))
+const { version } = pkg
+
+pkg.optionalDependencies = Object.fromEntries(
+  TRIPLES.map(triple => [`@alienplatform/bindings-${triple}`, version]),
+)
+
+writeFileSync(wrapperManifest, `${JSON.stringify(pkg, null, 2)}\n`)
+
+console.log(`Injected optionalDependencies (pinned to ${version}):`)
+console.log(JSON.stringify(pkg.optionalDependencies, null, 2))

--- a/packages/bindings/scripts/smoke-prebuild.mjs
+++ b/packages/bindings/scripts/smoke-prebuild.mjs
@@ -1,0 +1,50 @@
+/**
+ * Prebuild smoke: prove a PUBLISHED-shape install works with NO build toolchain.
+ *
+ * Runs from a throwaway consumer directory that has installed three tarballs —
+ * `@alienplatform/core`, the `@alienplatform/bindings` wrapper, and the
+ * per-platform `@alienplatform/bindings-<triple>` prebuild — and nothing else.
+ * No Rust, no `napi`, no `ALIEN_BINDINGS_ADDON_PATH`: the loader must resolve the
+ * prebuilt `.node` through the platform package (loader.ts step 2), so this only
+ * passes if the prebuilt addon carries its own compiled binary.
+ *
+ * It imports the wrapper (which pulls `AlienError` from the external
+ * `@alienplatform/core`, proving that dependency resolved) and performs a real
+ * local-provider KV put/get against a temp `local-kv` binding.
+ */
+
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { kv } from "@alienplatform/bindings"
+
+if (process.env.ALIEN_BINDINGS_ADDON_PATH) {
+  console.error("[smoke] FAIL: ALIEN_BINDINGS_ADDON_PATH is set; that bypasses the prebuild path")
+  process.exit(1)
+}
+
+const runtime = typeof Bun !== "undefined" ? "bun" : "node"
+
+async function main() {
+  const dataDir = mkdtempSync(join(tmpdir(), "alien-smoke-kv-"))
+  const env = {
+    ALIEN_DEPLOYMENT_TYPE: "local",
+    ALIEN_CACHE_BINDING: JSON.stringify({ service: "local-kv", dataDir }),
+  }
+
+  const cache = kv("cache", { env })
+  await cache.set("greeting", "hi")
+  const got = await cache.getText("greeting")
+
+  if (got !== "hi") {
+    console.error(`[smoke:${runtime}] FAIL: expected 'hi', got ${JSON.stringify(got)}`)
+    process.exit(1)
+  }
+
+  console.log(`[smoke:${runtime}] OK: kv put/get through the prebuilt addon returned '${got}'`)
+}
+
+main().catch(err => {
+  console.error(`[smoke:${runtime}] UNEXPECTED`, err)
+  process.exit(1)
+})

--- a/packages/bindings/src/__tests__/loader.test.ts
+++ b/packages/bindings/src/__tests__/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { isStaleLocalAddon } from "../loader.js"
+import { isStaleLocalAddon, platformTriple } from "../loader.js"
 
 describe("isStaleLocalAddon", () => {
   it("is not stale when the addon version matches the package version", () => {
@@ -8,5 +8,28 @@ describe("isStaleLocalAddon", () => {
 
   it("is stale when the addon version differs from the package version", () => {
     expect(isStaleLocalAddon("1.10.6", "1.10.7")).toBe(true)
+  })
+})
+
+describe("platformTriple", () => {
+  // Pins the full platform/arch -> napi triple mapping table (the
+  // optionalDependencies set in PACKAGE_LAYOUT.md). The existing loader suites
+  // bypass this function entirely via ALIEN_BINDINGS_ADDON_PATH, which is how
+  // the missing darwin-x64 branch slipped through — this test exercises
+  // platformTriple directly so every pair (and the unsupported case) is
+  // pinned regardless of the host running the suite.
+  it.each([
+    ["darwin", "arm64", "darwin-arm64"],
+    ["darwin", "x64", "darwin-x64"],
+    ["linux", "x64", "linux-x64-gnu"],
+    ["linux", "arm64", "linux-arm64-gnu"],
+  ] as const)("maps %s/%s to %s", (platform, arch, triple) => {
+    expect(platformTriple(platform, arch)).toBe(triple)
+  })
+
+  it("throws a clear error for an unsupported platform/arch pair", () => {
+    expect(() => platformTriple("win32", "x64")).toThrow(
+      "@alienplatform/bindings has no native addon for platform 'win32' arch 'x64'.",
+    )
   })
 })

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -131,10 +131,17 @@ export interface NativeAddon {
  * Map `process.platform` / `process.arch` to the napi triple used in both the
  * prebuild package name and the locally-built `.node` file name. Mirrors the
  * `optionalDependencies` set pinned in PACKAGE_LAYOUT.md.
+ *
+ * Exported for unit testing: accepts `platform`/`arch` explicitly (defaulting
+ * to the real `process` values) so every supported pair — and the unsupported
+ * case — can be exercised directly, without stubbing the `process` global.
  */
-function platformTriple(): string {
-  const { platform, arch } = process
+export function platformTriple(
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): string {
   if (platform === "darwin" && arch === "arm64") return "darwin-arm64"
+  if (platform === "darwin" && arch === "x64") return "darwin-x64"
   if (platform === "linux" && arch === "x64") return "linux-x64-gnu"
   if (platform === "linux" && arch === "arm64") return "linux-arm64-gnu"
   throw new Error(

--- a/packages/bindings/tsconfig.json
+++ b/packages/bindings/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@alienplatform/typescript-config/base.json",
   "compilerOptions": {
-    "allowArbitraryExtensions": true
+    "allowArbitraryExtensions": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*", "tests/**/*", "scripts/**/*.ts"]
 }

--- a/packages/package-layout/expected-failures.json
+++ b/packages/package-layout/expected-failures.json
@@ -44,7 +44,25 @@
   {
     "check": "packed-contents",
     "package": "@alienplatform/bindings-darwin-arm64",
-    "reason": "per-platform prebuild package not present (expected one .node addon + manifest)",
+    "reason": "per-platform prebuild addon not staged locally (release matrix: built natively on the macOS runner)",
+    "owningTask": "04a"
+  },
+  {
+    "check": "packed-contents",
+    "package": "@alienplatform/bindings-darwin-x64",
+    "reason": "per-platform prebuild addon not staged locally (release matrix: cross-compiled on the macOS runner via --target x86_64-apple-darwin)",
+    "owningTask": "04a"
+  },
+  {
+    "check": "packed-contents",
+    "package": "@alienplatform/bindings-linux-x64-gnu",
+    "reason": "per-platform prebuild addon not staged locally (release matrix: built natively on the linux-x64 runner)",
+    "owningTask": "04a"
+  },
+  {
+    "check": "packed-contents",
+    "package": "@alienplatform/bindings-linux-arm64-gnu",
+    "reason": "per-platform prebuild addon not staged locally (release matrix: built natively on the linux-arm64 runner)",
     "owningTask": "04a"
   }
 ]

--- a/packages/package-layout/run.ts
+++ b/packages/package-layout/run.ts
@@ -638,16 +638,120 @@ function main(): void {
     })
   }
 
-  // Per-platform prebuild package (@alienplatform/bindings-<platform>): not built
-  // until task 04a. Its packed shape (exactly one .node addon + manifest) cannot be
-  // asserted yet.
-  record({
-    check: "packed-contents",
-    package: "@alienplatform/bindings-darwin-arm64",
-    status: "fail",
-    reason: "per-platform prebuild package not present (expected one .node addon + manifest)",
-    evidence: "no @alienplatform/bindings-darwin-arm64 tarball to inspect",
-  })
+  // Per-platform prebuild packages (@alienplatform/bindings-<triple>): assert the
+  // packed shape — exactly one `.node` addon (named by the manifest `main`) plus
+  // its manifest, with os/cpu set — for every triple whose addon is staged in
+  // packages/bindings/npm/<triple>. Each addon is built by the release pipeline
+  // on a native runner (napi artifacts stages it into these dirs at publish
+  // time), so a plain workspace checkout has no addon for any triple and every
+  // one is recorded as an expected failure naming where it is produced. That set
+  // is host-independent — this fixture never stages the locally-built dev addon
+  // into an npm dir (the dev addon serves the import/compile checks via
+  // ALIEN_BINDINGS_ADDON_PATH instead) — so the committed expected-failures.json
+  // reconciles identically on the darwin dev host and the linux-arm64 CI runner.
+  // The inspection branch below is exercised for real whenever an addon IS staged
+  // (a release-pipeline dry run, or `bun run build:addon` followed by a manual
+  // stage), and was proven locally by packing the darwin-arm64 + darwin-x64 dirs.
+  const PREBUILD_TRIPLES = [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-x64-gnu",
+    "linux-arm64-gnu",
+  ] as const
+  const RELEASE_MATRIX_NOTE: Record<string, string> = {
+    "darwin-arm64": "built natively on the macOS runner",
+    "darwin-x64": "cross-compiled on the macOS runner via --target x86_64-apple-darwin",
+    "linux-x64-gnu": "built natively on the linux-x64 runner",
+    "linux-arm64-gnu": "built natively on the linux-arm64 runner",
+  }
+  const bindingsNpmDir = join(packagesDir, "bindings", "npm")
+
+  interface PrebuildManifest {
+    name: string
+    main: string
+    os?: string[]
+    cpu?: string[]
+    libc?: string[]
+  }
+
+  for (const prebuildTriple of PREBUILD_TRIPLES) {
+    const pkgName = `@alienplatform/bindings-${prebuildTriple}`
+    const npmDir = join(bindingsNpmDir, prebuildTriple)
+    const manifestPath = join(npmDir, "package.json")
+    if (!existsSync(manifestPath)) {
+      record({
+        check: "packed-contents",
+        package: pkgName,
+        status: "fail",
+        reason: `npm skeleton dir missing (${relative(scriptDir, npmDir)})`,
+        evidence: npmDir,
+      })
+      continue
+    }
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as PrebuildManifest
+    const stagedAddon = join(npmDir, manifest.main)
+    if (!existsSync(stagedAddon)) {
+      record({
+        check: "packed-contents",
+        package: pkgName,
+        status: "fail",
+        reason: `per-platform prebuild addon not staged locally (release matrix: ${RELEASE_MATRIX_NOTE[prebuildTriple]})`,
+        evidence: `no ${manifest.main} in ${relative(scriptDir, npmDir)} — built and published by the release pipeline`,
+      })
+      continue
+    }
+
+    const packed = run("npm", ["pack", "--pack-destination", tarballsDir, "--silent"], npmDir)
+    const version = (JSON.parse(readFileSync(manifestPath, "utf8")) as { version?: string }).version
+    const tarballName = readdirSync(tarballsDir).find(
+      entry =>
+        entry.startsWith(`alienplatform-bindings-${prebuildTriple}-`) && entry.endsWith(".tgz"),
+    )
+    if (packed.status !== 0 || !tarballName) {
+      record({
+        check: "packed-contents",
+        package: pkgName,
+        status: "fail",
+        reason: "npm pack failed",
+        evidence: lastLine(packed.stderr) || lastLine(packed.stdout) || `exit ${packed.status}`,
+      })
+      continue
+    }
+    const entries = tarEntries(join(tarballsDir, tarballName)).map(entry =>
+      entry.replace(/^package\//, ""),
+    )
+    const nodeFiles = entries.filter(entry => entry.endsWith(".node"))
+
+    const problems: string[] = []
+    if (!entries.includes("package.json")) problems.push("missing package.json")
+    if (nodeFiles.length !== 1) {
+      problems.push(`expected exactly one .node addon, found ${nodeFiles.length}`)
+    } else if (nodeFiles[0] !== manifest.main) {
+      problems.push(`.node addon '${nodeFiles[0]}' does not match manifest main '${manifest.main}'`)
+    }
+    if (manifest.name !== pkgName) {
+      problems.push(`manifest name '${manifest.name}' does not match '${pkgName}'`)
+    }
+    if (!manifest.os || manifest.os.length === 0) problems.push("manifest missing os")
+    if (!manifest.cpu || manifest.cpu.length === 0) problems.push("manifest missing cpu")
+    const denylisted = entries.filter(entry =>
+      HARD_DENYLIST_PATTERNS.some(pattern => pattern.test(entry)),
+    )
+    if (denylisted.length > 0) {
+      problems.push(`ships hard-denylisted file(s): ${denylisted.slice(0, 5).join(", ")}`)
+    }
+
+    record({
+      check: "packed-contents",
+      package: pkgName,
+      status: problems.length === 0 ? "pass" : "fail",
+      reason: problems.length === 0 ? "ok" : problems.join("; "),
+      evidence:
+        problems.length === 0
+          ? `${entries.length} entries in ${tarballName}: exactly one .node (${nodeFiles[0]}) + manifest (version=${version}, os=${manifest.os?.join(",")}, cpu=${manifest.cpu?.join(",")}${manifest.libc ? `, libc=${manifest.libc.join(",")}` : ""})`
+          : `${entries.length} entries in ${tarballName}`,
+    })
+  }
 
   // -------------------------------------------------------------------------
   // Step 8 — bun build --compile of the ./native embed entry

--- a/packages/package-layout/run.ts
+++ b/packages/package-layout/run.ts
@@ -348,6 +348,7 @@ function main(): void {
   function hostTriple(): string {
     const { platform, arch } = process
     if (platform === "darwin" && arch === "arm64") return "darwin-arm64"
+    if (platform === "darwin" && arch === "x64") return "darwin-x64"
     if (platform === "linux" && arch === "x64") return "linux-x64-gnu"
     if (platform === "linux" && arch === "arm64") return "linux-arm64-gnu"
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@napi-rs/cli':
+        specifier: ^3.0.0
+        version: 3.7.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.4)
       '@types/node':
         specifier: ^24.0.15
         version: 24.10.4
@@ -4278,7 +4281,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
 
   '@apidevtools/json-schema-ref-parser@15.1.3(@types/json-schema@7.0.15)':
     dependencies:
@@ -6098,7 +6101,7 @@ snapshots:
   '@readme/postman-to-openapi@4.1.0':
     dependencies:
       '@readme/http-status-codes': 7.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       jsonc-parser: 3.2.0
       lodash.camelcase: 4.3.0
       marked: 4.3.0

--- a/scripts/smoke-addon-prebuild.sh
+++ b/scripts/smoke-addon-prebuild.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Prebuild smoke: prove a published-shape install of the bindings addon works
+# with NO build toolchain. Packs the `@alienplatform/core` runtime dep, the
+# `@alienplatform/bindings` wrapper, and the per-platform
+# `@alienplatform/bindings-<triple>` prebuild into a throwaway consumer, installs
+# them from tarballs (npm, no Rust/napi), and runs a real local-KV put/get
+# through the prebuilt `.node` (loader step 2, no ALIEN_BINDINGS_ADDON_PATH).
+#
+# Usage: scripts/smoke-addon-prebuild.sh <triple>
+#   e.g. scripts/smoke-addon-prebuild.sh darwin-arm64
+#
+# Precondition: the built `.node` is already staged into
+# packages/bindings/npm/<triple>/ (the release job stages it from the artifact;
+# locally, run `napi build --platform --release --target <target>` and copy it).
+set -euo pipefail
+
+TRIPLE="${1:?usage: scripts/smoke-addon-prebuild.sh <triple>}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ADDON="packages/bindings/npm/${TRIPLE}/alien-bindings-node.${TRIPLE}.node"
+if [ ! -f "$ADDON" ]; then
+  echo "[smoke] no staged addon at ${ADDON}; build and stage it first" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The wrapper's dist must exist to be packed.
+pnpm --filter @alienplatform/bindings build
+
+# Pack the three packages a published wrapper install needs.
+pnpm --filter @alienplatform/core pack --pack-destination "$WORK"
+pnpm --filter @alienplatform/bindings pack --pack-destination "$WORK"
+( cd "packages/bindings/npm/${TRIPLE}" && npm pack --pack-destination "$WORK" )
+
+# Normalize the version-stamped filenames (order matters: the platform tarball
+# also matches the wrapper glob, so move it first).
+mv "$WORK"/alienplatform-core-*.tgz "$WORK/core.tgz"
+mv "$WORK"/alienplatform-bindings-"${TRIPLE}"-*.tgz "$WORK/platform.tgz"
+mv "$WORK"/alienplatform-bindings-*.tgz "$WORK/wrapper.tgz"
+
+cp packages/bindings/scripts/smoke-prebuild.mjs "$WORK/smoke.mjs"
+
+cat > "$WORK/package.json" <<'JSON'
+{
+  "name": "alien-prebuild-smoke",
+  "private": true,
+  "type": "module"
+}
+JSON
+# Inject file: deps (the triple is interpolated, so it can't live in the quoted
+# heredoc above).
+node -e '
+  const fs = require("fs");
+  const p = process.argv[1];
+  const triple = process.argv[2];
+  const pkg = JSON.parse(fs.readFileSync(p, "utf8"));
+  pkg.dependencies = {
+    "@alienplatform/core": "file:./core.tgz",
+    "@alienplatform/bindings": "file:./wrapper.tgz",
+    [`@alienplatform/bindings-${triple}`]: "file:./platform.tgz",
+  };
+  fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + "\n");
+' "$WORK/package.json" "$TRIPLE"
+
+# Install from tarballs only. No Rust, no napi — the prebuilt .node must carry
+# the compiled addon.
+( cd "$WORK" && npm install --no-audit --no-fund )
+
+echo "[smoke] node ..."
+( cd "$WORK" && node smoke.mjs )
+
+if command -v bun >/dev/null 2>&1; then
+  echo "[smoke] bun ..."
+  ( cd "$WORK" && bun smoke.mjs )
+fi
+
+echo "[smoke] ${TRIPLE}: PASS"


### PR DESCRIPTION
`npm/bun install @alienplatform/bindings` now works with no compiler toolchain: per-platform prebuild packages published as exact-version `optionalDependencies`, built and published in lockstep with the wrapper by the release pipeline.

## Target matrix (decision recorded per ticket)

| Triple | Why | Built on |
|---|---|---|
| darwin-arm64 | local dev | depot-macos-15 (native) |
| darwin-x64 | Intel-Mac local dev | depot-macos-15 (`--target`, same toolchain) |
| linux-x64-gnu | cloud workloads | depot-ubuntu-24.04-16 (native) |
| linux-arm64-gnu | cloud workloads | depot-ubuntu-24.04-arm-16 (native) |

**musl: skipped** — base images are `chainguard/wolfi-base` (glibc); the musl Rust binaries in them are statically-linked CLI artifacts, unrelated to the Node addon. **Windows: skipped** — not a deployment target. No cross-compilation toolchains needed anywhere (the zigbuild machinery is for user app builds, not this).

## What changed

- **napi v3 config migration**: the crate used v2-era keys (`napi.package.name` has NO v3 shim — it silently fell back to the package name); migrated to `binaryName`/`packageName`/`targets` and regenerated the loader — it now resolves `@alienplatform/bindings-<triple>` correctly. `platformTriple` in the TS loader gained darwin-x64 (was a shipped-break on Intel Macs; now pinned by a direct mapping-table test under Node AND Bun) and is the single mapping (compile-smoke's private copy deleted).
- **npm skeletons** (`packages/bindings/npm/*`): four per-platform manifests (name/version/os/cpu/libc), `.node` gitignored; `optionalDependencies` injected at publish by `scripts/inject-optional-deps.mjs` with exact versions (the ABI guard).
- **Release pipeline** (`release.yml`): `prepare` now version-rewrites the bindings wrapper, crate, and platform manifests; new `build-addon` matrix (4 legs, native runners, per-leg arch assertion via `file`, fail-loud triple mapping — the triple appears independently in the napi filename, artifact name, and staging path, so a mismatch is a missing-file error, never a mis-shipped binary); new `publish-bindings` job: platforms first → inject → wrapper LAST, gated on `publish-npm` success (wrapper must never publish against a failed core release), every publish honoring `dry_run`.
- **Smoke** (darwin-arm64 + linux-x64 legs): pack wrapper+platform tarballs → `npm install` in a temp dir → import + real local-kv op under node and bun — proves the published resolution path by elimination (ADDON_PATH refused, dev-fallback unreachable), zero toolchain.
- **Fixture**: packed-contents check now really packs+inspects staged platform dirs (exactly one `.node` + manifest); expectations host-independent.

## Proven pre-merge vs first release

Proven locally/CI: darwin-arm64 full build+smoke; darwin-x64 build (Mach-O-verified); all scripts verbatim-run; actionlint clean; fixture/suites green. **First `dry_run` release proves**: linux legs build+smoke, artifact round-trip, job graph — everything except real npm publishes and the version rewrites (dry-run uses placeholder versions; version-coherence is first proven by a real release). Recommend one `workflow_dispatch` dry-run after merge.

## Residuals (tracked, non-blocking)

Partial-publish re-runs aren't idempotent (EPUBLISHCONFLICT on re-run; same as existing publish jobs — safe end state, manual recovery); `run.ts` is near the size advisory — next fixture change should extract the packed-contents step first.

Blocks: ALIEN-214 (03) consumes the installable package; ALIEN-225 (13) stages these prebuilds.