### PR TITLE
fix: stop double-sizing managed compute machines

### DIFF
--- a/crates/alien-core/src/compute_planner.rs
+++ b/crates/alien-core/src/compute_planner.rs
@@ -205,7 +205,21 @@ fn merge_explicit_compute_groups(
             groups
                 .entry(group.group_id.clone())
                 .and_modify(|planned| {
-                    merge_requirements(&mut planned.requirements, &explicit_requirements);
+                    if group.instance_type.is_none() {
+                        merge_requirements(&mut planned.requirements, &explicit_requirements);
+                    } else {
+                        // A materialized capacity group profile describes the
+                        // selected machine, not additional workload demand.
+                        // Merging its full CPU and memory into requirements
+                        // would cause deployment package planning to size an
+                        // already-sized machine a second time. Keep only the
+                        // constraints that affect artifact compatibility.
+                        planned.requirements.architecture = planned
+                            .requirements
+                            .architecture
+                            .or(explicit_requirements.architecture);
+                        planned.requirements.nested_virt |= explicit_requirements.nested_virt;
+                    }
                     planned.scale = merge_scale_policy(&planned.scale, &scale);
                 })
                 .or_insert_with(|| PlannedGroup {
@@ -865,6 +879,44 @@ mod tests {
         assert_eq!(pool.selected.min_size(), 2);
         assert_eq!(pool.selected.max_size(), 5);
         assert!(pool.errors.is_empty());
+    }
+
+    #[test]
+    fn materialized_machine_profile_is_not_counted_as_workload_demand() {
+        let mut stack = stack_with_container();
+        let selected = instance_catalog::find_instance_type(Platform::Aws, "m7g.xlarge")
+            .expect("machine should exist in catalog");
+        let cluster = ComputeCluster::new("compute".to_string())
+            .capacity_group(CapacityGroup {
+                group_id: "general".to_string(),
+                instance_type: Some(selected.name.to_string()),
+                profile: Some(selected.to_machine_profile()),
+                min_size: 1,
+                max_size: 1,
+                scale_policy: None,
+                nested_virtualization: None,
+            })
+            .build();
+        stack.resources.insert(
+            "compute".to_string(),
+            ResourceEntry {
+                config: Resource::new(cluster),
+                lifecycle: ResourceLifecycle::Frozen,
+                dependencies: Vec::new(),
+                remote_access: false,
+            },
+        );
+
+        let plan = plan_compute(&stack, Platform::Aws, None).expect("plan should build");
+        let pool = plan.pools.first().expect("general pool should exist");
+
+        assert_eq!(pool.requirements.cpu, "2");
+        assert_eq!(pool.requirements.memory_bytes, 4 * 1024 * 1024 * 1024);
+        assert_eq!(pool.recommended.machine(), Some("m7g.xlarge"));
+        assert!(pool
+            .machines
+            .iter()
+            .any(|option| option.machine == "m7g.xlarge"));
     }
 
     #[test]

--- a/crates/alien-core/src/instance_catalog.rs
+++ b/crates/alien-core/src/instance_catalog.rs
@@ -1217,12 +1217,6 @@ const MAX_MACHINES_PER_CLUSTER: u32 = 10;
 /// Beyond this, horizontal scaling is always preferred over bigger machines.
 const MAX_STANDARD_VCPU: u32 = 8;
 
-/// How many of the largest standard container we want to fit per machine.
-const STANDARD_CONTAINERS_PER_MACHINE: f64 = 2.0;
-
-/// Overhead factor for system processes and bin-packing inefficiency.
-const OVERHEAD_FACTOR: f64 = 1.25;
-
 /// Runtime CPU reserved for system processes on each managed container machine.
 const SYSTEM_RESERVE_CPU: f64 = 0.5;
 
@@ -1338,29 +1332,24 @@ pub fn select_instance_type(
         };
 
     let desired_target_machines = desired_target_machines(requirements);
-    let target_cpu =
-        (requirements.max_cpu_per_container * STANDARD_CONTAINERS_PER_MACHINE * OVERHEAD_FACTOR)
-            .max(
-                requirements.total_cpu_at_desired * WORKLOAD_HEADROOM_FACTOR
-                    / desired_target_machines as f64,
-            )
-            .max(0.25);
-    let target_memory = (requirements.max_memory_per_container as f64
-        * STANDARD_CONTAINERS_PER_MACHINE
-        * OVERHEAD_FACTOR)
-        .max(
-            requirements.total_memory_bytes_at_desired as f64 * WORKLOAD_HEADROOM_FACTOR
-                / desired_target_machines as f64,
-        )
-        .max(256.0 * MI as f64);
+    let target_cpu = requirements
+        .max_cpu_per_container
+        .max(requirements.total_cpu_at_desired / desired_target_machines as f64)
+        * WORKLOAD_HEADROOM_FACTOR;
+    let target_memory = (requirements.max_memory_per_container as f64)
+        .max(requirements.total_memory_bytes_at_desired as f64 / desired_target_machines as f64)
+        * WORKLOAD_HEADROOM_FACTOR;
 
-    // Find the smallest instance that meets per-container targets within the cap.
+    // Find the smallest instance whose allocatable capacity meets the workload
+    // target after host reserve and workload headroom. Machine count already
+    // accounts for multiple replicas; requiring space for an arbitrary second
+    // copy here would size the same demand twice.
     let selected = candidates
         .iter()
         .filter(|spec| {
             spec.vcpu <= vcpu_cap
-                && spec.vcpu as f64 >= target_cpu
-                && spec.memory_bytes as f64 >= target_memory
+                && allocatable_cpu(spec) >= target_cpu
+                && allocatable_memory_bytes(spec) as f64 >= target_memory
         })
         .min_by_key(|spec| spec.vcpu)
         .or_else(|| {
@@ -1638,6 +1627,28 @@ mod tests {
         let sel = select_instance_type(Platform::Aws, &req).unwrap();
         let spec = find_instance_type(Platform::Aws, sel.instance_type).unwrap();
         assert_eq!(spec.family, InstanceFamily::Burstable);
+    }
+
+    #[test]
+    fn test_selects_smallest_burstable_machine_with_real_headroom() {
+        let req = WorkloadRequirements {
+            total_cpu_at_desired: 1.0,
+            total_memory_bytes_at_desired: 2 * GI,
+            total_cpu_at_max: 1.0,
+            total_memory_bytes_at_max: 2 * GI,
+            max_cpu_per_container: 1.0,
+            max_memory_per_container: 2 * GI,
+            max_ephemeral_storage_bytes: 10 * GI,
+            gpu: None,
+            architecture: None,
+            nested_virt: false,
+        };
+
+        let selection = select_instance_type(Platform::Aws, &req).unwrap();
+
+        assert_eq!(selection.instance_type, "t4g.medium");
+        assert_eq!(selection.min_machines, 1);
+        assert_eq!(selection.max_machines, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- size provider machines from actual workload demand plus host reserve and headroom
- avoid merging an already materialized machine profile back into workload requirements
- keep architecture and nested-virtualization compatibility constraints

## Verification

- `cargo fmt --check -- crates/alien-core/src/compute_planner.rs crates/alien-core/src/instance_catalog.rs`
- `cargo test -p alien-core compute_planner::tests --lib`
- `cargo test -p alien-core instance_catalog::tests::test_selects_smallest_burstable_machine_with_real_headroom --lib`

Real generated CloudFormation and AWS deployment validation will follow before release.