### PR TITLE
fix: set platform SDK TypeScript root

### DIFF
--- a/client-sdks/platform/typescript/tsconfig.json
+++ b/client-sdks/platform/typescript/tsconfig.json
@@ -13,6 +13,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "rootDir": "src",
     "outDir": "esm",
     
 


### PR DESCRIPTION
## Summary

- set the generated platform SDK rootDir explicitly to src
- match the already-correct manager SDK configuration
- restore compatibility with the TypeScript version resolved by isolated npm release builds

## Validation

- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @alienplatform/platform-api build
- git diff --check

Linear: ALIEN-298