### PR TITLE
feat: typescript commands sender and pull receiver (ALIEN-220)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -141,6 +141,16 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: pnpm build && pnpm -C packages/package-layout check
 
+      - name: Command twins real-wire integration
+        if: steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+        # Drives the TS command sender/receiver against the real Rust command
+        # server (test-command-server bin, test-utils feature). Cargo is already
+        # set up and warm from the Rust fast-tests step above; the suite fails
+        # loudly if the server can't build/start (no silent skip).
+        run: pnpm -C packages/commands test:integration
+
       - name: Run examples
         if: steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
         env:

--- a/crates/alien-commands/Cargo.toml
+++ b/crates/alien-commands/Cargo.toml
@@ -55,6 +55,14 @@ test-utils = [
     "alien-bindings/local",
 ]
 
+# Standalone test command server for the TypeScript integration suite. Only
+# built when `test-utils` is enabled (it reuses `TestCommandServer`); never part
+# of a normal build.
+[[bin]]
+name = "test-command-server"
+path = "src/bin/test-command-server.rs"
+required-features = ["test-utils"]
+
 [dependencies]
 # Core dependencies (always available)
 serde = { workspace = true, features = ["derive"] }

--- a/crates/alien-commands/src/bin/test-command-server.rs
+++ b/crates/alien-commands/src/bin/test-command-server.rs
@@ -1,0 +1,63 @@
+//! Standalone test command server for the TypeScript integration suite.
+//!
+//! Spins up a [`TestCommandServer`] in pull mode (which auto-registers a
+//! `test-daemon` target), prints `READY {base_url}` to stdout, and then runs
+//! until the parent closes our stdin (graceful) or sends `Ctrl-C`. This is the
+//! external process the TS `integration.real-server.test.ts` suite drives to
+//! prove the sender/receiver twins over the *real* Rust command wire.
+//!
+//! Gated behind the `test-utils` feature via `required-features` in
+//! `Cargo.toml`, so it is never part of a normal build.
+
+use std::io::Write;
+
+use alien_commands::test_utils::TestCommandServer;
+use alien_commands::CommandTargetType;
+use tokio::io::AsyncReadExt;
+
+#[tokio::main]
+async fn main() {
+    let server = TestCommandServer::builder().with_pull_mode().build().await;
+
+    // Optionally register an extra target:
+    //   test-command-server <resource_id> [container|daemon|worker]
+    // (env fallbacks let callers configure without argv). The default
+    // `test-daemon` target is already auto-registered by pull mode.
+    let mut args = std::env::args().skip(1);
+    if let Some(resource_id) = args
+        .next()
+        .or_else(|| std::env::var("TEST_TARGET_RESOURCE_ID").ok())
+    {
+        let resource_type = args
+            .next()
+            .or_else(|| std::env::var("TEST_TARGET_RESOURCE_TYPE").ok());
+        let resource_type = match resource_type.as_deref() {
+            Some("container") => CommandTargetType::Container,
+            Some("worker") => CommandTargetType::Worker,
+            _ => CommandTargetType::Daemon,
+        };
+        server
+            .registry
+            .register_target(resource_id, resource_type)
+            .await
+            .expect("register extra target");
+    }
+
+    println!("READY {}", server.base_url());
+    std::io::stdout().flush().expect("flush READY line");
+
+    // Run until the parent closes stdin (graceful shutdown, drops the server and
+    // its temp dir) or interrupts us.
+    let mut stdin = tokio::io::stdin();
+    let mut buf = [0u8; 64];
+    loop {
+        tokio::select! {
+            read = stdin.read(&mut buf) => {
+                if matches!(read, Ok(0) | Err(_)) {
+                    break;
+                }
+            }
+            _ = tokio::signal::ctrl_c() => break,
+        }
+    }
+}

--- a/packages/commands/PACKAGE_LAYOUT.md
+++ b/packages/commands/PACKAGE_LAYOUT.md
@@ -133,8 +133,18 @@ MAY depend on:
 
 ## DECIDED (task 08)
 
-The OPEN(08) sender-side type decisions, now pinned. (Receiver handler-context
-field types remain to be recorded by the receiver task.)
+The OPEN(08) type decisions, now pinned.
+
+- **`CommandReceiver` handler-context field types** (`CommandContext`, exported
+  from `"."`): `{ input: Uint8Array; signal: AbortSignal; deadline: Date;
+  commandId: string; attempt: number }`. `input` is the decoded param bytes
+  (byte-for-byte twin of the Rust `ctx.input`); `signal` is the twin of the Rust
+  `ctx.cancellation` token, firing at budget expiry; `deadline` is the effective
+  budget `min(envelope.deadline, leaseExpiresAt)`, always present. A
+  `CommandHandler` is `(ctx: CommandContext) => unknown | Promise<unknown>`; its
+  return value is the JSON success body. `createCommandReceiver()` returns a
+  `CommandReceiver` (`.handle` / `.run` / `.stop`); `.stop()` is the exposed
+  drain-and-return mechanism (twin of the Rust `ShutdownHandle`).
 
 - **`CommandsClient#target(name)` return type:** `TargetedCommands` — a class
   exported from `"."`, a thin sender bound to one `targetResourceId`. Its
@@ -149,11 +159,11 @@ field types remain to be recorded by the receiver task.)
   - response: generic `TResponse` (default `unknown`), the decoded success body.
 - **`InvokeOptions`:**
   `{ timeoutMs?: number; deadline?: Date; idempotencyKey?: string; targetResourceId?: string; pollIntervalMs?: number; maxPollIntervalMs?: number; pollBackoff?: number }`.
-  `timeoutMs` defaults to the client's `timeout`; polling knobs default to
+  `timeoutMs` defaults to the client's `timeoutMs`; polling knobs default to
   500ms / 5000ms / ×1.5.
 - **`CommandsClientConfig`:**
-  `{ managerUrl: string; deploymentId: string; token: string; timeout?: number; allowLocalStorage?: boolean }`
-  (`timeout` = default invoke timeout, 60000ms; `allowLocalStorage` gates the
+  `{ managerUrl: string; deploymentId: string; token: string; timeoutMs?: number; allowLocalStorage?: boolean }`
+  (`timeoutMs` = default invoke timeout, 60000ms; `allowLocalStorage` gates the
   `local` storage backend for dev).
 - **Exported sender-error set** (migrated from `@alienplatform/sdk/commands`,
   all `defineError` from `@alienplatform/core`): `CommandCreationFailedError`

--- a/packages/commands/PACKAGE_LAYOUT.md
+++ b/packages/commands/PACKAGE_LAYOUT.md
@@ -22,13 +22,13 @@ the same wire protocol.
 | Export | Kind | Signature sketch | Notes |
 |---|---|---|---|
 | `CommandsClient` | class | `new CommandsClient({ managerUrl, deploymentId, token })` | Sender. Constructor options `{ managerUrl: string; deploymentId: string; token: string }`. |
-| `CommandsClient#target` | method | `.target(name: string)` | Scopes the client to a target command-capable resource. Return type OPEN (task 08). |
-| `CommandsClient#invoke` | method | `.invoke(name: string, input, options?)` | Invokes a command and resolves to its response. `input`/`options`/response types OPEN (task 08). |
+| `CommandsClient#target` | method | `.target(name: string)` | Scopes the client to a target command-capable resource. Return type: `TargetedCommands` — DECIDED(08). |
+| `CommandsClient#invoke` | method | `.invoke(name: string, input, options?)` | Invokes a command and resolves to its response. types DECIDED(08) — see the DECIDED(08) section. |
 | `createCommandReceiver` | function | `createCommandReceiver(options?: CommandReceiverOptions): CommandReceiver` | Constructs the pull receiver from environment configuration. |
 | `CommandReceiverOptions` | type | constructor options | `{ env?, fetch?, pollIntervalMs?, leaseSeconds?, maxLeases? }`. Every field has a production default; the three tuning knobs exist mainly for tests. **DECIDED(08).** |
-| `CommandReceiver` | type | receiver handle | `.handle(name: string, handler)` registers a handler; `.run(): Promise<void>` leases and dispatches. Handler context `{ input, signal, deadline, commandId, attempt }`. Concrete field types OPEN (task 08). |
+| `CommandReceiver` | type | receiver handle | `.handle(name: string, handler)` registers a handler; `.run(): Promise<void>` leases and dispatches. Handler context `{ input, signal, deadline, commandId, attempt }`. Field types DECIDED(08) — see the DECIDED(08) section. |
 | `CommandReceiverConfigInvalidError` | error | `defineError({ code: "COMMAND_RECEIVER_CONFIG_INVALID", context: { … } })` | Thrown when receiver env config is empty/invalid. Context names the offending variable — any of the five in the receiver environment contract below. **DECIDED(09).** |
-| sender error types | error | migrated from the current `@alienplatform/sdk/commands` error set | The final exported sender-error set is OPEN (task 08); migration source is the existing `@alienplatform/sdk/commands` errors. |
+| sender error types | error | migrated from the current `@alienplatform/sdk/commands` error set | Sender-error set DECIDED(08) — the seven migrated errors; see the DECIDED(08) section. |
 | shared error primitives | re-export | `AlienError`, `defineError` (from `@alienplatform/core`) | Re-exported for consumer error handling. |
 
 ### Receiver environment contract
@@ -130,9 +130,9 @@ MAY depend on:
   command-polling defaults.
 - **DECIDED(09).** `ctx.input` is the decoded command param bytes: the same
   bytes the params envelope carries after decode, prior to any
-  handler-side parsing. The concrete TypeScript context field types remain
-  OPEN (task 08); only this byte-for-byte encoding identity between the
-  Rust and TypeScript receivers is pinned here.
+  handler-side parsing. The concrete TypeScript context field types are now
+  DECIDED(08) (see the DECIDED(08) section); the byte-for-byte encoding
+  identity between the Rust and TypeScript receivers remains pinned here.
 - **DECIDED(09).** A successful handler response body is the JSON encoding
   of the handler's return value (`JSON.stringify`-equivalent), submitted as
   the command's success response payload.

--- a/packages/commands/PACKAGE_LAYOUT.md
+++ b/packages/commands/PACKAGE_LAYOUT.md
@@ -24,7 +24,8 @@ the same wire protocol.
 | `CommandsClient` | class | `new CommandsClient({ managerUrl, deploymentId, token })` | Sender. Constructor options `{ managerUrl: string; deploymentId: string; token: string }`. |
 | `CommandsClient#target` | method | `.target(name: string)` | Scopes the client to a target command-capable resource. Return type OPEN (task 08). |
 | `CommandsClient#invoke` | method | `.invoke(name: string, input, options?)` | Invokes a command and resolves to its response. `input`/`options`/response types OPEN (task 08). |
-| `createCommandReceiver` | function | `createCommandReceiver(): CommandReceiver` | Constructs the pull receiver from environment configuration. |
+| `createCommandReceiver` | function | `createCommandReceiver(options?: CommandReceiverOptions): CommandReceiver` | Constructs the pull receiver from environment configuration. |
+| `CommandReceiverOptions` | type | constructor options | `{ env?, fetch?, pollIntervalMs?, leaseSeconds?, maxLeases? }`. Every field has a production default; the three tuning knobs exist mainly for tests. **DECIDED(08).** |
 | `CommandReceiver` | type | receiver handle | `.handle(name: string, handler)` registers a handler; `.run(): Promise<void>` leases and dispatches. Handler context `{ input, signal, deadline, commandId, attempt }`. Concrete field types OPEN (task 08). |
 | `CommandReceiverConfigInvalidError` | error | `defineError({ code: "COMMAND_RECEIVER_CONFIG_INVALID", context: { … } })` | Thrown when receiver env config is empty/invalid. Context names the offending variable — any of the five in the receiver environment contract below. **DECIDED(09).** |
 | sender error types | error | migrated from the current `@alienplatform/sdk/commands` error set | The final exported sender-error set is OPEN (task 08); migration source is the existing `@alienplatform/sdk/commands` errors. |
@@ -103,6 +104,15 @@ MAY depend on:
   handler threw/rejected, including a response-serialization failure), and
   `HANDLER_TIMEOUT` (budget expiry, above). A params-decode failure is
   submitted under the decode error's own code, not a receiver-specific one.
+- **DECIDED(09) — twin-pinned.** Envelope decode failures — malformed inline
+  base64 params, and storage-mode params missing `storageGetRequest` — are
+  submitted as `INVALID_ENVELOPE`, the identical code the Rust twin's
+  `decode_params_bytes` returns for the same two failures
+  (`crates/alien-commands/src/runtime/mod.rs`). The TypeScript receiver's
+  inline base64 decode is strict (canonical alphabet and padding only,
+  matching the Rust `base64` crate's `STANDARD` engine), not the lenient
+  `Buffer.from(str, "base64")` default, so both receivers reject the same
+  malformed envelopes.
 - **DECIDED(09).** Delivery is at-least-once: a lease that expires without a
   submitted response is redelivered. The handler context's `attempt` field
   carries the delivery attempt starting at 1 (greater than 1 means
@@ -145,6 +155,20 @@ The OPEN(08) type decisions, now pinned.
   return value is the JSON success body. `createCommandReceiver()` returns a
   `CommandReceiver` (`.handle` / `.run` / `.stop`); `.stop()` is the exposed
   drain-and-return mechanism (twin of the Rust `ShutdownHandle`).
+
+- **`CommandReceiverOptions`** (constructor options for `createCommandReceiver`,
+  exported from `"."`): `{ env?: Record<string, string | undefined>; fetch?:
+  typeof fetch; pollIntervalMs?: number; leaseSeconds?: number; maxLeases?:
+  number }`. `env` defaults to `process.env`; `fetch` defaults to the global
+  `fetch`; the three tuning knobs default to the DECIDED(09) production
+  values (5000ms poll / 60s lease / 10 max leases) and exist mainly so tests
+  can drive the lease loop fast and inject a stub `fetch`.
+
+- **`InvalidEnvelopeError`** (`defineError`, exported from `"."`): code
+  `INVALID_ENVELOPE`, context `{ field?: string; reason: string }`. Thrown by
+  the receiver for envelope decode failures — malformed inline base64 params
+  and storage-mode params missing `storageGetRequest` — matching the Rust
+  twin's `ErrorData::InvalidEnvelope` code (DECIDED(09), twin-pinned above).
 
 - **`CommandsClient#target(name)` return type:** `TargetedCommands` — a class
   exported from `"."`, a thin sender bound to one `targetResourceId`. Its

--- a/packages/commands/PACKAGE_LAYOUT.md
+++ b/packages/commands/PACKAGE_LAYOUT.md
@@ -131,6 +131,38 @@ MAY depend on:
   it is always present while a lease is held. The TypeScript receiver must
   expose the same value; anything else diverges the twins' timeout behavior.
 
+## DECIDED (task 08)
+
+The OPEN(08) sender-side type decisions, now pinned. (Receiver handler-context
+field types remain to be recorded by the receiver task.)
+
+- **`CommandsClient#target(name)` return type:** `TargetedCommands` — a class
+  exported from `"."`, a thin sender bound to one `targetResourceId`. Its
+  `.invoke(name, input, options?)` mirrors `CommandsClient#invoke` and presets
+  `targetResourceId`; the builder's target overrides any
+  `options.targetResourceId` (builder wins — same rule as the Rust
+  `TargetedCommands`).
+- **`CommandsClient#invoke` signature:**
+  `invoke<TResponse = unknown>(command: string, input: unknown, options?: InvokeOptions): Promise<TResponse>`.
+  - `input`: `unknown`, JSON-serialized to the inline `BodySpec` (string inputs
+    pass through, everything else is `JSON.stringify`-ed once).
+  - response: generic `TResponse` (default `unknown`), the decoded success body.
+- **`InvokeOptions`:**
+  `{ timeoutMs?: number; deadline?: Date; idempotencyKey?: string; targetResourceId?: string; pollIntervalMs?: number; maxPollIntervalMs?: number; pollBackoff?: number }`.
+  `timeoutMs` defaults to the client's `timeout`; polling knobs default to
+  500ms / 5000ms / ×1.5.
+- **`CommandsClientConfig`:**
+  `{ managerUrl: string; deploymentId: string; token: string; timeout?: number; allowLocalStorage?: boolean }`
+  (`timeout` = default invoke timeout, 60000ms; `allowLocalStorage` gates the
+  `local` storage backend for dev).
+- **Exported sender-error set** (migrated from `@alienplatform/sdk/commands`,
+  all `defineError` from `@alienplatform/core`): `CommandCreationFailedError`
+  (`COMMAND_CREATION_FAILED`), `CommandTimeoutError` (`COMMAND_TIMEOUT`),
+  `DeploymentCommandError` (`DEPLOYMENT_COMMAND_ERROR`), `CommandExpiredError`
+  (`COMMAND_EXPIRED`), `StorageOperationFailedError`
+  (`STORAGE_OPERATION_FAILED`), `ResponseDecodingFailedError`
+  (`RESPONSE_DECODING_FAILED`), `ManagerHttpError` (`MANAGER_HTTP_ERROR`).
+
 ## Status
 
 - Package implemented in task 08 (TypeScript — pure protocol sender + pull

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@alienplatform/commands",
+  "version": "1.10.7",
+  "type": "module",
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "engines": {
+    "node": ">=18",
+    "bun": ">=1.0.23"
+  },
+  "scripts": {
+    "build": "tsdown && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "prepare": "npm run build",
+    "test": "vitest run",
+    "test:bun": "BUN_EXPECTED=1 bun test",
+    "test:ts": "tsc --noEmit",
+    "format-and-lint": "biome check .",
+    "format-and-lint:fix": "biome check . --write"
+  },
+  "keywords": ["alien", "commands", "invoke", "receiver", "deployment", "fetch"],
+  "author": "Alien Software, Inc. <hi@alien.dev>",
+  "license": "FSL-1.1-Apache-2.0",
+  "description": "Pure-TypeScript command sender and pull receiver for the Alien platform, over fetch",
+  "homepage": "https://alien.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alienplatform/alien.git",
+    "directory": "packages/commands"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@alienplatform/typescript-config": "workspace:^",
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^24.0.15",
+    "tsdown": "^0.13.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4",
+    "zod": "4.3.2"
+  },
+  "dependencies": {
+    "@alienplatform/core": "workspace:^"
+  }
+}

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -19,7 +19,8 @@
     "build": "tsdown && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "prepare": "npm run build",
     "test": "vitest run",
-    "test:bun": "BUN_EXPECTED=1 bun test",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:bun": "BUN_EXPECTED=1 bun test tests/runtime-canary.test.ts tests/commands-client.test.ts tests/receiver.test.ts",
     "test:ts": "tsc --noEmit",
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write"

--- a/packages/commands/src/client.ts
+++ b/packages/commands/src/client.ts
@@ -1,0 +1,530 @@
+/**
+ * Command sender — invoke commands on remote Alien deployments.
+ *
+ * Migrated from `@alienplatform/sdk/commands`. Pure `fetch`; no gRPC, no
+ * bindings. Handles:
+ * - Base64 encoding/decoding of input and responses
+ * - Large payload download via storage presigned transfers
+ * - Polling with exponential backoff
+ * - Error handling and timeout
+ *
+ * `.target(name)` returns a {@link TargetedCommands} bound sender that presets
+ * `targetResourceId` on every invoke — mirroring the Rust
+ * `CommandsClient::target(...)` builder. The builder's target wins over any
+ * `options.targetResourceId` the caller also passes.
+ */
+
+import { AlienError } from "@alienplatform/core"
+import {
+  CommandCreationFailedError,
+  CommandExpiredError,
+  CommandTimeoutError,
+  DeploymentCommandError,
+  ManagerHttpError,
+  ResponseDecodingFailedError,
+  StorageOperationFailedError,
+} from "./errors.js"
+import type {
+  BodySpec,
+  CommandResponse,
+  CommandState,
+  CommandStatusResponse,
+  CreateCommandResponse,
+} from "./protocol.js"
+
+/**
+ * Configuration for {@link CommandsClient}.
+ */
+export interface CommandsClientConfig {
+  /** Manager URL (e.g. "https://manager.example.com"). Trailing slashes are stripped. */
+  managerUrl: string
+  /** Deployment ID to invoke commands on. */
+  deploymentId: string
+  /** Bearer token (deployment token or workspace token). */
+  token: string
+  /** Default invoke timeout in milliseconds (default: 60000). */
+  timeout?: number
+  /** Allow reading local files for storage responses (default: false, local dev only). */
+  allowLocalStorage?: boolean
+}
+
+/**
+ * Per-invoke options.
+ */
+export interface InvokeOptions {
+  /** Wall-clock timeout in milliseconds (default: the client's `timeout`). */
+  timeoutMs?: number
+  /** Optional server-side deadline for command completion. */
+  deadline?: Date
+  /** Optional idempotency key — the server dedupes retried creates by this key. */
+  idempotencyKey?: string
+  /** Target command-capable resource id; a `.target(name)` builder overrides this. */
+  targetResourceId?: string
+  /** Initial polling interval in milliseconds (default: 500). */
+  pollIntervalMs?: number
+  /** Maximum polling interval in milliseconds (default: 5000). */
+  maxPollIntervalMs?: number
+  /** Polling backoff multiplier (default: 1.5). */
+  pollBackoff?: number
+}
+
+/**
+ * Base64 encode data.
+ */
+function base64Encode(data: string | Record<string, unknown>): string {
+  const json = typeof data === "string" ? data : JSON.stringify(data)
+  if (typeof btoa !== "undefined") {
+    // Browser
+    return btoa(json)
+  }
+  // Node.js
+  return Buffer.from(json, "utf-8").toString("base64")
+}
+
+/**
+ * Base64 decode data.
+ */
+function base64Decode(encoded: string): string {
+  if (typeof atob !== "undefined") {
+    // Browser
+    return atob(encoded)
+  }
+  // Node.js
+  return Buffer.from(encoded, "base64").toString("utf-8")
+}
+
+/**
+ * Create an inline body spec. Always sends inline — the server handles storage
+ * decisions transparently (auto-promoting to blob if needed).
+ */
+function createBodySpec(data: string | Record<string, unknown>): BodySpec {
+  const json = typeof data === "string" ? data : JSON.stringify(data)
+  return {
+    mode: "inline",
+    inlineBase64: base64Encode(json),
+  }
+}
+
+/**
+ * Decode a response body spec into the handler's return value.
+ */
+async function decodeBodySpec(
+  body: BodySpec,
+  commandId: string,
+  command: string,
+  allowLocalStorage: boolean,
+): Promise<unknown> {
+  if (body.mode === "inline") {
+    const json = base64Decode(body.inlineBase64)
+    return JSON.parse(json)
+  }
+
+  if (body.mode === "storage") {
+    // Storage mode - download from presigned URL
+    if (!body.storageGetRequest) {
+      throw new AlienError(
+        ResponseDecodingFailedError.create({
+          commandId,
+          command,
+          reason: "Storage response missing storageGetRequest",
+        }),
+      )
+    }
+
+    const request = body.storageGetRequest
+
+    // Check if request has expired
+    const expiration = new Date(request.expiration)
+    if (Date.now() > expiration.getTime()) {
+      throw new AlienError(
+        StorageOperationFailedError.create({
+          operation: "download",
+          url: request.backend.type === "http" ? request.backend.url : "local",
+          reason: `Presigned request expired at ${expiration.toISOString()}`,
+        }),
+      )
+    }
+
+    // Handle different backend types
+    if (request.backend.type === "http") {
+      // HTTP backend (AWS S3, GCP GCS, Azure Blob)
+      try {
+        const response = await fetch(request.backend.url, {
+          method: request.backend.method,
+          headers: request.backend.headers,
+        })
+
+        if (!response.ok) {
+          throw new AlienError(
+            StorageOperationFailedError.create({
+              operation: "download",
+              url: request.backend.url,
+              reason: `HTTP ${response.status} ${response.statusText}`,
+            }),
+          )
+        }
+
+        const text = await response.text()
+        return JSON.parse(text)
+      } catch (error) {
+        if (error instanceof AlienError) {
+          throw error
+        }
+
+        // Wrap fetch/parse errors
+        const alienError = await AlienError.from(error)
+        throw alienError.withContext(
+          StorageOperationFailedError.create({
+            operation: "download",
+            url: request.backend.url,
+            reason: error instanceof Error ? error.message : String(error),
+          }),
+        )
+      }
+    } else if (request.backend.type === "local") {
+      // Local backend: Only enabled when explicitly allowed (local dev/testing)
+      if (!allowLocalStorage) {
+        throw new AlienError(
+          StorageOperationFailedError.create({
+            operation: "download",
+            url: `local://${request.backend.filePath}`,
+            reason: "Local storage backend not enabled (set allowLocalStorage: true for local dev)",
+          }),
+        )
+      }
+
+      // Validate path doesn't contain path traversal attempts
+      const filePath = request.backend.filePath
+      if (filePath.includes("..")) {
+        throw new AlienError(
+          StorageOperationFailedError.create({
+            operation: "download",
+            url: `local://${filePath}`,
+            reason: "Path traversal not allowed in local storage paths",
+          }),
+        )
+      }
+
+      // Dynamically import fs/promises only when needed (local dev)
+      try {
+        const { readFile } = await import("node:fs/promises")
+        const content = await readFile(filePath, "utf-8")
+        return JSON.parse(content)
+      } catch (error) {
+        if (error instanceof AlienError) {
+          throw error
+        }
+
+        // Wrap filesystem/parse errors
+        const alienError = await AlienError.from(error)
+        throw alienError.withContext(
+          StorageOperationFailedError.create({
+            operation: "download",
+            url: `local://${filePath}`,
+            reason: error instanceof Error ? error.message : String(error),
+          }),
+        )
+      }
+    } else {
+      throw new AlienError(
+        StorageOperationFailedError.create({
+          operation: "download",
+          url: "unknown",
+          reason: `Unknown storage backend type: ${(request.backend as { type: string }).type}`,
+        }),
+      )
+    }
+  }
+
+  throw new AlienError(
+    ResponseDecodingFailedError.create({
+      commandId,
+      command,
+      reason: `Unknown body mode: ${(body as { mode: string }).mode}`,
+    }),
+  )
+}
+
+/**
+ * Check if a state is terminal.
+ */
+function isTerminalState(state: CommandState): boolean {
+  return state === "SUCCEEDED" || state === "FAILED" || state === "EXPIRED"
+}
+
+/**
+ * Command sender for invoking deployment commands.
+ */
+export class CommandsClient {
+  private readonly managerUrl: string
+  private readonly deploymentId: string
+  private readonly token: string
+  private readonly defaultTimeout: number
+  private readonly allowLocalStorage: boolean
+
+  constructor(config: CommandsClientConfig) {
+    this.managerUrl = config.managerUrl.replace(/\/+$/, "")
+    this.deploymentId = config.deploymentId
+    this.token = config.token
+    this.defaultTimeout = config.timeout ?? 60_000
+    this.allowLocalStorage = config.allowLocalStorage ?? false
+  }
+
+  /**
+   * Scope this client to one target command-capable resource: every `invoke`
+   * made through the returned builder presets `targetResourceId` to `name`,
+   * mirroring the Rust `CommandsClient::target(...)` shorthand.
+   *
+   * If the caller also passes `options.targetResourceId`, the builder's target
+   * silently wins — passing two different targets is a programmer error, not a
+   * runtime conflict this builder tries to detect.
+   */
+  target(name: string): TargetedCommands {
+    return new TargetedCommands(this, name)
+  }
+
+  /**
+   * Invoke a command on the deployment and wait for its response.
+   *
+   * @param command - Command name (e.g. "generate-report").
+   * @param input - Command input (JSON-serializable).
+   * @param options - Invocation options.
+   * @returns Decoded response data.
+   */
+  async invoke<TResponse = unknown>(
+    command: string,
+    input: unknown,
+    options?: InvokeOptions,
+  ): Promise<TResponse> {
+    const timeout = options?.timeoutMs ?? this.defaultTimeout
+    const startTime = Date.now()
+
+    // Step 1: Create command
+    const createResponse = await this.createCommand(command, input, options)
+
+    // Step 2: Poll for completion
+    const pollInterval = options?.pollIntervalMs ?? 500
+    const maxPollInterval = options?.maxPollIntervalMs ?? 5000
+    const pollBackoff = options?.pollBackoff ?? 1.5
+    let currentInterval = pollInterval
+
+    while (Date.now() - startTime < timeout) {
+      await this.sleep(currentInterval)
+
+      const status = await this.getCommandStatus(createResponse.commandId)
+
+      if (isTerminalState(status.state)) {
+        return await this.handleTerminalState(command, status)
+      }
+
+      // Exponential backoff
+      currentInterval = Math.min(currentInterval * pollBackoff, maxPollInterval)
+    }
+
+    // Timeout
+    const finalStatus = await this.getCommandStatus(createResponse.commandId)
+    throw new AlienError(
+      CommandTimeoutError.create({
+        commandId: createResponse.commandId,
+        command,
+        timeoutMs: timeout,
+        lastState: finalStatus.state,
+      }),
+    )
+  }
+
+  /**
+   * Create a command.
+   */
+  private async createCommand(
+    command: string,
+    input: unknown,
+    options?: InvokeOptions,
+  ): Promise<CreateCommandResponse> {
+    const url = `${this.managerUrl}/v1/commands`
+    const body = {
+      deploymentId: this.deploymentId,
+      command,
+      params: createBodySpec(input as string | Record<string, unknown>),
+      deadline: options?.deadline?.toISOString(),
+      idempotencyKey: options?.idempotencyKey,
+      targetResourceId: options?.targetResourceId,
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.token}`,
+        },
+        body: JSON.stringify(body),
+      })
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => "")
+        throw new AlienError(
+          ManagerHttpError.create({
+            method: "POST",
+            url,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+          }),
+        )
+      }
+
+      return (await response.json()) as CreateCommandResponse
+    } catch (error) {
+      if (error instanceof AlienError) {
+        throw error
+      }
+
+      const alienError = await AlienError.from(error)
+      throw alienError.withContext(
+        CommandCreationFailedError.create({
+          deploymentId: this.deploymentId,
+          command,
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+
+  /**
+   * Get a command's status.
+   */
+  private async getCommandStatus(commandId: string): Promise<CommandStatusResponse> {
+    const url = `${this.managerUrl}/v1/commands/${commandId}`
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+        },
+      })
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => "")
+        throw new AlienError(
+          ManagerHttpError.create({
+            method: "GET",
+            url,
+            status: response.status,
+            statusText: response.statusText,
+            body: errorBody,
+          }),
+        )
+      }
+
+      return (await response.json()) as CommandStatusResponse
+    } catch (error) {
+      if (error instanceof AlienError) {
+        throw error
+      }
+
+      throw await AlienError.from(error)
+    }
+  }
+
+  /**
+   * Handle a terminal state and return the response.
+   */
+  private async handleTerminalState<TResponse>(
+    command: string,
+    status: CommandStatusResponse,
+  ): Promise<TResponse> {
+    if (status.state === "EXPIRED") {
+      throw new AlienError(
+        CommandExpiredError.create({
+          commandId: status.commandId,
+          command,
+        }),
+      )
+    }
+
+    if (!status.response) {
+      throw new AlienError(
+        ResponseDecodingFailedError.create({
+          commandId: status.commandId,
+          command,
+          reason: "Terminal state but no response present",
+        }),
+      )
+    }
+
+    const response: CommandResponse = status.response
+
+    if (response.status === "error") {
+      throw new AlienError(
+        DeploymentCommandError.create({
+          commandId: status.commandId,
+          command,
+          errorCode: response.code,
+          errorMessage: response.message,
+          errorDetails: response.details ?? undefined,
+        }),
+      )
+    }
+
+    // Decode success response
+    try {
+      return (await decodeBodySpec(
+        response.response,
+        status.commandId,
+        command,
+        this.allowLocalStorage,
+      )) as TResponse
+    } catch (error) {
+      if (error instanceof AlienError) {
+        throw error
+      }
+
+      throw new AlienError(
+        ResponseDecodingFailedError.create({
+          commandId: status.commandId,
+          command,
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    }
+  }
+
+  /**
+   * Sleep helper.
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+}
+
+/**
+ * A {@link CommandsClient} scoped to one target command-capable resource.
+ *
+ * Obtained via {@link CommandsClient.target}. Every `invoke` presets
+ * `targetResourceId` to this builder's resource id, overriding any
+ * `options.targetResourceId` the caller passes (builder wins — same rule as the
+ * Rust `TargetedCommands`).
+ */
+export class TargetedCommands {
+  constructor(
+    private readonly client: CommandsClient,
+    private readonly resourceId: string,
+  ) {}
+
+  /**
+   * Invoke a command against this builder's target and wait for the result.
+   * The builder's target overrides any `options.targetResourceId`.
+   */
+  invoke<TResponse = unknown>(
+    command: string,
+    input: unknown,
+    options?: InvokeOptions,
+  ): Promise<TResponse> {
+    return this.client.invoke<TResponse>(command, input, {
+      ...options,
+      targetResourceId: this.resourceId,
+    })
+  }
+}

--- a/packages/commands/src/client.ts
+++ b/packages/commands/src/client.ts
@@ -43,7 +43,7 @@ export interface CommandsClientConfig {
   /** Bearer token (deployment token or workspace token). */
   token: string
   /** Default invoke timeout in milliseconds (default: 60000). */
-  timeout?: number
+  timeoutMs?: number
   /** Allow reading local files for storage responses (default: false, local dev only). */
   allowLocalStorage?: boolean
 }
@@ -52,7 +52,7 @@ export interface CommandsClientConfig {
  * Per-invoke options.
  */
 export interface InvokeOptions {
-  /** Wall-clock timeout in milliseconds (default: the client's `timeout`). */
+  /** Wall-clock timeout in milliseconds (default: the client's `timeoutMs`). */
   timeoutMs?: number
   /** Optional server-side deadline for command completion. */
   deadline?: Date
@@ -266,7 +266,7 @@ export class CommandsClient {
     this.managerUrl = config.managerUrl.replace(/\/+$/, "")
     this.deploymentId = config.deploymentId
     this.token = config.token
-    this.defaultTimeout = config.timeout ?? 60_000
+    this.defaultTimeout = config.timeoutMs ?? 60_000
     this.allowLocalStorage = config.allowLocalStorage ?? false
   }
 

--- a/packages/commands/src/errors.ts
+++ b/packages/commands/src/errors.ts
@@ -111,6 +111,28 @@ export const ResponseDecodingFailedError = defineError({
 })
 
 /**
+ * Error thrown when a command envelope (or a param/response body it carries)
+ * fails to decode or validate — malformed inline base64, a storage-mode body
+ * missing its presigned request, or an envelope that fails schema validation.
+ *
+ * The Rust twin (`alien_commands::error::ErrorData::InvalidEnvelope`) raises
+ * the identical code (`INVALID_ENVELOPE`) for the same failures, so envelope
+ * decode failures are twin-pinned across both receivers (see
+ * `PACKAGE_LAYOUT.md` DECIDED(09)).
+ */
+export const InvalidEnvelopeError = defineError({
+  code: "INVALID_ENVELOPE",
+  context: z.object({
+    field: z.string().optional(),
+    reason: z.string(),
+  }),
+  message: ({ reason }) => `Invalid command envelope: ${reason}`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 400,
+})
+
+/**
  * Error thrown when the pull receiver's environment configuration is missing or
  * invalid. Fails fast (synchronously, from `createCommandReceiver`) and names
  * the offending variable in `context.envVar`.

--- a/packages/commands/src/errors.ts
+++ b/packages/commands/src/errors.ts
@@ -111,6 +111,27 @@ export const ResponseDecodingFailedError = defineError({
 })
 
 /**
+ * Error thrown when the pull receiver's environment configuration is missing or
+ * invalid. Fails fast (synchronously, from `createCommandReceiver`) and names
+ * the offending variable in `context.envVar`.
+ *
+ * The Rust twin (`alien_commands::Receiver::from_env`) raises the identical code
+ * (`COMMAND_RECEIVER_CONFIG_INVALID`) for the same five variables, so the two
+ * receivers reject the same misconfigurations.
+ */
+export const CommandReceiverConfigInvalidError = defineError({
+  code: "COMMAND_RECEIVER_CONFIG_INVALID",
+  context: z.object({
+    envVar: z.string(),
+    reason: z.string(),
+  }),
+  message: ({ reason }) => `Command receiver configuration invalid: ${reason}`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 400,
+})
+
+/**
  * Error thrown when Manager returns an HTTP error.
  */
 export const ManagerHttpError = defineError({

--- a/packages/commands/src/errors.ts
+++ b/packages/commands/src/errors.ts
@@ -1,0 +1,130 @@
+/**
+ * Command sender error definitions.
+ *
+ * Migrated from `@alienplatform/sdk/commands` — the seven `defineError`
+ * definitions the sender raises. Each is built with `defineError` from
+ * `@alienplatform/core` so it carries the shared `AlienError` identity.
+ */
+
+import { defineError } from "@alienplatform/core"
+import * as z from "zod/v4"
+
+/**
+ * Error thrown when command creation fails.
+ */
+export const CommandCreationFailedError = defineError({
+  code: "COMMAND_CREATION_FAILED",
+  context: z.object({
+    deploymentId: z.string(),
+    command: z.string(),
+    reason: z.string(),
+  }),
+  message: ({ deploymentId, command, reason }) =>
+    `Failed to create command '${command}' for deployment '${deploymentId}': ${reason}`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 500,
+})
+
+/**
+ * Error thrown when command execution times out.
+ */
+export const CommandTimeoutError = defineError({
+  code: "COMMAND_TIMEOUT",
+  context: z.object({
+    commandId: z.string(),
+    command: z.string(),
+    timeoutMs: z.number(),
+    lastState: z.string(),
+  }),
+  message: ({ command, timeoutMs, lastState }) =>
+    `Command '${command}' timed out after ${timeoutMs}ms (last state: ${lastState})`,
+  retryable: true,
+  internal: false,
+  httpStatusCode: 504,
+})
+
+/**
+ * Error thrown when the deployment returns an error response.
+ */
+export const DeploymentCommandError = defineError({
+  code: "DEPLOYMENT_COMMAND_ERROR",
+  context: z.object({
+    commandId: z.string(),
+    command: z.string(),
+    errorCode: z.string(),
+    errorMessage: z.string(),
+    errorDetails: z.string().optional(),
+  }),
+  message: ({ command, errorCode, errorMessage }) =>
+    `Deployment command '${command}' failed: [${errorCode}] ${errorMessage}`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 500,
+})
+
+/**
+ * Error thrown when command expires before completion.
+ */
+export const CommandExpiredError = defineError({
+  code: "COMMAND_EXPIRED",
+  context: z.object({
+    commandId: z.string(),
+    command: z.string(),
+  }),
+  message: ({ command }) => `Command '${command}' expired before completion`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 410,
+})
+
+/**
+ * Error thrown when storage upload/download fails.
+ */
+export const StorageOperationFailedError = defineError({
+  code: "STORAGE_OPERATION_FAILED",
+  context: z.object({
+    operation: z.enum(["upload", "download"]),
+    url: z.string(),
+    reason: z.string(),
+  }),
+  message: ({ operation, reason }) => `Storage ${operation} failed: ${reason}`,
+  retryable: true,
+  internal: false,
+  httpStatusCode: 500,
+})
+
+/**
+ * Error thrown when response decoding fails.
+ */
+export const ResponseDecodingFailedError = defineError({
+  code: "RESPONSE_DECODING_FAILED",
+  context: z.object({
+    commandId: z.string(),
+    command: z.string(),
+    reason: z.string(),
+  }),
+  message: ({ command, reason }) => `Failed to decode response for command '${command}': ${reason}`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 500,
+})
+
+/**
+ * Error thrown when Manager returns an HTTP error.
+ */
+export const ManagerHttpError = defineError({
+  code: "MANAGER_HTTP_ERROR",
+  context: z.object({
+    method: z.string(),
+    url: z.string(),
+    status: z.number(),
+    statusText: z.string(),
+    body: z.string().optional(),
+  }),
+  message: ({ method, url, status, statusText }) =>
+    `Manager ${method} ${url} failed: ${status} ${statusText}`,
+  retryable: false,
+  internal: false,
+  httpStatusCode: 500,
+})

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -47,6 +47,7 @@ export {
   CommandReceiverConfigInvalidError,
   CommandTimeoutError,
   DeploymentCommandError,
+  InvalidEnvelopeError,
   ManagerHttpError,
   ResponseDecodingFailedError,
   StorageOperationFailedError,

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -31,14 +31,20 @@
 export { CommandsClient, TargetedCommands } from "./client.js"
 export type { CommandsClientConfig, InvokeOptions } from "./client.js"
 
-// Receiver: `createCommandReceiver`, `CommandReceiver`, and
-// `CommandReceiverConfigInvalidError` are added in the receiver task; the
-// index is laid out so those exports slot in beside the sender here.
+// Receiver
+export { createCommandReceiver } from "./receiver.js"
+export type {
+  CommandContext,
+  CommandHandler,
+  CommandReceiver,
+  CommandReceiverOptions,
+} from "./receiver.js"
 
-// Sender error set
+// Error set
 export {
   CommandCreationFailedError,
   CommandExpiredError,
+  CommandReceiverConfigInvalidError,
   CommandTimeoutError,
   DeploymentCommandError,
   ManagerHttpError,

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1,0 +1,75 @@
+/**
+ * `@alienplatform/commands` — the public command package for TypeScript.
+ *
+ * Pure `fetch` over the command wire protocol: the command **sender**
+ * ({@link CommandsClient}, with {@link CommandsClient.target}) and — added in a
+ * follow-up task — the non-Worker pull **receiver** (`createCommandReceiver`).
+ * No native code, no gRPC, no bindings.
+ *
+ * @example
+ * ```typescript
+ * import { CommandsClient } from "@alienplatform/commands"
+ *
+ * const commands = new CommandsClient({
+ *   managerUrl: "https://manager.example.com",
+ *   deploymentId: "deployment_123",
+ *   token: "bearer_token",
+ * })
+ *
+ * const result = await commands.invoke("generate-report", {
+ *   startDate: "2024-01-01",
+ *   endDate: "2024-01-31",
+ * })
+ *
+ * // Or scoped to a specific target resource:
+ * const scoped = commands.target("container-7")
+ * await scoped.invoke("restart", {})
+ * ```
+ */
+
+// Sender
+export { CommandsClient, TargetedCommands } from "./client.js"
+export type { CommandsClientConfig, InvokeOptions } from "./client.js"
+
+// Receiver: `createCommandReceiver`, `CommandReceiver`, and
+// `CommandReceiverConfigInvalidError` are added in the receiver task; the
+// index is laid out so those exports slot in beside the sender here.
+
+// Sender error set
+export {
+  CommandCreationFailedError,
+  CommandExpiredError,
+  CommandTimeoutError,
+  DeploymentCommandError,
+  ManagerHttpError,
+  ResponseDecodingFailedError,
+  StorageOperationFailedError,
+} from "./errors.js"
+
+// Wire protocol types
+export type {
+  BodySpec,
+  CommandResponse,
+  CommandState,
+  CommandStatusResponse,
+  CommandTarget,
+  CommandTargetType,
+  CreateCommandRequest,
+  CreateCommandResponse,
+  Envelope,
+  ErrorResponse,
+  LeaseInfo,
+  LeaseRequest,
+  LeaseResponse,
+  PresignedRequest,
+  ReleaseRequest,
+  ResponseHandling,
+  StorageUpload,
+  SubmitResponseRequest,
+  UploadCompleteRequest,
+  UploadCompleteResponse,
+} from "./protocol.js"
+export { COMMANDS_INLINE_MAX_BYTES, COMMANDS_PROTOCOL_VERSION } from "./protocol.js"
+
+// Shared error primitives, re-exported for consumer error handling.
+export { AlienError, defineError } from "@alienplatform/core"

--- a/packages/commands/src/protocol.ts
+++ b/packages/commands/src/protocol.ts
@@ -1,0 +1,140 @@
+/**
+ * Command wire protocol — TypeScript twin of the Rust serde shapes in
+ * `crates/alien-core/src/commands_types.rs` and `crates/alien-core/src/presigned.rs`.
+ *
+ * These are the on-the-wire JSON shapes exchanged with the command server
+ * (`/v1/commands…`). They are transcribed here so this package owns its
+ * protocol surface with no cross-package type dependency; the field names and
+ * tag values must stay byte-identical to the Rust side (both are
+ * `#[serde(rename_all = "camelCase")]` unless noted).
+ */
+
+/** Command lifecycle state — SCREAMING_SNAKE_CASE on the wire. */
+export type CommandState =
+  | "PENDING_UPLOAD"
+  | "PENDING"
+  | "DISPATCHED"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "EXPIRED"
+
+/** Payload container — internally tagged by `mode` (lowercase). */
+export type BodySpec =
+  | { mode: "inline"; inlineBase64: string }
+  | {
+      mode: "storage"
+      size?: number | null
+      storageGetRequest?: PresignedRequest
+      storagePutUsed?: boolean
+    }
+
+/** Terminal command result — internally tagged by `status` (lowercase). */
+export type CommandResponse =
+  | { status: "success"; response: BodySpec }
+  | { status: "error"; code: string; message: string; details?: string }
+
+/** Target resource type — lowercase; `worker` is only valid for the worker runtime. */
+export type CommandTargetType = "worker" | "container" | "daemon"
+
+export type CommandTarget = {
+  resourceId: string
+  resourceType: CommandTargetType
+}
+
+export type CreateCommandRequest = {
+  deploymentId: string
+  command: string
+  params: BodySpec
+  deadline?: string /* RFC3339 */
+  idempotencyKey?: string
+  targetResourceId?: string
+}
+
+export type StorageUpload = {
+  putRequest: PresignedRequest
+  expiresAt: string
+}
+
+export type CreateCommandResponse = {
+  commandId: string
+  state: CommandState
+  storageUpload?: StorageUpload
+  inlineAllowedUpTo: number
+  next: string /* "upload" | "poll" */
+}
+
+export type UploadCompleteRequest = { size: number }
+export type UploadCompleteResponse = { commandId: string; state: CommandState }
+
+export type CommandStatusResponse = {
+  commandId: string
+  state: CommandState
+  attempt: number
+  target: CommandTarget
+  response?: CommandResponse
+}
+
+/**
+ * `SubmitResponseRequest` is a `#[serde(flatten)]` of `CommandResponse` — the
+ * wire body IS the `CommandResponse` itself.
+ */
+export type SubmitResponseRequest = CommandResponse
+
+export type ResponseHandling = {
+  maxInlineBytes: number
+  submitResponseUrl: string
+  storageUploadRequest: PresignedRequest
+}
+
+export type Envelope = {
+  protocol: string /* "arc.v1" */
+  deploymentId: string
+  target: CommandTarget
+  commandId: string
+  attempt: number
+  deadline?: string
+  command: string
+  params: BodySpec
+  responseHandling: ResponseHandling
+}
+
+export type LeaseRequest = {
+  deploymentId: string
+  target: CommandTarget /* REQUIRED — deser fails without it */
+  maxLeases?: number /* serde default 1 */
+  leaseSeconds?: number /* default 60 */
+}
+
+export type LeaseInfo = {
+  leaseId: string
+  leaseExpiresAt: string
+  commandId: string
+  attempt: number
+  envelope: Envelope
+}
+
+export type LeaseResponse = { leases: LeaseInfo[] }
+
+export type ReleaseRequest = { leaseId: string }
+
+/**
+ * Presigned transfer descriptor (`presigned.rs`, camelCase; backend tagged by
+ * `type`, camelCase).
+ */
+export type PresignedRequest = {
+  backend:
+    | { type: "http"; url: string; method: string; headers: Record<string, string> }
+    | { type: "local"; filePath: string; operation: "put" | "get" | "delete" }
+  expiration: string
+  operation: "put" | "get" | "delete"
+  path: string
+}
+
+/** Error envelope returned by the axum handlers on non-2xx responses. */
+export type ErrorResponse = { code: string; message: string; details?: string }
+
+/** Protocol version carried by command envelopes. */
+export const COMMANDS_PROTOCOL_VERSION = "arc.v1"
+
+/** Server inline payload ceiling (bytes). */
+export const COMMANDS_INLINE_MAX_BYTES = 150_000

--- a/packages/commands/src/receiver.ts
+++ b/packages/commands/src/receiver.ts
@@ -37,7 +37,7 @@
 import { AlienError } from "@alienplatform/core"
 import {
   CommandReceiverConfigInvalidError,
-  ResponseDecodingFailedError,
+  InvalidEnvelopeError,
   StorageOperationFailedError,
 } from "./errors.js"
 import type {
@@ -290,7 +290,7 @@ class PullCommandReceiver implements CommandReceiver {
   }
 
   private async acquireLeases(): Promise<LeaseInfo[]> {
-    const endpoint = `${this.config.url.replace(/\/+$/, "")}/commands/leases`
+    const endpoint = buildLeaseEndpoint(this.config.url)
     const response = await this.fetchImpl(endpoint, {
       method: "POST",
       headers: {
@@ -402,6 +402,20 @@ class PullCommandReceiver implements CommandReceiver {
     request: PresignedRequest,
     bytes: Uint8Array,
   ): Promise<void> {
+    // Same expiration guard as decodeParamsBytes' download path: an upload
+    // presigned request that expired before we could use it fails loudly
+    // rather than attempting (and possibly succeeding against) a stale URL.
+    const expiration = new Date(request.expiration)
+    if (Date.now() > expiration.getTime()) {
+      throw new AlienError(
+        StorageOperationFailedError.create({
+          operation: "upload",
+          url: request.backend.type === "http" ? request.backend.url : "local",
+          reason: `Presigned request expired at ${expiration.toISOString()}`,
+        }),
+      )
+    }
+
     if (request.backend.type === "http") {
       const res = await this.fetchImpl(request.backend.url, {
         method: request.backend.method,
@@ -420,7 +434,17 @@ class PullCommandReceiver implements CommandReceiver {
       return
     }
 
-    // Local backend (dev only).
+    // Local backend (dev only). Same traversal guard as decodeParamsBytes'
+    // local download path.
+    if (request.backend.filePath.includes("..")) {
+      throw new AlienError(
+        StorageOperationFailedError.create({
+          operation: "upload",
+          url: `local://${request.backend.filePath}`,
+          reason: "Path traversal not allowed in local storage paths",
+        }),
+      )
+    }
     const { writeFile } = await import("node:fs/promises")
     await writeFile(request.backend.filePath, bytes)
   }
@@ -455,6 +479,54 @@ export function commandBudget(deadline: string | undefined, leaseExpiresAt: stri
   }
   const envelopeDeadline = new Date(deadline)
   return envelopeDeadline.getTime() < lease.getTime() ? envelopeDeadline : lease
+}
+
+/**
+ * Build the `/commands/leases` endpoint from the configured base URL.
+ *
+ * Twin of the Rust receiver's `acquire_leases`, which parses the base as a
+ * `Url` and appends segments via `path_segments_mut()` — that mutates only
+ * the path, leaving any query string untouched and correctly ordered after
+ * the appended segments (M1). The naive string approach this replaced
+ * (`url.replace(/\/+$/, "") + "/commands/leases"`) corrupted any base URL
+ * carrying a query string, e.g. `https://h/v1?token=x` became
+ * `https://h/v1?token=x/commands/leases` instead of
+ * `https://h/v1/commands/leases?token=x`.
+ *
+ * `path_segments_mut()` fails (and the Rust receiver raises
+ * `COMMAND_RECEIVER_CONFIG_INVALID`) for a base that cannot be a hierarchical
+ * URL — in practice, anything that isn't HTTP(S). This mirrors that check.
+ */
+export function buildLeaseEndpoint(baseUrl: string): string {
+  let url: URL
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    throw new AlienError(
+      CommandReceiverConfigInvalidError.create({
+        envVar: ENV_ALIEN_COMMANDS_URL,
+        reason: `${ENV_ALIEN_COMMANDS_URL} '${baseUrl}' must be an HTTP(S) URL with a path`,
+      }),
+    )
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new AlienError(
+      CommandReceiverConfigInvalidError.create({
+        envVar: ENV_ALIEN_COMMANDS_URL,
+        reason: `${ENV_ALIEN_COMMANDS_URL} '${baseUrl}' must be an HTTP(S) URL with a path`,
+      }),
+    )
+  }
+
+  // `pop_if_empty` equivalent: a trailing slash produces a trailing empty
+  // path segment; drop exactly one so we don't double up the separator.
+  const segments = url.pathname.split("/")
+  if (segments[segments.length - 1] === "") {
+    segments.pop()
+  }
+  segments.push("commands", "leases")
+  url.pathname = segments.join("/")
+  return url.toString()
 }
 
 /**
@@ -528,15 +600,14 @@ export async function decodeParamsBytes(
 ): Promise<Uint8Array> {
   const params = envelope.params
   if (params.mode === "inline") {
-    return base64ToBytes(params.inlineBase64)
+    return decodeInlineParamsBase64(params.inlineBase64)
   }
 
   // Storage mode: download from the presigned request.
   if (!params.storageGetRequest) {
     throw new AlienError(
-      ResponseDecodingFailedError.create({
-        commandId: envelope.commandId,
-        command: envelope.command,
+      InvalidEnvelopeError.create({
+        field: "params.storageGetRequest",
         reason: "Storage params missing storageGetRequest",
       }),
     )
@@ -601,6 +672,34 @@ function bytesToInlineBody(bytes: Uint8Array): BodySpec {
 
 function base64ToBytes(base64: string): Uint8Array {
   return new Uint8Array(Buffer.from(base64, "base64"))
+}
+
+/**
+ * Canonical base64 (RFC 4648 §4): 4-char groups from the standard alphabet,
+ * with correct padding on the final group. `Buffer.from(str, "base64")` is
+ * lenient by design — it silently skips invalid characters and tolerates
+ * missing/incorrect padding instead of failing — so untrusted wire input
+ * needs this check in front of it to fail loudly instead of decoding to
+ * truncated garbage bytes.
+ */
+const STRICT_BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+/**
+ * Decode inline command params bytes, matching the Rust twin's strict
+ * `base64::engine::general_purpose::STANDARD` decode: any input outside the
+ * canonical alphabet/padding fails with `INVALID_ENVELOPE`
+ * (DECIDED(09) — twin-pinned; see `PACKAGE_LAYOUT.md`).
+ */
+function decodeInlineParamsBase64(inlineBase64: string): Uint8Array {
+  if (!STRICT_BASE64_PATTERN.test(inlineBase64)) {
+    throw new AlienError(
+      InvalidEnvelopeError.create({
+        field: "params.inlineBase64",
+        reason: "Failed to decode base64 params",
+      }),
+    )
+  }
+  return base64ToBytes(inlineBase64)
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/packages/commands/src/receiver.ts
+++ b/packages/commands/src/receiver.ts
@@ -1,0 +1,620 @@
+/**
+ * Pull command receiver — the app-owned lease loop for Containers and Daemons.
+ *
+ * Behavior-identical twin of the Rust `alien_commands::Receiver`. It leases
+ * commands addressed to its own target resource from the command server over
+ * outbound HTTPS (no inbound connections, no gRPC), dispatches them to
+ * in-process handlers, and submits responses through the envelope's
+ * response-handling flow (inline or presigned storage upload).
+ *
+ * Pure `fetch`; no bindings, no gRPC. See `PACKAGE_LAYOUT.md` DECIDED(09) for
+ * the binding semantics this file implements:
+ * - env quintet, fail-fast naming the offending variable (worker type rejected)
+ * - execution budget = `min(envelope.deadline, leaseExpiresAt)`; on expiry the
+ *   handler's `signal` fires and a `HANDLER_TIMEOUT` response is submitted
+ * - error codes `UNKNOWN_COMMAND` / `HANDLER_ERROR` / `HANDLER_TIMEOUT`, with a
+ *   params-decode failure submitted under the decode error's own code
+ * - at-least-once delivery; `ctx.attempt` starts at 1
+ * - drain: shutdown stops *starting* new polls; in-flight commands complete
+ * - lease params 5s / maxLeases 10 / leaseSeconds 60
+ * - `ctx.input` = decoded param bytes; success body = `JSON.stringify(return)`;
+ *   `ctx.deadline` = the effective budget, always present while a lease is held
+ *
+ * # Bootstrap
+ *
+ * ```typescript
+ * import { createCommandReceiver } from "@alienplatform/commands"
+ *
+ * const receiver = createCommandReceiver()
+ * receiver.handle("generate-report", async ctx => {
+ *   const params = JSON.parse(new TextDecoder().decode(ctx.input))
+ *   return { report: params }
+ * })
+ * await receiver.run() // call receiver.stop() to drain and return
+ * ```
+ */
+
+import { AlienError } from "@alienplatform/core"
+import {
+  CommandReceiverConfigInvalidError,
+  ResponseDecodingFailedError,
+  StorageOperationFailedError,
+} from "./errors.js"
+import type {
+  BodySpec,
+  CommandResponse,
+  CommandTargetType,
+  Envelope,
+  LeaseInfo,
+  LeaseRequest,
+  LeaseResponse,
+  PresignedRequest,
+} from "./protocol.js"
+
+/** Error code submitted when a leased command has no registered handler. */
+export const ERROR_CODE_UNKNOWN_COMMAND = "UNKNOWN_COMMAND"
+/** Error code submitted when a handler exceeds its execution budget. */
+export const ERROR_CODE_HANDLER_TIMEOUT = "HANDLER_TIMEOUT"
+/** Error code submitted when a handler throws/rejects (or its response fails to serialize). */
+export const ERROR_CODE_HANDLER_ERROR = "HANDLER_ERROR"
+
+/** Lease poll interval, in ms (DECIDED(09) — 5s). */
+const DEFAULT_POLL_INTERVAL_MS = 5_000
+/** Max leases requested per poll (DECIDED(09) — 10). */
+const DEFAULT_MAX_LEASES = 10
+/** Requested lease duration, in seconds (DECIDED(09) — 60). */
+const DEFAULT_LEASE_SECONDS = 60
+
+// Env variable names — identical strings to the Rust twin
+// (`alien_core::runtime_environment`).
+const ENV_ALIEN_COMMANDS_URL = "ALIEN_COMMANDS_URL"
+const ENV_ALIEN_COMMANDS_TOKEN = "ALIEN_COMMANDS_TOKEN"
+const ENV_ALIEN_DEPLOYMENT_ID = "ALIEN_DEPLOYMENT_ID"
+const ENV_ALIEN_COMMANDS_TARGET_RESOURCE_ID = "ALIEN_COMMANDS_TARGET_RESOURCE_ID"
+const ENV_ALIEN_COMMANDS_TARGET_RESOURCE_TYPE = "ALIEN_COMMANDS_TARGET_RESOURCE_TYPE"
+
+/**
+ * Per-command context passed to a {@link CommandHandler}.
+ *
+ * DECIDED(08) — the concrete handler-context field types. These are the twin of
+ * the Rust `Context` struct (`input`/`deadline`/`command_id`/`attempt`/
+ * `cancellation`), the last mapping to `signal` here.
+ */
+export interface CommandContext {
+  /**
+   * Decoded command param bytes — the same bytes the params envelope carries
+   * after decode, prior to any handler-side parsing (DECIDED(09), byte-for-byte
+   * twin identity with the Rust receiver's `ctx.input`).
+   */
+  input: Uint8Array
+  /**
+   * Fires when the execution budget expires. The handler promise is abandoned
+   * regardless; observe this to stop cooperative work the handler started.
+   * Twin of the Rust `ctx.cancellation` token.
+   */
+  signal: AbortSignal
+  /**
+   * The effective execution budget: `min(envelope.deadline, leaseExpiresAt)`.
+   * Always present while a lease is held (DECIDED(09)).
+   */
+  deadline: Date
+  /** Unique command identifier. */
+  commandId: string
+  /**
+   * Delivery attempt, starting at 1. Greater than 1 means redelivery
+   * (at-least-once semantics); handlers must tolerate running more than once.
+   */
+  attempt: number
+}
+
+/**
+ * A command handler. Receives a {@link CommandContext} and returns any
+ * JSON-serializable value, submitted as the command's success response
+ * (`JSON.stringify`-encoded). Throwing/rejecting submits a `HANDLER_ERROR`.
+ */
+export type CommandHandler = (ctx: CommandContext) => unknown | Promise<unknown>
+
+/**
+ * The pull receiver handle. Register handlers with {@link CommandReceiver.handle},
+ * drive the lease loop with {@link CommandReceiver.run}, and stop it (draining
+ * in-flight commands) with {@link CommandReceiver.stop}.
+ */
+export interface CommandReceiver {
+  /** Register a handler for a command name. Registering a name twice replaces it. */
+  handle(name: string, handler: CommandHandler): CommandReceiver
+  /**
+   * Drive the lease loop until {@link CommandReceiver.stop} is called. No new
+   * lease poll *starts* once draining begins; a poll already in flight
+   * completes and its leases are dispatched and drained. Every in-flight
+   * command finishes within its budget before this resolves.
+   */
+  run(): Promise<void>
+  /** Signal the receiver to drain and stop (see {@link CommandReceiver.run}). */
+  stop(): void
+}
+
+/** Options for {@link createCommandReceiver}; every field has a production default. */
+export interface CommandReceiverOptions {
+  /** Environment source (defaults to `process.env`). */
+  env?: Record<string, string | undefined>
+  /** `fetch` implementation (defaults to the global `fetch`). */
+  fetch?: typeof fetch
+  /** Lease poll interval in ms (default 5000). Mainly for tests. */
+  pollIntervalMs?: number
+  /** Requested lease duration in seconds (default 60). Mainly for tests. */
+  leaseSeconds?: number
+  /** Max leases requested per poll (default 10). Mainly for tests. */
+  maxLeases?: number
+}
+
+interface ReceiverConfig {
+  url: string
+  token: string
+  deploymentId: string
+  resourceId: string
+  resourceType: CommandTargetType
+}
+
+/**
+ * Construct the pull receiver from environment configuration.
+ *
+ * Validates the required env quintet **synchronously** — an empty, missing, or
+ * invalid value throws {@link CommandReceiverConfigInvalidError} naming the
+ * offending variable in `context.envVar` (DECIDED(09)). `resourceType` must be
+ * `container` or `daemon`; `worker` (and anything else) is rejected — a receiver
+ * must not guess its target type.
+ */
+export function createCommandReceiver(options: CommandReceiverOptions = {}): CommandReceiver {
+  const env = options.env ?? (typeof process !== "undefined" ? process.env : {})
+  const config = validateConfig(env)
+  return new PullCommandReceiver(config, options)
+}
+
+function requireEnv(env: Record<string, string | undefined>, name: string): string {
+  const value = env[name]
+  if (value === undefined) {
+    throw new AlienError(
+      CommandReceiverConfigInvalidError.create({ envVar: name, reason: `${name} is required` }),
+    )
+  }
+  if (value === "") {
+    throw new AlienError(
+      CommandReceiverConfigInvalidError.create({
+        envVar: name,
+        reason: `${name} must not be empty`,
+      }),
+    )
+  }
+  return value
+}
+
+function validateConfig(env: Record<string, string | undefined>): ReceiverConfig {
+  const url = requireEnv(env, ENV_ALIEN_COMMANDS_URL)
+  try {
+    // eslint-disable-next-line no-new -- validating parseability only
+    new URL(url)
+  } catch {
+    throw new AlienError(
+      CommandReceiverConfigInvalidError.create({
+        envVar: ENV_ALIEN_COMMANDS_URL,
+        reason: `${ENV_ALIEN_COMMANDS_URL} is not a valid URL: ${url}`,
+      }),
+    )
+  }
+
+  const token = requireEnv(env, ENV_ALIEN_COMMANDS_TOKEN)
+  const deploymentId = requireEnv(env, ENV_ALIEN_DEPLOYMENT_ID)
+  const resourceId = requireEnv(env, ENV_ALIEN_COMMANDS_TARGET_RESOURCE_ID)
+
+  const rawType = requireEnv(env, ENV_ALIEN_COMMANDS_TARGET_RESOURCE_TYPE)
+  if (rawType !== "container" && rawType !== "daemon") {
+    throw new AlienError(
+      CommandReceiverConfigInvalidError.create({
+        envVar: ENV_ALIEN_COMMANDS_TARGET_RESOURCE_TYPE,
+        reason: `${ENV_ALIEN_COMMANDS_TARGET_RESOURCE_TYPE} must be 'container' or 'daemon', got '${rawType}'`,
+      }),
+    )
+  }
+
+  return { url, token, deploymentId, resourceId, resourceType: rawType }
+}
+
+class PullCommandReceiver implements CommandReceiver {
+  private readonly config: ReceiverConfig
+  private readonly fetchImpl: typeof fetch
+  private readonly pollIntervalMs: number
+  private readonly leaseSeconds: number
+  private readonly maxLeases: number
+  private readonly handlers = new Map<string, CommandHandler>()
+  private readonly shutdown = new AbortController()
+
+  constructor(config: ReceiverConfig, options: CommandReceiverOptions) {
+    this.config = config
+    this.fetchImpl = options.fetch ?? globalThis.fetch
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    this.leaseSeconds = options.leaseSeconds ?? DEFAULT_LEASE_SECONDS
+    this.maxLeases = options.maxLeases ?? DEFAULT_MAX_LEASES
+  }
+
+  handle(name: string, handler: CommandHandler): CommandReceiver {
+    this.handlers.set(name, handler)
+    return this
+  }
+
+  stop(): void {
+    this.shutdown.abort()
+  }
+
+  async run(): Promise<void> {
+    const inFlight = new Set<Promise<void>>()
+
+    // Mirrors the Rust run loop: check shutdown at the top of each iteration
+    // (no new poll starts once draining begins), acquire leases (a poll already
+    // in flight completes and its leases are dispatched), then sleep-or-stop.
+    while (!this.shutdown.signal.aborted) {
+      let leases: LeaseInfo[] = []
+      try {
+        leases = await this.acquireLeases()
+      } catch (error) {
+        // Transient lease errors are logged and retried next interval.
+        logWarn("Failed to acquire command leases, will retry", error)
+      }
+
+      for (const lease of leases) {
+        const task = this.processLease(lease)
+        inFlight.add(task)
+        void task.finally(() => inFlight.delete(task))
+      }
+
+      if (this.shutdown.signal.aborted) {
+        break
+      }
+      await this.sleepOrStop(this.pollIntervalMs)
+    }
+
+    // Drain: every in-flight command finishes within its own budget.
+    await Promise.all([...inFlight])
+  }
+
+  /** Build the lease request this receiver sends (pure — unit-testable). */
+  private buildLeaseRequest(): LeaseRequest {
+    return {
+      deploymentId: this.config.deploymentId,
+      target: {
+        resourceId: this.config.resourceId,
+        resourceType: this.config.resourceType,
+      },
+      maxLeases: this.maxLeases,
+      leaseSeconds: this.leaseSeconds,
+    }
+  }
+
+  private async acquireLeases(): Promise<LeaseInfo[]> {
+    const endpoint = `${this.config.url.replace(/\/+$/, "")}/commands/leases`
+    const response = await this.fetchImpl(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.config.token}`,
+      },
+      body: JSON.stringify(this.buildLeaseRequest()),
+    })
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "")
+      throw new Error(`Lease request failed with status ${response.status}: ${body}`)
+    }
+
+    const parsed = (await response.json()) as LeaseResponse
+    return parsed.leases ?? []
+  }
+
+  /**
+   * Process one leased command end to end: execute (or reject) it, then submit
+   * exactly one response. Only this path submits — a handler cannot double
+   * submit, and a submit failure produces no ack, so the lease expires and the
+   * command is redelivered.
+   */
+  private async processLease(lease: LeaseInfo): Promise<void> {
+    const response = await this.executeLease(lease)
+    try {
+      await this.submitResponse(lease.envelope, response)
+    } catch (error) {
+      // No ack: the lease will expire and the command is redelivered.
+      logError(`Failed to submit response for command '${lease.commandId}'`, error)
+    }
+  }
+
+  /**
+   * Execute a leased command under its budget and produce the response to
+   * submit. Never submits (keeps the "only the loop submits, once" invariant).
+   */
+  private async executeLease(lease: LeaseInfo): Promise<CommandResponse> {
+    const { envelope, leaseExpiresAt, attempt } = lease
+    const handler = this.handlers.get(envelope.command)
+    if (!handler) {
+      return errorResponse(
+        ERROR_CODE_UNKNOWN_COMMAND,
+        `No handler registered for command '${envelope.command}'`,
+      )
+    }
+
+    let input: Uint8Array
+    try {
+      input = await decodeParamsBytes(envelope, this.fetchImpl)
+    } catch (error) {
+      // Decode failure is submitted under the decode error's own code, not a
+      // receiver-specific one (DECIDED(09)).
+      const code = error instanceof AlienError ? error.code : ERROR_CODE_HANDLER_ERROR
+      return errorResponse(code, error instanceof Error ? error.message : String(error))
+    }
+
+    const budget = commandBudget(envelope.deadline, leaseExpiresAt)
+    const controller = new AbortController()
+    const ctx: CommandContext = {
+      input,
+      signal: controller.signal,
+      deadline: budget,
+      commandId: envelope.commandId,
+      attempt,
+    }
+
+    return runUnderBudget(handler, ctx, budget, controller, envelope.command)
+  }
+
+  private async submitResponse(envelope: Envelope, response: CommandResponse): Promise<void> {
+    let finalResponse = response
+
+    if (response.status === "success" && response.response.mode === "inline") {
+      const bytes = base64ToBytes(response.response.inlineBase64)
+      const maxInline = envelope.responseHandling.maxInlineBytes
+      if (bytes.byteLength > maxInline) {
+        // Large response: upload to storage first, then reference it.
+        await this.uploadResponseToStorage(envelope.responseHandling.storageUploadRequest, bytes)
+        finalResponse = {
+          status: "success",
+          response: { mode: "storage", size: bytes.byteLength, storagePutUsed: true },
+        }
+      }
+    }
+
+    // The submit URL is fully qualified and pre-authorized by the envelope, so
+    // it carries no bearer header (matching the Rust twin's submit path).
+    const res = await this.fetchImpl(envelope.responseHandling.submitResponseUrl, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(finalResponse),
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      throw new AlienError(
+        StorageOperationFailedError.create({
+          operation: "upload",
+          url: envelope.responseHandling.submitResponseUrl,
+          reason: `Response submission failed with status ${res.status}: ${body}`,
+        }),
+      )
+    }
+  }
+
+  private async uploadResponseToStorage(
+    request: PresignedRequest,
+    bytes: Uint8Array,
+  ): Promise<void> {
+    if (request.backend.type === "http") {
+      const res = await this.fetchImpl(request.backend.url, {
+        method: request.backend.method,
+        headers: request.backend.headers,
+        body: bytes,
+      })
+      if (!res.ok) {
+        throw new AlienError(
+          StorageOperationFailedError.create({
+            operation: "upload",
+            url: request.backend.url,
+            reason: `Storage upload failed with status ${res.status}`,
+          }),
+        )
+      }
+      return
+    }
+
+    // Local backend (dev only).
+    const { writeFile } = await import("node:fs/promises")
+    await writeFile(request.backend.filePath, bytes)
+  }
+
+  private sleepOrStop(ms: number): Promise<void> {
+    return new Promise<void>(resolve => {
+      if (this.shutdown.signal.aborted) {
+        resolve()
+        return
+      }
+      const timer = setTimeout(() => {
+        this.shutdown.signal.removeEventListener("abort", onAbort)
+        resolve()
+      }, ms)
+      const onAbort = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      this.shutdown.signal.addEventListener("abort", onAbort, { once: true })
+    })
+  }
+}
+
+/**
+ * Per-command execution budget: `min(envelope.deadline, leaseExpiresAt)`. There
+ * is no lease-renew call, so the lease expiry always bounds it.
+ */
+export function commandBudget(deadline: string | undefined, leaseExpiresAt: string): Date {
+  const lease = new Date(leaseExpiresAt)
+  if (deadline === undefined) {
+    return lease
+  }
+  const envelopeDeadline = new Date(deadline)
+  return envelopeDeadline.getTime() < lease.getTime() ? envelopeDeadline : lease
+}
+
+/**
+ * Run the handler racing a budget timer. On budget expiry the `signal` fires,
+ * the handler promise is abandoned (its later settlement is ignored — only this
+ * function's return is ever submitted), and a `HANDLER_TIMEOUT` is returned.
+ */
+async function runUnderBudget(
+  handler: CommandHandler,
+  ctx: CommandContext,
+  budget: Date,
+  controller: AbortController,
+  command: string,
+): Promise<CommandResponse> {
+  const remainingMs = Math.max(0, budget.getTime() - Date.now())
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const budgetPromise = new Promise<{ kind: "timeout" }>(resolve => {
+    timer = setTimeout(() => resolve({ kind: "timeout" }), remainingMs)
+  })
+
+  const handlerPromise = Promise.resolve()
+    .then(() => handler(ctx))
+    .then(
+      value => ({ kind: "return" as const, value }),
+      (error: unknown) => ({ kind: "throw" as const, error }),
+    )
+
+  const outcome = await Promise.race([handlerPromise, budgetPromise])
+  if (timer !== undefined) {
+    clearTimeout(timer)
+  }
+
+  if (outcome.kind === "timeout") {
+    // Budget expired: fire the signal for cooperative work; abandon the handler
+    // promise so a late settlement can't double-submit.
+    controller.abort()
+    void handlerPromise.catch(() => {})
+    return errorResponse(
+      ERROR_CODE_HANDLER_TIMEOUT,
+      `Command '${command}' exceeded its execution budget (${budget.toISOString()})`,
+    )
+  }
+
+  if (outcome.kind === "throw") {
+    const message = outcome.error instanceof Error ? outcome.error.message : String(outcome.error)
+    return errorResponse(ERROR_CODE_HANDLER_ERROR, message)
+  }
+
+  // Success: JSON-encode the return value (DECIDED(09)).
+  let json: string
+  try {
+    json = JSON.stringify(outcome.value) ?? "null"
+  } catch (error) {
+    return errorResponse(
+      ERROR_CODE_HANDLER_ERROR,
+      `Failed to serialize handler response: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+  return successResponse(new TextEncoder().encode(json))
+}
+
+/**
+ * Decode command param bytes from an envelope (DECIDED(09) — `ctx.input`):
+ * inline base64 → raw bytes; storage → GET the presigned request, use the body
+ * bytes. Never JSON-parses (that is the handler's job).
+ */
+export async function decodeParamsBytes(
+  envelope: Envelope,
+  fetchImpl: typeof fetch,
+): Promise<Uint8Array> {
+  const params = envelope.params
+  if (params.mode === "inline") {
+    return base64ToBytes(params.inlineBase64)
+  }
+
+  // Storage mode: download from the presigned request.
+  if (!params.storageGetRequest) {
+    throw new AlienError(
+      ResponseDecodingFailedError.create({
+        commandId: envelope.commandId,
+        command: envelope.command,
+        reason: "Storage params missing storageGetRequest",
+      }),
+    )
+  }
+
+  const request = params.storageGetRequest
+  const expiration = new Date(request.expiration)
+  if (Date.now() > expiration.getTime()) {
+    throw new AlienError(
+      StorageOperationFailedError.create({
+        operation: "download",
+        url: request.backend.type === "http" ? request.backend.url : "local",
+        reason: `Presigned request expired at ${expiration.toISOString()}`,
+      }),
+    )
+  }
+
+  if (request.backend.type === "http") {
+    const response = await fetchImpl(request.backend.url, {
+      method: request.backend.method,
+      headers: request.backend.headers,
+    })
+    if (!response.ok) {
+      throw new AlienError(
+        StorageOperationFailedError.create({
+          operation: "download",
+          url: request.backend.url,
+          reason: `HTTP ${response.status} ${response.statusText}`,
+        }),
+      )
+    }
+    return new Uint8Array(await response.arrayBuffer())
+  }
+
+  // Local backend (dev only).
+  const filePath = request.backend.filePath
+  if (filePath.includes("..")) {
+    throw new AlienError(
+      StorageOperationFailedError.create({
+        operation: "download",
+        url: `local://${filePath}`,
+        reason: "Path traversal not allowed in local storage paths",
+      }),
+    )
+  }
+  const { readFile } = await import("node:fs/promises")
+  const content = await readFile(filePath)
+  return new Uint8Array(content)
+}
+
+function successResponse(bytes: Uint8Array): CommandResponse {
+  return { status: "success", response: bytesToInlineBody(bytes) }
+}
+
+function errorResponse(code: string, message: string): CommandResponse {
+  return { status: "error", code, message }
+}
+
+function bytesToInlineBody(bytes: Uint8Array): BodySpec {
+  return { mode: "inline", inlineBase64: bytesToBase64(bytes) }
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(base64, "base64"))
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64")
+}
+
+function logWarn(message: string, error: unknown): void {
+  console.warn(`[command-receiver] ${message}: ${describeError(error)}`)
+}
+
+function logError(message: string, error: unknown): void {
+  console.error(`[command-receiver] ${message}: ${describeError(error)}`)
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/commands/tests/commands-client.test.ts
+++ b/packages/commands/tests/commands-client.test.ts
@@ -5,6 +5,9 @@
  * would. Runs identically under Node (`vitest run`) and Bun (`bun test`).
  */
 
+import { writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { AlienError } from "@alienplatform/core"
 import { afterEach, describe, expect, it } from "vitest"
 import { CommandsClient } from "../src/client.js"
@@ -210,6 +213,117 @@ describe("CommandsClient.invoke", () => {
 
     const result = await client(server.baseUrl).invoke("fetch-big", {}, FAST_POLL)
     expect(result).toEqual(stored)
+  })
+})
+
+describe("CommandsClient storage decode edge cases", () => {
+  /** Build a status stub that answers with a storage-mode success body. */
+  function storageStatus(bodyOverrides: Record<string, unknown>) {
+    return {
+      commandId: "cmd_1",
+      state: "SUCCEEDED",
+      attempt: 1,
+      target: { resourceId: "container-1", resourceType: "container" },
+      response: {
+        status: "success",
+        response: { mode: "storage", size: 10, ...bodyOverrides },
+      },
+    }
+  }
+
+  it("reads a local-backend storage response when allowLocalStorage is set", async () => {
+    const stored = { local: true, n: 5 }
+    const filePath = join(tmpdir(), `alien-cmd-decode-${Date.now()}.json`)
+    await writeFile(filePath, JSON.stringify(stored), "utf-8")
+
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return {
+        json: storageStatus({
+          storageGetRequest: {
+            backend: { type: "local", filePath, operation: "get" },
+            expiration: new Date(Date.now() + 60_000).toISOString(),
+            operation: "get",
+            path: "local-blob",
+          },
+        }),
+      }
+    })
+
+    const result = await client(server.baseUrl, true).invoke("read-local", {}, FAST_POLL)
+    expect(result).toEqual(stored)
+  })
+
+  it("refuses the local backend when allowLocalStorage is false", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return {
+        json: storageStatus({
+          storageGetRequest: {
+            backend: { type: "local", filePath: "/tmp/whatever.json", operation: "get" },
+            expiration: new Date(Date.now() + 60_000).toISOString(),
+            operation: "get",
+            path: "local-blob",
+          },
+        }),
+      }
+    })
+
+    const err = await client(server.baseUrl, false)
+      .invoke("read-local", {}, FAST_POLL)
+      .catch((e: unknown) => e)
+    expect((err as AlienError).code).toBe("STORAGE_OPERATION_FAILED")
+    expect((err as AlienError).context).toMatchObject({
+      reason: expect.stringContaining("not enabled"),
+    })
+  })
+
+  it("rejects an expired presigned storage request", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return {
+        json: storageStatus({
+          storageGetRequest: {
+            backend: { type: "http", url: `${server?.baseUrl}/blob`, method: "GET", headers: {} },
+            expiration: new Date(Date.now() - 1_000).toISOString(),
+            operation: "get",
+            path: "blob",
+          },
+        }),
+      }
+    })
+
+    const err = await client(server.baseUrl)
+      .invoke("fetch-expired", {}, FAST_POLL)
+      .catch((e: unknown) => e)
+    expect((err as AlienError).code).toBe("STORAGE_OPERATION_FAILED")
+    expect((err as AlienError).context).toMatchObject({
+      reason: expect.stringContaining("expired"),
+    })
+  })
+
+  it("guards against path traversal in a local storage path", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return {
+        json: storageStatus({
+          storageGetRequest: {
+            backend: { type: "local", filePath: "../../etc/passwd", operation: "get" },
+            expiration: new Date(Date.now() + 60_000).toISOString(),
+            operation: "get",
+            path: "local-blob",
+          },
+        }),
+      }
+    })
+
+    const err = await client(server.baseUrl, true)
+      .invoke("traverse", {}, FAST_POLL)
+      .catch((e: unknown) => e)
+    expect((err as AlienError).code).toBe("STORAGE_OPERATION_FAILED")
+    expect((err as AlienError).context).toMatchObject({
+      reason: expect.stringContaining("Path traversal"),
+    })
   })
 })
 

--- a/packages/commands/tests/commands-client.test.ts
+++ b/packages/commands/tests/commands-client.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Sender unit tests against an in-test HTTP stub (no mocked fetch, no real
+ * network). Every test drives the actual create → poll → decode machinery over
+ * the platform global `fetch`, so the suite exercises exactly what production
+ * would. Runs identically under Node (`vitest run`) and Bun (`bun test`).
+ */
+
+import { AlienError } from "@alienplatform/core"
+import { afterEach, describe, expect, it } from "vitest"
+import { CommandsClient } from "../src/client.js"
+import type { CapturedRequest, RouteResult, StubServer } from "./helpers/stub-server.js"
+import { encodeInlineJson, startStubServer } from "./helpers/stub-server.js"
+
+let server: StubServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+/** Fast polling so the wall-clock loop resolves in milliseconds, not seconds. */
+const FAST_POLL = { pollIntervalMs: 2, maxPollIntervalMs: 8 } as const
+
+function client(baseUrl: string, allowLocalStorage = false) {
+  return new CommandsClient({
+    managerUrl: baseUrl,
+    deploymentId: "dep_1",
+    token: "tok_secret",
+    allowLocalStorage,
+  })
+}
+
+function createResponse(commandId = "cmd_1") {
+  return { commandId, state: "PENDING", inlineAllowedUpTo: 150_000, next: "poll" }
+}
+
+function successStatus(commandId: string, value: unknown) {
+  return {
+    commandId,
+    state: "SUCCEEDED",
+    attempt: 1,
+    target: { resourceId: "container-1", resourceType: "container" },
+    response: {
+      status: "success",
+      response: { mode: "inline", inlineBase64: encodeInlineJson(value) },
+    },
+  }
+}
+
+describe("CommandsClient.invoke", () => {
+  it("creates, polls, and decodes an inline success response", async () => {
+    const returned = { report: "ok", rows: 3 }
+    let polls = 0
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST" && req.path === "/v1/commands") {
+        return { json: createResponse() }
+      }
+      // GET status: stay PENDING once, then succeed (proves the poll loop runs).
+      polls += 1
+      if (polls < 2) {
+        return {
+          json: {
+            commandId: "cmd_1",
+            state: "PENDING",
+            attempt: 1,
+            target: { resourceId: "container-1", resourceType: "container" },
+          },
+        }
+      }
+      return { json: successStatus("cmd_1", returned) }
+    })
+
+    const result = await client(server.baseUrl).invoke("generate-report", { a: 1 }, FAST_POLL)
+
+    expect(result).toEqual(returned)
+    expect(polls).toBeGreaterThanOrEqual(2)
+
+    // create request shape + bearer auth
+    const create = server.requests.find(r => r.method === "POST") as CapturedRequest
+    expect(create.headers.authorization).toBe("Bearer tok_secret")
+    const body = create.body as Record<string, unknown>
+    expect(body.deploymentId).toBe("dep_1")
+    expect(body.command).toBe("generate-report")
+    // createBodySpec JSON-stringifies the input once, then base64s it.
+    expect(body.params).toEqual({ mode: "inline", inlineBase64: encodeInlineJson({ a: 1 }) })
+  })
+
+  it("maps an error terminal state to DeploymentCommandError", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return {
+        json: {
+          commandId: "cmd_1",
+          state: "FAILED",
+          attempt: 1,
+          target: { resourceId: "container-1", resourceType: "container" },
+          response: { status: "error", code: "BOOM", message: "handler blew up", details: "stack" },
+        },
+      }
+    })
+
+    const err = await client(server.baseUrl)
+      .invoke("do-thing", {}, FAST_POLL)
+      .catch((e: unknown) => e)
+
+    expect(err).toBeInstanceOf(AlienError)
+    const alien = err as AlienError
+    expect(alien.code).toBe("DEPLOYMENT_COMMAND_ERROR")
+    expect(alien.context).toMatchObject({ errorCode: "BOOM", errorMessage: "handler blew up" })
+  })
+
+  it("maps an EXPIRED terminal state to CommandExpiredError", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return {
+        json: {
+          commandId: "cmd_1",
+          state: "EXPIRED",
+          attempt: 1,
+          target: { resourceId: "container-1", resourceType: "container" },
+        },
+      }
+    })
+
+    const err = await client(server.baseUrl)
+      .invoke("do-thing", {}, FAST_POLL)
+      .catch((e: unknown) => e)
+
+    expect((err as AlienError).code).toBe("COMMAND_EXPIRED")
+  })
+
+  it("throws CommandTimeoutError (with lastState) when polling never terminates", async () => {
+    let polls = 0
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      polls += 1
+      return {
+        json: {
+          commandId: "cmd_1",
+          state: "DISPATCHED",
+          attempt: 1,
+          target: { resourceId: "container-1", resourceType: "container" },
+        },
+      }
+    })
+
+    const err = await client(server.baseUrl)
+      .invoke("slow", {}, { timeoutMs: 30, ...FAST_POLL })
+      .catch((e: unknown) => e)
+
+    const alien = err as AlienError
+    expect(alien.code).toBe("COMMAND_TIMEOUT")
+    expect(alien.context).toMatchObject({ timeoutMs: 30, lastState: "DISPATCHED" })
+    // Multiple polls happened before the wall-clock timeout tripped (backoff loop ran).
+    expect(polls).toBeGreaterThanOrEqual(2)
+  })
+
+  it("threads idempotencyKey and deadline into the create body", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return { json: successStatus("cmd_1", "done") }
+    })
+
+    const deadline = new Date("2030-01-01T00:00:00.000Z")
+    await client(server.baseUrl).invoke(
+      "x",
+      {},
+      { idempotencyKey: "idem-42", deadline, ...FAST_POLL },
+    )
+
+    const create = server.requests.find(r => r.method === "POST") as CapturedRequest
+    const body = create.body as Record<string, unknown>
+    expect(body.idempotencyKey).toBe("idem-42")
+    expect(body.deadline).toBe("2030-01-01T00:00:00.000Z")
+  })
+
+  it("decodes a storage-mode (http backend) success response", async () => {
+    const stored = { big: "payload", n: 7 }
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST" && req.path === "/v1/commands") return { json: createResponse() }
+      if (req.method === "GET" && req.path === "/blob") return { text: JSON.stringify(stored) }
+      // status → storage response pointing at /blob on this same server
+      return {
+        json: {
+          commandId: "cmd_1",
+          state: "SUCCEEDED",
+          attempt: 1,
+          target: { resourceId: "container-1", resourceType: "container" },
+          response: {
+            status: "success",
+            response: {
+              mode: "storage",
+              size: 42,
+              storageGetRequest: {
+                backend: {
+                  type: "http",
+                  url: `${server?.baseUrl}/blob`,
+                  method: "GET",
+                  headers: {},
+                },
+                expiration: new Date(Date.now() + 60_000).toISOString(),
+                operation: "get",
+                path: "blob",
+              },
+            },
+          },
+        },
+      }
+    })
+
+    const result = await client(server.baseUrl).invoke("fetch-big", {}, FAST_POLL)
+    expect(result).toEqual(stored)
+  })
+})
+
+describe("CommandsClient target threading", () => {
+  it("sends targetResourceId from options.targetResourceId", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return { json: successStatus("cmd_1", "ok") }
+    })
+
+    await client(server.baseUrl).invoke("x", {}, { targetResourceId: "daemon-3", ...FAST_POLL })
+
+    const create = server.requests.find(r => r.method === "POST") as CapturedRequest
+    expect((create.body as Record<string, unknown>).targetResourceId).toBe("daemon-3")
+  })
+
+  it(".target(name) presets targetResourceId on the wire body", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return { json: successStatus("cmd_1", "ok") }
+    })
+
+    await client(server.baseUrl).target("container-9").invoke("x", {}, FAST_POLL)
+
+    const create = server.requests.find(r => r.method === "POST") as CapturedRequest
+    expect((create.body as Record<string, unknown>).targetResourceId).toBe("container-9")
+  })
+
+  it(".target(name) wins over a conflicting options.targetResourceId (builder wins)", async () => {
+    server = await startStubServer((req): RouteResult => {
+      if (req.method === "POST") return { json: createResponse() }
+      return { json: successStatus("cmd_1", "ok") }
+    })
+
+    await client(server.baseUrl)
+      .target("container-9")
+      .invoke("x", {}, { targetResourceId: "container-other", ...FAST_POLL })
+
+    const create = server.requests.find(r => r.method === "POST") as CapturedRequest
+    expect((create.body as Record<string, unknown>).targetResourceId).toBe("container-9")
+  })
+})

--- a/packages/commands/tests/helpers/stub-server.ts
+++ b/packages/commands/tests/helpers/stub-server.ts
@@ -1,0 +1,96 @@
+/**
+ * Minimal in-test HTTP server built on `node:http` so the exact same helper
+ * runs under BOTH `vitest run` (Node) and `bun test` (Bun implements
+ * `node:http`). It records every request (method, path, headers, parsed JSON
+ * body) and delegates the response to a route callback.
+ *
+ * Deliberately dependency-free: no `undici`, no framework — the sender talks to
+ * it over the platform global `fetch`, exactly as it would to the real command
+ * server.
+ */
+
+import { createServer } from "node:http"
+
+export interface CapturedRequest {
+  method: string
+  path: string
+  headers: Record<string, string | string[] | undefined>
+  body: unknown
+}
+
+export interface RouteResult {
+  status?: number
+  json?: unknown
+  text?: string
+}
+
+export type RouteHandler = (req: CapturedRequest) => RouteResult | Promise<RouteResult>
+
+export interface StubServer {
+  baseUrl: string
+  requests: CapturedRequest[]
+  close: () => Promise<void>
+}
+
+export async function startStubServer(route: RouteHandler): Promise<StubServer> {
+  const requests: CapturedRequest[] = []
+
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on("data", chunk => chunks.push(chunk as Buffer))
+    req.on("end", async () => {
+      const raw = Buffer.concat(chunks).toString("utf-8")
+      let body: unknown
+      try {
+        body = raw ? JSON.parse(raw) : undefined
+      } catch {
+        body = raw
+      }
+
+      const captured: CapturedRequest = {
+        method: req.method ?? "",
+        path: req.url ?? "",
+        headers: req.headers,
+        body,
+      }
+      requests.push(captured)
+
+      try {
+        const result = await route(captured)
+        const status = result.status ?? 200
+        if (result.json !== undefined) {
+          res.writeHead(status, { "content-type": "application/json" })
+          res.end(JSON.stringify(result.json))
+        } else if (result.text !== undefined) {
+          res.writeHead(status, { "content-type": "text/plain" })
+          res.end(result.text)
+        } else {
+          res.writeHead(status)
+          res.end()
+        }
+      } catch (error) {
+        res.writeHead(500)
+        res.end(String(error))
+      }
+    })
+  })
+
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", () => resolve()))
+
+  const address = server.address()
+  const port = typeof address === "object" && address !== null ? address.port : 0
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close(error => (error ? reject(error) : resolve())),
+      ),
+  }
+}
+
+/** Base64-encode a value the way the wire protocol expects (JSON → base64). */
+export function encodeInlineJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf-8").toString("base64")
+}

--- a/packages/commands/tests/integration.real-server.test.ts
+++ b/packages/commands/tests/integration.real-server.test.ts
@@ -15,7 +15,7 @@
  * and the Bun canary, and wired as the dedicated `test:integration` script.
  */
 
-import { type ChildProcessWithoutNullStreams, execFileSync, spawn } from "node:child_process"
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process"
 import { existsSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { AlienError } from "@alienplatform/core"
@@ -37,25 +37,63 @@ const TOKEN = "test-token"
 let serverBinPath = ""
 
 /**
+ * Run the cargo build asynchronously and collect its JSON artifact stream.
+ *
+ * Deliberately NOT `execFileSync`: a cold CI build (compile + link) can take
+ * minutes, and a synchronous spawn blocks this worker's event loop for that
+ * whole duration — vitest's worker↔main RPC misses its heartbeats and reports
+ * a spurious `[vitest-worker]: Timeout calling "onTaskUpdate"` unhandled error
+ * even though every test passes. No `*Sync` child-process calls anywhere in
+ * this suite; the event loop stays responsive and only the generous
+ * `hookTimeout` bounds the build.
+ */
+function runCargoBuild(): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const proc = spawn(
+      CARGO,
+      [
+        "build",
+        "-p",
+        "alien-commands",
+        "--features",
+        "test-utils",
+        "--bin",
+        "test-command-server",
+        "--message-format=json",
+      ],
+      { cwd: WORKSPACE_ROOT, stdio: ["ignore", "pipe", "pipe"] },
+    )
+
+    let stdout = ""
+    let stderr = ""
+    proc.stdout.setEncoding("utf-8")
+    proc.stdout.on("data", (chunk: string) => {
+      stdout += chunk
+    })
+    proc.stderr.setEncoding("utf-8")
+    proc.stderr.on("data", (chunk: string) => {
+      stderr += chunk
+    })
+    proc.on("error", err => {
+      reject(new Error(`failed to spawn cargo: ${err.message}`))
+    })
+    proc.on("close", code => {
+      if (code === 0) {
+        resolve(stdout)
+      } else {
+        reject(new Error(`cargo build failed with exit code ${code}. stderr:\n${stderr}`))
+      }
+    })
+  })
+}
+
+/**
  * Build the test-command-server bin once and resolve its executable path from
  * cargo's JSON artifact stream. Fails loudly (throws) if cargo is missing or the
  * build fails — the whole suite is meaningless without the real server.
  */
-beforeAll(() => {
-  const stdout = execFileSync(
-    CARGO,
-    [
-      "build",
-      "-p",
-      "alien-commands",
-      "--features",
-      "test-utils",
-      "--bin",
-      "test-command-server",
-      "--message-format=json",
-    ],
-    { cwd: WORKSPACE_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
-  )
+beforeAll(async () => {
+  const stdout = await runCargoBuild()
 
   for (const line of stdout.split("\n")) {
     if (!line.trim()) continue

--- a/packages/commands/tests/integration.real-server.test.ts
+++ b/packages/commands/tests/integration.real-server.test.ts
@@ -137,14 +137,31 @@ async function startRealServer(): Promise<RealServer> {
 
   const stop = () =>
     new Promise<void>(resolve => {
-      if (proc.exitCode !== null) {
+      const finish = () => {
+        // Detach the pipes explicitly rather than relying on process exit to
+        // reclaim them — an undestroyed stream can keep the event loop (and
+        // vitest's worker↔main RPC) busy past teardown.
+        proc.stdout.destroy()
+        proc.stderr.destroy()
         resolve()
+      }
+
+      if (proc.exitCode !== null || proc.signalCode !== null) {
+        finish()
         return
       }
-      proc.on("exit", () => resolve())
-      // Closing stdin is the bin's graceful shutdown; kill as a hard fallback.
+
+      proc.once("exit", () => {
+        clearTimeout(killTimer)
+        finish()
+      })
+
+      // Closing stdin is the bin's graceful shutdown; SIGTERM backs it up in
+      // case the bin doesn't treat stdin-close as a shutdown signal, and
+      // SIGKILL is the hard fallback if it ignores both.
       proc.stdin.end()
-      setTimeout(() => proc.kill("SIGKILL"), 2_000)
+      proc.kill("SIGTERM")
+      const killTimer = setTimeout(() => proc.kill("SIGKILL"), 2_000)
     })
 
   return {

--- a/packages/commands/tests/integration.real-server.test.ts
+++ b/packages/commands/tests/integration.real-server.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Real-wire integration suite: the TS sender and receiver twins driven against
+ * the ACTUAL Rust command server (`crates/alien-commands` `test-command-server`
+ * bin, `test-utils` feature). No stub, no mock — every byte crosses a real HTTP
+ * socket to the same axum router production uses.
+ *
+ * The bin is compiled once in `beforeAll` (`cargo build … --message-format=json`,
+ * which also tells us the executable path), then each test spawns that prebuilt
+ * binary directly and parses its `READY {base_url}` line.
+ *
+ * This suite FAILS LOUDLY if cargo or the server is unavailable — there is no
+ * silent skip. It runs in CI (where cargo is present and warm) and locally.
+ *
+ * Runs under Node (vitest) only; it is excluded from the default `vitest run`
+ * and the Bun canary, and wired as the dedicated `test:integration` script.
+ */
+
+import { type ChildProcessWithoutNullStreams, execFileSync, spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { AlienError } from "@alienplatform/core"
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
+import { CommandsClient } from "../src/client.js"
+import type { LeaseInfo, LeaseResponse } from "../src/protocol.js"
+import { type CommandContext, createCommandReceiver } from "../src/receiver.js"
+
+// Workspace root (…/tests → …/commands → …/packages → root) — the cwd cargo runs in.
+const WORKSPACE_ROOT = fileURLToPath(new URL("../../../", import.meta.url))
+const CARGO = process.env.CARGO ?? "cargo"
+
+const DEPLOYMENT_ID = "test-deployment"
+const TARGET_RESOURCE_ID = "test-daemon"
+const TARGET_RESOURCE_TYPE = "daemon"
+const TOKEN = "test-token"
+
+/** Path to the prebuilt bin, resolved once in beforeAll. */
+let serverBinPath = ""
+
+/**
+ * Build the test-command-server bin once and resolve its executable path from
+ * cargo's JSON artifact stream. Fails loudly (throws) if cargo is missing or the
+ * build fails — the whole suite is meaningless without the real server.
+ */
+beforeAll(() => {
+  const stdout = execFileSync(
+    CARGO,
+    [
+      "build",
+      "-p",
+      "alien-commands",
+      "--features",
+      "test-utils",
+      "--bin",
+      "test-command-server",
+      "--message-format=json",
+    ],
+    { cwd: WORKSPACE_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+  )
+
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue
+    let msg: { reason?: string; executable?: string | null; target?: { name?: string } }
+    try {
+      msg = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (
+      msg.reason === "compiler-artifact" &&
+      msg.target?.name === "test-command-server" &&
+      msg.executable
+    ) {
+      serverBinPath = msg.executable
+    }
+  }
+
+  // Fallback: default target dir layout, if the artifact stream didn't name it.
+  if (!serverBinPath) {
+    const fallback = fileURLToPath(
+      new URL("target/debug/test-command-server", `file://${WORKSPACE_ROOT}`),
+    )
+    if (existsSync(fallback)) serverBinPath = fallback
+  }
+
+  if (!serverBinPath || !existsSync(serverBinPath)) {
+    throw new Error(
+      `test-command-server binary not found after cargo build (looked at '${serverBinPath}'). The real-wire integration suite cannot run without it.`,
+    )
+  }
+}, 600_000)
+
+interface RealServer {
+  /** Sender base URL (router is nested under /v1, which the sender appends). */
+  managerUrl: string
+  /** Receiver `ALIEN_COMMANDS_URL` (the /v1 command base). */
+  commandsUrl: string
+  stop: () => Promise<void>
+}
+
+/** Spawn the prebuilt bin and wait for its `READY {base_url}` line. */
+async function startRealServer(): Promise<RealServer> {
+  const proc: ChildProcessWithoutNullStreams = spawn(serverBinPath, [], {
+    cwd: WORKSPACE_ROOT,
+    stdio: ["pipe", "pipe", "pipe"],
+  }) as ChildProcessWithoutNullStreams
+
+  let stderr = ""
+  proc.stderr.setEncoding("utf-8")
+  proc.stderr.on("data", chunk => {
+    stderr += chunk
+  })
+
+  const baseUrl = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`test-command-server did not print READY within 15s. stderr:\n${stderr}`))
+    }, 15_000)
+
+    let buffer = ""
+    proc.stdout.setEncoding("utf-8")
+    proc.stdout.on("data", (chunk: string) => {
+      buffer += chunk
+      const match = buffer.match(/^READY (\S+)/m)
+      if (match?.[1]) {
+        clearTimeout(timer)
+        resolve(match[1])
+      }
+    })
+    proc.on("exit", code => {
+      clearTimeout(timer)
+      reject(new Error(`test-command-server exited early (code ${code}). stderr:\n${stderr}`))
+    })
+    proc.on("error", err => {
+      clearTimeout(timer)
+      reject(new Error(`failed to spawn test-command-server: ${err.message}`))
+    })
+  })
+
+  const stop = () =>
+    new Promise<void>(resolve => {
+      if (proc.exitCode !== null) {
+        resolve()
+        return
+      }
+      proc.on("exit", () => resolve())
+      // Closing stdin is the bin's graceful shutdown; kill as a hard fallback.
+      proc.stdin.end()
+      setTimeout(() => proc.kill("SIGKILL"), 2_000)
+    })
+
+  return {
+    managerUrl: baseUrl,
+    commandsUrl: `${baseUrl}/v1`,
+    stop,
+  }
+}
+
+function makeSender(server: RealServer): CommandsClient {
+  return new CommandsClient({
+    managerUrl: server.managerUrl,
+    deploymentId: DEPLOYMENT_ID,
+    token: TOKEN,
+  })
+}
+
+function receiverEnv(server: RealServer): Record<string, string> {
+  return {
+    ALIEN_COMMANDS_URL: server.commandsUrl,
+    ALIEN_COMMANDS_TOKEN: TOKEN,
+    ALIEN_DEPLOYMENT_ID: DEPLOYMENT_ID,
+    ALIEN_COMMANDS_TARGET_RESOURCE_ID: TARGET_RESOURCE_ID,
+    ALIEN_COMMANDS_TARGET_RESOURCE_TYPE: TARGET_RESOURCE_TYPE,
+  }
+}
+
+/** Fast sender polling so round-trips resolve in tens of ms, not seconds. */
+const FAST_POLL = { pollIntervalMs: 40, maxPollIntervalMs: 200, timeoutMs: 20_000 }
+
+/** Harness lease request against the daemon target (bypasses the receiver). */
+async function harnessLease(server: RealServer): Promise<LeaseInfo | undefined> {
+  const res = await fetch(`${server.commandsUrl}/commands/leases`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify({
+      deploymentId: DEPLOYMENT_ID,
+      target: { resourceId: TARGET_RESOURCE_ID, resourceType: TARGET_RESOURCE_TYPE },
+      maxLeases: 1,
+      leaseSeconds: 60,
+    }),
+  })
+  if (!res.ok) throw new Error(`harness lease failed: ${res.status} ${await res.text()}`)
+  const body = (await res.json()) as LeaseResponse
+  return body.leases?.[0]
+}
+
+/** Harness lease release — increments the server's attempt counter (redelivery). */
+async function harnessRelease(server: RealServer, leaseId: string): Promise<void> {
+  const res = await fetch(`${server.commandsUrl}/commands/leases/${leaseId}/release`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  })
+  if (!res.ok) throw new Error(`harness release failed: ${res.status} ${await res.text()}`)
+}
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+describe("real-wire command twins", () => {
+  let server: RealServer | undefined
+
+  afterEach(async () => {
+    await server?.stop()
+    server = undefined
+  })
+
+  it("full twin loop: sender invoke → real receiver leases/handles/submits → sender resolves", async () => {
+    server = await startRealServer()
+
+    let seen: CommandContext | undefined
+    const receiver = createCommandReceiver({
+      env: receiverEnv(server),
+      pollIntervalMs: 25,
+      leaseSeconds: 60,
+    })
+    receiver.handle("echo", ctx => {
+      seen = ctx
+      const params = JSON.parse(new TextDecoder().decode(ctx.input)) as Record<string, unknown>
+      return { echoed: params, attempt: ctx.attempt }
+    })
+    const running = receiver.run()
+
+    const result = await makeSender(server)
+      .target(TARGET_RESOURCE_ID)
+      .invoke<{ echoed: { hello: string }; attempt: number }>("echo", { hello: "world" }, FAST_POLL)
+
+    receiver.stop()
+    await running
+
+    // Sender resolved with the handler's return, round-tripped over the real wire.
+    expect(result).toEqual({ echoed: { hello: "world" }, attempt: 1 })
+    // The handler observed the twin-identity context: decoded input bytes,
+    // attempt 1, and a Date deadline.
+    expect(seen).toBeDefined()
+    expect(JSON.parse(new TextDecoder().decode(seen!.input))).toEqual({ hello: "world" })
+    expect(seen!.attempt).toBe(1)
+    expect(seen!.deadline).toBeInstanceOf(Date)
+  }, 30_000)
+
+  it("budget: short lease → slow handler → real lease-expiry fires signal → HANDLER_TIMEOUT surfaced", async () => {
+    server = await startRealServer()
+
+    let signalFired = false
+    const receiver = createCommandReceiver({
+      env: receiverEnv(server),
+      // Poll fast so the command is caught right after creation; the short
+      // lease then bounds the budget. Once HANDLER_TIMEOUT settles the command
+      // Failed (terminal), re-leasing is a no-op, so a small interval is safe.
+      pollIntervalMs: 25,
+      leaseSeconds: 1,
+    })
+    receiver.handle("slow", async ctx => {
+      // Deliberately ignore the abort signal (only record it) and outlive the
+      // budget so the receiver must time it out on us.
+      ctx.signal.addEventListener("abort", () => {
+        signalFired = true
+      })
+      await sleep(10_000)
+      return { neverReached: true }
+    })
+    const running = receiver.run()
+
+    const err = await makeSender(server)
+      .target(TARGET_RESOURCE_ID)
+      .invoke("slow", { work: "forever" }, FAST_POLL)
+      .catch((e: unknown) => e)
+
+    receiver.stop()
+    await running
+
+    // The real lease's expiry drove the budget: the signal fired in-process…
+    expect(signalFired).toBe(true)
+    // …and the receiver submitted HANDLER_TIMEOUT, which the sender surfaces.
+    expect(err).toBeInstanceOf(AlienError)
+    const alien = err as AlienError
+    expect(alien.code).toBe("DEPLOYMENT_COMMAND_ERROR")
+    expect(alien.context).toMatchObject({ errorCode: "HANDLER_TIMEOUT" })
+  }, 30_000)
+
+  it("redelivery: released lease bumps the server attempt → receiver observes attempt 2", async () => {
+    server = await startRealServer()
+    const sender = makeSender(server)
+
+    // Kick off the invoke in the background: it creates the command and polls.
+    const invoked = sender
+      .target(TARGET_RESOURCE_ID)
+      .invoke<{ ok: boolean; attempt: number }>("redeliver", { n: 1 }, FAST_POLL)
+
+    // Simulate a crashed/expired first delivery: lease it ourselves (attempt 1),
+    // then release it — which increments the server's attempt counter and
+    // returns the command to Pending (the real-wire twin of the reaper path).
+    let firstLease: LeaseInfo | undefined
+    for (let i = 0; i < 100 && !firstLease; i++) {
+      firstLease = await harnessLease(server)
+      if (!firstLease) await sleep(20)
+    }
+    expect(firstLease).toBeDefined()
+    expect(firstLease!.attempt).toBe(1)
+    await harnessRelease(server, firstLease!.leaseId)
+
+    // Now bring up the real receiver; it must lease the redelivered command
+    // and see the incremented attempt.
+    const receiver = createCommandReceiver({
+      env: receiverEnv(server),
+      pollIntervalMs: 25,
+      leaseSeconds: 60,
+    })
+    receiver.handle("redeliver", ctx => ({ ok: true, attempt: ctx.attempt }))
+    const running = receiver.run()
+
+    const result = await invoked
+    receiver.stop()
+    await running
+
+    expect(result).toEqual({ ok: true, attempt: 2 })
+  }, 30_000)
+
+  it("UNKNOWN_COMMAND: no handler → command settles Failed → sender surfaces DeploymentCommandError", async () => {
+    server = await startRealServer()
+
+    // Receiver with a handler for a DIFFERENT command, so the leased command
+    // has no handler and the receiver submits UNKNOWN_COMMAND.
+    const receiver = createCommandReceiver({
+      env: receiverEnv(server),
+      pollIntervalMs: 25,
+      leaseSeconds: 60,
+    })
+    receiver.handle("something-else", () => ({}))
+    const running = receiver.run()
+
+    const err = await makeSender(server)
+      .target(TARGET_RESOURCE_ID)
+      .invoke("mystery", {}, FAST_POLL)
+      .catch((e: unknown) => e)
+
+    receiver.stop()
+    await running
+
+    expect(err).toBeInstanceOf(AlienError)
+    const alien = err as AlienError
+    expect(alien.code).toBe("DEPLOYMENT_COMMAND_ERROR")
+    expect(alien.context).toMatchObject({ errorCode: "UNKNOWN_COMMAND" })
+  }, 30_000)
+})

--- a/packages/commands/tests/receiver.test.ts
+++ b/packages/commands/tests/receiver.test.ts
@@ -446,6 +446,175 @@ describe("CommandReceiver.run", () => {
     expect(leasePolls()).toBe(after)
   })
 
+  it("submits INVALID_ENVELOPE for malformed inline base64 params (twin of Rust's decode_params_bytes)", async () => {
+    server = await openServer()
+    const env = envelope({
+      baseUrl: server.baseUrl,
+      params: { mode: "inline", inlineBase64: "not-valid-base64!!" },
+    })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => ({ ok: true }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "error" }>
+    expect(body.status).toBe("error")
+    expect(body.code).toBe("INVALID_ENVELOPE")
+  })
+
+  it("submits INVALID_ENVELOPE when storage params are missing storageGetRequest (twin-pinned)", async () => {
+    server = await openServer()
+    const env = envelope({
+      baseUrl: server.baseUrl,
+      params: { mode: "storage" },
+    })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => ({ ok: true }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "error" }>
+    expect(body.status).toBe("error")
+    expect(body.code).toBe("INVALID_ENVELOPE")
+  })
+
+  it("sends the lease POST with typed target, defaults, and bearer auth (mirrors Rust's lease_request_carries_typed_target_and_defaults)", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => ({ ok: true }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+
+    const leaseReq = server.requests.find(
+      req => req.method === "POST" && req.path === "/v1/commands/leases",
+    )
+    expect(leaseReq).toBeDefined()
+    expect(leaseReq?.body).toEqual({
+      deploymentId: "dep-123",
+      target: { resourceId: "agent", resourceType: "daemon" },
+      maxLeases: 10,
+      leaseSeconds: 60,
+    })
+    expect(leaseReq?.headers.authorization).toBe("Bearer tok")
+  })
+
+  it("builds the lease endpoint from a query-string base URL without corrupting path/query (M1 — mirrors Rust's path_segments_mut)", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+
+    let leaseServed = false
+    let capturedLeasePath: string | undefined
+    route = req => {
+      if (req.method === "POST" && req.path.startsWith("/v1/commands/leases")) {
+        capturedLeasePath = req.path
+        if (leaseServed) return { json: { leases: [] } }
+        leaseServed = true
+        return { json: { leases: [lease(env)] } }
+      }
+      if (req.method === "PUT") return { status: 200 }
+      return { status: 404 }
+    }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1?token=abc` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => ({ ok: true }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    expect(capturedLeasePath).toBe("/v1/commands/leases?token=abc")
+  })
+
+  it("rejects an expired presigned upload before attempting the PUT (M2)", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    env.responseHandling.maxInlineBytes = 5 // force overflow to storage
+    env.responseHandling.storageUploadRequest.expiration = new Date(
+      Date.now() - 60_000,
+    ).toISOString()
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const big = { payload: "x".repeat(64) }
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => big)
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(
+      () =>
+        (server?.requests.filter(req => req.method === "POST" && req.path === "/v1/commands/leases")
+          .length ?? 0) >= 1,
+    )
+    // No ack path exists for this failure — give the (rejected) submit attempt
+    // time to run, then assert it never reached the storage PUT.
+    await new Promise(res => setTimeout(res, 60))
+
+    const upload = server.requests.find(req => req.method === "PUT" && req.path === "/storage-put")
+    expect(upload).toBeUndefined()
+    expect(submitBody("cmd_1")).toBeUndefined()
+  })
+
+  it("rejects a path-traversal local upload backend before writing (M2)", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    env.responseHandling.maxInlineBytes = 5 // force overflow to storage
+    env.responseHandling.storageUploadRequest = {
+      backend: { type: "local", filePath: "../evil.json", operation: "put" },
+      expiration: new Date(Date.now() + 3_600_000).toISOString(),
+      operation: "put",
+      path: "resp-path",
+    }
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const big = { payload: "x".repeat(64) }
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => big)
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(
+      () =>
+        (server?.requests.filter(req => req.method === "POST" && req.path === "/v1/commands/leases")
+          .length ?? 0) >= 1,
+    )
+    await new Promise(res => setTimeout(res, 60))
+
+    expect(submitBody("cmd_1")).toBeUndefined()
+  })
+
   it("does not submit twice when the submit fails (no ack → redelivery)", async () => {
     server = await openServer()
     const env = envelope({ baseUrl: server.baseUrl })

--- a/packages/commands/tests/receiver.test.ts
+++ b/packages/commands/tests/receiver.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Pull receiver unit tests against the in-test HTTP stub (no mocked fetch, no
+ * real network). Every test drives the actual lease → decode → handle → submit
+ * machinery over the platform global `fetch`, so the suite exercises exactly
+ * what production would. Runs identically under Node (`vitest run`) and Bun
+ * (`bun test`).
+ */
+
+import { AlienError } from "@alienplatform/core"
+import { afterEach, describe, expect, it } from "vitest"
+import type { CommandResponse, Envelope, LeaseInfo } from "../src/protocol.js"
+import { createCommandReceiver } from "../src/receiver.js"
+import type { CommandContext } from "../src/receiver.js"
+import type {
+  CapturedRequest,
+  RouteHandler,
+  RouteResult,
+  StubServer,
+} from "./helpers/stub-server.js"
+import { encodeInlineJson, startStubServer } from "./helpers/stub-server.js"
+
+let server: StubServer | undefined
+let receiverStop: (() => void) | undefined
+let running: Promise<void> | undefined
+// Reassignable route so the stub keeps its port while we bind the envelope
+// (which needs the base url) after the server is already listening.
+let route: RouteHandler = () => ({ status: 404 })
+
+afterEach(async () => {
+  receiverStop?.()
+  await running?.catch(() => {})
+  await server?.close()
+  server = undefined
+  receiverStop = undefined
+  running = undefined
+  route = () => ({ status: 404 })
+})
+
+/** Start the stub once; its port never changes. Set the real route afterwards. */
+async function openServer(): Promise<StubServer> {
+  const s = await startStubServer(req => route(req))
+  server = s
+  return s
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out")
+    await new Promise(r => setTimeout(r, 2))
+  }
+}
+
+const FULL_ENV = {
+  ALIEN_COMMANDS_URL: "http://127.0.0.1:1/v1/",
+  ALIEN_COMMANDS_TOKEN: "tok",
+  ALIEN_DEPLOYMENT_ID: "dep-123",
+  ALIEN_COMMANDS_TARGET_RESOURCE_ID: "agent",
+  ALIEN_COMMANDS_TARGET_RESOURCE_TYPE: "daemon",
+} as const
+
+function inlineParams(value: unknown) {
+  return { mode: "inline" as const, inlineBase64: encodeInlineJson(value) }
+}
+
+function envelope(overrides: Partial<Envelope> & { baseUrl: string }): Envelope {
+  const { baseUrl, ...rest } = overrides
+  return {
+    protocol: "arc.v1",
+    deploymentId: "dep-123",
+    target: { resourceId: "agent", resourceType: "daemon" },
+    commandId: "cmd_1",
+    attempt: 1,
+    command: "echo",
+    params: inlineParams({ key: "value" }),
+    responseHandling: {
+      maxInlineBytes: 150_000,
+      submitResponseUrl: `${baseUrl}/v1/commands/cmd_1/response`,
+      storageUploadRequest: {
+        backend: { type: "http", url: `${baseUrl}/storage-put`, method: "PUT", headers: {} },
+        expiration: new Date(Date.now() + 3_600_000).toISOString(),
+        operation: "put",
+        path: "resp-path",
+      },
+    },
+    ...rest,
+  }
+}
+
+function lease(env: Envelope, over: Partial<LeaseInfo> = {}): LeaseInfo {
+  return {
+    leaseId: "lease_1",
+    leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    commandId: env.commandId,
+    attempt: env.attempt,
+    envelope: env,
+    ...over,
+  }
+}
+
+/** Serve a single lease batch on the first poll, empty batches afterwards. */
+function leaseOnce(leases: LeaseInfo[]): (req: CapturedRequest) => RouteResult | undefined {
+  let served = false
+  return req => {
+    if (req.method === "POST" && req.path === "/v1/commands/leases") {
+      if (served) return { json: { leases: [] } }
+      served = true
+      return { json: { leases } }
+    }
+    return undefined
+  }
+}
+
+/** Find the submit PUT (a CommandResponse body) for a command id. */
+function submitBody(id: string): CommandResponse | undefined {
+  const put = server?.requests.find(
+    r => r.method === "PUT" && r.path === `/v1/commands/${id}/response`,
+  )
+  return put?.body as CommandResponse | undefined
+}
+
+function decodeInline(response: Extract<CommandResponse, { status: "success" }>): unknown {
+  if (response.response.mode !== "inline") throw new Error("expected inline body")
+  return JSON.parse(Buffer.from(response.response.inlineBase64, "base64").toString("utf-8"))
+}
+
+// ---------------------------------------------------------------------------
+// Environment validation (sync-throwing; no server)
+// ---------------------------------------------------------------------------
+
+describe("createCommandReceiver env validation", () => {
+  it("accepts a valid container config", () => {
+    expect(() =>
+      createCommandReceiver({
+        env: { ...FULL_ENV, ALIEN_COMMANDS_TARGET_RESOURCE_TYPE: "container" },
+      }),
+    ).not.toThrow()
+  })
+
+  it("accepts a valid daemon config", () => {
+    expect(() => createCommandReceiver({ env: { ...FULL_ENV } })).not.toThrow()
+  })
+
+  for (const missing of Object.keys(FULL_ENV)) {
+    it(`fails fast naming ${missing} when it is missing`, () => {
+      const env: Record<string, string> = { ...FULL_ENV }
+      delete env[missing]
+      let err: unknown
+      try {
+        createCommandReceiver({ env })
+      } catch (e) {
+        err = e
+      }
+      expect(err).toBeInstanceOf(AlienError)
+      const alien = err as AlienError
+      expect(alien.code).toBe("COMMAND_RECEIVER_CONFIG_INVALID")
+      expect(alien.context).toMatchObject({ envVar: missing })
+    })
+  }
+
+  it("rejects an empty string value (fixture path)", () => {
+    let err: unknown
+    try {
+      createCommandReceiver({ env: { ...FULL_ENV, ALIEN_COMMANDS_URL: "" } })
+    } catch (e) {
+      err = e
+    }
+    expect((err as AlienError).code).toBe("COMMAND_RECEIVER_CONFIG_INVALID")
+    expect((err as AlienError).context).toMatchObject({ envVar: "ALIEN_COMMANDS_URL" })
+  })
+
+  it("rejects the worker target type", () => {
+    let err: unknown
+    try {
+      createCommandReceiver({ env: { ...FULL_ENV, ALIEN_COMMANDS_TARGET_RESOURCE_TYPE: "worker" } })
+    } catch (e) {
+      err = e
+    }
+    const alien = err as AlienError
+    expect(alien.code).toBe("COMMAND_RECEIVER_CONFIG_INVALID")
+    expect(alien.context).toMatchObject({ envVar: "ALIEN_COMMANDS_TARGET_RESOURCE_TYPE" })
+    expect(alien.message).toContain("container")
+    expect(alien.message).toContain("daemon")
+  })
+
+  it("rejects an unparseable URL", () => {
+    let err: unknown
+    try {
+      createCommandReceiver({ env: { ...FULL_ENV, ALIEN_COMMANDS_URL: "not a url" } })
+    } catch (e) {
+      err = e
+    }
+    expect((err as AlienError).code).toBe("COMMAND_RECEIVER_CONFIG_INVALID")
+    expect((err as AlienError).context).toMatchObject({ envVar: "ALIEN_COMMANDS_URL" })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Lease → handle → submit round trips (against the stub)
+// ---------------------------------------------------------------------------
+
+describe("CommandReceiver.run", () => {
+  it("leases, gives the handler the input bytes/deadline/attempt, and submits the JSON success", async () => {
+    // The stub needs the envelope, which needs the base url: bind, then reopen.
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl, attempt: 2 })
+    const serve = leaseOnce([lease(env, { attempt: 2 })])
+    route = req => serve(req) ?? { status: 200 }
+
+    let seen: { input: string; deadline: number; attempt: number; commandId: string } | undefined
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", (ctx: CommandContext) => {
+      seen = {
+        input: new TextDecoder().decode(ctx.input),
+        deadline: ctx.deadline.getTime(),
+        attempt: ctx.attempt,
+        commandId: ctx.commandId,
+      }
+      return { echoed: JSON.parse(new TextDecoder().decode(ctx.input)) }
+    })
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    r.stop()
+    await running
+
+    expect(seen?.input).toBe(JSON.stringify({ key: "value" }))
+    expect(seen?.attempt).toBe(2)
+    expect(seen?.commandId).toBe("cmd_1")
+    expect(seen?.deadline).toBeGreaterThan(Date.now())
+
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "success" }>
+    expect(body.status).toBe("success")
+    expect(decodeInline(body)).toEqual({ echoed: { key: "value" } })
+  })
+
+  it("submits UNKNOWN_COMMAND when no handler is registered", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl, command: "nobody-home" })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "error" }>
+    expect(body.status).toBe("error")
+    expect(body.code).toBe("UNKNOWN_COMMAND")
+    expect(body.message).toContain("nobody-home")
+  })
+
+  it("maps a throwing handler to HANDLER_ERROR", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => {
+      throw new Error("database on fire")
+    })
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "error" }>
+    expect(body.code).toBe("HANDLER_ERROR")
+    expect(body.message).toContain("database on fire")
+  })
+
+  it("aborts on budget expiry: fires the signal, submits HANDLER_TIMEOUT, drops the late result", async () => {
+    server = await openServer()
+    const env = envelope({
+      baseUrl: server.baseUrl,
+      deadline: new Date(Date.now() + 30).toISOString(),
+    })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    let signalFired = false
+    let completed = false
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", async (ctx: CommandContext) => {
+      ctx.signal.addEventListener("abort", () => {
+        signalFired = true
+      })
+      await new Promise(res => setTimeout(res, 150))
+      completed = true
+      return { done: true }
+    })
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "error" }>
+    expect(body.code).toBe("HANDLER_TIMEOUT")
+    expect(signalFired).toBe(true)
+    expect(completed).toBe(false)
+
+    // Let the late handler resolve, then confirm no second submit happened.
+    await new Promise(res => setTimeout(res, 200))
+    const submits = server.requests.filter(
+      req => req.method === "PUT" && req.path === "/v1/commands/cmd_1/response",
+    )
+    expect(submits).toHaveLength(1)
+  })
+
+  it("passes the lease attempt through to the handler", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl, attempt: 4 })
+    const serve = leaseOnce([lease(env, { attempt: 4 })])
+    route = req => serve(req) ?? { status: 200 }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", (ctx: CommandContext) => ({ attempt: ctx.attempt }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "success" }>
+    expect(decodeInline(body)).toEqual({ attempt: 4 })
+  })
+
+  it("decodes storage-mode (http backend) command input", async () => {
+    server = await openServer()
+    const params = { fromStorage: true, n: 9 }
+    const env = envelope({
+      baseUrl: server.baseUrl,
+      params: {
+        mode: "storage",
+        size: 20,
+        storageGetRequest: {
+          backend: { type: "http", url: `${server.baseUrl}/blob`, method: "GET", headers: {} },
+          expiration: new Date(Date.now() + 60_000).toISOString(),
+          operation: "get",
+          path: "blob",
+        },
+      },
+    })
+    const serve = leaseOnce([lease(env)])
+    route = req => {
+      if (req.method === "GET" && req.path === "/blob") return { text: JSON.stringify(params) }
+      return serve(req) ?? { status: 200 }
+    }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", (ctx: CommandContext) => JSON.parse(new TextDecoder().decode(ctx.input)))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "success" }>
+    expect(decodeInline(body)).toEqual(params)
+  })
+
+  it("overflows a large response to a presigned storage PUT", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    env.responseHandling.maxInlineBytes = 5 // force overflow
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    const big = { payload: "x".repeat(64) }
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => big)
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+
+    const upload = server.requests.find(req => req.method === "PUT" && req.path === "/storage-put")
+    expect(upload).toBeDefined()
+
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "success" }>
+    expect(body.response.mode).toBe("storage")
+    if (body.response.mode === "storage") {
+      expect(body.response.storagePutUsed).toBe(true)
+      expect(body.response.size).toBe(JSON.stringify(big).length)
+    }
+  })
+
+  it("drains: stop() lets the in-flight command finish and stops further lease polls", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+
+    let release!: () => void
+    const gate = new Promise<void>(res => {
+      release = res
+    })
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    let handlerStarted = false
+    r.handle("echo", async () => {
+      handlerStarted = true
+      await gate
+      return { drained: true }
+    })
+    receiverStop = () => {
+      release()
+      r.stop()
+    }
+    running = r.run()
+
+    await waitFor(() => handlerStarted)
+    r.stop() // request shutdown while the handler is still in flight
+    release() // let the in-flight handler complete
+    await running // run() only resolves after the in-flight command drains
+
+    expect(submitBody("cmd_1")).toBeDefined()
+
+    // No further lease polls after run() returned.
+    const leasePolls = () =>
+      server?.requests.filter(req => req.method === "POST" && req.path === "/v1/commands/leases")
+        .length ?? 0
+    const after = leasePolls()
+    await new Promise(res => setTimeout(res, 40)) // >> pollIntervalMs
+    expect(leasePolls()).toBe(after)
+  })
+
+  it("does not submit twice when the submit fails (no ack → redelivery)", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl })
+    const serve = leaseOnce([lease(env)])
+    route = req => {
+      if (req.method === "PUT" && req.path === "/v1/commands/cmd_1/response") {
+        return { status: 500, text: "nope" }
+      }
+      return serve(req) ?? { status: 200 }
+    }
+
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.handle("echo", () => ({ ok: true }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(
+      () =>
+        (server?.requests.filter(
+          req => req.method === "PUT" && req.path === "/v1/commands/cmd_1/response",
+        ).length ?? 0) >= 1,
+    )
+    // Give any (incorrect) retry a chance to happen.
+    await new Promise(res => setTimeout(res, 40))
+    const submits = server.requests.filter(
+      req => req.method === "PUT" && req.path === "/v1/commands/cmd_1/response",
+    )
+    expect(submits).toHaveLength(1)
+  })
+})

--- a/packages/commands/tests/runtime-canary.test.ts
+++ b/packages/commands/tests/runtime-canary.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Runtime-identity canary: makes the "runs under real Bun" claim for
+ * `test:bun` self-enforcing instead of aspirational.
+ *
+ * This exact file executes under both `vitest run` (Node, via `test`) and
+ * `bun test` (Bun's native test runner, via `test:bun`). It records which
+ * runtime ran it and — since `test:bun` sets `BUN_EXPECTED=1` — asserts that
+ * a run made under that env var actually observes the `Bun` global. If
+ * `test:bun` ever regresses to executing under Node, this test fails instead
+ * of the suite quietly passing for the wrong reason.
+ */
+
+import { describe, expect, it } from "vitest"
+
+describe("runtime canary", () => {
+  it("proves which runtime executed this file", () => {
+    const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined"
+    console.log(`[runtime-canary] executing under ${isBun ? "Bun" : "Node"}`)
+
+    if (process.env.BUN_EXPECTED === "1") {
+      expect(isBun).toBe(true)
+    } else {
+      expect(isBun).toBe(false)
+    }
+  })
+})

--- a/packages/commands/tsconfig.build.json
+++ b/packages/commands/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "src/**/__tests__/**", "tests/**", "scripts/**"]
+}

--- a/packages/commands/tsconfig.json
+++ b/packages/commands/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@alienplatform/typescript-config/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*.ts"]
+}

--- a/packages/commands/tsdown.config.ts
+++ b/packages/commands/tsdown.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  // Declarations are emitted by `tsc --emitDeclarationOnly` (see package.json).
+  // tsdown's rolldown-based dts code-splits shared types, which breaks the
+  // package.json "types" fields — same reason as @alienplatform/bindings.
+  dts: false,
+  hash: false,
+  ignoreWatch: ".turbo",
+  // `@alienplatform/core` is a declared runtime dependency and MUST stay
+  // external: bundling a copy would give `dist` its own `AlienError` class, so
+  // `err instanceof AlienError` would fail across the package boundary. Only
+  // `zod` is bundled — it is a devDependency used solely to build the error
+  // definitions, so it must not leak into the runtime dependency set.
+  noExternal: [/^zod(\/|$)/],
+})

--- a/packages/commands/vitest.config.ts
+++ b/packages/commands/vitest.config.ts
@@ -1,0 +1,12 @@
+import { configDefaults, defineConfig } from "vitest/config"
+
+/**
+ * Default unit-suite config (`test` / `test:bun`). The real-wire integration
+ * suite is excluded here — it requires cargo + the Rust command server and runs
+ * only via the dedicated `test:integration` script (see `vitest.integration.config.ts`).
+ */
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "tests/integration.real-server.test.ts"],
+  },
+})

--- a/packages/commands/vitest.integration.config.ts
+++ b/packages/commands/vitest.integration.config.ts
@@ -4,11 +4,24 @@ import { defineConfig } from "vitest/config"
  * Dedicated real-wire integration config (`test:integration`). Runs ONLY the
  * suite that drives the actual Rust command server. The hook timeout covers a
  * cold `cargo build` of the `test-command-server` bin in `beforeAll`.
+ *
+ * `pool: "forks"` is load-bearing, not cosmetic: each test spawns a real
+ * `test-command-server` child and exercises real `fetch` sockets against it.
+ * Even with careful teardown, an abandoned handler timer (the budget test
+ * deliberately outlives its lease) or an undici keep-alive socket can leave
+ * the vitest `threads` worker's event loop busy enough that the worker↔main
+ * RPC (`onTaskUpdate`) misses its deadline — surfacing as a spurious
+ * `[vitest-worker]: Timeout calling "onTaskUpdate"` unhandled error even
+ * though every test already passed. Running the file in its own forked
+ * process sidesteps that: the process hard-exits after the run instead of
+ * relying on the shared worker thread staying responsive.
  */
 export default defineConfig({
   test: {
     include: ["tests/integration.real-server.test.ts"],
     hookTimeout: 600_000,
     testTimeout: 30_000,
+    teardownTimeout: 10_000,
+    pool: "forks",
   },
 })

--- a/packages/commands/vitest.integration.config.ts
+++ b/packages/commands/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config"
+
+/**
+ * Dedicated real-wire integration config (`test:integration`). Runs ONLY the
+ * suite that drives the actual Rust command server. The hook timeout covers a
+ * cold `cargo build` of the `test-command-server` bin in `beforeAll`.
+ */
+export default defineConfig({
+  test: {
+    include: ["tests/integration.real-server.test.ts"],
+    hookTimeout: 600_000,
+    testTimeout: 30_000,
+  },
+})

--- a/packages/package-layout/expected-failures.json
+++ b/packages/package-layout/expected-failures.json
@@ -1,11 +1,5 @@
 [
   {
-    "check": "pack",
-    "package": "commands",
-    "reason": "publishable package not present (nothing to pack)",
-    "owningTask": "08"
-  },
-  {
     "check": "import-error-reexports",
     "package": "sdk",
     "reason": "facade root is missing pinned error re-exports",
@@ -18,28 +12,10 @@
     "owningTask": "03"
   },
   {
-    "check": "import",
-    "package": "commands",
-    "reason": "cannot import @alienplatform/commands (package not installed)",
-    "owningTask": "08"
-  },
-  {
-    "check": "error-code",
-    "package": "commands",
-    "reason": "cannot assert COMMAND_RECEIVER_CONFIG_INVALID (commands package not installed)",
-    "owningTask": "08"
-  },
-  {
     "check": "typecheck",
     "package": "sdk",
     "reason": "cannot find module '@alienplatform/sdk/worker-runtime'",
     "owningTask": "03"
-  },
-  {
-    "check": "typecheck",
-    "package": "commands",
-    "reason": "cannot find module '@alienplatform/commands'",
-    "owningTask": "08"
   },
   {
     "check": "packed-contents",

--- a/packages/package-layout/fixture/package.json
+++ b/packages/package-layout/fixture/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@alienplatform/sdk": "file:../.tarballs/alienplatform-sdk-1.10.7.tgz",
-    "@alienplatform/bindings": "file:../.tarballs/alienplatform-bindings-1.10.7.tgz"
+    "@alienplatform/bindings": "file:../.tarballs/alienplatform-bindings-1.10.7.tgz",
+    "@alienplatform/commands": "file:../.tarballs/alienplatform-commands-1.10.7.tgz"
   },
   "overrides": {
     "@alienplatform/core": "file:../.tarballs/alienplatform-core-1.10.7.tgz",
     "@alienplatform/sdk": "file:../.tarballs/alienplatform-sdk-1.10.7.tgz",
-    "@alienplatform/bindings": "file:../.tarballs/alienplatform-bindings-1.10.7.tgz"
+    "@alienplatform/bindings": "file:../.tarballs/alienplatform-bindings-1.10.7.tgz",
+    "@alienplatform/commands": "file:../.tarballs/alienplatform-commands-1.10.7.tgz"
   }
 }

--- a/packages/scripts/expected-failures.json
+++ b/packages/scripts/expected-failures.json
@@ -28,11 +28,5 @@
     "package": "sdk",
     "reason": "generated binding-service proto client shipped in the package",
     "owningTask": "03/17"
-  },
-  {
-    "check": "package-not-implemented",
-    "package": "commands",
-    "reason": "package not yet implemented (only PACKAGE_LAYOUT.md present)",
-    "owningTask": "08"
   }
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,34 @@ importers:
         specifier: 4.3.2
         version: 4.3.2
 
+  packages/commands:
+    dependencies:
+      '@alienplatform/core':
+        specifier: link:../core
+        version: link:../core
+    devDependencies:
+      '@alienplatform/typescript-config':
+        specifier: link:../config-typescript
+        version: link:../config-typescript
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^24.0.15
+        version: 24.10.4
+      tsdown:
+        specifier: ^0.13.0
+        version: 0.13.5(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.1.4
+        version: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.4)(typescript@5.8.3))(tsx@4.21.0)
+      zod:
+        specifier: 4.3.2
+        version: 4.3.2
+
   packages/config-typescript: {}
 
   packages/core:


### PR DESCRIPTION
`@alienplatform/commands` becomes real: the pure-TypeScript command sender (migrated from the old SDK's fetch implementation, now target-aware) and the pull `CommandReceiver` — the behavior-identical TypeScript twin of the Rust receiver, proven on the real wire.

## What changed

- **Sender**: `CommandsClient` migrated (polling/backoff/base64/presigned-storage machinery preserved verbatim, including the security guards); `.target(name)` builder mirrors the Rust `TargetedCommands` (presets `targetResourceId`, builder wins); `params`→`input` rename per contract; the seven sender error types carried over.
- **Receiver**: `createCommandReceiver()` (SYNC-throwing env validation — the fixture contract) implementing every DECIDED(09) line: env quintet fail-fast naming the exact var (worker type rejected); budget = min(envelope deadline, lease expiry) → `AbortSignal` fired → `HANDLER_TIMEOUT` submitted, with submission structurally single-flighted (handlers return values; only the loop submits, once — a late handler result cannot double-submit); at-least-once with `attempt` passthrough; submit-failure → no ack → redelivery; `.stop()` drain twinning the Rust `ShutdownHandle`; 5s/10/60 cadence.
- **Twin alignment hardened in review**: strict base64 validation + `INVALID_ENVELOPE` for envelope decode failures (was silently lenient — the same malformed input now produces the same wire output as Rust; twin-pinned in the contract); upload-path presigned expiry + traversal guards; twin-consistent URL joining.
- **Real-wire proof**: a new `test-command-server` bin (test-utils feature) runs the actual Rust command server; the integration suite drives sender → server → TS receiver → sender on one wire (4 scenarios incl. real-lease-expiry budget abort and release-driven redelivery at attempt 2). Wired into ci-fast after the TS build (warm cargo); fails loudly, never skips.
- **Contract end-state**: every OPEN(08) is now DECIDED(08) (ctx `{input: Uint8Array, signal, deadline: Date, commandId, attempt}`, invoke/options types, `CommandReceiverOptions`, sender errors); zero DECIDED(09) lines altered.
- **Fixture burn-down**: the five task-08 ledger entries deleted; `22 passed, 9 expected, 0 unexpected, 0 stale`.

## Disclosed twin edges (tracked)

- Base64 leniency edge: non-canonical trailing bits pass TS validation where Rust's engine rejects (alphabet-valid inputs only).
- Redelivery is proven release-driven on both twins; expiry-driven redelivery is unproven e2e on either — the server has no lease reaper (pre-existing server design; candidate for the cleanup ticket).
- Follow-up: extract a shared `presigned.ts` once task 03 deletes the old SDK copy (the transfer leg is deliberately divergent today: sender = legacy-verbatim, receiver = twin-pinned).

## Validation

39/39 unit tests under Node AND real Bun (canary-enforced) + 4/4 real-wire integration; build/tsc/biome/frozen-lockfile green; deps = `@alienplatform/core` only (grep-proven no gRPC/bindings/worker-protocol).

Blocks: ALIEN-222 (10 — receiver env injection). Consumes: ALIEN-219's protocol, ALIEN-221's DECIDED(09) contract.