### PR TITLE
feat: add Azure compute SKU discovery

### DIFF
--- a/crates/alien-azure-clients/src/azure/mod.rs
+++ b/crates/alien-azure-clients/src/azure/mod.rs
@@ -29,6 +29,7 @@ pub mod monitor;
 pub mod network;
 pub mod private_networking;
 pub mod resource_graph;
+pub mod resource_skus;
 pub mod resources;
 pub mod service_bus;
 pub mod storage_accounts;

--- a/crates/alien-azure-clients/src/azure/resource_skus.rs
+++ b/crates/alien-azure-clients/src/azure/resource_skus.rs
@@ -1,0 +1,345 @@
+use crate::azure::{
+    common::{AzureClientBase, AzureRequestBuilder},
+    token_cache::AzureTokenCache,
+};
+use alien_client_core::{ErrorData, Result};
+use alien_error::{Context, IntoAlienError};
+use reqwest::{Client, Method};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "test-utils")]
+use mockall::automock;
+
+/// One Microsoft.Compute SKU returned for the current subscription.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSku {
+    /// Provider SKU name, for example `Standard_D4s_v5`.
+    pub name: Option<String>,
+    /// Compute resource type to which the SKU applies.
+    pub resource_type: Option<String>,
+    /// Locations and availability zones in which the SKU is offered.
+    #[serde(default)]
+    pub location_info: Vec<ResourceSkuLocationInfo>,
+    /// Subscription- or capacity-specific restrictions on the SKU.
+    #[serde(default)]
+    pub restrictions: Vec<ResourceSkuRestriction>,
+}
+
+impl ResourceSku {
+    /// Returns the zones in which this subscription can use the SKU in `location`.
+    ///
+    /// Azure reports offered zones in `locationInfo` and separately reports
+    /// subscription/capacity restrictions. Location restrictions make the SKU
+    /// unavailable; zone restrictions are subtracted from the offered set.
+    pub fn available_zones_in(&self, location: &str) -> Vec<String> {
+        let location_is_restricted = self.restrictions.iter().any(|restriction| {
+            restriction
+                .restriction_type
+                .eq_ignore_ascii_case("Location")
+                && restriction.applies_to_location(location)
+        });
+        if location_is_restricted {
+            return Vec::new();
+        }
+
+        let mut zones = self
+            .location_info
+            .iter()
+            .filter(|info| info.location.eq_ignore_ascii_case(location))
+            .flat_map(|info| info.zones.iter().cloned())
+            .collect::<Vec<_>>();
+        zones.sort();
+        zones.dedup();
+
+        zones.retain(|zone| {
+            !self.restrictions.iter().any(|restriction| {
+                restriction.restriction_type.eq_ignore_ascii_case("Zone")
+                    && restriction.applies_to_location(location)
+                    && restriction
+                        .restriction_info
+                        .as_ref()
+                        .is_some_and(|info| info.zones.iter().any(|value| value == zone))
+            })
+        });
+        zones
+    }
+}
+
+/// Location-specific availability information for a compute SKU.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSkuLocationInfo {
+    /// Azure location name.
+    pub location: String,
+    /// Logical availability zone names offered in this location.
+    #[serde(default)]
+    pub zones: Vec<String>,
+}
+
+/// A restriction that prevents use of a compute SKU.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSkuRestriction {
+    /// Restriction type (`Location` or `Zone`).
+    #[serde(rename = "type")]
+    pub restriction_type: String,
+    /// Restricted locations for location restrictions.
+    #[serde(default)]
+    pub values: Vec<String>,
+    /// Structured location and zone restriction details.
+    pub restriction_info: Option<ResourceSkuRestrictionInfo>,
+    /// Azure reason code such as `QuotaId` or `NotAvailableForSubscription`.
+    pub reason_code: Option<String>,
+}
+
+impl ResourceSkuRestriction {
+    fn applies_to_location(&self, location: &str) -> bool {
+        let structured_locations = self
+            .restriction_info
+            .as_ref()
+            .map(|info| info.locations.as_slice())
+            .unwrap_or_default();
+        let locations = if structured_locations.is_empty() {
+            self.values.as_slice()
+        } else {
+            structured_locations
+        };
+        locations.is_empty()
+            || locations
+                .iter()
+                .any(|value| value.eq_ignore_ascii_case(location))
+    }
+}
+
+/// Structured scope for a compute SKU restriction.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSkuRestrictionInfo {
+    /// Locations to which the restriction applies.
+    #[serde(default)]
+    pub locations: Vec<String>,
+    /// Availability zones to which the restriction applies.
+    #[serde(default)]
+    pub zones: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceSkusPage {
+    #[serde(default)]
+    value: Vec<ResourceSku>,
+    next_link: Option<String>,
+}
+
+/// Read-only Microsoft.Compute Resource SKUs operations.
+#[cfg_attr(feature = "test-utils", automock)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait ResourceSkusApi: Send + Sync + std::fmt::Debug {
+    /// Lists all SKU pages returned for an Azure location.
+    async fn list_resource_skus(&self, location: &str) -> Result<Vec<ResourceSku>>;
+
+    /// Finds an exact virtual-machine SKU in a location.
+    async fn get_virtual_machine_sku(
+        &self,
+        location: &str,
+        sku_name: &str,
+    ) -> Result<Option<ResourceSku>> {
+        Ok(self
+            .list_resource_skus(location)
+            .await?
+            .into_iter()
+            .find(|sku| {
+                sku.resource_type
+                    .as_deref()
+                    .is_some_and(|value| value.eq_ignore_ascii_case("virtualMachines"))
+                    && sku
+                        .name
+                        .as_deref()
+                        .is_some_and(|value| value.eq_ignore_ascii_case(sku_name))
+            }))
+    }
+}
+
+/// Client for subscription-aware Microsoft.Compute SKU discovery.
+#[derive(Debug)]
+pub struct AzureResourceSkusClient {
+    base: AzureClientBase,
+    token_cache: AzureTokenCache,
+}
+
+impl AzureResourceSkusClient {
+    const API_VERSION: &'static str = "2021-07-01";
+
+    pub fn new(client: Client, token_cache: AzureTokenCache) -> Self {
+        let endpoint = token_cache.management_endpoint().to_string();
+        Self {
+            base: AzureClientBase::with_client_config(
+                client,
+                endpoint,
+                token_cache.config().clone(),
+            ),
+            token_cache,
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ResourceSkusApi for AzureResourceSkusClient {
+    async fn list_resource_skus(&self, location: &str) -> Result<Vec<ResourceSku>> {
+        let bearer_token = self
+            .token_cache
+            .get_bearer_token_with_scope("https://management.azure.com/.default")
+            .await?;
+        let mut next_url = Some(self.base.build_url(
+            &format!(
+                "/subscriptions/{}/providers/Microsoft.Compute/skus",
+                self.token_cache.config().subscription_id
+            ),
+            Some(vec![
+                ("api-version", Self::API_VERSION.to_string()),
+                ("$filter", format!("location eq '{location}'")),
+            ]),
+        ));
+        let mut skus = Vec::new();
+
+        while let Some(url) = next_url {
+            let request = AzureRequestBuilder::new(Method::GET, url.clone())
+                .content_length("")
+                .build()?;
+            let signed = self.base.sign_request(request, &bearer_token).await?;
+            let response = self
+                .base
+                .execute_request(signed, "ListResourceSkus", location)
+                .await?;
+            let body =
+                response
+                    .text()
+                    .await
+                    .into_alien_error()
+                    .context(ErrorData::HttpResponseError {
+                        message: format!(
+                            "Azure ListResourceSkus: failed to read response body for {location}"
+                        ),
+                        url: url.clone(),
+                        http_status: 200,
+                        http_response_text: None,
+                        http_request_text: None,
+                    })?;
+            let page: ResourceSkusPage = serde_json::from_str(&body).into_alien_error().context(
+                ErrorData::HttpResponseError {
+                    message: format!("Azure ListResourceSkus: JSON parse error for {location}"),
+                    url,
+                    http_status: 200,
+                    http_response_text: Some(body),
+                    http_request_text: None,
+                },
+            )?;
+            skus.extend(page.value);
+            next_url = page.next_link;
+        }
+
+        Ok(skus)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use httpmock::{Method::GET, MockServer};
+    use serde_json::json;
+
+    use super::*;
+    use crate::azure::{AzureClientConfig, AzureClientConfigExt, ServiceOverrides};
+
+    const SUBSCRIPTION_ID: &str = "12345678-1234-1234-1234-123456789012";
+
+    fn test_client(server: &MockServer) -> AzureResourceSkusClient {
+        let config = AzureClientConfig::mock().with_service_overrides(ServiceOverrides {
+            endpoints: HashMap::from([("management".to_string(), server.base_url())]),
+        });
+        AzureResourceSkusClient::new(Client::new(), AzureTokenCache::new(config))
+    }
+
+    #[tokio::test]
+    async fn lists_real_response_shape_across_every_page_and_finds_vm_sku() {
+        let server = MockServer::start_async().await;
+        let next_link = format!("{}/sku-pages/2?continuation=next", server.base_url());
+        let first = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path(format!(
+                        "/subscriptions/{SUBSCRIPTION_ID}/providers/Microsoft.Compute/skus"
+                    ))
+                    .query_param("api-version", "2021-07-01")
+                    .query_param("$filter", "location eq 'eastus'");
+                then.status(200).json_body(json!({
+                    "value": [{
+                        "resourceType": "disks",
+                        "name": "Premium_LRS",
+                        "locationInfo": [{"location": "eastus", "zones": ["1", "2", "3"]}],
+                        "restrictions": []
+                    }],
+                    "nextLink": next_link
+                }));
+            })
+            .await;
+        let second = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/sku-pages/2")
+                    .query_param("continuation", "next");
+                then.status(200).json_body(json!({
+                    "value": [{
+                        "resourceType": "virtualMachines",
+                        "name": "Standard_D4s_v5",
+                        "locations": ["eastus"],
+                        "locationInfo": [{
+                            "location": "eastus",
+                            "zones": ["1", "2", "3"],
+                            "zoneDetails": [{"name": ["1"], "capabilities": []}]
+                        }],
+                        "restrictions": [{
+                            "type": "Zone",
+                            "reasonCode": "NotAvailableForSubscription",
+                            "restrictionInfo": {"locations": ["eastus"], "zones": ["2"]},
+                            "values": ["eastus"]
+                        }],
+                        "capabilities": [{"name": "vCPUs", "value": "4"}]
+                    }],
+                    "nextLink": null
+                }));
+            })
+            .await;
+
+        let sku = test_client(&server)
+            .get_virtual_machine_sku("eastus", "Standard_D4s_v5")
+            .await
+            .expect("SKU pages should be readable")
+            .expect("VM SKU should be present");
+
+        first.assert_async().await;
+        second.assert_async().await;
+        assert_eq!(sku.available_zones_in("eastus"), ["1", "3"]);
+    }
+
+    #[test]
+    fn location_restriction_makes_sku_unavailable() {
+        let sku: ResourceSku = serde_json::from_value(json!({
+            "resourceType": "virtualMachines",
+            "name": "Standard_D4s_v5",
+            "locationInfo": [{"location": "eastus", "zones": ["1", "2", "3"]}],
+            "restrictions": [{
+                "type": "Location",
+                "reasonCode": "NotAvailableForSubscription",
+                "values": ["eastus"]
+            }]
+        }))
+        .expect("real Azure response shape should deserialize");
+
+        assert!(sku.available_zones_in("eastus").is_empty());
+    }
+}

--- a/crates/alien-azure-clients/src/azure/resource_skus.rs
+++ b/crates/alien-azure-clients/src/azure/resource_skus.rs
@@ -189,6 +189,7 @@ impl AzureResourceSkusClient {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl ResourceSkusApi for AzureResourceSkusClient {
     async fn list_resource_skus(&self, location: &str) -> Result<Vec<ResourceSku>> {
+        let escaped_location = location.replace('\'', "''");
         let bearer_token = self
             .token_cache
             .get_bearer_token_with_scope("https://management.azure.com/.default")
@@ -200,7 +201,7 @@ impl ResourceSkusApi for AzureResourceSkusClient {
             ),
             Some(vec![
                 ("api-version", Self::API_VERSION.to_string()),
-                ("$filter", format!("location eq '{location}'")),
+                ("$filter", format!("location eq '{escaped_location}'")),
             ]),
         ));
         let mut skus = Vec::new();
@@ -214,6 +215,7 @@ impl ResourceSkusApi for AzureResourceSkusClient {
                 .base
                 .execute_request(signed, "ListResourceSkus", location)
                 .await?;
+            let status = response.status().as_u16();
             let body =
                 response
                     .text()
@@ -224,7 +226,7 @@ impl ResourceSkusApi for AzureResourceSkusClient {
                             "Azure ListResourceSkus: failed to read response body for {location}"
                         ),
                         url: url.clone(),
-                        http_status: 200,
+                        http_status: status,
                         http_response_text: None,
                         http_request_text: None,
                     })?;
@@ -232,7 +234,7 @@ impl ResourceSkusApi for AzureResourceSkusClient {
                 ErrorData::HttpResponseError {
                     message: format!("Azure ListResourceSkus: JSON parse error for {location}"),
                     url,
-                    http_status: 200,
+                    http_status: status,
                     http_response_text: Some(body),
                     http_request_text: None,
                 },

--- a/crates/alien-azure-clients/src/lib.rs
+++ b/crates/alien-azure-clients/src/lib.rs
@@ -31,6 +31,10 @@ pub use azure::managed_identity::{
 pub use azure::monitor::{AzureMonitorClient, MonitorApi};
 pub use azure::network::{AzureNetworkClient, NetworkApi};
 pub use azure::resource_graph::{AzureResourceGraphClient, ResourceGraphApi};
+pub use azure::resource_skus::{
+    AzureResourceSkusClient, ResourceSku, ResourceSkuLocationInfo, ResourceSkuRestriction,
+    ResourceSkuRestrictionInfo, ResourceSkusApi,
+};
 pub use azure::resources::{AzureResourcesClient, ResourcesApi};
 pub use azure::service_bus::{
     AzureServiceBusDataPlaneClient, AzureServiceBusManagementClient, ServiceBusDataPlaneApi,

--- a/crates/alien-infra/src/core/service_provider.rs
+++ b/crates/alien-infra/src/core/service_provider.rs
@@ -40,6 +40,7 @@ use alien_azure_clients::{
     managed_identity::{AzureManagedIdentityClient, ManagedIdentityApi},
     network::{AzureNetworkClient, NetworkApi as AzureNetworkApi},
     private_networking::{AzurePrivateNetworkingClient, PrivateNetworkingApi},
+    resource_skus::{AzureResourceSkusClient, ResourceSkusApi},
     resources::{AzureResourcesClient, ResourcesApi},
     service_bus::{
         AzureServiceBusDataPlaneClient, AzureServiceBusManagementClient, ServiceBusDataPlaneApi,
@@ -180,6 +181,10 @@ pub trait PlatformServiceProvider: Send + Sync {
         &self,
         config: &AzureClientConfig,
     ) -> Result<Arc<dyn VirtualMachineScaleSetsApi>>;
+    fn get_azure_resource_skus_client(
+        &self,
+        config: &AzureClientConfig,
+    ) -> Result<Arc<dyn ResourceSkusApi>>;
     fn get_azure_container_apps_client(
         &self,
         config: &AzureClientConfig,
@@ -828,6 +833,16 @@ impl PlatformServiceProvider for DefaultPlatformServiceProvider {
         config: &AzureClientConfig,
     ) -> Result<Arc<dyn VirtualMachineScaleSetsApi>> {
         Ok(Arc::new(AzureVmssClient::new(
+            reqwest::Client::new(),
+            AzureTokenCache::new(config.clone()),
+        )))
+    }
+
+    fn get_azure_resource_skus_client(
+        &self,
+        config: &AzureClientConfig,
+    ) -> Result<Arc<dyn ResourceSkusApi>> {
+        Ok(Arc::new(AzureResourceSkusClient::new(
             reqwest::Client::new(),
             AzureTokenCache::new(config.clone()),
         )))

--- a/crates/alien-permissions/permission-sets/compute-cluster/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/heartbeat.jsonc
@@ -48,6 +48,23 @@
       }
     ],
     "azure": [
+      // Resource SKU availability is subscription-specific and cannot be read through a
+      // resource-group-scoped role assignment.
+      {
+        "grant": {
+          "actions": [
+            "Microsoft.Compute/skus/read"
+          ]
+        },
+        "binding": {
+          "stack": {
+            "scope": "/subscriptions/${subscriptionId}"
+          },
+          "resource": {
+            "scope": "/subscriptions/${subscriptionId}"
+          }
+        }
+      },
       {
         "grant": {
           "actions": [

--- a/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
@@ -533,6 +533,23 @@
       }
     ],
     "azure": [
+      // Resource SKU availability is subscription-specific and cannot be read through a
+      // resource-group-scoped role assignment.
+      {
+        "grant": {
+          "actions": [
+            "Microsoft.Compute/skus/read"
+          ]
+        },
+        "binding": {
+          "stack": {
+            "scope": "/subscriptions/${subscriptionId}"
+          },
+          "resource": {
+            "scope": "/subscriptions/${subscriptionId}"
+          }
+        }
+      },
       {
         "grant": {
           "actions": [

--- a/crates/alien-permissions/permission-sets/compute-cluster/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/provision.jsonc
@@ -396,6 +396,23 @@
       }
     ],
     "azure": [
+      // Resource SKU availability is subscription-specific and cannot be read through a
+      // resource-group-scoped role assignment.
+      {
+        "grant": {
+          "actions": [
+            "Microsoft.Compute/skus/read"
+          ]
+        },
+        "binding": {
+          "stack": {
+            "scope": "/subscriptions/${subscriptionId}"
+          },
+          "resource": {
+            "scope": "/subscriptions/${subscriptionId}"
+          }
+        }
+      },
       // VMSS management + VM listing + boot diagnostics for startup log visibility
       {
         "grant": {

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -107,6 +107,52 @@ fn compute_cluster_execute_does_not_read_workload_secrets() {
 }
 
 #[test]
+fn compute_cluster_lifecycle_can_discover_subscription_sku_availability() {
+    let generator = AzureRuntimePermissionsGenerator::new();
+    let context = create_test_context();
+
+    for permission_set_id in [
+        "compute-cluster/provision",
+        "compute-cluster/management",
+        "compute-cluster/heartbeat",
+    ] {
+        let permission_set = get_permission_set(permission_set_id).expect("permission set exists");
+        let result = generator
+            .generate_grant_plan(permission_set, BindingTarget::Stack, &context)
+            .expect("compute cluster grant plan should generate");
+
+        let sku_role = result
+            .custom_roles
+            .iter()
+            .find(|role| {
+                role.role_definition
+                    .actions
+                    .iter()
+                    .any(|action| action == "Microsoft.Compute/skus/read")
+            })
+            .expect("SKU discovery must have a custom role");
+        assert_eq!(
+            sku_role.role_definition.assignable_scopes,
+            ["/subscriptions/00000000-0000-0000-0000-000000000000"]
+        );
+        let sku_binding = result
+            .bindings
+            .iter()
+            .find(|binding| {
+                binding.role_definition
+                    == AzureRoleDefinitionRef::Custom {
+                        key: sku_role.key.clone(),
+                    }
+            })
+            .expect("SKU discovery role must be assigned");
+        assert_eq!(
+            sku_binding.scope,
+            "/subscriptions/00000000-0000-0000-0000-000000000000"
+        );
+    }
+}
+
+#[test]
 fn test_azure_hybrid_grant_plan() {
     let generator = AzureRuntimePermissionsGenerator::new();
     let permission_set = create_azure_hybrid_permission_set();

--- a/crates/alien-terraform/tests/generator/azure_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_identity_tests.rs
@@ -132,6 +132,30 @@ fn azure_remote_stack_management_emits_uami_with_federated_credential() {
 }
 
 #[test]
+fn azure_compute_management_emits_subscription_scoped_sku_discovery() {
+    let stack = Stack::new("acme-compute-zones".to_string())
+        .management(ManagementPermissions::extend(
+            PermissionProfile::new().global(["compute-cluster/management"]),
+        ))
+        .add(resource_group(), ResourceLifecycle::Frozen)
+        .add(
+            RemoteStackManagement::new("management".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+    let module = render(&stack, TerraformTarget::Azure, StackSettings::default());
+    let rendered = module
+        .iter()
+        .map(|(_, contents)| contents)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Microsoft.Compute/skus/read"));
+    assert!(rendered.contains("\"/subscriptions/${var.azure_subscription_id}\""));
+    assert_terraform_valid(&module, "azure_compute_management_sku_discovery");
+}
+
+#[test]
 fn azure_global_network_heartbeat_does_not_emit_resource_scoped_setup_role() {
     let settings = StackSettings {
         network: Some(NetworkSettings::Create {


### PR DESCRIPTION
## Summary

- add a subscription-aware Azure Resource SKUs client
- follow opaque `nextLink` pagination and expose exact virtual-machine SKU lookup
- derive usable availability zones from location metadata and subscription restrictions

## Azure API contract

- `GET /subscriptions/{subscriptionId}/providers/Microsoft.Compute/skus`
- API version `2021-07-01`
- server-side filter: `$filter=location eq '<location>'`\n- SKU name and `resourceType == virtualMachines` are selected client-side because this operation only documents the location filter\n\n## Validation\n\n- `cargo test -p alien-azure-clients resource_skus -- --nocapture`\n- `cargo test -p alien-azure-clients`\n- `cargo check -p alien-azure-clients --features test-utils`\n- `git diff --check`\n\nThe wire test uses Azure-shaped two-page responses, verifies the request contract and opaque continuation URL, and verifies that location/zone restrictions affect the returned usable zones.