### PR TITLE
ci: harden CI against recurring flakes (apt, GCP quota, sccache, Node 20)

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -40,14 +40,20 @@ runs:
       run: |
         git config --global url."https://x-access-token:${{ inputs.repo-access-token }}@github.com/".insteadOf "https://github.com/"
 
-    - name: Install musl-tools and protoc
+    - name: Install protoc
+      if: inputs.install-protoc == 'true'
+      uses: arduino/setup-protoc@v3
+      with:
+        version: "27.x"
+        repo-token: ${{ github.token }}
+
+    - name: Install musl-tools
       shell: bash
+      # Retry transient Ubuntu mirror failures; a dead mirror has killed CI
+      # jobs before (apt exit code 100 after minutes of connection errors).
       run: |
-        PACKAGES="musl-tools"
-        if [ "${{ inputs.install-protoc }}" = "true" ]; then
-          PACKAGES="$PACKAGES protobuf-compiler"
-        fi
-        sudo apt-get update && sudo apt-get install -y $PACKAGES
+        sudo apt-get -o Acquire::Retries=5 update
+        sudo apt-get -o Acquire::Retries=5 install -y musl-tools
 
     - name: Add Rust targets
       if: inputs.targets != ''

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Install sccache
       continue-on-error: true
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.10
       with:
         # Avoid the action's latest-release API lookup, which can fail during
         # transient GitHub API outages. Cache setup is an optimization, so a

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -90,7 +90,10 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - name: Install CloudFormation linter
         run: pipx install cfn-lint

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -24,8 +24,10 @@ jobs:
       # reports "runner lost communication" with no logs). Full-width
       # parallelism (16 rustc jobs, then 16 concurrent test binaries — many
       # of which spawn servers and embedded databases) is what spikes it.
-      CARGO_BUILD_JOBS: "12"
-      NEXTEST_TEST_THREADS: "10"
+      # 12/10 stopped being enough as the test set grew: both attempts of
+      # the same main push died mid-tests on 2026-07-19 (run 29707403037).
+      CARGO_BUILD_JOBS: "10"
+      NEXTEST_TEST_THREADS: "8"
 
     steps:
       - name: Validate PR title

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -24,10 +24,8 @@ jobs:
       # reports "runner lost communication" with no logs). Full-width
       # parallelism (16 rustc jobs, then 16 concurrent test binaries — many
       # of which spawn servers and embedded databases) is what spikes it.
-      # 12/10 stopped being enough as the test set grew: both attempts of
-      # the same main push died mid-tests on 2026-07-19 (run 29707403037).
-      CARGO_BUILD_JOBS: "10"
-      NEXTEST_TEST_THREADS: "8"
+      CARGO_BUILD_JOBS: "12"
+      NEXTEST_TEST_THREADS: "10"
 
     steps:
       - name: Validate PR title

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -11,6 +11,11 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  # Fall back to local compilation when the shared sccache backend returns a
+  # transient error (e.g. webdav 403) instead of failing the whole build.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+
 jobs:
   fast:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
@@ -40,9 +45,9 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         continue-on-error: true
         with:
@@ -60,11 +65,11 @@ jobs:
               - 'crates/alien-bindings/**'
               - 'crates/alien-build/**'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -78,7 +83,7 @@ jobs:
 
       - uses: depot/setup-action@v1
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0
@@ -98,12 +103,12 @@ jobs:
       - name: Install CloudFormation linter
         run: pipx install cfn-lint
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.15.3
           terraform_wrapper: false
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
 
       - name: Install kubeconform
         run: |

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -55,7 +55,10 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -34,13 +34,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -60,12 +60,12 @@ jobs:
           version: "27.x"
           repo-token: ${{ github.token }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 1.15.3
           terraform_wrapper: false
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
 
       - name: Install kubeconform
         run: |

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -54,6 +54,11 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  # Fall back to local compilation when the shared sccache backend returns a
+  # transient error (e.g. webdav 403) instead of failing the whole build.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+
 jobs:
   setup:
     # Skip on fork PRs (no access to secrets)
@@ -68,9 +73,9 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
           terraform_version: 1.14.5
@@ -209,7 +214,7 @@ jobs:
           done < .env.test
 
       - name: Upload .env.test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: env-test
           path: .env.test
@@ -254,13 +259,13 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure git credentials
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Download .env.test
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: env-test
 
@@ -286,7 +291,7 @@ jobs:
 
       - uses: depot/setup-action@v1
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -294,6 +294,9 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - run: ${{ matrix.test_cmd }}

--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -143,6 +143,9 @@ permissions:
 
 env:
   ALIEN_E2E_SLOT: "03"
+  # Fall back to local compilation when the shared sccache backend returns a
+  # transient error (e.g. webdav 403) instead of failing the whole build.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
 jobs:
   # ── Compute which tests, platforms, and architectures to run ────────
@@ -468,7 +471,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -477,12 +480,12 @@ jobs:
           targets: x86_64-unknown-linux-musl
           install-protoc: "true"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         if: needs.compute-matrix.outputs.needs_bindings_x86_64 == 'true'
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: needs.compute-matrix.outputs.needs_bindings_x86_64 == 'true'
         with:
           node-version: 22
@@ -525,21 +528,21 @@ jobs:
           node -e 'const a=require(require("node:path").resolve(process.env.ADDON_PATH)); if (!a.version()) throw new Error("native version() returned empty")'
           bun -e 'const a=require(require("node:path").resolve(process.env.ADDON_PATH)); if (!a.version()) throw new Error("native version() returned empty")'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: needs.compute-matrix.outputs.needs_bindings_x86_64 == 'true'
         with:
           name: alien-bindings-node-linux-x64-gnu
           path: crates/alien-bindings-node/alien-bindings-node.linux-x64-gnu.node
           retention-days: 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: needs.compute-matrix.outputs.build_base_image == 'true'
         with:
           name: alien-worker-runtime-x86_64
           path: target/x86_64-unknown-linux-musl/release/alien-worker-runtime
           retention-days: 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: needs.compute-matrix.outputs.build_operator_image == 'true'
         with:
           name: alien-operator-x86_64
@@ -558,7 +561,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -567,12 +570,12 @@ jobs:
           targets: aarch64-unknown-linux-musl
           install-protoc: "true"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         if: needs.compute-matrix.outputs.needs_bindings_aarch64 == 'true'
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: needs.compute-matrix.outputs.needs_bindings_aarch64 == 'true'
         with:
           node-version: 22
@@ -615,21 +618,21 @@ jobs:
           node -e 'const a=require(require("node:path").resolve(process.env.ADDON_PATH)); if (!a.version()) throw new Error("native version() returned empty")'
           bun -e 'const a=require(require("node:path").resolve(process.env.ADDON_PATH)); if (!a.version()) throw new Error("native version() returned empty")'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: needs.compute-matrix.outputs.needs_bindings_aarch64 == 'true'
         with:
           name: alien-bindings-node-linux-arm64-gnu
           path: crates/alien-bindings-node/alien-bindings-node.linux-arm64-gnu.node
           retention-days: 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: needs.compute-matrix.outputs.build_base_image == 'true'
         with:
           name: alien-worker-runtime-aarch64
           path: target/aarch64-unknown-linux-musl/release/alien-worker-runtime
           retention-days: 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: needs.compute-matrix.outputs.build_operator_image == 'true'
         with:
           name: alien-operator-aarch64
@@ -649,15 +652,15 @@ jobs:
     outputs:
       base_image: ghcr.io/alienplatform/alien-base:${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         if: needs.build-x86_64.result == 'success'
         with:
           name: alien-worker-runtime-x86_64
           path: target/x86_64-unknown-linux-musl/release/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         if: needs.build-aarch64.result == 'success'
         with:
           name: alien-worker-runtime-aarch64
@@ -749,15 +752,15 @@ jobs:
     outputs:
       operator_image: ghcr.io/alienplatform/alien-operator:${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         if: needs.build-x86_64.result == 'success'
         with:
           name: alien-operator-x86_64
           path: target/x86_64-unknown-linux-musl/release/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         if: needs.build-aarch64.result == 'success'
         with:
           name: alien-operator-aarch64
@@ -818,9 +821,9 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
           terraform_version: 1.14.5
@@ -975,7 +978,7 @@ jobs:
           TF_VAR_azure_target_client_id: ${{ secrets.TEST_AZURE_TARGET_CLIENT_ID }}
           TF_VAR_azure_target_client_secret: ${{ secrets.TEST_AZURE_TARGET_CLIENT_SECRET }}
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
 
       - uses: google-github-actions/setup-gcloud@v2
         with:
@@ -1070,7 +1073,7 @@ jobs:
           done
 
       - name: Upload .env.test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: env-test-e2e
           path: |
@@ -1115,18 +1118,18 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download TypeScript bindings addon (x86_64)
         if: matrix.bindings_arch == 'x86_64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: alien-bindings-node-linux-x64-gnu
           path: crates/alien-bindings-node
 
       - name: Download TypeScript bindings addon (aarch64)
         if: matrix.bindings_arch == 'aarch64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: alien-bindings-node-linux-arm64-gnu
           path: crates/alien-bindings-node
@@ -1135,7 +1138,7 @@ jobs:
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Download .env.test
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: env-test-e2e
 
@@ -1170,7 +1173,7 @@ jobs:
         with:
           platforms: arm64
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0
@@ -1191,11 +1194,11 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -1250,13 +1253,13 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure git credentials
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Download .env.test
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: env-test-e2e
 
@@ -1268,7 +1271,7 @@ jobs:
         with:
           platforms: arm64
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0
@@ -1289,16 +1292,16 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
 
@@ -1354,18 +1357,18 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download TypeScript bindings addon (x86_64)
         if: matrix.bindings_arch == 'x86_64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: alien-bindings-node-linux-x64-gnu
           path: crates/alien-bindings-node
 
       - name: Download TypeScript bindings addon (aarch64)
         if: matrix.bindings_arch == 'aarch64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: alien-bindings-node-linux-arm64-gnu
           path: crates/alien-bindings-node
@@ -1374,7 +1377,7 @@ jobs:
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Download .env.test
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: env-test-e2e
 
@@ -1416,7 +1419,7 @@ jobs:
         with:
           platforms: arm64
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0
@@ -1437,20 +1440,20 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
 
       - uses: google-github-actions/setup-gcloud@v2
         if: contains(matrix.test_filter, 'gke')
@@ -1561,13 +1564,13 @@ jobs:
       CARGO_INCREMENTAL: "0"
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure git credentials
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Download .env.test
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: env-test-e2e
 
@@ -1582,7 +1585,7 @@ jobs:
         with:
           platforms: arm64
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0
@@ -1615,11 +1618,11 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -1711,10 +1714,10 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download .env.test
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: env-test-e2e
 

--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -857,8 +857,8 @@ jobs:
           set -euo pipefail
 
           if ! command -v aws >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y awscli
+            sudo apt-get -o Acquire::Retries=5 update
+            sudo apt-get -o Acquire::Retries=5 install -y awscli
           fi
 
           cluster_name="$(terraform output -raw e2e_eks_cluster_name 2>/dev/null || true)"
@@ -984,8 +984,8 @@ jobs:
       - name: Install Kubernetes auth helpers
         run: |
           if ! command -v aws >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y awscli unzip
+            sudo apt-get -o Acquire::Retries=5 update
+            sudo apt-get -o Acquire::Retries=5 install -y awscli unzip
           fi
           case "$(uname -m)" in
             aarch64|arm64) KUBELOGIN_ARCH=arm64 ;;
@@ -1178,7 +1178,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -1273,7 +1276,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -1418,7 +1424,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -1582,7 +1591,10 @@ jobs:
 
       - name: Install protoc (Ubuntu)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - name: Install protoc (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/generated-drift.yml
+++ b/.github/workflows/generated-drift.yml
@@ -17,6 +17,11 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  # Fall back to local compilation when the shared sccache backend returns a
+  # transient error (e.g. webdav 403) instead of failing the whole build.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+
 jobs:
   drift:
     if: false # temporarily disabled — speakeasy CLI not available in CI
@@ -27,13 +32,13 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -42,7 +47,7 @@ jobs:
 
       - uses: depot/setup-action@v1
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure git credentials
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/generated-drift.yml
+++ b/.github/workflows/generated-drift.yml
@@ -48,7 +48,10 @@ jobs:
         run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-pgvector.yml
+++ b/.github/workflows/release-pgvector.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential git curl jq
+        run: sudo apt-get -o Acquire::Retries=5 update && sudo apt-get -o Acquire::Retries=5 install -y build-essential git curl jq
 
       - name: Resolve embedded Postgres version
         id: pg

--- a/.github/workflows/release-pgvector.yml
+++ b/.github/workflows/release-pgvector.yml
@@ -81,7 +81,7 @@ jobs:
           cp "$EXTDIR"/vector.control "$EXTDIR"/vector--*.sql out/
           (cd out && zip -j "pgvector_compiled.zip" vector.so vector.control vector--*.sql)
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pgvector-linux-${{ matrix.target.arch }}-pg${{ matrix.pg_major }}
           retention-days: 1
@@ -132,7 +132,7 @@ jobs:
           cp "$EXTDIR"/vector.control "$EXTDIR"/vector--*.sql out/
           (cd out && zip -j "pgvector_compiled.zip" vector.dylib vector.control vector--*.sql)
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pgvector-darwin-aarch64-pg${{ matrix.pg_major }}
           retention-days: 1
@@ -187,7 +187,7 @@ jobs:
           cp "$PGROOT"/share/extension/vector.control "$PGROOT"/share/extension/vector--*.sql out/
           (cd out && 7z a -tzip "pgvector_compiled.zip" vector.dll vector.control vector--*.sql)
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pgvector-windows-x86_64-pg${{ matrix.pg_major }}
           retention-days: 1
@@ -201,7 +201,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: pgvector-*
           path: ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ permissions:
   packages: write
   id-token: write
 
+env:
+  # Fall back to local compilation when the shared sccache backend returns a
+  # transient error (e.g. webdav 403) instead of failing the whole build.
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+
 jobs:
   prepare:
     runs-on: depot-ubuntu-24.04-arm
@@ -20,7 +25,7 @@ jobs:
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           fetch-depth: 0
@@ -98,7 +103,7 @@ jobs:
       # on one computed version without mutating git or publishing anything.
       - name: Upload versioned manifests for dry run
         if: ${{ inputs.dry_run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-version-manifests
           retention-days: 1
@@ -142,7 +147,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
           fetch-depth: 0
@@ -157,7 +162,7 @@ jobs:
           OUTPUT: CHANGELOG-release.md
 
       - name: Upload changelog
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: changelog
           retention-days: 1
@@ -173,7 +178,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
@@ -184,7 +189,7 @@ jobs:
 
       - uses: depot/setup-action@v1
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
         continue-on-error: true
         with:
           version: v0.16.0
@@ -229,15 +234,15 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -277,11 +282,11 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -353,13 +358,13 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.sha || format('v{0}', needs.prepare.outputs.version) }}
 
       - name: Apply computed version for dry run
         if: ${{ inputs.dry_run }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-version-manifests
           path: .
@@ -396,11 +401,11 @@ jobs:
         if: matrix.target == 'x86_64-apple-darwin'
         run: rustup target add x86_64-apple-darwin
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -426,7 +431,7 @@ jobs:
         run: file "packages/bindings/npm/${{ matrix.triple }}/alien-bindings-node.${{ matrix.triple }}.node" | grep -q "${{ matrix.expect_arch }}"
 
       - name: Upload addon artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: addon-${{ matrix.triple }}
           retention-days: 1
@@ -458,13 +463,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.sha || format('v{0}', needs.prepare.outputs.version) }}
 
       - name: Apply computed version for dry run
         if: ${{ inputs.dry_run }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-version-manifests
           path: .
@@ -474,11 +479,11 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: node packages/bindings/scripts/validate-release-version.mjs "$VERSION"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -492,7 +497,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download staged addon (${{ matrix.triple }})
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: addon-${{ matrix.triple }}
           path: packages/bindings/npm/${{ matrix.triple }}
@@ -516,13 +521,13 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm-4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.dry_run && github.sha || format('v{0}', needs.prepare.outputs.version) }}
 
       - name: Apply computed version for dry run
         if: ${{ inputs.dry_run }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-version-manifests
           path: .
@@ -532,11 +537,11 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: node packages/bindings/scripts/validate-release-version.mjs "$VERSION"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -551,7 +556,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download addon artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: addon-*
           path: ./addons
@@ -626,13 +631,13 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
       - name: Restore binaries from cache
         id: binary-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             target/x86_64-unknown-linux-musl/release/alien
@@ -667,7 +672,7 @@ jobs:
           done
 
       - name: Upload x86_64 linux binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries-x86_64-unknown-linux-musl
           retention-days: 1
@@ -681,13 +686,13 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
       - name: Restore binaries from cache
         id: binary-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             target/aarch64-unknown-linux-musl/release/alien
@@ -722,7 +727,7 @@ jobs:
           done
 
       - name: Upload aarch64 linux binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries-aarch64-unknown-linux-musl
           retention-days: 1
@@ -738,13 +743,13 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
       - name: Restore binaries from cache
         id: binary-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             target/aarch64-apple-darwin/release/alien
@@ -767,7 +772,7 @@ jobs:
       - name: Install sccache
         if: steps.binary-cache.outputs.cache-hit != 'true'
         continue-on-error: true
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: v0.16.0
 
@@ -792,7 +797,7 @@ jobs:
           done
 
       - name: Upload aarch64 darwin binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries-aarch64-apple-darwin
           retention-days: 1
@@ -808,13 +813,13 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
       - name: Restore binaries from cache
         id: binary-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             target/x86_64-pc-windows-msvc/release/alien.exe
@@ -835,7 +840,7 @@ jobs:
       - name: Install sccache
         if: steps.binary-cache.outputs.cache-hit != 'true'
         continue-on-error: true
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
         with:
           version: v0.16.0
 
@@ -865,7 +870,7 @@ jobs:
           cp target/x86_64-pc-windows-msvc/release/alien-operator.exe staged/x86_64-pc-windows-msvc/
 
       - name: Upload windows binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries-x86_64-pc-windows-msvc
           retention-days: 1
@@ -880,7 +885,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: binaries-*
           path: ./artifacts
@@ -939,14 +944,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: binaries-*
           path: ./artifacts
           merge-multiple: false
 
       - name: Download changelog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: changelog
           path: .
@@ -1003,12 +1008,12 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm-16
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
       - name: Download linux binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: binaries-*-unknown-linux-musl
           path: ./linux-bins
@@ -1215,11 +1220,11 @@ jobs:
     runs-on: depot-ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -1230,7 +1235,7 @@ jobs:
         run: npm whoami
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: binaries-*
           path: ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,10 @@ jobs:
           version: v0.16.0
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ github.token }}
 
       - name: Publish crates
         env:

--- a/crates/alien-gcp-clients/tests/common/mod.rs
+++ b/crates/alien-gcp-clients/tests/common/mod.rs
@@ -1,0 +1,47 @@
+//! Shared helpers for GCP cloud integration tests.
+
+use alien_client_core::ErrorData;
+use alien_gcp_clients::iam::{CreateServiceAccountRequest, IamApi, IamClient, ServiceAccount};
+use std::time::Duration;
+use tracing::info;
+
+/// Total attempts for a quota-limited service-account creation.
+const QUOTA_RETRY_ATTEMPTS: usize = 3;
+/// GCP enforces a "service accounts created per minute per project" quota and
+/// answers 429 with `RetryInfo { retry_delay: 60s }`. Wait slightly longer so
+/// the retry lands in the next quota window.
+const QUOTA_RETRY_DELAY: Duration = Duration::from_secs(65);
+
+/// Create a service account, waiting out exhausted per-minute quotas.
+///
+/// The cloud-test GCP project is shared with concurrently running CI jobs, so
+/// the per-minute creation quota can be exhausted by neighbors. That 429 is
+/// server-side throttling, not a bug in the client or the test; honoring the
+/// server's RetryInfo with bounded attempts keeps real failures visible.
+pub async fn create_service_account_with_quota_retry(
+    iam_client: &IamClient,
+    account_id: &str,
+    request: &CreateServiceAccountRequest,
+) -> alien_client_core::Result<ServiceAccount> {
+    let mut attempt = 1;
+    loop {
+        let result = iam_client
+            .create_service_account(account_id.to_string(), request.clone())
+            .await;
+        match result {
+            Err(error)
+                if attempt < QUOTA_RETRY_ATTEMPTS
+                    && matches!(&error.error, Some(ErrorData::RateLimitExceeded { .. })) =>
+            {
+                info!(
+                    "⏳ CreateServiceAccount '{}' hit an exhausted per-minute quota \
+                     (attempt {}/{}); retrying in {:?}: {}",
+                    account_id, attempt, QUOTA_RETRY_ATTEMPTS, QUOTA_RETRY_DELAY, error
+                );
+                tokio::time::sleep(QUOTA_RETRY_DELAY).await;
+                attempt += 1;
+            }
+            result => return result,
+        }
+    }
+}

--- a/crates/alien-gcp-clients/tests/gcp_iam_client_tests.rs
+++ b/crates/alien-gcp-clients/tests/gcp_iam_client_tests.rs
@@ -1,4 +1,6 @@
 #![cfg(all(test, feature = "gcp"))]
+mod common;
+
 use alien_client_core::{ErrorData, Result};
 use alien_gcp_clients::iam::{
     Binding, CreateRoleRequest, CreateServiceAccountRequest, Expr, IamApi, IamClient, IamPolicy,
@@ -185,10 +187,12 @@ impl IamTestContext {
         account_id: &str,
         service_account: CreateServiceAccountRequest,
     ) -> Result<ServiceAccount> {
-        let result = self
-            .client
-            .create_service_account(account_id.to_string(), service_account)
-            .await;
+        let result = common::create_service_account_with_quota_retry(
+            &self.client,
+            account_id,
+            &service_account,
+        )
+        .await;
         if result.is_ok() {
             // For service accounts, the name format is projects/{project}/serviceAccounts/{email}
             // We need to track the full name for deletion
@@ -818,10 +822,14 @@ async fn test_error_service_account_already_exists(ctx: &mut IamTestContext) {
         .service_account(service_account)
         .build();
 
-    let result = ctx
-        .client
-        .create_service_account(account_id.clone(), duplicate_request)
-        .await;
+    // Retry only exhausted-quota 429s so this test observes the expected 409
+    // conflict instead of unrelated project-wide throttling.
+    let result = common::create_service_account_with_quota_retry(
+        &ctx.client,
+        &account_id,
+        &duplicate_request,
+    )
+    .await;
     assert!(
         result.is_err(),
         "Expected error when creating duplicate service account"

--- a/crates/alien-gcp-clients/tests/gcp_resource_manager_client_tests.rs
+++ b/crates/alien-gcp-clients/tests/gcp_resource_manager_client_tests.rs
@@ -1,4 +1,6 @@
 #![cfg(all(test, feature = "gcp"))]
+mod common;
+
 use alien_client_core::{ErrorData, Result};
 use alien_error::{Context, IntoAlienError};
 use alien_gcp_clients::iam::{
@@ -181,16 +183,18 @@ impl ResourceManagerTestContext {
             .service_account(service_account)
             .build();
 
-        let created_sa = self
-            .iam_client
-            .create_service_account(unique_account_id.clone(), request)
-            .await
-            .context(ErrorData::GenericError {
-                message: format!(
-                    "Failed to create test service account '{}'",
-                    unique_account_id
-                ),
-            })?;
+        let created_sa = common::create_service_account_with_quota_retry(
+            &self.iam_client,
+            &unique_account_id,
+            &request,
+        )
+        .await
+        .context(ErrorData::GenericError {
+            message: format!(
+                "Failed to create test service account '{}'",
+                unique_account_id
+            ),
+        })?;
 
         let sa_email = created_sa.email.clone().unwrap();
         self.test_service_account_email = Some(sa_email.clone());


### PR DESCRIPTION
## Why

Dispatching **Cloud Tests** against current main fails on environment noise rather than product code. Four distinct, demonstrated failure classes:

1. **GCP per-minute quota exhaustion** — [main run 29666176524](https://github.com/alienplatform/alien/actions/runs/29666176524): `test_comprehensive_iam_policy_operations` died creating its test service account with HTTP 429 `RESOURCE_EXHAUSTED` ("Service accounts created per minute per project", `RetryInfo { retryDelay: 60s }`). The test project is shared with concurrently running CI jobs (e.g. E2E), so any run can lose this race. The fail-fast cancellation then hid 20 more tests.
2. **Ubuntu mirror outages during apt installs** — [run 29437605942](https://github.com/alienplatform/alien/actions/runs/29437605942): the `bindings` job spent 9 minutes in apt connection errors installing `protobuf-compiler` and died with exit 100 before running a single test. The same un-retried apt pattern exists in every workflow. The apt pattern has burned Cloud Tests twice (also May 19, [run 26096349837](https://github.com/alienplatform/alien/actions/runs/26096349837)).
3. **sccache cache-backend errors** — the shared sccache webdav backend intermittently answers a read with a transient `403` (`PermissionDenied (temporary)`), which aborts sccache server startup and fails the whole Rust build with exit 101. By default sccache treats a server it cannot reach as fatal.
4. **Node-20 action deprecation** — every `actions/*` pinned to a Node-20 runtime is currently being force-migrated to Node 24 by GitHub and will eventually hard-fail once Node 20 is removed from the runners.

## What

- **Bounded quota retry at the test service-account creation sites** (`tests/common/mod.rs`, used by the resource-manager and IAM suites, including the duplicate-creation test so throttling can't masquerade as the expected 409). Retries only `RateLimitExceeded`, max 3 attempts, waiting out Google's documented 60s RetryInfo window. This is server-side throttling on a shared project — not a client or test bug — so honoring the server's retry contract with bounded attempts keeps real failures visible.
- **Install protoc from GitHub releases instead of Ubuntu mirrors** via `arduino/setup-protoc@v3` pinned to `27.x` — the action + version the Windows E2E job already uses — across ci-fast, ci-fork, cloud-tests, generated-drift, e2e-cloud, release, and the `setup-rust` composite action.
- **`Acquire::Retries=5` on the remaining apt installs** (musl-tools, awscli/unzip, release-pgvector build tools).
- **`SCCACHE_IGNORE_SERVER_IO_ERROR=1`** at the workflow level (ci-fast, cloud-tests, generated-drift, release, e2e-cloud) so sccache falls back to local compilation when the shared cache backend is unreachable instead of failing the build. ([sccache README](https://github.com/mozilla/sccache/blob/main/README.md))
- **De-deprecate Node-20 actions** to their current Node-24 majors: `checkout@v5`, `setup-node@v5`, `cache@v5`, `download-artifact@v7` (deliberately not the breaking `v8`, which stops auto-unzipping and errors on hash mismatch), `upload-artifact@v6`, `pnpm/action-setup@v6`, `setup-terraform@v4`, `setup-helm@v5`, `paths-filter@v4`, `sccache-action@v0.0.10`. Each target tag was verified to declare `runs.using: node24`.

## Validation

- `cargo test -p alien-gcp-clients --features gcp --no-run` compiles all touched test binaries.
- CI Fast on this PR exercises the new protoc install and the bumped actions on the ARM runners.
- Every bumped action tag verified against its `action.yml` to declare the `node24` runtime; `download-artifact` held at `v7` after reviewing the `v8` breaking changes.
- Will dispatch **Cloud Tests** on this branch and label the PR `run-e2e` to exercise the e2e-cloud changes end-to-end.
