### PR TITLE
fix: serialize aoss policy documents with explicit field order

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/open_search.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/open_search.rs
@@ -186,17 +186,58 @@ fn collection_name(id: &str) -> CfExpression {
     )])
 }
 
+// AOSS policy documents as structs rather than `serde_json::json!` maps: the
+// macro's key order follows serde_json's `preserve_order` feature, which
+// feature-unification can toggle between builds, changing the emitted
+// template text. Struct fields always serialize in declaration order.
+// PascalCase names are the AOSS policy document schema.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct AossPolicyRule {
+    resource_type: &'static str,
+    resource: [&'static str; 1],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    permission: Option<&'static [&'static str]>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct AossNetworkPolicy {
+    rules: [AossPolicyRule; 2],
+    allow_from_public: bool,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct AossDataAccessPolicy {
+    description: String,
+    rules: [AossPolicyRule; 2],
+    principal: Vec<String>,
+}
+
+fn policy_json<T: serde::Serialize>(policy: &[&T; 1]) -> String {
+    serde_json::to_string(policy).expect("static AOSS policy document serializes")
+}
+
 /// Public network policy for the collection and its dashboard. Requests are
 /// still gated by IAM (`aoss:APIAccessAll`) plus the data-access policy.
 fn network_policy(name: &CfExpression) -> CfExpression {
-    let policy = serde_json::json!([{
-        "Rules": [
-            {"ResourceType": "collection", "Resource": ["collection/${Name}"]},
-            {"ResourceType": "dashboard", "Resource": ["collection/${Name}"]}
+    let policy = AossNetworkPolicy {
+        rules: [
+            AossPolicyRule {
+                resource_type: "collection",
+                resource: ["collection/${Name}"],
+                permission: None,
+            },
+            AossPolicyRule {
+                resource_type: "dashboard",
+                resource: ["collection/${Name}"],
+                permission: None,
+            },
         ],
-        "AllowFromPublic": true
-    }]);
-    CfExpression::sub_with(policy.to_string(), [("Name", name.clone())])
+        allow_from_public: true,
+    };
+    CfExpression::sub_with(policy_json(&[&policy]), [("Name", name.clone())])
 }
 
 /// Data-access policy granting collection- and index-level permissions to the
@@ -232,34 +273,34 @@ fn data_access_policy(
         principals.push(format!("${{Principal{index}}}"));
     }
 
-    let policy = serde_json::json!([{
-        "Description": format!("Alien-managed data access for '{}'", search.id()),
-        "Rules": [
-            {
-                "ResourceType": "collection",
-                "Resource": ["collection/${Name}"],
-                "Permission": [
+    let policy = AossDataAccessPolicy {
+        description: format!("Alien-managed data access for '{}'", search.id()),
+        rules: [
+            AossPolicyRule {
+                resource_type: "collection",
+                resource: ["collection/${Name}"],
+                permission: Some(&[
                     "aoss:CreateCollectionItems",
                     "aoss:DeleteCollectionItems",
                     "aoss:UpdateCollectionItems",
-                    "aoss:DescribeCollectionItems"
-                ]
+                    "aoss:DescribeCollectionItems",
+                ]),
             },
-            {
-                "ResourceType": "index",
-                "Resource": ["index/${Name}/*"],
-                "Permission": [
+            AossPolicyRule {
+                resource_type: "index",
+                resource: ["index/${Name}/*"],
+                permission: Some(&[
                     "aoss:CreateIndex",
                     "aoss:DeleteIndex",
                     "aoss:UpdateIndex",
                     "aoss:DescribeIndex",
                     "aoss:ReadDocument",
-                    "aoss:WriteDocument"
-                ]
-            }
+                    "aoss:WriteDocument",
+                ]),
+            },
         ],
-        "Principal": principals
-    }]);
+        principal: principals,
+    };
 
     let logical_id = ctx.name_for(ctx.resource_id)?;
     let mut access = CfResource::new(
@@ -272,7 +313,7 @@ fn data_access_policy(
         .insert("Type".to_string(), CfExpression::from("data"));
     access.properties.insert(
         "Policy".to_string(),
-        CfExpression::sub_with(policy.to_string(), variables),
+        CfExpression::sub_with(policy_json(&[&policy]), variables),
     );
     Some(access)
 }

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_open_search_tests__aws_open_search.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_open_search_tests__aws_open_search.snap
@@ -150,7 +150,7 @@ Resources:
       Type: network
       Policy:
         Fn::Sub:
-        - '[{"AllowFromPublic":true,"Rules":[{"Resource":["collection/${Name}"],"ResourceType":"collection"},{"Resource":["collection/${Name}"],"ResourceType":"dashboard"}]}]'
+        - '[{"Rules":[{"ResourceType":"collection","Resource":["collection/${Name}"]},{"ResourceType":"dashboard","Resource":["collection/${Name}"]}],"AllowFromPublic":true}]'
         - Name:
             Fn::Join:
             - '-'
@@ -229,7 +229,7 @@ Resources:
       Type: data
       Policy:
         Fn::Sub:
-        - '[{"Description":"Alien-managed data access for ''articles''","Principal":["${Principal0}"],"Rules":[{"Permission":["aoss:CreateCollectionItems","aoss:DeleteCollectionItems","aoss:UpdateCollectionItems","aoss:DescribeCollectionItems"],"Resource":["collection/${Name}"],"ResourceType":"collection"},{"Permission":["aoss:CreateIndex","aoss:DeleteIndex","aoss:UpdateIndex","aoss:DescribeIndex","aoss:ReadDocument","aoss:WriteDocument"],"Resource":["index/${Name}/*"],"ResourceType":"index"}]}]'
+        - '[{"Description":"Alien-managed data access for ''articles''","Rules":[{"ResourceType":"collection","Resource":["collection/${Name}"],"Permission":["aoss:CreateCollectionItems","aoss:DeleteCollectionItems","aoss:UpdateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"index","Resource":["index/${Name}/*"],"Permission":["aoss:CreateIndex","aoss:DeleteIndex","aoss:UpdateIndex","aoss:DescribeIndex","aoss:ReadDocument","aoss:WriteDocument"]}],"Principal":["${Principal0}"]}]'
         - Name:
             Fn::Join:
             - '-'


### PR DESCRIPTION
Main's "Rust fast tests" job is red on the aws_open_search generator snapshot — but not because the snapshot is stale: the policy JSON was built with `serde_json::json!` maps, whose key order depends on serde_json's `preserve_order` feature. CI's full-workspace build unifies that feature on (insertion order); a narrow local build sorts keys alphabetically — so the same code emits different template text depending on which crates are in the build, and the snapshot can only ever match one of them.

Fix: express the network and data-access policy documents as `Serialize` structs (declaration-order fields, PascalCase per the AOSS schema) and regenerate the snapshot. Policy content is unchanged — only key order is now stable. All 45 generator tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)