### PR TITLE
fix: remove workload secret reads from compute machine roles

### DIFF
--- a/crates/alien-permissions/permission-sets/compute-cluster/execute.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/execute.jsonc
@@ -1,6 +1,6 @@
 {
   "id": "compute-cluster/execute",
-  "description": "Runtime permissions for managed container VMs: cross-account image pull, per-container service account impersonation, stack-scoped secret resolution, disk attach, and LB target registration.",
+  "description": "Runtime permissions for managed container VMs: cross-account image pull, per-container service account impersonation, EBS/disk attach, and LB target registration.",
   "platforms": {
     "aws": [
       // Cross-account ECR image pull from managing account's registry
@@ -41,26 +41,6 @@
           },
           "resource": {
             "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*-sa"]
-          }
-        }
-      },
-      // The machine hosting layer resolves typed workload SecretRefs with the VM's ambient
-      // identity before starting the container. Keep reads inside this
-      // deployment's setup-owned app-secret vault.
-      {
-        "grant": {
-          "actions": ["ssm:GetParameter"]
-        },
-        "binding": {
-          "stack": {
-            "resources": [
-              "arn:aws:ssm:${awsRegion}:${awsAccountId}:parameter/${stackPrefix}-secrets-*"
-            ]
-          },
-          "resource": {
-            "resources": [
-              "arn:aws:ssm:${awsRegion}:${awsAccountId}:parameter/${stackPrefix}-secrets-*"
-            ]
           }
         }
       },
@@ -174,29 +154,6 @@
           }
         }
       },
-      // Machine-wide workload secret resolution. The condition restricts the
-      // predefined accessor role to Secret Manager values owned by this stack.
-      {
-        "grant": {
-          "predefinedRoles": ["roles/secretmanager.secretAccessor"]
-        },
-        "binding": {
-          "stack": {
-            "scope": "projects/${projectName}",
-            "condition": {
-              "title": "ComputeClusterStackSecretsRead",
-              "expression": "(resource.type == \"secretmanager.googleapis.com/Secret\" || resource.type == \"secretmanager.googleapis.com/SecretVersion\") && resource.name.startsWith(\"projects/${projectNumber}/secrets/${stackPrefix}-\")"
-            }
-          },
-          "resource": {
-            "scope": "projects/${projectName}",
-            "condition": {
-              "title": "ComputeClusterStackSecretsRead",
-              "expression": "(resource.type == \"secretmanager.googleapis.com/Secret\" || resource.type == \"secretmanager.googleapis.com/SecretVersion\") && resource.name.startsWith(\"projects/${projectNumber}/secrets/${stackPrefix}-\")"
-            }
-          }
-        }
-      },
       // Disk attach/detach for persistent storage containers (container runtime)
       {
         "grant": {
@@ -251,10 +208,6 @@
           }
         }
       },
-      // The setup-owned Key Vault has a generated uniqueness suffix, so its
-      // exact scope cannot be expressed by this stack-prefix permission set.
-      // The provider ComputeCluster controller grants Key Vault Secrets User
-      // after resolving the concrete vault binding.
       // Disk attach/detach for persistent storage containers (container runtime)
       {
         "grant": {

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -50,7 +50,7 @@ fn test_aws_observe_generates_account_wide_read_policy() {
 }
 
 #[test]
-fn compute_cluster_execute_reads_only_stack_secret_parameters() {
+fn compute_cluster_execute_does_not_read_workload_secrets() {
     let generator = AwsRuntimePermissionsGenerator::new();
     let permission_set =
         get_permission_set("compute-cluster/execute").expect("permission set exists");
@@ -59,17 +59,23 @@ fn compute_cluster_execute_reads_only_stack_secret_parameters() {
     let result = generator
         .generate_policy(permission_set, BindingTarget::Stack, &context)
         .expect("compute cluster execute policy should generate");
-    let statement = result
+    let actions = result
         .statement
         .iter()
-        .find(|statement| statement.action == ["ssm:GetParameter"])
-        .expect("scoped SSM read statement");
+        .flat_map(|statement| statement.action.iter().map(String::as_str))
+        .collect::<Vec<_>>();
 
-    assert_eq!(
-        statement.resource,
-        vec!["arn:aws:ssm:us-east-1:123456789012:parameter/my-stack-secrets-*".to_string()]
-    );
-    assert!(!statement.resource.iter().any(|resource| resource == "*"));
+    for action in [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath",
+        "secretsmanager:GetSecretValue",
+    ] {
+        assert!(
+            !actions.contains(&action),
+            "machine role must not grant {action}"
+        );
+    }
 }
 
 #[test]

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -83,7 +83,7 @@ fn test_azure_observe_generates_subscription_scoped_read_grant_plan() {
 }
 
 #[test]
-fn compute_cluster_execute_does_not_guess_the_setup_owned_secrets_vault() {
+fn compute_cluster_execute_does_not_read_workload_secrets() {
     let generator = AzureRuntimePermissionsGenerator::new();
     let permission_set =
         get_permission_set("compute-cluster/execute").expect("permission set exists");
@@ -94,13 +94,16 @@ fn compute_cluster_execute_does_not_guess_the_setup_owned_secrets_vault() {
     let result = generator
         .generate_grant_plan(permission_set, BindingTarget::Stack, &context)
         .expect("compute cluster execute grant plan should generate");
-    assert!(
-        result
-            .bindings
-            .iter()
-            .all(|binding| binding.role_name != "Key Vault Secrets User"),
-        "the provider controller must grant the exact generated Key Vault scope"
-    );
+
+    assert!(result
+        .bindings
+        .iter()
+        .all(|binding| binding.role_name != "Key Vault Secrets User"));
+    assert!(result.custom_roles.iter().all(|role| !role
+        .role_definition
+        .data_actions
+        .iter()
+        .any(|action| action == "Microsoft.KeyVault/vaults/secrets/read")));
 }
 
 #[test]

--- a/crates/alien-permissions/tests/gcp_runtime.rs
+++ b/crates/alien-permissions/tests/gcp_runtime.rs
@@ -101,19 +101,13 @@ fn gcp_compute_cluster_execute_keeps_distinct_generated_role_permissions() {
     let project_bindings = grant_plan.bindings_for_target(GcpBindingTargetScope::Project);
     let project_roles = grant_plan.custom_roles_for_bindings(&project_bindings);
 
-    let secret_binding = project_bindings
+    assert!(project_bindings
         .iter()
-        .find(|binding| binding.role == "roles/secretmanager.secretAccessor")
-        .expect("compute-cluster machine secret accessor binding");
-    let secret_condition = secret_binding
-        .condition
-        .as_ref()
-        .expect("stack-scoped Secret Manager condition");
-    assert_eq!(secret_condition.title, "ComputeClusterStackSecretsRead");
-    assert_eq!(
-        secret_condition.expression,
-        "(resource.type == \"secretmanager.googleapis.com/Secret\" || resource.type == \"secretmanager.googleapis.com/SecretVersion\") && resource.name.startsWith(\"projects/123456789012/secrets/my-stack-\")"
-    );
+        .all(|binding| binding.role != "roles/secretmanager.secretAccessor"));
+    assert!(project_roles.iter().all(|role| !role
+        .included_permissions
+        .iter()
+        .any(|permission| permission == "secretmanager.versions.access")));
 
     assert!(
         project_roles.iter().any(|role| {


### PR DESCRIPTION
## Summary

Horizon now owns encrypted workload-secret storage and per-machine delivery. Compute machine identities no longer need direct access to customer cloud secret stores.

- remove AWS SSM parameter reads from `compute-cluster/execute`
- remove GCP Secret Manager accessor from `compute-cluster/execute`
- remove the obsolete Azure exact-vault handoff comment
- invert provider tests so sensitive workload-secret reads cannot be reintroduced

This intentionally leaves `vault/data-read` unchanged: that is the explicit customer workload permission, not Horizon transport.

## Validation

- `cargo test -p alien-permissions --tests`

## Rollout

Merge before or with the Platform controller cleanup. It is independent of the Islo Machines deployment and does not change machine join or Horizon connectivity.