### PR TITLE
fix: resolve CLI manager from deployment ownership (ALIEN-277)

### DIFF
--- a/crates/alien-cli/src/commands/commands.rs
+++ b/crates/alien-cli/src/commands/commands.rs
@@ -72,16 +72,32 @@ pub async fn commands_task(args: CommandsArgs, ctx: ExecutionMode) -> Result<()>
         } => {
             let is_dev = ctx.is_dev();
 
-            // Resolve the manager the same way `deployments` does. In platform
-            // mode this discovers the manager URL and builds a workspace-aware
-            // client; server_sdk_client() isn't available there.
-            // Invoking a command never pushes container images, so resolve
-            // metadata-only and skip artifact-repo provisioning (~10–15s on
-            // platform/dev clusters — see resolve_manager_metadata_only).
-            let (_, project_link) = ctx.resolve_project(None, true).await?;
-            let manager = ctx
-                .resolve_manager_metadata_only(&project_link.project_id, "aws")
+            // Platform deployments retain their owning manager even when a
+            // project's defaults change. Direct modes still use their known manager.
+            #[cfg(feature = "platform")]
+            let (manager, deployment) = if ctx.is_platform() {
+                let resolved = crate::platform_deployment_resolver::resolve_with_manager(
+                    &ctx,
+                    &deployment,
+                    None,
+                    true,
+                )
                 .await?;
+                (resolved.manager, String::from(resolved.detail.id))
+            } else {
+                let (_, project_link) = ctx.resolve_project(None, true).await?;
+                (
+                    ctx.resolve_manager_metadata_only(&project_link.project_id, "aws")
+                        .await?,
+                    deployment,
+                )
+            };
+            #[cfg(not(feature = "platform"))]
+            let manager = {
+                let (_, project_link) = ctx.resolve_project(None, true).await?;
+                ctx.resolve_manager_metadata_only(&project_link.project_id, "aws")
+                    .await?
+            };
 
             invoke_command(
                 &manager.client,

--- a/crates/alien-cli/src/commands/debug.rs
+++ b/crates/alien-cli/src/commands/debug.rs
@@ -180,15 +180,7 @@ pub async fn debug_task(args: DebugArgs, ctx: ExecutionMode) -> Result<()> {
         })
     })?;
 
-    let (_, project_link) = ctx.resolve_project(None, true).await?;
-    // `debug` never pushes images, so skip the artifact-registry repo
-    // provisioning step — saves ~10s per invocation against cloud managers.
-    let manager = ctx
-        .resolve_manager_metadata_only(&project_link.project_id, "aws")
-        .await?;
-
-    let is_dev = ctx.is_dev();
-    let deployment_id = resolve_deployment_id(&manager, deployment, is_dev).await?;
+    let (manager, deployment_id) = resolve_debug_target(&ctx, deployment, true).await?;
 
     // No CLI-side caching: every invocation asks the manager to create-or-
     // reuse a session. The manager controls session lifetime, token rotation,
@@ -227,11 +219,7 @@ async fn runtime_shell_task(args: DebugShellArgs, ctx: ExecutionMode) -> Result<
         }));
     }
 
-    let (_, project_link) = ctx.resolve_project(None, true).await?;
-    let manager = ctx
-        .resolve_manager_metadata_only(&project_link.project_id, "aws")
-        .await?;
-    let deployment_id = resolve_deployment_id(&manager, &args.deployment, ctx.is_dev()).await?;
+    let (manager, deployment_id) = resolve_debug_target(&ctx, &args.deployment, true).await?;
     let session = request_debug_session(
         &manager,
         CreateDebugSessionRequest {
@@ -261,11 +249,7 @@ async fn runtime_shell_task(args: DebugShellArgs, ctx: ExecutionMode) -> Result<
 }
 
 async fn runtime_exec_task(args: DebugExecArgs, ctx: ExecutionMode) -> Result<()> {
-    let (_, project_link) = ctx.resolve_project(None, true).await?;
-    let manager = ctx
-        .resolve_manager_metadata_only(&project_link.project_id, "aws")
-        .await?;
-    let deployment_id = resolve_deployment_id(&manager, &args.deployment, ctx.is_dev()).await?;
+    let (manager, deployment_id) = resolve_debug_target(&ctx, &args.deployment, true).await?;
     let session = request_debug_session(
         &manager,
         CreateDebugSessionRequest {
@@ -965,9 +949,32 @@ pub async fn debug_task_dev(args: DebugArgs, port: u16) -> Result<()> {
 
 /// Parse the user-supplied deployment spec and resolve it to a `dep_...` ID.
 ///
-/// Delegates to the shared `deployment_resolver` so the spec form, server-side
-/// `search` filtering, and "not found / ambiguous" messages stay in sync
-/// across `debug`, `commands`, and `deployments {get,delete,retry,redeploy}`.
+/// Resolve both the canonical deployment ID and the manager that owns it.
+async fn resolve_debug_target(
+    ctx: &ExecutionMode,
+    deployment: &str,
+    allow_prompt: bool,
+) -> Result<(crate::execution_context::ManagerContext, String)> {
+    #[cfg(feature = "platform")]
+    if ctx.is_platform() {
+        let resolved = crate::platform_deployment_resolver::resolve_with_manager(
+            ctx,
+            deployment,
+            None,
+            allow_prompt,
+        )
+        .await?;
+        return Ok((resolved.manager, String::from(resolved.detail.id)));
+    }
+
+    let (_, project_link) = ctx.resolve_project(None, allow_prompt).await?;
+    let manager = ctx
+        .resolve_manager_metadata_only(&project_link.project_id, "aws")
+        .await?;
+    let deployment_id = resolve_deployment_id(&manager, deployment, ctx.is_dev()).await?;
+    Ok((manager, deployment_id))
+}
+
 async fn resolve_deployment_id(
     manager: &ManagerContext,
     spec: &str,

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -196,18 +196,92 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
             list_deployments_task(&manager, json).await
         }
         DeploymentsCmd::Get { id, json } => {
+            #[cfg(feature = "platform")]
+            if ctx.is_platform() {
+                let workspace = ctx.resolve_workspace_with_bootstrap(!json).await?;
+                let client = ctx.sdk_client().await?;
+                let deployment = crate::platform_deployment_resolver::resolve(
+                    &ctx, &client, &workspace, &id, None, !json,
+                )
+                .await?;
+                if json {
+                    return print_json(&deployment);
+                }
+                println!(
+                    "{}",
+                    contextual_heading(
+                        "Showing deployment",
+                        &String::from(deployment.name.clone()),
+                        &[]
+                    )
+                );
+                println!("{} {}", dim_label("ID"), String::from(deployment.id));
+                println!("{} {}", dim_label("Status"), deployment.status);
+                println!("{} {}", dim_label("Platform"), deployment.platform);
+                println!(
+                    "{} {}",
+                    dim_label("Group"),
+                    String::from(deployment.deployment_group_id)
+                );
+                println!(
+                    "{} {}",
+                    dim_label("Manager"),
+                    String::from(deployment.manager_id)
+                );
+                println!("{} {}", dim_label("Created"), deployment.created_at);
+                return Ok(());
+            }
             let manager = resolve_manager_client(&ctx, None, !json).await?;
             get_deployment_task(&ctx, &manager, &id, json).await
         }
         DeploymentsCmd::Delete { id, yes } => {
+            #[cfg(feature = "platform")]
+            if ctx.is_platform() {
+                let resolved = crate::platform_deployment_resolver::resolve_with_manager(
+                    &ctx, &id, None, true,
+                )
+                .await?;
+                return delete_deployment_task(
+                    &resolved.manager.client,
+                    &String::from(resolved.detail.id),
+                    yes,
+                )
+                .await;
+            }
             let manager = resolve_manager_client(&ctx, None, true).await?;
             delete_deployment_task(&manager, &id, yes).await
         }
         DeploymentsCmd::Retry { id, json } => {
+            #[cfg(feature = "platform")]
+            if ctx.is_platform() {
+                let resolved = crate::platform_deployment_resolver::resolve_with_manager(
+                    &ctx, &id, None, !json,
+                )
+                .await?;
+                return retry_deployment_task(
+                    &resolved.manager.client,
+                    &String::from(resolved.detail.id),
+                    json,
+                )
+                .await;
+            }
             let manager = resolve_manager_client(&ctx, None, !json).await?;
             retry_deployment_task(&manager, &id, json).await
         }
         DeploymentsCmd::Redeploy { id, json } => {
+            #[cfg(feature = "platform")]
+            if ctx.is_platform() {
+                let resolved = crate::platform_deployment_resolver::resolve_with_manager(
+                    &ctx, &id, None, !json,
+                )
+                .await?;
+                return redeploy_deployment_task(
+                    &resolved.manager.client,
+                    &String::from(resolved.detail.id),
+                    json,
+                )
+                .await;
+            }
             let manager = resolve_manager_client(&ctx, None, !json).await?;
             redeploy_deployment_task(&manager, &id, json).await
         }

--- a/crates/alien-cli/src/commands/logs.rs
+++ b/crates/alien-cli/src/commands/logs.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::io::{self, Write};
-use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
 
@@ -363,106 +362,34 @@ async fn resolve_deployment_target(
     project_override: Option<&str>,
     allow_prompt: bool,
 ) -> Result<ResolvedLogsTarget> {
-    if deployment.starts_with("dep_") {
-        let response = client
-            .get_deployment()
-            .id(deployment)
-            .workspace(workspace)
-            .send()
-            .await
-            .into_sdk_error()
-            .context(ErrorData::ApiRequestFailed {
-                message: format!("Failed to get deployment {deployment}"),
-                url: None,
-            })?
-            .into_inner();
+    #[cfg(feature = "platform")]
+    {
+        let response = crate::platform_deployment_resolver::resolve(
+            ctx,
+            client,
+            workspace,
+            deployment,
+            project_override,
+            allow_prompt,
+        )
+        .await?;
         return target_from_deployment_detail(response, None).await;
     }
 
-    let Some((group_name, deployment_name)) = deployment.split_once('/') else {
-        return Err(AlienError::new(ErrorData::ValidationError {
-            field: "deployment".to_string(),
-            message:
-                "Use a deployment ID like dep_... or <deployment-group-name>/<deployment-name>."
-                    .to_string(),
-        }));
-    };
-
-    let (project_id, project_link) = ctx.resolve_project(project_override, allow_prompt).await?;
-    let groups = client
-        .list_deployment_groups()
-        .workspace(workspace)
-        .project(project_id.as_str())
-        .search(group_name)
-        .limit(NonZeroU64::new(50).expect("constant is non-zero"))
-        .send()
-        .await
-        .into_sdk_error()
-        .context(ErrorData::ApiRequestFailed {
-            message: format!("Failed to resolve deployment group {group_name}"),
-            url: None,
-        })?
-        .into_inner()
-        .items;
-
-    let group = groups
-        .into_iter()
-        .find(|group| {
-            let name: String = group.name.clone().into();
-            name == group_name
-        })
-        .ok_or_else(|| {
-            AlienError::new(ErrorData::ValidationError {
-                field: "deployment".to_string(),
-                message: format!(
-                    "Deployment group '{group_name}' was not found in project {}.",
-                    project_link.project_name
-                ),
-            })
-        })?;
-    let group_id: String = group.id.clone().into();
-
-    let deployments = client
-        .list_deployments()
-        .workspace(workspace)
-        .project(project_id.as_str())
-        .deployment_group(group_id.as_str())
-        .search(deployment_name)
-        .limit(NonZeroU64::new(50).expect("constant is non-zero"))
-        .send()
-        .await
-        .into_sdk_error()
-        .context(ErrorData::ApiRequestFailed {
-            message: format!("Failed to resolve deployment {deployment}"),
-            url: None,
-        })?
-        .into_inner()
-        .items;
-
-    let deployment = deployments
-        .into_iter()
-        .find(|item| item.name == deployment_name)
-        .ok_or_else(|| {
-            AlienError::new(ErrorData::ValidationError {
-                field: "deployment".to_string(),
-                message: format!(
-                    "Deployment '{deployment_name}' was not found in group '{group_name}'."
-                ),
-            })
-        })?;
-
-    let deployment_id: String = deployment.id.clone().into();
-    let deployment_project_id: String = deployment.project_id.clone().into();
-    let manager_id = String::from(deployment.manager_id.clone());
-
-    Ok(ResolvedLogsTarget {
-        manager_id,
-        project_id: Some(deployment_project_id),
-        project_name: Some(project_link.project_name),
-        deployment_id: Some(deployment_id),
-        deployment_name: Some(deployment.name),
-        deployment_group_name: Some(group_name.to_string()),
-    })
+    #[cfg(not(feature = "platform"))]
+    {
+        let _ = (
+            ctx,
+            client,
+            workspace,
+            deployment,
+            project_override,
+            allow_prompt,
+        );
+        Err(AlienError::new(ErrorData::ConfigurationError {
+            message: "Deployment log discovery requires platform support.".to_string(),
+        }))
+    }
 }
 
 async fn target_from_deployment_detail(

--- a/crates/alien-cli/src/execution_context.rs
+++ b/crates/alien-cli/src/execution_context.rs
@@ -84,6 +84,14 @@ pub enum ExecutionMode {
 }
 
 impl ExecutionMode {
+    pub fn is_platform(&self) -> bool {
+        #[cfg(feature = "platform")]
+        if matches!(self, Self::Platform { .. }) {
+            return true;
+        }
+        false
+    }
+
     /// Get the manager URL for this execution mode.
     pub fn manager_url(&self) -> String {
         match self {
@@ -457,6 +465,54 @@ impl ExecutionMode {
         platform: &str,
     ) -> Result<ManagerContext> {
         self.resolve_manager_inner(project, platform, false).await
+    }
+
+    #[cfg(feature = "platform")]
+    pub async fn connect_manager_by_id(
+        &self,
+        manager_id: &str,
+        workspace: &str,
+    ) -> Result<ManagerContext> {
+        let http = self.auth_http().await?;
+        let manager = http
+            .sdk_client()
+            .get_manager()
+            .id(manager_id)
+            .workspace(workspace)
+            .send()
+            .await
+            .into_sdk_error()
+            .context(ErrorData::ApiRequestFailed {
+                message: format!("Failed to get manager {manager_id}"),
+                url: None,
+            })?
+            .into_inner();
+        let manager_url = normalize_base_url(manager.url.as_deref().ok_or_else(|| {
+            AlienError::new(ErrorData::ApiRequestFailed {
+                message: format!("Manager {manager_id} has not reported a URL"),
+                url: None,
+            })
+        })?);
+        let auth_token = http.bearer_token.clone();
+        let manager_http_client = match &auth_token {
+            Some(token) => {
+                crate::auth::client_with_auth_and_workspace(&format!("Bearer {token}"), workspace)?
+            }
+            None => http.client.clone(),
+        };
+        let client = ServerSdkClient::new_with_client(&manager_url, manager_http_client.clone());
+        Ok(ManagerContext {
+            manager_url,
+            manager_name: Some(manager.name),
+            manager_is_system: Some(manager.is_system),
+            manager_cloud: manager.cloud.map(|cloud| cloud.to_string()),
+            client,
+            http_client: manager_http_client,
+            auth_token,
+            repository_name: None,
+            repository_uri: None,
+            workspace: Some(workspace.to_string()),
+        })
     }
 
     /// Resolve manager URL and return an authenticated manager SDK client.

--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -10,6 +10,8 @@ pub mod execution_context;
 pub mod git_utils;
 pub mod interaction;
 pub mod output;
+#[cfg(feature = "platform")]
+pub mod platform_deployment_resolver;
 pub mod project_link;
 pub mod ui;
 

--- a/crates/alien-cli/src/platform_deployment_resolver.rs
+++ b/crates/alien-cli/src/platform_deployment_resolver.rs
@@ -1,0 +1,125 @@
+use std::num::NonZeroU64;
+
+use alien_error::{AlienError, Context};
+use alien_platform_api::{types, SdkResultExt as _};
+
+use crate::error::{ErrorData, Result};
+use crate::execution_context::{ExecutionMode, ManagerContext};
+
+pub struct ResolvedDeployment {
+    pub detail: types::DeploymentDetailResponse,
+    pub manager: ManagerContext,
+}
+
+pub async fn resolve_with_manager(
+    ctx: &ExecutionMode,
+    reference: &str,
+    project_override: Option<&str>,
+    allow_prompt: bool,
+) -> Result<ResolvedDeployment> {
+    let workspace = ctx.resolve_workspace_with_bootstrap(allow_prompt).await?;
+    let client = ctx.sdk_client().await?;
+    let detail = resolve(
+        ctx,
+        &client,
+        &workspace,
+        reference,
+        project_override,
+        allow_prompt,
+    )
+    .await?;
+    let manager_id = String::from(detail.manager_id.clone());
+    let manager = ctx.connect_manager_by_id(&manager_id, &workspace).await?;
+    Ok(ResolvedDeployment { detail, manager })
+}
+
+pub async fn resolve(
+    ctx: &ExecutionMode,
+    client: &alien_platform_api::Client,
+    workspace: &str,
+    reference: &str,
+    project_override: Option<&str>,
+    allow_prompt: bool,
+) -> Result<types::DeploymentDetailResponse> {
+    let id = if reference.starts_with("dep_") {
+        reference.to_string()
+    } else {
+        let Some((group_name, deployment_name)) = reference.split_once('/') else {
+            return Err(AlienError::new(ErrorData::ValidationError {
+                field: "deployment".to_string(),
+                message:
+                    "Use a deployment ID like dep_... or <deployment-group-name>/<deployment-name>."
+                        .to_string(),
+            }));
+        };
+        let (project_id, _) = ctx.resolve_project(project_override, allow_prompt).await?;
+        let groups = client
+            .list_deployment_groups()
+            .workspace(workspace)
+            .project(project_id.as_str())
+            .search(group_name)
+            .limit(NonZeroU64::new(50).expect("constant is non-zero"))
+            .send()
+            .await
+            .into_sdk_error()
+            .context(ErrorData::ApiRequestFailed {
+                message: format!("Failed to resolve deployment group {group_name}"),
+                url: None,
+            })?
+            .into_inner()
+            .items;
+        let group = groups
+            .into_iter()
+            .find(|group| String::from(group.name.clone()) == group_name)
+            .ok_or_else(|| {
+                AlienError::new(ErrorData::ValidationError {
+                    field: "deployment".to_string(),
+                    message: format!("Deployment group '{group_name}' was not found."),
+                })
+            })?;
+        let group_id = String::from(group.id);
+        let deployments = client
+            .list_deployments()
+            .workspace(workspace)
+            .project(project_id.as_str())
+            .deployment_group(group_id.as_str())
+            .search(deployment_name)
+            .limit(NonZeroU64::new(50).expect("constant is non-zero"))
+            .send()
+            .await
+            .into_sdk_error()
+            .context(ErrorData::ApiRequestFailed {
+                message: format!("Failed to resolve deployment {reference}"),
+                url: None,
+            })?
+            .into_inner()
+            .items;
+        String::from(
+            deployments
+                .into_iter()
+                .find(|item| item.name == deployment_name)
+                .ok_or_else(|| {
+                    AlienError::new(ErrorData::ValidationError {
+                        field: "deployment".to_string(),
+                        message: format!(
+                            "Deployment '{deployment_name}' was not found in group '{group_name}'."
+                        ),
+                    })
+                })?
+                .id,
+        )
+    };
+
+    client
+        .get_deployment()
+        .id(id.as_str())
+        .workspace(workspace)
+        .send()
+        .await
+        .into_sdk_error()
+        .context(ErrorData::ApiRequestFailed {
+            message: format!("Failed to get deployment {id}"),
+            url: None,
+        })
+        .map(|response| response.into_inner())
+}


### PR DESCRIPTION
## Summary

- resolve platform deployments through the Platform API by ID or exact deployment-group/name
- connect debug and command traffic to the manager recorded on the deployment
- reuse the resolver for logs and deployment operations while preserving standalone and dev behavior

## Validation

- `cargo check -p alien-cli`
- `cargo test -p alien-cli --lib` (154 passed)
- branch-built `alien deployments get <machines-deployment> --json` returned `platform: machines` and its recorded `managerId`
- branch-built `alien logs --deployment <machines-deployment> --json --limit 1` returned live logs through that manager
- branch-built `alien debug exec <machines-deployment> -- true` reached the owning manager; the request then surfaced an upstream Platform API 500/502 with its request ID

Linear: ALIEN-277