### PR TITLE
fix: install pnpm before publishing CLI packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1248,6 +1248,10 @@ jobs:
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
       - uses: actions/setup-node@v5
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- install the pinned workspace package manager before Node setup in the CLI wrapper publication job
- make every Node job in the stable release workflow initialize pnpm consistently

## Validation
- `git diff --check`
- verified every `actions/setup-node@v5` occurrence in the workflow now has a corresponding `pnpm/action-setup@v6` step
- failure reproduced in release run 29791117756 at `actions/setup-node` because `pnpm` was unavailable

Linear: ALIEN-270