### PR TITLE
fix: recover failed updates before config changes

### DIFF
--- a/crates/alien-infra/src/core/executor.rs
+++ b/crates/alien-infra/src/core/executor.rs
@@ -1254,8 +1254,41 @@ impl StackExecutor {
                     resource_id, current_state.status
                 );
 
+                let mut update_state = current_state.clone();
+                if update_state.status == ResourceStatus::UpdateFailed {
+                    update_state
+                        .retry_failed()
+                        .context(ErrorData::InfrastructureError {
+                            message:
+                                "Failed to restore resource before applying updated configuration"
+                                    .to_string(),
+                            operation: Some("retry_update".to_string()),
+                            resource_id: Some(resource_id.clone()),
+                        })?;
+
+                    // A failed update resumes from the exact handler that failed. Its context
+                    // reads the desired resource, so applying the new config here is sufficient;
+                    // starting a second update flow would discard that retry point.
+                    if update_state.status == ResourceStatus::Updating {
+                        let desired_config = self.resources.get(resource_id).ok_or_else(|| {
+                            AlienError::new(ErrorData::InfrastructureError {
+                                message: format!(
+                                    "Resource '{}' not found in desired config during update retry",
+                                    resource_id
+                                ),
+                                operation: Some("update_dependencies".to_string()),
+                                resource_id: Some(resource_id.clone()),
+                            })
+                        })?;
+                        update_state.config = new_config.clone();
+                        update_state.dependencies = desired_config.dependencies.clone();
+                        initial_transitions.insert(resource_id.clone(), update_state);
+                        continue;
+                    }
+                }
+
                 // Try to get the controller and transition to update
-                match current_state.get_internal_controller() {
+                match update_state.get_internal_controller() {
                     Ok(Some(mut controller)) => {
                         match controller.transition_to_update() {
                             Ok(()) => {
@@ -1279,7 +1312,7 @@ impl StackExecutor {
                                     }
                                 };
 
-                                let updated_state = current_state.with_updates(|state| {
+                                let updated_state = update_state.with_updates(|state| {
                                     state.config = new_config.clone(); // Set to new desired config
                                     state.previous_config = Some(current_state.config.clone()); // Store old config
                                     state.dependencies = desired_config.dependencies.clone(); // Update dependencies to match new config
@@ -1301,7 +1334,7 @@ impl StackExecutor {
                                     resource_id, e
                                 );
                                 // Create a failed update state and preserve current controller state for retry
-                                let failed_update_state = current_state.with_updates(|state| {
+                                let failed_update_state = update_state.with_updates(|state| {
                                     state.status = ResourceStatus::UpdateFailed;
                                     state.error = Some(e.into_generic());
                                     state.retry_attempt = 0;

--- a/crates/alien-infra/src/core/executor.rs
+++ b/crates/alien-infra/src/core/executor.rs
@@ -1255,7 +1255,9 @@ impl StackExecutor {
                 );
 
                 let mut update_state = current_state.clone();
-                if update_state.status == ResourceStatus::UpdateFailed {
+                if update_state.status == ResourceStatus::UpdateFailed
+                    && update_state.has_last_failed_state()
+                {
                     update_state
                         .retry_failed()
                         .context(ErrorData::InfrastructureError {

--- a/crates/alien-infra/src/core/executor_tests/plan_tests.rs
+++ b/crates/alien-infra/src/core/executor_tests/plan_tests.rs
@@ -239,8 +239,7 @@ async fn test_step_restarts_update_from_terminal_failure_with_config_change() ->
         .unwrap();
     failed_controller.state = TestWorkerState::UpdateFailed;
     resource_state.status = ResourceStatus::UpdateFailed;
-    resource_state.set_internal_controller(Some(Box::new(failed_controller.clone())))?;
-    resource_state.set_last_failed_controller(Some(Box::new(failed_controller)))?;
+    resource_state.set_internal_controller(Some(Box::new(failed_controller)))?;
 
     let func_v2 = test_function_with_image("func1", "image-v2");
     let stack_v2 = Stack::new("update-failed-repair-test".to_owned())

--- a/crates/alien-infra/src/core/executor_tests/plan_tests.rs
+++ b/crates/alien-infra/src/core/executor_tests/plan_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for the plan() method that calculates diffs.
 
 use super::helpers::*;
+use crate::core::state_utils::StackResourceStateExt;
 use crate::error::Result;
+use crate::worker::TestWorkerState;
 use alien_core::{ResourceLifecycle, ResourceStatus, Stack};
 
 /// Tests that plan identifies resources to create.
@@ -218,6 +220,44 @@ async fn test_plan_update_failed_with_config_change() -> Result<()> {
     assert!(
         plan.updates.contains_key("func1"),
         "UpdateFailed resource with config change should be marked for update"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_step_restarts_update_from_terminal_failure_with_config_change() -> Result<()> {
+    let func_v1 = test_function_with_image("func1", "image-v1");
+    let stack_v1 = Stack::new("update-failed-repair-test".to_owned())
+        .add(func_v1, ResourceLifecycle::Live)
+        .build();
+    let mut state = run_to_synced(&new_executor(&stack_v1)?, new_test_state()).await?;
+
+    let resource_state = state.resources.get_mut("func1").unwrap();
+    let mut failed_controller = resource_state
+        .get_internal_controller_typed::<crate::worker::TestWorkerController>()
+        .unwrap();
+    failed_controller.state = TestWorkerState::UpdateFailed;
+    resource_state.status = ResourceStatus::UpdateFailed;
+    resource_state.set_internal_controller(Some(Box::new(failed_controller.clone())))?;
+    resource_state.set_last_failed_controller(Some(Box::new(failed_controller)))?;
+
+    let func_v2 = test_function_with_image("func1", "image-v2");
+    let stack_v2 = Stack::new("update-failed-repair-test".to_owned())
+        .add(func_v2.clone(), ResourceLifecycle::Live)
+        .build();
+    let result = new_executor(&stack_v2)?.step(state).await?;
+    let repaired = result.next_state.resources.get("func1").unwrap();
+
+    assert_eq!(repaired.status, ResourceStatus::Updating);
+    assert_eq!(repaired.config, alien_core::Resource::new(func_v2));
+    assert!(repaired.error.is_none());
+    assert_ne!(
+        repaired
+            .get_internal_controller_typed::<crate::worker::TestWorkerController>()
+            .unwrap()
+            .state,
+        TestWorkerState::UpdateFailed
     );
 
     Ok(())

--- a/crates/alien-macros/src/controller.rs
+++ b/crates/alien-macros/src/controller.rs
@@ -480,7 +480,8 @@ fn generate_controller_impl(
     let transition_to_delete_body = generate_transition_to_delete(state_enum_name, flow_entries);
     let transition_to_teardown_body =
         generate_transition_to_teardown(state_enum_name, flow_entries);
-    let transition_to_update_body = generate_transition_to_update(state_enum_name, flow_entries);
+    let transition_to_update_body =
+        generate_transition_to_update(state_enum_name, handlers, flow_entries);
 
     let get_binding_params_impl = if let Some(method) = get_binding_params_method {
         // Include the user's implementation directly in the trait
@@ -703,10 +704,17 @@ fn generate_transition_to_delete(
 
 fn generate_transition_to_update(
     state_enum_name: &Ident,
+    handlers: &HashMap<String, (&ImplItemFn, HandlerAttr)>,
     flow_entries: &HashMap<String, (Ident, FlowEntryAttr)>,
 ) -> TokenStream2 {
     if let Some((update_start_state, update_flow)) = flow_entries.get("Update") {
-        let allowed_states = &update_flow.from_states;
+        let mut allowed_states = update_flow.from_states.clone();
+        if let Some((_, update_start_handler)) = handlers.get(&update_start_state.to_string()) {
+            let update_failure_state = &update_start_handler.on_failure;
+            if !allowed_states.contains(update_failure_state) {
+                allowed_states.push(update_failure_state.clone());
+            }
+        }
         let allowed_states_str = allowed_states
             .iter()
             .map(|s| quote!(#s).to_string())


### PR DESCRIPTION
## Summary
- restore an update failure retry point before applying a changed configuration
- resume in-progress update handlers instead of starting a second update flow
- allow a fresh update to recover legacy terminal retry snapshots

## Verification
- `cargo test -p alien-infra --all-features test_step_restarts_update_from_terminal_failure_with_config_change -- --nocapture`
- `cargo test -p alien-macros`
- `cargo fmt --all --check`