### PR TITLE
fix: speed up CLI commands/deployments and honor explicit workspace for user tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "aegis",
  "alien-bindings",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-error",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-error",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "alien-runtime"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-bindings",
  "alien-commands",
@@ -1007,14 +1007,14 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-bindings",
 ]
 
 [[package]]
 name = "alien-terraform"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "alien-bindings",
  "alien-error",

--- a/crates/alien-cli/src/commands/commands.rs
+++ b/crates/alien-cli/src/commands/commands.rs
@@ -75,8 +75,13 @@ pub async fn commands_task(args: CommandsArgs, ctx: ExecutionMode) -> Result<()>
             // Resolve the manager the same way `deployments` does. In platform
             // mode this discovers the manager URL and builds a workspace-aware
             // client; server_sdk_client() isn't available there.
+            // Invoking a command never pushes container images, so resolve
+            // metadata-only and skip artifact-repo provisioning (~10–15s on
+            // platform/dev clusters — see resolve_manager_metadata_only).
             let (_, project_link) = ctx.resolve_project(None, true).await?;
-            let manager = ctx.resolve_manager(&project_link.project_id, "aws").await?;
+            let manager = ctx
+                .resolve_manager_metadata_only(&project_link.project_id, "aws")
+                .await?;
 
             invoke_command(
                 &manager.client,

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -278,6 +278,11 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
 ///
 /// Uses the linked project (or `--project` override) to discover the manager URL
 /// in platform mode. In dev/standalone modes, the manager URL is known directly.
+///
+/// All `deployments` subcommands are Manager API operations that never push
+/// container images, so we resolve metadata-only and skip the artifact-repo
+/// provisioning step. On platform/dev clusters that provisioning is a cloud
+/// API round trip that adds ~10–15s per invocation for a repo we never use.
 pub(crate) async fn resolve_manager_client(
     ctx: &ExecutionMode,
     project_override: Option<&str>,
@@ -288,7 +293,9 @@ pub(crate) async fn resolve_manager_client(
         .await?;
     // The platform parameter is only used in platform mode for build-config
     // discovery; the manager URL is the same regardless of platform.
-    let manager_ctx = ctx.resolve_manager(&project_link.project_id, "aws").await?;
+    let manager_ctx = ctx
+        .resolve_manager_metadata_only(&project_link.project_id, "aws")
+        .await?;
     Ok(manager_ctx.client)
 }
 

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -259,13 +259,28 @@ impl ExecutionMode {
     /// Resolve the optional workspace query/header for platform API requests.
     ///
     /// User credentials need an explicit workspace because roles are per-workspace.
-    /// API keys are already scoped, so the CLI does not add a workspace query.
+    /// A workspace-scoped API key is already scoped, so it normally omits the
+    /// query. The exception is when the caller *explicitly* set a workspace
+    /// (`--workspace` / `ALIEN_WORKSPACE`): pass it through regardless of
+    /// credential kind. The API ignores `?workspace=` for API keys (they hit
+    /// the service-account path), but user bearer tokens — e.g. the per-turn
+    /// user session the ai-agent mints and hands to the CLI via `ALIEN_API_KEY`
+    /// — *require* it. Since the CLI can't tell an API key from a user token
+    /// (both arrive via `ALIEN_API_KEY`), honoring an explicit workspace is the
+    /// correct, harmless-for-API-keys behavior.
     #[cfg(feature = "platform")]
     pub async fn resolve_workspace_query_with_bootstrap(
         &self,
         allow_prompt: bool,
     ) -> Result<Option<String>> {
         match self {
+            // Explicit workspace wins even with an api_key present — the
+            // credential may be a user token that needs it.
+            Self::Platform {
+                api_key: Some(_),
+                workspace: Some(workspace),
+                ..
+            } => Ok(Some(workspace.clone())),
             Self::Platform {
                 api_key: Some(_), ..
             } => Ok(None),
@@ -284,6 +299,19 @@ impl ExecutionMode {
         allow_prompt: bool,
     ) -> Result<PlatformWorkspaceContext> {
         match self {
+            // An explicit workspace is honored even with an api_key present:
+            // the credential may be a user bearer token (e.g. the ai-agent's
+            // per-turn user session via `ALIEN_API_KEY`) that requires it. The
+            // API ignores the query for real API keys. See
+            // `resolve_workspace_query_with_bootstrap` for the full rationale.
+            Self::Platform {
+                api_key: Some(_),
+                workspace: Some(workspace),
+                ..
+            } => Ok(PlatformWorkspaceContext {
+                name: workspace.clone(),
+                query: Some(workspace.clone()),
+            }),
             Self::Platform {
                 api_key: Some(_), ..
             } => Ok(PlatformWorkspaceContext {
@@ -1001,7 +1029,11 @@ mod tests {
 
     #[cfg(feature = "platform")]
     #[tokio::test]
-    async fn api_key_with_explicit_workspace_omits_workspace_query() {
+    async fn api_key_with_explicit_workspace_sends_workspace_query() {
+        // The credential arriving via `ALIEN_API_KEY` may be a user bearer
+        // token (e.g. the ai-agent's per-turn user session), which the API
+        // requires `?workspace=` for. When a workspace is explicitly set we
+        // send it; the API harmlessly ignores it for real API keys.
         let mode = ExecutionMode::Platform {
             base_url: "https://api.alien.localhost".to_string(),
             api_key: Some("ax_test".to_string()),
@@ -1014,7 +1046,7 @@ mod tests {
             mode.resolve_workspace_query_with_bootstrap(false)
                 .await
                 .unwrap(),
-            None
+            Some("demo".to_string())
         );
     }
 
@@ -1034,12 +1066,13 @@ mod tests {
 
     #[cfg(feature = "platform")]
     #[tokio::test]
-    async fn api_key_platform_query_context_omits_workspace_query() {
+    async fn api_key_without_workspace_platform_query_context_omits_workspace_query() {
+        // No explicit workspace → a real API key is self-scoped, so no query.
         let mode = ExecutionMode::Platform {
             base_url: "https://api.alien.localhost".to_string(),
             api_key: Some("ax_test".to_string()),
             no_browser: true,
-            workspace: Some("demo".to_string()),
+            workspace: None,
             project: None,
         };
 
@@ -1049,5 +1082,27 @@ mod tests {
                 .unwrap(),
             None
         );
+    }
+
+    #[cfg(feature = "platform")]
+    #[tokio::test]
+    async fn api_key_with_explicit_workspace_platform_context_sends_workspace_query() {
+        // `resolve_platform_workspace_context` mirrors the query resolver: an
+        // explicit workspace is honored (name + query) even with an api_key,
+        // since the credential may be a user token that needs it.
+        let mode = ExecutionMode::Platform {
+            base_url: "https://api.alien.localhost".to_string(),
+            api_key: Some("ax_test".to_string()),
+            no_browser: true,
+            workspace: Some("demo".to_string()),
+            project: None,
+        };
+
+        let ctx = mode
+            .resolve_platform_workspace_context(false)
+            .await
+            .unwrap();
+        assert_eq!(ctx.name, "demo");
+        assert_eq!(ctx.query, Some("demo".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

Two related `alien-cli` fixes.

### 1. CLI slowness (`commands` / `deployments`)

The `commands` and `deployments` subcommands are Manager API operations that never push container images, yet they resolved the manager the full way — which provisions an artifact repo. On platform/dev clusters that provisioning is a cloud API round trip adding **~10-15s per invocation** for a repo we never use.

Both now call `resolve_manager_metadata_only(...)`, skipping artifact-repo provisioning.

### 2. Explicit workspace ignored for user bearer tokens

`resolve_workspace_query_with_bootstrap` and `resolve_platform_workspace_context` previously dropped the `?workspace=` query whenever an api_key was present. But the credential arriving via `ALIEN_API_KEY` may actually be a **user bearer token** (e.g. the per-turn user session), and the API *requires* `?workspace=` for those — roles are per-workspace.

Both now honor an explicit `--workspace` / `ALIEN_WORKSPACE` even when an api_key is present. The CLI can't distinguish a real API key from a user token (both arrive via `ALIEN_API_KEY`), and the API harmlessly ignores the query for real API keys, so passing an explicitly-set workspace through is the correct, safe behavior.

## Test plan

- [x] `cargo test --features platform -p alien-cli execution_context` — 7 passed
  - Updated existing tests and added `api_key_with_explicit_workspace_platform_context_sends_workspace_query` to cover the new explicit-workspace behavior across both resolvers.
- [ ] Manual: run a `deployments` / `commands` invocation against a platform/dev cluster and confirm the ~10-15s artifact-repo provisioning delay is gone.
- [ ] Manual: confirm the ai-agent's per-turn user session (with explicit workspace) now resolves correctly through the CLI.