### PR TITLE
chore: format sdk event-loop dispatch helpers

### DIFF
--- a/packages/sdk/src/worker-runtime/event-loop.ts
+++ b/packages/sdk/src/worker-runtime/event-loop.ts
@@ -37,7 +37,11 @@ export function physicalSourceNames(source: string): string[] {
   const raw = process.env[`ALIEN_${source.replaceAll("-", "_").toUpperCase()}_BINDING`]
   if (!raw) return []
   try {
-    const binding = JSON.parse(raw) as { bucketName?: string; queueName?: string; queueUrl?: string }
+    const binding = JSON.parse(raw) as {
+      bucketName?: string
+      queueName?: string
+      queueUrl?: string
+    }
     return [binding.bucketName, binding.queueName, binding.queueUrl?.split("/").pop()].filter(
       (name): name is string => typeof name === "string" && name.length > 0,
     )

--- a/packages/sdk/tests/worker-runtime-event-dispatch.test.ts
+++ b/packages/sdk/tests/worker-runtime-event-dispatch.test.ts
@@ -11,7 +11,10 @@ describe("event dispatch source matching", () => {
   })
 
   it("matches a storage handler registered by logical name against the bound bucket", () => {
-    vi.stubEnv("ALIEN_EMAIL_BINDING", JSON.stringify({ service: "s3", bucketName: "stack-email-8b090660" }))
+    vi.stubEnv(
+      "ALIEN_EMAIL_BINDING",
+      JSON.stringify({ service: "s3", bucketName: "stack-email-8b090660" }),
+    )
 
     expect(physicalSourceNames("email")).toEqual(["stack-email-8b090660"])
     expect(sourceMatches("email", "stack-email-8b090660")).toBe(true)
@@ -21,7 +24,10 @@ describe("event dispatch source matching", () => {
   it("matches a queue handler registered by logical name against the queue name from queueUrl", () => {
     vi.stubEnv(
       "ALIEN_SES_EVENTS_BINDING",
-      JSON.stringify({ service: "sqs", queueUrl: "https://sqs.us-east-1.amazonaws.com/230470760195/stack-SesEvents-aHhH" }),
+      JSON.stringify({
+        service: "sqs",
+        queueUrl: "https://sqs.us-east-1.amazonaws.com/230470760195/stack-SesEvents-aHhH",
+      }),
     )
 
     // '-' in the logical name maps to '_' in the env var name.


### PR DESCRIPTION
#151 merged with a Biome formatting failure (the inline binding type annotation and test env stubs needed multi-line formatting), which left main's Lint job red. This is `biome check --write` output only — no behavior change; dispatch tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)