### PR TITLE
fix: harden joined machine lifecycle and debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -1007,14 +1007,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "1.14.0"
+version = "1.14.1"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -57,37 +57,37 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "1.14.0", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "1.14.1", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "1.14.0", default-features = false }
-alien-sdk = { path = "crates/alien-sdk", version = "1.14.0", default-features = false }
-alien-runtime = { path = "crates/alien-runtime", version = "1.14.0" }
+alien-bindings = { path = "crates/alien-bindings", version = "1.14.1", default-features = false }
+alien-sdk = { path = "crates/alien-sdk", version = "1.14.1", default-features = false }
+alien-runtime = { path = "crates/alien-runtime", version = "1.14.1" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "1.14.0" }
-alien-infra = { path = "crates/alien-infra", version = "1.14.0" }
-alien-build = { path = "crates/alien-build", version = "1.14.0" }
-alien-macros = { path = "crates/alien-macros", version = "1.14.0" }
-alien-client-core = { path = "crates/alien-client-core", version = "1.14.0" }
-alien-client-config = { path = "crates/alien-client-config", version = "1.14.0" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "1.14.0" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "1.14.0" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "1.14.0" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "1.14.0" }
-alien-error = { path = "crates/alien-error", version = "1.14.0", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "1.14.0" }
-alien-permissions = { path = "crates/alien-permissions", version = "1.14.0" }
-alien-preflights = { path = "crates/alien-preflights", version = "1.14.0" }
-alien-deployment = { path = "crates/alien-deployment", version = "1.14.0" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "1.14.0" }
-alien-local = { path = "crates/alien-local", version = "1.14.0" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "1.14.0" }
-alien-terraform = { path = "crates/alien-terraform", version = "1.14.0" }
-alien-helm = { path = "crates/alien-helm", version = "1.14.0" }
-alien-manager = { path = "crates/alien-manager", version = "1.14.0" }
-alien-observer = { path = "crates/alien-observer", version = "1.14.0" }
+alien-core = { path = "crates/alien-core", version = "1.14.1" }
+alien-infra = { path = "crates/alien-infra", version = "1.14.1" }
+alien-build = { path = "crates/alien-build", version = "1.14.1" }
+alien-macros = { path = "crates/alien-macros", version = "1.14.1" }
+alien-client-core = { path = "crates/alien-client-core", version = "1.14.1" }
+alien-client-config = { path = "crates/alien-client-config", version = "1.14.1" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "1.14.1" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "1.14.1" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "1.14.1" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "1.14.1" }
+alien-error = { path = "crates/alien-error", version = "1.14.1", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "1.14.1" }
+alien-permissions = { path = "crates/alien-permissions", version = "1.14.1" }
+alien-preflights = { path = "crates/alien-preflights", version = "1.14.1" }
+alien-deployment = { path = "crates/alien-deployment", version = "1.14.1" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "1.14.1" }
+alien-local = { path = "crates/alien-local", version = "1.14.1" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "1.14.1" }
+alien-terraform = { path = "crates/alien-terraform", version = "1.14.1" }
+alien-helm = { path = "crates/alien-helm", version = "1.14.1" }
+alien-manager = { path = "crates/alien-manager", version = "1.14.1" }
+alien-observer = { path = "crates/alien-observer", version = "1.14.1" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "1.14.0", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "1.14.0", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "1.14.1", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "1.14.1", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-aws-clients/src/aws/secrets_manager.rs
+++ b/crates/alien-aws-clients/src/aws/secrets_manager.rs
@@ -580,7 +580,8 @@ mod tests {
 
     #[test]
     fn get_secret_value_response_parses_all_caps_arn() {
-        let body = r#"{"ARN":"arn:aws:secretsmanager:us-east-1:0:secret:db-abc","SecretString":"pw"}"#;
+        let body =
+            r#"{"ARN":"arn:aws:secretsmanager:us-east-1:0:secret:db-abc","SecretString":"pw"}"#;
         let resp: GetSecretValueResponse = serde_json::from_str(body).expect("parses");
         assert_eq!(
             resp.arn.as_deref(),

--- a/crates/alien-azure-clients/src/azure/private_networking.rs
+++ b/crates/alien-azure-clients/src/azure/private_networking.rs
@@ -531,7 +531,11 @@ impl PrivateNetworkingApi for AzurePrivateNetworkingClient {
             .build()?;
         let signed = self.base.sign_request(req, &token).await?;
         self.base
-            .execute_request_with_long_running_support(signed, "DeleteVirtualNetworkLink", link_name)
+            .execute_request_with_long_running_support(
+                signed,
+                "DeleteVirtualNetworkLink",
+                link_name,
+            )
             .await
     }
 

--- a/crates/alien-cli/src/commands/debug.rs
+++ b/crates/alien-cli/src/commands/debug.rs
@@ -249,7 +249,9 @@ async fn runtime_shell_task(args: DebugShellArgs, ctx: ExecutionMode) -> Result<
         DebugSessionResponse::RuntimeTunnel(tunnel) => {
             run_runtime_shell(tunnel, &args.deployment).await
         }
-        DebugSessionResponse::RemoteExec(session) => run_remote_exec_attach(session).await,
+        DebugSessionResponse::RemoteExec(session) => {
+            run_remote_exec_attach(session, None, false).await
+        }
         _ => Err(AlienError::new(ErrorData::ApiRequestFailed {
             message: "Manager returned a non-runtime debug session for `alien debug shell`"
                 .to_string(),
@@ -281,7 +283,9 @@ async fn runtime_exec_task(args: DebugExecArgs, ctx: ExecutionMode) -> Result<()
         DebugSessionResponse::RuntimeTunnel(tunnel) => {
             run_runtime_exec(tunnel, args.cmd, args.timeout_seconds, args.json).await
         }
-        DebugSessionResponse::RemoteExec(session) => run_remote_exec_attach(session).await,
+        DebugSessionResponse::RemoteExec(session) => {
+            run_remote_exec_attach(session, Some(args.timeout_seconds), args.json).await
+        }
         _ => Err(AlienError::new(ErrorData::ApiRequestFailed {
             message: "Manager returned a non-runtime debug session for `alien debug exec`"
                 .to_string(),
@@ -607,7 +611,11 @@ fn runtime_ws_url(tunnel: &RuntimeTunnelDebugSession) -> Result<String> {
     ))
 }
 
-async fn run_remote_exec_attach(session: RemoteExecDebugSession) -> Result<()> {
+async fn run_remote_exec_attach(
+    session: RemoteExecDebugSession,
+    timeout_seconds: Option<u64>,
+    json: bool,
+) -> Result<()> {
     let ws_url = remote_exec_ws_url(&session)?;
     let (socket, _) = connect_async(ws_url.as_str())
         .await
@@ -646,8 +654,22 @@ async fn run_remote_exec_attach(session: RemoteExecDebugSession) -> Result<()> {
         let _ = sink.close().await;
     });
 
-    let mut exit_code = 255;
-    while let Some(incoming) = stream.next().await {
+    let mut exit_code = None;
+    let mut output = Vec::new();
+    let deadline = timeout_seconds
+        .map(|seconds| tokio::time::Instant::now() + std::time::Duration::from_secs(seconds));
+    loop {
+        let incoming = match deadline {
+            Some(deadline) => match tokio::time::timeout_at(deadline, stream.next()).await {
+                Ok(incoming) => incoming,
+                Err(_) => {
+                    writer.abort();
+                    return finish_remote_exec(&session, 124, output, true, json);
+                }
+            },
+            None => stream.next().await,
+        };
+        let Some(incoming) = incoming else { break };
         match incoming
             .into_alien_error()
             .context(ErrorData::ApiRequestFailed {
@@ -655,6 +677,10 @@ async fn run_remote_exec_attach(session: RemoteExecDebugSession) -> Result<()> {
                 url: Some(session.attach_url.clone()),
             })? {
             Message::Binary(bytes) => {
+                if json {
+                    output.extend_from_slice(&bytes);
+                    continue;
+                }
                 std::io::stdout()
                     .write_all(&bytes)
                     .into_alien_error()
@@ -669,8 +695,19 @@ async fn run_remote_exec_attach(session: RemoteExecDebugSession) -> Result<()> {
             }
             Message::Text(text) => {
                 if let Some(code) = parse_remote_exec_exit_code(&text) {
-                    exit_code = code;
+                    exit_code = Some(code);
                     break;
+                }
+                if let Some(message) = parse_remote_exec_error(&text) {
+                    writer.abort();
+                    return Err(AlienError::new(ErrorData::ApiRequestFailed {
+                        message,
+                        url: Some(session.attach_url.clone()),
+                    }));
+                }
+                if json {
+                    output.extend_from_slice(text.as_str().as_bytes());
+                    continue;
                 }
                 std::io::stdout()
                     .write_all(text.as_str().as_bytes())
@@ -689,6 +726,42 @@ async fn run_remote_exec_attach(session: RemoteExecDebugSession) -> Result<()> {
         }
     }
     writer.abort();
+    let Some(exit_code) = exit_code else {
+        return Err(AlienError::new(ErrorData::ApiRequestFailed {
+            message: "Remote exec session closed before reporting an exit status".to_string(),
+            url: Some(session.attach_url.clone()),
+        }));
+    };
+    finish_remote_exec(&session, exit_code, output, false, json)
+}
+
+fn finish_remote_exec(
+    session: &RemoteExecDebugSession,
+    exit_code: i32,
+    output: Vec<u8>,
+    timed_out: bool,
+    json: bool,
+) -> Result<()> {
+    if json {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RemoteExecJson<'a> {
+            session_id: &'a str,
+            exit_code: i32,
+            stdout_b64: String,
+            stderr_b64: String,
+            timed_out: bool,
+            output_truncated: bool,
+        }
+        crate::output::print_json(&RemoteExecJson {
+            session_id: &session.session_id,
+            exit_code,
+            stdout_b64: BASE64.encode(output),
+            stderr_b64: String::new(),
+            timed_out,
+            output_truncated: false,
+        })?;
+    }
     if exit_code != 0 {
         std::process::exit(exit_code);
     }
@@ -780,6 +853,14 @@ fn parse_remote_exec_exit_code(text: &str) -> Option<i32> {
         return None;
     }
     value["exitCode"].as_i64().map(|code| code as i32)
+}
+
+fn parse_remote_exec_error(text: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(text).ok()?;
+    if value["type"].as_str()? != "error" {
+        return None;
+    }
+    value["message"].as_str().map(str::to_string)
 }
 
 struct RawModeGuard;
@@ -1481,6 +1562,17 @@ mod tests {
         assert_eq!(
             parse_remote_exec_exit_code(&serde_json::json!({"type": "stdout"}).to_string()),
             None
+        );
+    }
+
+    #[test]
+    fn parse_remote_exec_error_reads_error_frame() {
+        assert_eq!(
+            parse_remote_exec_error(
+                &serde_json::json!({"type": "error", "message": "spawn failed"}).to_string()
+            )
+            .as_deref(),
+            Some("spawn failed")
         );
     }
 }

--- a/crates/alien-deploy-cli/src/commands/join.rs
+++ b/crates/alien-deploy-cli/src/commands/join.rs
@@ -149,6 +149,47 @@ struct MachineBundleService {
     args: Vec<String>,
     #[serde(default)]
     environment: BTreeMap<String, String>,
+    #[serde(default)]
+    restart_policy: MachineBundleRestartPolicy,
+    #[serde(default)]
+    restart_delay_seconds: Option<u32>,
+    #[serde(default)]
+    systemd: Option<MachineBundleSystemdService>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum MachineBundleRestartPolicy {
+    Always,
+    #[default]
+    OnFailure,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MachineBundleSystemdService {
+    service_type: MachineBundleSystemdServiceType,
+    #[serde(default)]
+    notify_access: Option<MachineBundleSystemdNotifyAccess>,
+    #[serde(default)]
+    pid_file: Option<String>,
+    #[serde(default)]
+    timeout_start_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum MachineBundleSystemdServiceType {
+    Simple,
+    Notify,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum MachineBundleSystemdNotifyAccess {
+    Main,
+    Exec,
+    All,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1154,24 +1195,48 @@ fn install_machine_service(
         )
     };
 
+    let restart_policy = match service.restart_policy {
+        MachineBundleRestartPolicy::Always => RestartPolicy::Always {
+            delay_secs: service.restart_delay_seconds,
+        },
+        MachineBundleRestartPolicy::OnFailure => RestartPolicy::OnFailure {
+            delay_secs: service.restart_delay_seconds.or(Some(5)),
+        },
+    };
+    let contents = service
+        .systemd
+        .as_ref()
+        .map(|systemd| {
+            render_systemd_machine_service(
+                service,
+                systemd,
+                executable_path,
+                config_path,
+                executable_path.parent(),
+            )
+        })
+        .transpose()?;
+
     manager
         .install(ServiceInstallCtx {
             label: label.clone(),
             program: executable_path.to_path_buf(),
             args: rendered_args,
-            contents: None,
+            contents,
             username: None,
             working_directory: executable_path.parent().map(Path::to_path_buf),
             environment,
             autostart: true,
-            restart_policy: RestartPolicy::OnFailure {
-                delay_secs: Some(5),
-            },
+            restart_policy,
         })
         .into_alien_error()
         .context(ErrorData::OperatorServiceError {
             message: "Failed to install machine service".to_string(),
         })?;
+
+    if service.systemd.is_some() {
+        reload_systemd_units()?;
+    }
 
     let _ = manager.stop(ServiceStopCtx {
         label: label.clone(),
@@ -1185,6 +1250,122 @@ fn install_machine_service(
         })?;
 
     Ok(())
+}
+
+fn render_systemd_machine_service(
+    service: &MachineBundleService,
+    systemd: &MachineBundleSystemdService,
+    executable_path: &Path,
+    config_path: &Path,
+    working_directory: Option<&Path>,
+) -> Result<String> {
+    if matches!(
+        systemd.service_type,
+        MachineBundleSystemdServiceType::Notify
+    ) && !matches!(
+        systemd.notify_access,
+        Some(MachineBundleSystemdNotifyAccess::All)
+    ) {
+        return Err(AlienError::new(ErrorData::ValidationError {
+            field: "bundle.service.systemd.notifyAccess".to_string(),
+            message: "notify machine services must use notifyAccess=all so handoff children can promote themselves".to_string(),
+        }));
+    }
+
+    let rendered_args = service
+        .args
+        .iter()
+        .map(|arg| arg.replace("{config_path}", &config_path.display().to_string()));
+    let mut exec_start = systemd_quote(executable_path.as_os_str().to_string_lossy().as_ref());
+    for arg in rendered_args {
+        exec_start.push(' ');
+        exec_start.push_str(&systemd_quote(&arg));
+    }
+
+    let mut unit = format!(
+        "[Unit]\nDescription={}\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType={}\n",
+        service.label,
+        match systemd.service_type {
+            MachineBundleSystemdServiceType::Simple => "simple",
+            MachineBundleSystemdServiceType::Notify => "notify",
+        }
+    );
+    if let Some(notify_access) = systemd.notify_access {
+        unit.push_str(&format!(
+            "NotifyAccess={}\n",
+            match notify_access {
+                MachineBundleSystemdNotifyAccess::Main => "main",
+                MachineBundleSystemdNotifyAccess::Exec => "exec",
+                MachineBundleSystemdNotifyAccess::All => "all",
+            }
+        ));
+    }
+    if let Some(pid_file) = &systemd.pid_file {
+        unit.push_str(&format!("PIDFile={}\n", systemd_escape_value(pid_file)));
+    }
+    if let Some(timeout) = systemd.timeout_start_seconds {
+        unit.push_str(&format!("TimeoutStartSec={timeout}\n"));
+    }
+    if let Some(working_directory) = working_directory {
+        unit.push_str(&format!(
+            "WorkingDirectory={}\n",
+            systemd_escape_value(&working_directory.display().to_string())
+        ));
+    }
+    for (key, value) in &service.environment {
+        let value = value.replace("{config_path}", &config_path.display().to_string());
+        unit.push_str(&format!(
+            "Environment={}\n",
+            systemd_quote(&format!("{key}={value}"))
+        ));
+    }
+    unit.push_str(&format!("ExecStart={exec_start}\n"));
+    unit.push_str(match service.restart_policy {
+        MachineBundleRestartPolicy::Always => "Restart=always\n",
+        MachineBundleRestartPolicy::OnFailure => "Restart=on-failure\n",
+    });
+    if let Some(delay) = service.restart_delay_seconds {
+        unit.push_str(&format!("RestartSec={delay}\n"));
+    }
+    unit.push_str("\n[Install]\nWantedBy=multi-user.target\n");
+    Ok(unit)
+}
+
+fn systemd_quote(value: &str) -> String {
+    format!(
+        "\"{}\"",
+        value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('%', "%%")
+            .replace('$', "$$")
+    )
+}
+
+fn systemd_escape_value(value: &str) -> String {
+    value
+        .replace('%', "%%")
+        .replace(char::is_whitespace, "\\x20")
+}
+
+fn reload_systemd_units() -> Result<()> {
+    let output = Command::new("systemctl")
+        .arg("daemon-reload")
+        .output()
+        .into_alien_error()
+        .context(ErrorData::OperatorServiceError {
+            message: "Failed to reload systemd after installing machine service".to_string(),
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(AlienError::new(ErrorData::OperatorServiceError {
+        message: format!(
+            "systemctl daemon-reload failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+    }))
 }
 
 async fn uninstall_joined_machine(install_root: &Path, purge: bool) -> Result<()> {
@@ -1623,6 +1804,9 @@ mod tests {
                 executable: "bin/machine".to_string(),
                 args: vec![],
                 environment: BTreeMap::new(),
+                restart_policy: MachineBundleRestartPolicy::OnFailure,
+                restart_delay_seconds: None,
+                systemd: None,
             },
             artifacts: vec![],
             registration: None,
@@ -2283,6 +2467,67 @@ mod tests {
         let absolute_error =
             safe_join(root.path(), "/bin/machine").expect_err("absolute executable should fail");
         assert_eq!(absolute_error.code, "VALIDATION_ERROR");
+    }
+
+    #[test]
+    fn notify_machine_service_renders_handoff_and_restart_contract() {
+        let service = MachineBundleService {
+            label: "dev.alien.machine".to_string(),
+            executable: "bin/machine-entrypoint".to_string(),
+            args: vec![],
+            environment: BTreeMap::from([(
+                "HORIZON_CONFIG".to_string(),
+                "{config_path}".to_string(),
+            )]),
+            restart_policy: MachineBundleRestartPolicy::Always,
+            restart_delay_seconds: Some(5),
+            systemd: None,
+        };
+        let systemd = MachineBundleSystemdService {
+            service_type: MachineBundleSystemdServiceType::Notify,
+            notify_access: Some(MachineBundleSystemdNotifyAccess::All),
+            pid_file: Some("/run/horizond.pid".to_string()),
+            timeout_start_seconds: Some(600),
+        };
+
+        let unit = render_systemd_machine_service(
+            &service,
+            &systemd,
+            Path::new("/opt/alien/machine-bundle/bin/machine-entrypoint"),
+            Path::new("/etc/horizond/horizond.toml"),
+            Some(Path::new("/opt/alien/machine-bundle/bin")),
+        )
+        .expect("notify service should render");
+
+        assert!(unit.contains("Type=notify\n"));
+        assert!(unit.contains("NotifyAccess=all\n"));
+        assert!(unit.contains("PIDFile=/run/horizond.pid\n"));
+        assert!(unit.contains("TimeoutStartSec=600\n"));
+        assert!(unit.contains("Restart=always\nRestartSec=5\n"));
+        assert!(unit.contains("Environment=\"HORIZON_CONFIG=/etc/horizond/horizond.toml\"\n"));
+    }
+
+    #[test]
+    fn notify_machine_service_rejects_main_only_notifications() {
+        let mut manifest = test_manifest();
+        manifest.service.restart_policy = MachineBundleRestartPolicy::Always;
+        let systemd = MachineBundleSystemdService {
+            service_type: MachineBundleSystemdServiceType::Notify,
+            notify_access: Some(MachineBundleSystemdNotifyAccess::Main),
+            pid_file: Some("/run/horizond.pid".to_string()),
+            timeout_start_seconds: Some(600),
+        };
+
+        let error = render_systemd_machine_service(
+            &manifest.service,
+            &systemd,
+            Path::new("/opt/alien/machine"),
+            Path::new("/etc/horizond.toml"),
+            None,
+        )
+        .expect_err("handoff children require notify access all");
+
+        assert_eq!(error.code, "VALIDATION_ERROR");
     }
 
     fn write_test_archive(path: &Path, entries: &[(&str, &[u8])]) {

--- a/crates/alien-deploy-cli/src/commands/join.rs
+++ b/crates/alien-deploy-cli/src/commands/join.rs
@@ -2170,6 +2170,43 @@ mod tests {
     }
 
     #[test]
+    fn bundle_manifest_ignores_machine_image_catalog_fields() {
+        let raw = r#"{
+          "channel": "prod",
+          "machineImageVersion": "1.1.5+abc.42",
+          "horizondVersion": "1.1.5",
+          "gitSha": "abc",
+          "createdAt": "2026-07-12T00:00:00Z",
+          "baseImage": { "name": "flatcar", "version": "stable-current" },
+          "horizondArtifacts": {},
+          "aws": { "amis": {} },
+          "version": "1.1.5+abc.42",
+          "config": {
+            "path": "etc/horizond/horizond.toml",
+            "joinTokenFile": "var/lib/horizond/join-token",
+            "machineIdFile": "var/lib/horizond/machine-id",
+            "machineTokenFile": "var/lib/horizond/machine-token",
+            "entries": []
+          },
+          "service": {
+            "label": "dev.alien.machine",
+            "executable": "bin/machine-entrypoint"
+          },
+          "artifacts": [{
+            "os": "linux",
+            "arch": "x64",
+            "url": "https://releases.example.com/machine-bundle.tar.gz",
+            "sha256": "00"
+          }]
+        }"#;
+
+        let manifest: MachineBundleManifest =
+            serde_json::from_str(raw).expect("combined release manifest should parse");
+
+        assert_eq!(manifest.version, "1.1.5+abc.42");
+    }
+
+    #[test]
     fn machine_config_writes_secret_files_under_install_root() {
         let root = tempfile::tempdir().expect("install root");
         let args = JoinArgs {

--- a/crates/alien-error/src/lib.rs
+++ b/crates/alien-error/src/lib.rs
@@ -509,6 +509,20 @@ where
         }
     }
 
+    /// Convert this error into the representation safe to expose to external users.
+    ///
+    /// Internal errors are replaced with a generic message. Externally safe errors
+    /// retain their complete structured context and source chain.
+    pub fn into_external(self) -> AlienError<GenericError> {
+        if self.internal {
+            AlienError::new(GenericError {
+                message: "Internal server error".to_string(),
+            })
+        } else {
+            self.into_generic()
+        }
+    }
+
     pub fn human_report(&self) -> HumanErrorReport {
         let mut layers = Vec::new();
         collect_human_layers(
@@ -670,15 +684,7 @@ where
         use axum::http::StatusCode;
         use axum::response::{IntoResponse, Json};
 
-        // For external responses, sanitize internal errors
-        let response_error = if self.internal {
-            // For internal errors, return a generic error message with 500 status code
-            AlienError::new(GenericError {
-                message: "Internal server error".to_string(),
-            })
-        } else {
-            self.into_generic()
-        };
+        let response_error = self.into_external();
 
         // Convert HTTP status code to StatusCode
         let status_code = response_error
@@ -789,5 +795,40 @@ mod tests {
 
         assert_eq!(report.code, "HINT");
         assert_eq!(report.hint.as_deref(), Some("Run the setup command first."));
+    }
+
+    #[test]
+    fn into_external_preserves_safe_error_data() {
+        let source = AlienError::new(GenericError {
+            message: "Socket closed".to_string(),
+        });
+        let error = Err::<(), _>(source)
+            .context(TestError::Hint)
+            .unwrap_err()
+            .into_external();
+
+        assert_eq!(error.code, "HINT");
+        assert_eq!(error.hint.as_deref(), Some("Run the setup command first."));
+        assert_eq!(
+            error
+                .source
+                .as_deref()
+                .map(|source| source.message.as_str()),
+            Some("Socket closed")
+        );
+    }
+
+    #[test]
+    fn into_external_sanitizes_internal_error_data() {
+        let mut error = AlienError::new(TestError::Normal);
+        error.internal = true;
+        error.context = Some(serde_json::json!({ "secret": "do-not-expose" }));
+
+        let external = error.into_external();
+
+        assert_eq!(external.code, "GENERIC_ERROR");
+        assert_eq!(external.message, "Internal server error");
+        assert!(external.context.is_none());
+        assert!(external.source.is_none());
     }
 }

--- a/crates/alien-infra/src/core/executor.rs
+++ b/crates/alien-infra/src/core/executor.rs
@@ -143,6 +143,13 @@ fn status_halts_stepping(status: ResourceStatus) -> bool {
     status.is_terminal() && status != ResourceStatus::RefreshFailed
 }
 
+fn status_allows_update_planning(status: ResourceStatus) -> bool {
+    matches!(
+        status,
+        ResourceStatus::Running | ResourceStatus::RefreshFailed | ResourceStatus::UpdateFailed
+    )
+}
+
 fn controller_platform_for_entry(
     stack_platform: Platform,
     base_platform: Option<Platform>,
@@ -735,7 +742,7 @@ impl StackExecutor {
                     // Compare desired resource config with the config in the *current* state
                     if Some(&desired_config.resource) != current_resource_config_opt {
                         match current_resource_state.status {
-                            ResourceStatus::Running | ResourceStatus::UpdateFailed => {
+                            status if status_allows_update_planning(status) => {
                                 // Check if all new dependencies are ready before planning the update
                                 let new_dependencies_ready =
                                     desired_config.dependencies.iter().all(|dep_ref| {
@@ -830,10 +837,7 @@ impl StackExecutor {
                                 );
                             }
                         }
-                    } else if matches!(
-                        current_resource_state.status,
-                        ResourceStatus::Running | ResourceStatus::UpdateFailed
-                    ) {
+                    } else if status_allows_update_planning(current_resource_state.status) {
                         if let Some(resource_controller) =
                             current_resource_state.get_internal_controller()?
                         {
@@ -896,7 +900,7 @@ impl StackExecutor {
                     // Check if the resource exists in current state and is in a status that allows updates
                     if let Some(current_resource_state) = state.resources.get(resource_id) {
                         match current_resource_state.status {
-                            ResourceStatus::Running | ResourceStatus::UpdateFailed => {
+                            status if status_allows_update_planning(status) => {
                                 // Check if all dependencies are ready before planning the update from dependency propagation
                                 let dependencies_ready =
                                     desired_config.dependencies.iter().all(|dep_ref| {

--- a/crates/alien-infra/src/core/executor_tests/helpers.rs
+++ b/crates/alien-infra/src/core/executor_tests/helpers.rs
@@ -260,6 +260,19 @@ pub fn create_update_failed_function_state(id: &str) -> StackResourceState {
     state
 }
 
+/// Create a refresh-failed function state for testing.
+pub fn create_refresh_failed_function_state(id: &str) -> StackResourceState {
+    let func = test_function(id);
+    let mut state = StackResourceState::new_pending(
+        Worker::RESOURCE_TYPE.to_string(),
+        Resource::new(func),
+        Some(ResourceLifecycle::Live),
+        vec![],
+    );
+    state.status = ResourceStatus::RefreshFailed;
+    state
+}
+
 /// Create a state with specified resources already running.
 pub fn create_state_with_running(resources: Vec<(&str, ResourceLifecycle)>) -> StackState {
     let mut state = new_test_state();

--- a/crates/alien-infra/src/core/executor_tests/plan_tests.rs
+++ b/crates/alien-infra/src/core/executor_tests/plan_tests.rs
@@ -223,6 +223,30 @@ async fn test_plan_update_failed_with_config_change() -> Result<()> {
     Ok(())
 }
 
+/// A failed observation must not prevent a new desired configuration from
+/// repairing the resource.
+#[tokio::test]
+async fn test_plan_refresh_failed_with_config_change() -> Result<()> {
+    let func1_v1 = test_function_with_image("func1", "image-v1");
+    let mut state = new_test_state();
+    let mut failed_state = create_refresh_failed_function_state("func1");
+    failed_state.config = alien_core::Resource::new(func1_v1);
+    state.resources.insert("func1".to_string(), failed_state);
+
+    let func1_v2 = test_function_with_image("func1", "image-v2");
+    let stack = Stack::new("plan-refresh-failed-test".to_owned())
+        .add(func1_v2, ResourceLifecycle::Live)
+        .build();
+
+    let plan = new_executor(&stack)?.plan(&state)?;
+
+    assert!(
+        plan.updates.contains_key("func1"),
+        "RefreshFailed resource with a new configuration should be updated"
+    );
+    Ok(())
+}
+
 /// Tests plan ignores deleting resources (waits for deletion to complete).
 #[tokio::test]
 async fn test_plan_on_deleting_resource() -> Result<()> {

--- a/crates/alien-permissions/tests/operation_coverage.rs
+++ b/crates/alien-permissions/tests/operation_coverage.rs
@@ -415,9 +415,13 @@ fn postgres_provision_and_heartbeat_grant_no_secret_value_read() {
         "key vault administrator",
     ];
 
-    for set_id in ["postgres/provision", "postgres/heartbeat", "postgres/management"] {
-        let permission_set = get_permission_set(set_id)
-            .unwrap_or_else(|| panic!("missing permission set {set_id}"));
+    for set_id in [
+        "postgres/provision",
+        "postgres/heartbeat",
+        "postgres/management",
+    ] {
+        let permission_set =
+            get_permission_set(set_id).unwrap_or_else(|| panic!("missing permission set {set_id}"));
 
         let aws_actions: Vec<&str> = permission_set
             .platforms
@@ -478,7 +482,9 @@ fn postgres_provision_and_heartbeat_grant_no_secret_value_read() {
             .collect();
         for forbidden in FORBIDDEN_GCP_ROLES {
             assert!(
-                !gcp_roles.iter().any(|role| role == &forbidden.to_ascii_lowercase()),
+                !gcp_roles
+                    .iter()
+                    .any(|role| role == &forbidden.to_ascii_lowercase()),
                 "{set_id} must not grant the secret-reading GCP role '{forbidden}'"
             );
         }

--- a/crates/alien-runtime/src/main.rs
+++ b/crates/alien-runtime/src/main.rs
@@ -1,9 +1,9 @@
 use alien_runtime::{
-    init_tracing, run, setup_shutdown_on_signals, BindingsSource, Result, RuntimeConfig,
+    init_tracing, run, setup_shutdown_on_signals, BindingsSource, Error, Result, RuntimeConfig,
 };
 use tracing::{error, info};
 
-fn main() -> Result<()> {
+fn main() -> std::process::ExitCode {
     // Build tokio runtime manually with a larger worker thread stack size.
     // The default musl stack size (128KB) is too small for the deep async call
     // stacks from gRPC + OTLP initialization, causing stack overflows.
@@ -13,7 +13,30 @@ fn main() -> Result<()> {
         .build()
         .expect("Failed to build tokio runtime");
 
-    runtime.block_on(async_main())
+    match runtime.block_on(async_main()) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            report_error(error);
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn report_error(error: Error) {
+    let error = error.into_external();
+    let report = error.human_report();
+    let serialized = serde_json::to_string(&error).unwrap_or_else(|serialization_error| {
+        format!("failed to serialize error: {serialization_error}")
+    });
+
+    error!(
+        message = %report.message,
+        error_code = %error.code,
+        error_retryable = error.retryable,
+        error_internal = error.internal,
+        error_http_status_code = i64::from(error.http_status_code.unwrap_or(500)),
+        alien_error = %serialized,
+    );
 }
 
 async fn async_main() -> Result<()> {
@@ -24,10 +47,7 @@ async fn async_main() -> Result<()> {
     info!("Initializing Alien Runtime...");
 
     // Load configuration from CLI arguments and environment variables
-    let config = RuntimeConfig::from_cli().map_err(|e| {
-        error!(error = %e, "Failed to load configuration");
-        e
-    })?;
+    let config = RuntimeConfig::from_cli()?;
 
     info!(
         transport = ?config.transport,

--- a/crates/alien-runtime/src/runtime.rs
+++ b/crates/alien-runtime/src/runtime.rs
@@ -447,19 +447,15 @@ fn handle_child_exit(
         }
         Ok(status) => {
             let code = status.code().unwrap_or(-1);
-            error!(exit_code = code, "Application exited with error");
             Err(AlienError::new(ErrorData::ProcessFailed {
                 exit_code: Some(code),
                 message: format!("Application exited with code {}", code),
             }))
         }
-        Err(e) => {
-            error!(error = %e, "Failed to wait for application");
-            Err(AlienError::new(ErrorData::ProcessFailed {
-                exit_code: None,
-                message: format!("Failed to wait for process: {}", e),
-            }))
-        }
+        Err(e) => Err(AlienError::new(ErrorData::ProcessFailed {
+            exit_code: None,
+            message: format!("Failed to wait for process: {}", e),
+        })),
     }
 }
 

--- a/crates/alien-runtime/tests/process_exit.rs
+++ b/crates/alien-runtime/tests/process_exit.rs
@@ -1,0 +1,46 @@
+use std::process::Command;
+
+#[test]
+fn process_failure_is_reported_as_structured_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_alien-runtime"))
+        .env("ALIEN_DEPLOYMENT_TYPE", "local")
+        .args([
+            "--bindings-address",
+            "127.0.0.1:0",
+            "--transport",
+            "passthrough",
+            "--",
+            "sh",
+            "-c",
+            "exit 7",
+        ])
+        .output()
+        .expect("alien-runtime should start");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).expect("runtime stdout should be UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("runtime stderr should be UTF-8");
+    assert!(!stdout.contains("AlienError {"));
+    assert!(!stderr.contains("AlienError {"));
+
+    let event = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|event| event["fields"]["error_code"] == "PROCESS_FAILED")
+        .expect("runtime should emit a structured PROCESS_FAILED event");
+    assert_eq!(
+        event["fields"]["message"],
+        "Process failed: Application exited with code 7"
+    );
+
+    let serialized = event["fields"]["alien_error"]
+        .as_str()
+        .expect("structured event should include serialized AlienError");
+    let error: serde_json::Value =
+        serde_json::from_str(serialized).expect("AlienError field should be valid JSON");
+    assert_eq!(error["code"], "PROCESS_FAILED");
+    assert_eq!(error["context"]["exit_code"], 7);
+    assert_eq!(error["retryable"], false);
+    assert_eq!(error["internal"], false);
+    assert_eq!(error["httpStatusCode"], 500);
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
## What changed

- Install joined machine services with a notify-capable systemd contract and automatic restart.
- Harden Machines debug timeout, JSON output, and early-close error handling.
- Include the coordinated runtime and error-handling fixes accumulated on ALIEN-260.

## Why

Horizond Ecdysis handoff requires systemd notifications and MAINPID transfer. Generic joined-host units did not provide that contract, making upgrades unreliable on fresh BYOC machines.

## Validation

- `cargo check -p alien-deploy-cli -p alien-cli`
- Notify service rendering tests
- Remote exec frame parsing tests
- `git diff --check`

Linear: [ALIEN-260](https://linear.app/alienplatform/issue/ALIEN-260/make-horizond-upgrades-and-machines-debug-reliable-on-joined-hosts)
