### PR TITLE
fix: install pnpm before publishing client SDKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,10 @@ jobs:
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
       - uses: actions/setup-node@v5
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- install the pinned workspace package manager before Node setup in the client SDK publish job
- keep the SDK release environment consistent with the other npm publication jobs

## Validation
- `git diff --check`
- `actionlint .github/workflows/release.yml` reaches only the repository’s pre-existing custom-runner and shellcheck findings
- failure reproduced in release run 29790807972 at `actions/setup-node` because `pnpm` was unavailable

Linear: ALIEN-270