### PR TITLE
fix: generate a valid baseline stack policy

### DIFF
--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -580,10 +580,20 @@ fn quote_yaml_1_1_mode_scalars(yaml: &str) -> String {
     quoted
 }
 
-/// Generate a CloudFormation stack policy that prevents stack updates from
-/// mutating runtime-managed resources after setup registration.
+/// Generate the baseline CloudFormation stack policy.
+///
+/// Runtime-managed resources are not part of the setup stack, so the baseline
+/// policy is equivalent to CloudFormation's behavior when no policy is set.
+/// An empty statement list is not valid when supplied through `StackPolicyURL`.
 pub fn generate_cloudformation_stack_policy(_stack: &Stack) -> Result<serde_json::Value> {
-    Ok(json!({ "Statement": [] }))
+    Ok(json!({
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": "Update:*",
+            "Principal": "*",
+            "Resource": "*"
+        }]
+    }))
 }
 
 fn validate_stack_for_cloudformation(stack: &Stack) -> Result<()> {


### PR DESCRIPTION
## Summary
- emit a valid allow-all baseline when generated setup resources need no update restrictions
- preserve CloudFormation's default update behavior when consumers apply the advertised stack-policy URL

## Root cause
The generated policy used an empty `Statement` array. AWS rejects that document when supplied through `StackPolicyURL`, so otherwise valid generated packages could not create a stack when the published policy was applied.

## Validation
- `cargo fmt --check`
- `cargo check -p alien-cloudformation`
- production package will be regenerated and launched with its published stack-policy URL against real AWS