### PR TITLE
fix: harden Azure setup handoff and example coverage

### DIFF
--- a/crates/alien-core/src/import/data/azure/compute_cluster.rs
+++ b/crates/alien-core/src/import/data/azure/compute_cluster.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct AzureComputeClusterImportData {
     /// Cluster identifier used by the controller.
     pub cluster_id: String,
+    /// Resource ID of the user-assigned identity attached to cluster VMs.
+    pub identity_id: String,
     /// AKS cluster identity principal id (system-assigned identity).
     pub cluster_identity_principal_id: String,
     /// kubelet UAMI client id used by node pools.

--- a/crates/alien-core/src/import/data/snapshots/alien_core__import__data__schema_snapshots__import_data_schemas.snap
+++ b/crates/alien-core/src/import/data/snapshots/alien_core__import__data__schema_snapshots__import_data_schemas.snap
@@ -610,6 +610,10 @@ expression: schemas
         "description": "AKS cluster identity principal id (system-assigned identity).",
         "type": "string"
       },
+      "identityId": {
+        "description": "Resource ID of the user-assigned identity attached to cluster VMs.",
+        "type": "string"
+      },
       "kubeletIdentityClientId": {
         "description": "kubelet UAMI client id used by node pools.",
         "type": "string"
@@ -618,6 +622,7 @@ expression: schemas
     "required": [
       "clusterId",
       "clusterIdentityPrincipalId",
+      "identityId",
       "kubeletIdentityClientId"
     ],
     "title": "AzureComputeClusterImportData",

--- a/crates/alien-terraform/src/emitters/azure/container_apps_environment.rs
+++ b/crates/alien-terraform/src/emitters/azure/container_apps_environment.rs
@@ -87,11 +87,10 @@ impl TfEmitter for AzureContainerAppsEnvironmentEmitter {
         // VNet-integrate the environment when the stack has a Network, so Container Apps can reach
         // private-only resources (a Flexible Server reachable only through its private endpoint).
         // Without this the environment is public and a worker's connection to the private server
-        // times out. The stack private subnet IS the infrastructure subnet (the network emitter
-        // delegates it to `Microsoft.App/environments`; the postgres private endpoint gets its own
-        // subnet); `internal_load_balancer_enabled = false` keeps public ingress while egressing
-        // through the VNet. Mirrors the runtime controller's `get_vnet_configuration` — a
-        // consumption environment on the /24 private subnet, proven to reach a private server.
+        // times out. Managed networks give the environment its own delegated infrastructure
+        // subnet so VMSS NICs can continue using the private workload subnet. BYO networks retain
+        // their explicitly supplied private subnet contract. `internal_load_balancer_enabled =
+        // false` keeps public ingress while egressing through the VNet.
         if let Some(infrastructure_subnet_id) = infrastructure_subnet_id(ctx) {
             env_body.push(attr("infrastructure_subnet_id", infrastructure_subnet_id));
             env_body.push(attr(
@@ -243,9 +242,8 @@ impl TfEmitter for AzureContainerAppsEnvironmentEmitter {
 /// Network (then the environment stays public, matching the runtime controller's
 /// `get_vnet_configuration` returning `None`).
 ///
-/// Resolves to the network emitter's private subnet, matching how the Azure network emitter
-/// materializes it: a managed `azurerm_subnet.<network>_private` in create / use-default mode, a
-/// looked-up `data.azurerm_subnet.<network>_private` in bring-your-own-VNet mode.
+/// Resolves to the network emitter's dedicated Container Apps subnet for managed networks and the
+/// explicitly supplied private subnet in bring-your-own-VNet mode.
 fn infrastructure_subnet_id(ctx: &EmitContext<'_>) -> Option<Expression> {
     let (network_id, entry) = ctx
         .stack
@@ -253,12 +251,19 @@ fn infrastructure_subnet_id(ctx: &EmitContext<'_>) -> Option<Expression> {
         .find(|(_id, entry)| entry.config.resource_type() == Network::RESOURCE_TYPE)?;
     let network = entry.config.downcast_ref::<Network>()?;
     let network_label = ctx.name_for(network_id)?;
-    let private_subnet_label = format!("{network_label}_private");
-
     let byo = matches!(network.settings, NetworkSettings::ByoVnetAzure { .. });
     Some(if byo {
-        expr::traversal(["data", "azurerm_subnet", &private_subnet_label, "id"])
+        expr::traversal([
+            "data",
+            "azurerm_subnet",
+            &format!("{network_label}_private"),
+            "id",
+        ])
     } else {
-        expr::traversal(["azurerm_subnet", &private_subnet_label, "id"])
+        expr::traversal([
+            "azurerm_subnet",
+            &format!("{network_label}_container_apps"),
+            "id",
+        ])
     })
 }

--- a/crates/alien-terraform/src/emitters/azure/network.rs
+++ b/crates/alien-terraform/src/emitters/azure/network.rs
@@ -12,8 +12,9 @@
 //!   resource id and subnet names; we surface the resolved ids in
 //!   ImportData so the controller can plug them into AKS / Container
 //!   Apps without an extra cloud round-trip.
-//! * `Create` — full topology: VNet, public + private subnet, NAT
-//!   gateway with its public IP, NSG.
+//! * `Create` — full topology: VNet, public + private workload subnets,
+//!   a dedicated Container Apps infrastructure subnet, NAT gateway with
+//!   its public IP, and an NSG.
 //!
 //! Subnets land at deterministic addresses derived from the VNet CIDR.
 //! Default CIDR `10.46.0.0/16` mirrors the AWS (`10.42`) / GCP
@@ -154,6 +155,7 @@ fn create_topology(ctx: &EmitContext<'_>, label: &str, cidr: Option<String>) -> 
     let cidr = cidr.unwrap_or_else(|| "10.46.0.0/16".to_string());
     let public_label = format!("{label}_public");
     let private_label = format!("{label}_private");
+    let container_apps_label = format!("{label}_container_apps");
     let appgw_label = format!("{label}_appgw");
     let alb_label = format!("{label}_alb");
     let pe_label = format!("{label}_pe");
@@ -209,12 +211,10 @@ fn create_topology(ctx: &EmitContext<'_>, label: &str, cidr: Option<String>) -> 
         ],
     ));
 
-    // The private subnet doubles as the Container Apps environment infrastructure subnet (the
-    // env emitter points `infrastructure_subnet_id` here, mirroring the runtime controller). Azure
-    // requires that subnet to be delegated to `Microsoft.App/environments`; unlike the `az` CLI,
-    // the azurerm provider does not auto-delegate, so the delegation is declared here. A /24 is
-    // sufficient for the consumption environment the env emitter creates (proven against real
-    // Azure: a consumption env on a /24 delegated subnet provisions and schedules apps).
+    // The private subnet is reserved for VM and other workload NICs. Container Apps environments
+    // are external resources from Azure Networking's perspective, so a VMSS cannot attach NICs to
+    // the same subnet as an environment. Keep this subnet undelegated and give Container Apps its
+    // own subnet below.
     fragment.resource_blocks.push(resource_block(
         "azurerm_subnet",
         &private_label,
@@ -235,6 +235,33 @@ fn create_topology(ctx: &EmitContext<'_>, label: &str, cidr: Option<String>) -> 
                 "address_prefixes",
                 Expression::Array(vec![expr::raw(format!(
                     "cidrsubnet(tolist(azurerm_virtual_network.{label}.address_space)[0], 8, 1)"
+                ))]),
+            ),
+        ],
+    ));
+
+    // Azure requires a delegated infrastructure subnet for a VNet-integrated Container Apps
+    // environment. A /24 is sufficient for the consumption environment emitted by Alien.
+    fragment.resource_blocks.push(resource_block(
+        "azurerm_subnet",
+        &container_apps_label,
+        [
+            attr(
+                "name",
+                expr::template(format!("${{local.resource_prefix}}-{label}-container-apps")),
+            ),
+            attr(
+                "resource_group_name",
+                expr::raw("var.azure_resource_group_name"),
+            ),
+            attr(
+                "virtual_network_name",
+                expr::traversal(["azurerm_virtual_network", label, "name"]),
+            ),
+            attr(
+                "address_prefixes",
+                Expression::Array(vec![expr::raw(format!(
+                    "cidrsubnet(tolist(azurerm_virtual_network.{label}.address_space)[0], 8, 5)"
                 ))]),
             ),
             nested(crate::block::block(
@@ -340,8 +367,8 @@ fn create_topology(ctx: &EmitContext<'_>, label: &str, cidr: Option<String>) -> 
     ));
 
     // Dedicated Private Endpoint subnet for Postgres Flexible Server (and any future PE-reached
-    // service). It must NOT share the delegated Container Apps "private" subnet: a subnet delegated
-    // to `Microsoft.App/environments` cannot host a Private Endpoint. Left undelegated, with
+    // service). It must not share either the workload subnet or the delegated Container Apps
+    // subnet. Left undelegated, with
     // Private Endpoint network policies disabled as Azure requires for PE NICs.
     fragment.resource_blocks.push(resource_block(
         "azurerm_subnet",

--- a/crates/alien-terraform/tests/generator/azure_full_stack_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_full_stack_tests.rs
@@ -144,8 +144,8 @@ fn azure_full_stack_renders_audit_ready_module() {
     let has = |needle: &str| rendered.iter().any(|line| line == needle);
 
     assert!(
-        has("infrastructure_subnet_id = azurerm_subnet.default_network_private.id"),
-        "container apps environment must point its infrastructure subnet at the network private subnet"
+        has("infrastructure_subnet_id = azurerm_subnet.default_network_container_apps.id"),
+        "container apps environment must use its dedicated infrastructure subnet"
     );
     assert!(
         has("internal_load_balancer_enabled = false"),
@@ -153,7 +153,7 @@ fn azure_full_stack_renders_audit_ready_module() {
     );
     assert!(
         has("name = \"Microsoft.App/environments\""),
-        "the private subnet must be delegated to Microsoft.App/environments for the env infra subnet"
+        "the container apps subnet must be delegated to Microsoft.App/environments"
     );
 
     assert_terraform_valid(&module, "azure_full_stack");

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
@@ -461,7 +461,7 @@ resource "azurerm_container_app_environment" "default_container_apps_environment
   resource_group_name            = var.azure_resource_group_name
   location                       = var.azure_location
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.default_container_apps_environment_logs.id
-  infrastructure_subnet_id       = azurerm_subnet.default_network_private.id
+  infrastructure_subnet_id       = azurerm_subnet.default_network_container_apps.id
   internal_load_balancer_enabled = false
   tags = {
     "managed-by"    = "setup"
@@ -511,6 +511,18 @@ resource "azurerm_subnet" "default_network_private" {
   virtual_network_name = azurerm_virtual_network.default_network.name
   address_prefixes = [
     cidrsubnet(tolist(azurerm_virtual_network.default_network.address_space)[0], 8, 1)
+  ]
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
+}
+
+resource "azurerm_subnet" "default_network_container_apps" {
+  name                 = "${local.resource_prefix}-default_network-container-apps"
+  resource_group_name  = var.azure_resource_group_name
+  virtual_network_name = azurerm_virtual_network.default_network.name
+  address_prefixes = [
+    cidrsubnet(tolist(azurerm_virtual_network.default_network.address_space)[0], 8, 5)
   ]
 
   delegation {
@@ -997,6 +1009,7 @@ resource "terraform_data" "deployment_registration" {
     azurerm_virtual_network.default_network,
     azurerm_subnet.default_network_public,
     azurerm_subnet.default_network_private,
+    azurerm_subnet.default_network_container_apps,
     azurerm_subnet.default_network_appgw,
     azurerm_subnet.default_network_alb,
     azurerm_subnet.default_network_pe,

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.11.0",
   "scripts": {
     "test": "pnpm run test:projects",
-    "test:projects": "pnpm -C basic-worker-ts test && pnpm -C remote-worker-ts test && pnpm -C data-connector-ts test && pnpm -C event-pipeline-ts test"
+    "test:projects": "pnpm -C basic-worker-ts test && pnpm -C remote-worker-ts test && pnpm -C data-connector-ts test && pnpm -C event-pipeline-ts test && pnpm -C command-routing-ts test:ts"
   },
   "pnpm": {
     "overrides": {

--- a/scripts/test-examples-local.sh
+++ b/scripts/test-examples-local.sh
@@ -50,7 +50,8 @@ if [[ "${ALIEN_EXAMPLES_REUSE_BUILT_PACKAGES:-}" != "true" ]]; then
 fi
 
 if (( ${#build_filters[@]} > 0 )); then
-  pnpm -r "${build_filters[@]}" run build
+  NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192" \
+    pnpm -r "${build_filters[@]}" run build
 fi
 
 node - "$EXAMPLES_PACKAGE_JSON" "$ROOT_DIR" <<'NODE'


### PR DESCRIPTION
## Summary

- exercise the command-routing example in the examples validation gate
- carry the Azure VM identity resource ID through setup registration
- isolate the Azure Container Apps infrastructure subnet from the VM workload subnet

## Validation

- `cargo test -p alien-terraform --test generator azure_full_stack -- --nocapture`
- `pnpm test:examples`
- generated Azure Terraform passes `terraform validate` as part of the generator test

