### PR TITLE
fix: dispatch cloud events registered by logical binding name

### DIFF
--- a/packages/sdk/src/worker-runtime/event-loop.ts
+++ b/packages/sdk/src/worker-runtime/event-loop.ts
@@ -26,6 +26,32 @@ import {
 import type { getControlServiceDefinition } from "./service-definitions.js"
 
 /**
+ * Handlers register by the resource's logical name (the name given in the
+ * stack program), but cloud transports deliver events keyed by the provider's
+ * physical identifier — the S3 bucket name for storage events, the SQS queue
+ * name for queue messages. Resolve a registered source through its
+ * `ALIEN_<NAME>_BINDING` env payload so both spellings match. Local transports
+ * dispatch logical names directly, so this only widens the match.
+ */
+export function physicalSourceNames(source: string): string[] {
+  const raw = process.env[`ALIEN_${source.replaceAll("-", "_").toUpperCase()}_BINDING`]
+  if (!raw) return []
+  try {
+    const binding = JSON.parse(raw) as { bucketName?: string; queueName?: string; queueUrl?: string }
+    return [binding.bucketName, binding.queueName, binding.queueUrl?.split("/").pop()].filter(
+      (name): name is string => typeof name === "string" && name.length > 0,
+    )
+  } catch {
+    return []
+  }
+}
+
+/** @internal exported for tests */
+export function sourceMatches(src: string, physical: string): boolean {
+  return src === "*" || src === physical || physicalSourceNames(src).includes(physical)
+}
+
+/**
  * Event loop runner for processing tasks from the runtime.
  *
  * @internal
@@ -134,7 +160,7 @@ export class EventLoop {
       for (const entry of getEventHandlers().values()) {
         const src = entry.registration.source
         if (task.storageEvent && entry.registration.type === "storage") {
-          if (src === "*" || src === task.storageEvent.bucket) {
+          if (sourceMatches(src, task.storageEvent.bucket)) {
             matchedEntry = entry
             break
           }
@@ -144,7 +170,7 @@ export class EventLoop {
             break
           }
         } else if (task.queueMessage && entry.registration.type === "queue") {
-          if (src === "*" || src === task.queueMessage.source) {
+          if (sourceMatches(src, task.queueMessage.source)) {
             matchedEntry = entry
             break
           }
@@ -152,7 +178,14 @@ export class EventLoop {
       }
 
       if (!matchedEntry) {
+        // Report the miss as a failed result — without it the runtime waits
+        // for the task until its event timeout (a 2-minute hang per event on
+        // Lambda) instead of failing loudly.
         console.warn(`No handler found for task: ${task.taskId}`)
+        await this.sendTaskResult(task.taskId, {
+          success: false,
+          error: `No handler registered for task ${task.taskId}`,
+        })
         return
       }
 

--- a/packages/sdk/tests/worker-runtime-event-dispatch.test.ts
+++ b/packages/sdk/tests/worker-runtime-event-dispatch.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { physicalSourceNames, sourceMatches } from "../src/worker-runtime/event-loop.js"
+
+// Cloud transports deliver tasks keyed by the provider's physical identifier
+// (S3 bucket name, SQS queue name) while handlers register by the resource's
+// logical stack name; dispatch must accept both spellings via the
+// ALIEN_<NAME>_BINDING env contract.
+describe("event dispatch source matching", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("matches a storage handler registered by logical name against the bound bucket", () => {
+    vi.stubEnv("ALIEN_EMAIL_BINDING", JSON.stringify({ service: "s3", bucketName: "stack-email-8b090660" }))
+
+    expect(physicalSourceNames("email")).toEqual(["stack-email-8b090660"])
+    expect(sourceMatches("email", "stack-email-8b090660")).toBe(true)
+    expect(sourceMatches("email", "some-other-bucket")).toBe(false)
+  })
+
+  it("matches a queue handler registered by logical name against the queue name from queueUrl", () => {
+    vi.stubEnv(
+      "ALIEN_SES_EVENTS_BINDING",
+      JSON.stringify({ service: "sqs", queueUrl: "https://sqs.us-east-1.amazonaws.com/230470760195/stack-SesEvents-aHhH" }),
+    )
+
+    // '-' in the logical name maps to '_' in the env var name.
+    expect(physicalSourceNames("ses-events")).toEqual(["stack-SesEvents-aHhH"])
+    expect(sourceMatches("ses-events", "stack-SesEvents-aHhH")).toBe(true)
+  })
+
+  it("still matches physical names and wildcards directly", () => {
+    expect(sourceMatches("stack-email-8b090660", "stack-email-8b090660")).toBe(true)
+    expect(sourceMatches("*", "anything")).toBe(true)
+  })
+
+  it("does not match when the binding env var is absent or malformed", () => {
+    expect(sourceMatches("email", "stack-email-8b090660")).toBe(false)
+
+    vi.stubEnv("ALIEN_EMAIL_BINDING", "not-json")
+    expect(physicalSourceNames("email")).toEqual([])
+    expect(sourceMatches("email", "stack-email-8b090660")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

On cloud transports (Lambda), storage and queue tasks reach the worker keyed by the provider's **physical** identifier — the S3 bucket name (`stack-email-8b090660`) or the SQS queue name from the event-source ARN. Handlers, however, register by the resource's **logical** stack name (`onStorageEvent('email', ...)`), so the exact-string match in the event loop never fired: every S3/SQS event logged `No handler found for task` and was dropped. Locally the trigger service dispatches logical names, which is why this only surfaces on AWS.

A second issue compounded it: the no-handler path returned **without sending a task result**, so the runtime's wait-until extension held the invocation open until the event timeout — a 2-minute hang (and full Lambda billing) per dropped event.

## Fix

- Resolve a registered source through its `ALIEN_<NAME>_BINDING` env payload (`bucketName`, `queueName`, or the last segment of `queueUrl`) when matching storage/queue tasks. Physical-name and `"*"` registrations keep working; local dispatch is unaffected (pure widening).
- On a genuine miss, send a failed task result so the invocation completes immediately and the failure is loud in the runtime logs.

Parsing the binding env in the event loop (rather than through `@alienplatform/bindings`) is deliberate: the payload parsing lives in the native addon, and exposing a resolver from there is a bigger API change than this needs.

## Validation

- Unit tests for the matching semantics (logical→bucket, logical→queue name from `queueUrl`, physical passthrough, wildcard, absent/malformed binding env).
- Live-verified on an AWS deployment: an S3-triggered worker registered as `onStorageEvent('email', ...)` received and processed the event end-to-end after this change (previously: `No handler found` + 120s timeout on every delivery), and an SQS-consuming worker registered by logical queue name drained its queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)