### PR TITLE
feat!: simplify commands and runtime bindings

### DIFF
--- a/crates/alien-bindings-node/src/container.rs
+++ b/crates/alien-bindings-node/src/container.rs
@@ -1,0 +1,32 @@
+//! Linked-container binding handle.
+
+use alien_bindings::traits::Container;
+use napi_derive::napi;
+use std::sync::Arc;
+
+/// Read-only service discovery for a linked container.
+#[napi]
+pub struct ContainerHandle {
+    inner: Arc<dyn Container>,
+}
+
+impl ContainerHandle {
+    pub(crate) fn new(inner: Arc<dyn Container>) -> Self {
+        Self { inner }
+    }
+}
+
+#[napi]
+impl ContainerHandle {
+    /// Return the URL reachable from the deployment's private network.
+    #[napi]
+    pub async fn get_internal_url(&self) -> String {
+        self.inner.get_internal_url().to_string()
+    }
+
+    /// Return the public URL when the linked container is publicly exposed.
+    #[napi]
+    pub async fn get_public_url(&self) -> Option<String> {
+        self.inner.get_public_url().map(str::to_string)
+    }
+}

--- a/crates/alien-bindings-node/src/lib.rs
+++ b/crates/alien-bindings-node/src/lib.rs
@@ -1,5 +1,5 @@
 //! `alien-bindings-node` — a napi-rs addon exposing `alien-bindings`
-//! storage / kv / queue / vault to JavaScript.
+//! storage / kv / queue / vault / container to JavaScript.
 //!
 //! This crate is a pure argument/error translation layer. It contains no
 //! provider logic: every method marshals arguments across the JS boundary,
@@ -8,6 +8,7 @@
 
 #![deny(clippy::all)]
 
+mod container;
 mod error;
 mod kv;
 mod queue;
@@ -19,6 +20,7 @@ use alien_bindings::Bindings;
 use napi_derive::napi;
 use std::sync::Arc;
 
+pub use container::ContainerHandle;
 pub use kv::KvHandle;
 pub use queue::QueueHandle;
 pub use storage::StorageHandle;
@@ -80,5 +82,13 @@ impl BindingsHandle {
         let inner = self.inner.clone();
         let vault = inner.vault(&name).await.map_err(map_alien_error)?;
         Ok(VaultHandle::new(vault))
+    }
+
+    /// Resolve the linked-container binding named `name`.
+    #[napi]
+    pub async fn container(&self, name: String) -> napi::Result<ContainerHandle> {
+        let inner = self.inner.clone();
+        let container = inner.container(&name).await.map_err(map_alien_error)?;
+        Ok(ContainerHandle::new(container))
     }
 }

--- a/crates/alien-bindings-node/src/queue.rs
+++ b/crates/alien-bindings-node/src/queue.rs
@@ -3,10 +3,10 @@
 
 use crate::error::map_alien_error;
 use alien_bindings::error::ErrorData;
-use alien_bindings::traits::{MessagePayload, Queue, QueueMessage};
+use alien_bindings::traits::{MessagePayload, QueueMessage};
+use alien_bindings::BoundQueue;
 use alien_error::AlienError;
 use napi_derive::napi;
-use std::sync::Arc;
 
 /// A message received from a queue.
 ///
@@ -71,11 +71,11 @@ fn message_to_js(message: QueueMessage) -> napi::Result<QueueMessageJs> {
 /// Handle to a resolved queue binding.
 #[napi]
 pub struct QueueHandle {
-    inner: Arc<dyn Queue>,
+    inner: BoundQueue,
 }
 
 impl QueueHandle {
-    pub(crate) fn new(inner: Arc<dyn Queue>) -> Self {
+    pub(crate) fn new(inner: BoundQueue) -> Self {
         Self { inner }
     }
 }
@@ -84,52 +84,49 @@ impl QueueHandle {
 impl QueueHandle {
     /// Send a JSON message. `json_string` must be valid JSON.
     #[napi]
-    pub async fn send_json(&self, queue: String, json_string: String) -> napi::Result<()> {
+    pub async fn send_json(&self, json_string: String) -> napi::Result<()> {
         let payload = parse_json_payload(&json_string)?;
         let inner = self.inner.clone();
-        inner.send(&queue, payload).await.map_err(map_alien_error)
+        inner.send(payload).await.map_err(map_alien_error)
     }
 
     /// Send a text message.
     #[napi]
-    pub async fn send_text(&self, queue: String, text: String) -> napi::Result<()> {
+    pub async fn send_text(&self, text: String) -> napi::Result<()> {
         let inner = self.inner.clone();
         inner
-            .send(&queue, MessagePayload::Text(text))
+            .send(MessagePayload::Text(text))
             .await
             .map_err(map_alien_error)
     }
 
     /// Receive up to `max` messages.
     #[napi]
-    pub async fn receive(&self, queue: String, max: u32) -> napi::Result<Vec<QueueMessageJs>> {
+    pub async fn receive(&self, max: u32) -> napi::Result<Vec<QueueMessageJs>> {
         let inner = self.inner.clone();
-        let messages = inner
-            .receive(&queue, max as usize)
-            .await
-            .map_err(map_alien_error)?;
+        let messages = inner.receive(max as usize).await.map_err(map_alien_error)?;
         messages.into_iter().map(message_to_js).collect()
     }
 
     /// Acknowledge a message by its receipt handle.
     #[napi]
-    pub async fn ack(&self, queue: String, receipt: String) -> napi::Result<()> {
+    pub async fn ack(&self, receipt: String) -> napi::Result<()> {
         let inner = self.inner.clone();
-        inner.ack(&queue, &receipt).await.map_err(map_alien_error)
+        inner.ack(&receipt).await.map_err(map_alien_error)
     }
 
     /// Negative-acknowledge a message, making it immediately redeliverable.
     #[napi]
-    pub async fn nack(&self, queue: String, receipt: String) -> napi::Result<()> {
+    pub async fn nack(&self, receipt: String) -> napi::Result<()> {
         let inner = self.inner.clone();
-        inner.nack(&queue, &receipt).await.map_err(map_alien_error)
+        inner.nack(&receipt).await.map_err(map_alien_error)
     }
 
     /// Delete every message in the queue.
     #[napi]
-    pub async fn purge(&self, queue: String) -> napi::Result<()> {
+    pub async fn purge(&self) -> napi::Result<()> {
         let inner = self.inner.clone();
-        inner.purge(&queue).await.map_err(map_alien_error)
+        inner.purge().await.map_err(map_alien_error)
     }
 }
 

--- a/crates/alien-bindings/src/bindings.rs
+++ b/crates/alien-bindings/src/bindings.rs
@@ -1,13 +1,15 @@
 //! App-facing convenience API for accessing bindings.
 //!
 //! [`Bindings`] wraps a [`crate::provider::LazyEnvBindingsProvider`], giving application
-//! code a small, stable surface — `storage`, `kv`, `queue`, `vault` — instead of the full
+//! code a small, stable surface — `storage`, `kv`, `queue`, `vault`, `container` — instead of the full
 //! [`crate::traits::BindingsProviderApi`] used internally by the manager and controllers.
 
 use crate::error::Result;
 use crate::provider::{BindingsProvider, LazyEnvBindingsProvider};
 use crate::refreshing::{RefreshingKv, RefreshingQueue, RefreshingStorage, RefreshingVault};
-use crate::traits::{BindingsProviderApi, Kv, Queue, Storage, Vault};
+use crate::traits::{
+    BindingsProviderApi, Container, Kv, MessagePayload, Queue, QueueMessage, Storage, Vault,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -43,6 +45,56 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct Bindings {
     provider: Arc<LazyEnvBindingsProvider>,
+}
+
+/// A queue binding scoped to its configured queue name.
+#[derive(Clone)]
+pub struct BoundQueue {
+    inner: Arc<dyn Queue>,
+    name: Arc<str>,
+}
+
+impl std::fmt::Debug for BoundQueue {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Queue")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BoundQueue {
+    fn new(inner: Arc<dyn Queue>, name: impl Into<Arc<str>>) -> Self {
+        Self {
+            inner,
+            name: name.into(),
+        }
+    }
+
+    /// Send a message to this queue.
+    pub async fn send(&self, message: MessagePayload) -> Result<()> {
+        self.inner.send(&self.name, message).await
+    }
+
+    /// Receive up to `max_messages` messages from this queue.
+    pub async fn receive(&self, max_messages: usize) -> Result<Vec<QueueMessage>> {
+        self.inner.receive(&self.name, max_messages).await
+    }
+
+    /// Acknowledge a received message.
+    pub async fn ack(&self, receipt_handle: &str) -> Result<()> {
+        self.inner.ack(&self.name, receipt_handle).await
+    }
+
+    /// Release a received message for redelivery.
+    pub async fn nack(&self, receipt_handle: &str) -> Result<()> {
+        self.inner.nack(&self.name, receipt_handle).await
+    }
+
+    /// Delete every message in this queue.
+    pub async fn purge(&self) -> Result<()> {
+        self.inner.purge(&self.name).await
+    }
 }
 
 impl Bindings {
@@ -90,12 +142,13 @@ impl Bindings {
     }
 
     /// Loads a queue binding that refreshes minted credentials before use.
-    pub async fn queue(&self, binding_name: &str) -> Result<Arc<dyn Queue>> {
+    pub async fn queue(&self, binding_name: &str) -> Result<BoundQueue> {
         self.provider.load_queue(binding_name).await?;
-        Ok(Arc::new(RefreshingQueue::new(
+        let queue: Arc<dyn Queue> = Arc::new(RefreshingQueue::new(
             self.provider.clone(),
             binding_name.to_string(),
-        )))
+        ));
+        Ok(BoundQueue::new(queue, binding_name))
     }
 
     /// Loads a vault binding that refreshes minted credentials before use.
@@ -105,6 +158,11 @@ impl Bindings {
             self.provider.clone(),
             binding_name.to_string(),
         )))
+    }
+
+    /// Loads a linked container for read-only service discovery.
+    pub async fn container(&self, binding_name: &str) -> Result<Arc<dyn Container>> {
+        self.provider.load_container(binding_name).await
     }
 }
 
@@ -338,20 +396,15 @@ mod tests {
             .expect("queue binding should load");
 
         queue
-            .send("jobs", MessagePayload::Text("hello".to_string()))
+            .send(MessagePayload::Text("hello".to_string()))
             .await
             .expect("send should succeed");
-        let messages = queue
-            .receive("jobs", 1)
-            .await
-            .expect("receive should succeed");
+        let messages = queue.receive(1).await.expect("receive should succeed");
         assert_eq!(messages.len(), 1);
     }
 
     #[tokio::test]
-    async fn queue_nack_and_purge_reachable_through_trait_object() {
-        // The point of promoting nack/purge onto the Queue trait: they must be
-        // callable on the `Arc<dyn Queue>` the app-facing API hands back.
+    async fn bound_queue_uses_its_configured_name_for_every_operation() {
         let temp_dir = TempDir::new().expect("tempdir");
         let json = format!(
             r#"{{"service":"local-queue","queuePath":"{}"}}"#,
@@ -368,42 +421,57 @@ mod tests {
         // nack: an in-flight message under the default lease is hidden, but a
         // nack makes it immediately redeliverable.
         queue
-            .send("jobs", MessagePayload::Text("retry".to_string()))
+            .send(MessagePayload::Text("retry".to_string()))
             .await
             .expect("send should succeed");
-        let first = queue
-            .receive("jobs", 1)
-            .await
-            .expect("receive should succeed");
+        let first = queue.receive(1).await.expect("receive should succeed");
         assert_eq!(first.len(), 1);
         assert!(
             queue
-                .receive("jobs", 1)
+                .receive(1)
                 .await
                 .expect("receive should succeed")
                 .is_empty(),
             "in-flight message must be hidden before nack"
         );
         queue
-            .nack("jobs", &first[0].receipt_handle)
+            .nack(&first[0].receipt_handle)
             .await
             .expect("nack should succeed");
-        let redelivered = queue
-            .receive("jobs", 1)
-            .await
-            .expect("receive should succeed");
+        let redelivered = queue.receive(1).await.expect("receive should succeed");
         assert_eq!(redelivered.len(), 1, "nacked message must be redelivered");
 
         // purge: clears everything, in flight or visible.
-        queue.purge("jobs").await.expect("purge should succeed");
+        queue.purge().await.expect("purge should succeed");
         assert!(
             queue
-                .receive("jobs", 1)
+                .receive(1)
                 .await
                 .expect("receive should succeed")
                 .is_empty(),
             "purge must empty the queue"
         );
+    }
+
+    #[tokio::test]
+    async fn container_exposes_internal_and_optional_public_urls() {
+        let env = with_binding(
+            base_env(),
+            "database",
+            r#"{"service":"local","containerName":"database","internalUrl":"http://database.internal:5432","publicUrl":"http://localhost:15432"}"#,
+        );
+        let bindings = Bindings::from_env_map(env).expect("valid env should construct Bindings");
+
+        let container = bindings
+            .container("database")
+            .await
+            .expect("container binding should load");
+
+        assert_eq!(
+            container.get_internal_url(),
+            "http://database.internal:5432"
+        );
+        assert_eq!(container.get_public_url(), Some("http://localhost:15432"));
     }
 
     #[tokio::test]

--- a/crates/alien-bindings/src/lib.rs
+++ b/crates/alien-bindings/src/lib.rs
@@ -2,7 +2,7 @@ use alien_error::AlienError;
 
 // Re-export core traits and types
 pub use alien_core::{Platform, ENV_ALIEN_DEPLOYMENT_TYPE, ENV_OPERATOR_BASE_PLATFORM};
-pub use bindings::Bindings;
+pub use bindings::{Bindings, BoundQueue};
 pub use error::{ErrorData, Result};
 pub use provider::BindingsProvider;
 pub use traits::{

--- a/crates/alien-commands/src/receiver.rs
+++ b/crates/alien-commands/src/receiver.rs
@@ -1,7 +1,7 @@
 //! App-owned pull command receiver for Containers and Daemons.
 //!
 //! A [`Receiver`] leases commands addressed to its own target resource from
-//! the command server over outbound HTTPS (no inbound connections, no gRPC),
+//! the command server over outbound HTTPS (no inbound connections),
 //! dispatches them to in-process handlers, and submits responses through the
 //! envelope's response-handling flow (inline or presigned storage upload).
 //!
@@ -10,8 +10,7 @@
 //! ```no_run
 //! # async fn example() -> alien_commands::error::Result<()> {
 //! let mut receiver = alien_commands::Receiver::from_env()?;
-//! receiver.handle("generate-report", |ctx| async move {
-//!     let params: serde_json::Value = ctx.input_json()?;
+//! receiver.command("generate-report", |params: serde_json::Value, _ctx| async move {
 //!     Ok(serde_json::json!({ "report": params }))
 //! });
 //! receiver.run().await?;
@@ -452,13 +451,37 @@ impl Receiver {
         self
     }
 
-    /// Register a handler for a command name.
+    /// Register a JSON command handler.
     ///
-    /// The handler receives a [`Context`] and returns any serializable
-    /// value, submitted as the command's JSON success response. A returned
-    /// error is submitted as a `HANDLER_ERROR` response. Registering the
-    /// same name twice replaces the previous handler.
-    pub fn handle<F, Fut, T>(&mut self, name: impl Into<String>, handler: F) -> &mut Self
+    /// The command input is deserialized as `P` before the handler runs. The
+    /// handler returns any serializable value, which is submitted as the
+    /// command's JSON success response. Deserialization and handler errors are
+    /// submitted as `HANDLER_ERROR` responses. Registering the same name twice
+    /// replaces the previous handler.
+    pub fn command<P, F, Fut, T>(&mut self, name: impl Into<String>, handler: F) -> &mut Self
+    where
+        P: DeserializeOwned + Send + 'static,
+        F: Fn(P, Context) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = HandlerResult<T>> + Send + 'static,
+        T: Serialize + 'static,
+    {
+        let handler = Arc::new(handler);
+        self.handle_raw(name, move |context| {
+            let handler = Arc::clone(&handler);
+            async move {
+                let input = context.input_json::<P>()?;
+                handler(input, context).await
+            }
+        })
+    }
+
+    /// Register a raw command handler.
+    ///
+    /// Raw handlers receive the encoded input bytes through [`Context::input`].
+    /// Prefer [`Receiver::command`] for normal JSON commands. The returned
+    /// value is still serialized as JSON. Registering the same name twice
+    /// replaces the previous handler.
+    pub fn handle_raw<F, Fut, T>(&mut self, name: impl Into<String>, handler: F) -> &mut Self
     where
         F: Fn(Context) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = HandlerResult<T>> + Send + 'static,
@@ -1551,10 +1574,11 @@ mod tests {
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.expect("accept params request");
             let mut request = [0_u8; 1024];
-            socket
+            let bytes_read = socket
                 .read(&mut request)
                 .await
                 .expect("read params request");
+            assert!(bytes_read > 0, "params request was empty");
             tokio::time::sleep(Duration::from_millis(500)).await;
             let body = br#"{"fromStorage":true}"#;
             let headers = format!(

--- a/crates/alien-commands/tests/receiver_tests.rs
+++ b/crates/alien-commands/tests/receiver_tests.rs
@@ -83,10 +83,9 @@ async fn receiver_round_trips_success_response() {
     let mut receiver = Receiver::from_env_vars(&env)
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle("sync-data", move |ctx| {
+    receiver.command("sync-data", move |input: serde_json::Value, ctx| {
         let ctx_tx = ctx_tx.clone();
         async move {
-            let input: serde_json::Value = ctx.input_json()?;
             ctx_tx
                 .send((
                     ctx.command_id.clone(),
@@ -151,7 +150,7 @@ async fn receiver_does_not_lease_beyond_max_concurrency() {
         .expect("receiver should build from env")
         .with_max_leases(1)
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle("bounded", {
+    receiver.handle_raw("bounded", {
         let calls = Arc::clone(&calls);
         let first_started = Arc::clone(&first_started);
         let release_first = Arc::clone(&release_first);
@@ -216,7 +215,7 @@ async fn panicked_handler_releases_receiver_capacity() {
         .expect("receiver should build from env")
         .with_max_leases(1)
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle("panic-once", {
+    receiver.handle_raw("panic-once", {
         let calls = Arc::clone(&calls);
         move |_ctx| {
             let calls = Arc::clone(&calls);
@@ -261,7 +260,7 @@ async fn receiver_submits_unknown_command_error() {
     let mut receiver = Receiver::from_env_vars(&env)
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle(
+    receiver.handle_raw(
         "something-else",
         |_ctx| async move { Ok(serde_json::json!({})) },
     );
@@ -299,7 +298,7 @@ async fn receiver_aborts_handler_at_lease_expiry_budget() {
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL)
         .with_lease_seconds(1);
-    receiver.handle("slow-command", |_ctx| async move {
+    receiver.handle_raw("slow-command", |_ctx| async move {
         tokio::time::sleep(Duration::from_secs(300)).await;
         Ok(serde_json::json!({ "should": "never happen" }))
     });
@@ -354,7 +353,7 @@ async fn receiver_passes_attempt_through_on_redelivery() {
     let mut receiver = Receiver::from_env_vars(&env)
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle("retry-me", move |ctx| {
+    receiver.handle_raw("retry-me", move |ctx| {
         let attempt_tx = attempt_tx.clone();
         async move {
             attempt_tx.send(ctx.attempt).expect("test channel open");
@@ -394,7 +393,7 @@ async fn receiver_shutdown_drains_in_flight_and_stops_leasing() {
     let mut receiver = Receiver::from_env_vars(&env)
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle("drain-me", move |_ctx| {
+    receiver.handle_raw("drain-me", move |_ctx| {
         let started_tx = started_tx.clone();
         async move {
             started_tx.send(()).expect("test channel open");
@@ -456,7 +455,7 @@ async fn receiver_shutdown_timeout_cancels_and_releases_in_flight_lease() {
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL)
         .with_drain_timeout(Duration::from_millis(10));
-    receiver.handle("release-me", move |ctx| {
+    receiver.handle_raw("release-me", move |ctx| {
         let started_tx = started_tx.clone();
         async move {
             started_tx.send(()).expect("test channel open");
@@ -498,7 +497,7 @@ async fn receiver_round_trips_large_response_via_storage() {
     let mut receiver = Receiver::from_env_vars(&env)
         .expect("receiver should build from env")
         .with_poll_interval(POLL_INTERVAL);
-    receiver.handle("big-report", move |_ctx| {
+    receiver.handle_raw("big-report", move |_ctx| {
         let large_payload = large_payload.clone();
         async move { Ok(serde_json::json!({ "report": large_payload })) }
     });

--- a/crates/alien-sdk/src/lib.rs
+++ b/crates/alien-sdk/src/lib.rs
@@ -1,12 +1,12 @@
 //! Alien SDK for Rust.
 //!
-//! Cloud-agnostic bindings for storage, KV, queues, and vaults, plus the
+//! Cloud-agnostic bindings for storage, KV, queues, vaults, and linked containers, plus the
 //! Worker application context.
 //! Works on AWS, GCP, Azure, Kubernetes, and locally.
 //!
 //! This is the public-facing crate for Alien app developers. Its binding API is
-//! deliberately limited to [`Bindings`] and the four kinds applications can
-//! use directly: [`Storage`], [`Kv`], [`Queue`], and [`Vault`].
+//! deliberately limited to [`Bindings`] and the kinds applications use directly:
+//! [`Storage`], [`Kv`], [`Queue`], [`Vault`], and [`Container`].
 //!
 //! Platform tooling that needs provider construction or managed resource kinds
 //! such as builds and artifact registries uses `alien_bindings` directly.
@@ -46,7 +46,7 @@
 //! ```
 //!
 //! ```compile_fail
-//! use alien_sdk::{ArtifactRegistry, Build, Container, Postgres, ServiceAccount, Worker};
+//! use alien_sdk::{ArtifactRegistry, Build, Postgres, ServiceAccount, Worker};
 //! ```
 //!
 //! ```compile_fail
@@ -61,7 +61,9 @@
 //! use alien_sdk::http_client;
 //! ```
 //!
-pub use alien_bindings::{Bindings, ErrorData, Kv, Queue, Result, Storage, Vault};
+pub use alien_bindings::{
+    Bindings, BoundQueue as Queue, Container, ErrorData, Kv, Result, Storage, Vault,
+};
 
 /// Errors returned by the application binding and Worker APIs.
 pub mod error {
@@ -77,11 +79,12 @@ pub mod presigned {
 }
 
 /// App-facing binding value types (the option/message/result types that flow
-/// through storage/KV/queue/vault calls).
+/// through storage/KV/queue/vault/container calls).
 pub mod traits {
     pub use alien_bindings::traits::{
-        Kv, MessagePayload, PutOptions, Queue, QueueMessage, ScanResult, Storage, Vault,
+        Kv, MessagePayload, PutOptions, QueueMessage, ScanResult, Storage, Vault,
     };
+    pub use alien_bindings::{BoundQueue as Queue, Container};
 }
 
 #[cfg(feature = "worker")]
@@ -94,7 +97,7 @@ mod wait_until;
 pub mod worker {
     //! Worker task, event, lifecycle, and `waitUntil` APIs.
     //!
-    //! `AlienContext` exposes the same four-kind application [`Bindings`]
+    //! `AlienContext` exposes the same application [`Bindings`]
     //! facade, not the internal provider API:
     //!
     //! ```compile_fail

--- a/crates/alien-sdk/tests/public_facade.rs
+++ b/crates/alien-sdk/tests/public_facade.rs
@@ -16,7 +16,7 @@ fn alien_context_accessors_return_the_application_bindings_facade() {
 }
 
 #[tokio::test]
-async fn bindings_facade_exposes_all_four_application_binding_kinds() {
+async fn bindings_facade_exposes_all_application_binding_kinds() {
     let bindings =
         Bindings::from_env_map(HashMap::new()).expect("empty environment should construct");
 
@@ -36,6 +36,10 @@ async fn bindings_facade_exposes_all_four_application_binding_kinds() {
         .vault("secrets")
         .await
         .expect_err("missing vault binding should fail");
+    let container_error = bindings
+        .container("database")
+        .await
+        .expect_err("missing container binding should fail");
 
     assert_eq!(
         [
@@ -43,7 +47,8 @@ async fn bindings_facade_exposes_all_four_application_binding_kinds() {
             kv_error.code.as_str(),
             queue_error.code.as_str(),
             vault_error.code.as_str(),
+            container_error.code.as_str(),
         ],
-        ["BINDING_NOT_CONFIGURED"; 4],
+        ["BINDING_NOT_CONFIGURED"; 5],
     );
 }

--- a/examples/byoc-database/src/main.rs
+++ b/examples/byoc-database/src/main.rs
@@ -202,10 +202,9 @@ fn command_receiver_from_env(
 }
 
 fn register_stats_handler(receiver: &mut alien_commands::Receiver, reader: Arc<Reader>) {
-    receiver.handle("stats", move |ctx| {
+    receiver.command("stats", move |request: StatsRequest, _ctx| {
         let reader = reader.clone();
         async move {
-            let request: StatsRequest = ctx.input_json()?;
             let stats = reader.stats(&request.namespace).await?;
             Ok(stats)
         }

--- a/examples/command-routing-ts/services/api/package.json
+++ b/examples/command-routing-ts/services/api/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@alienplatform/sdk": "^1.3.5",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "zod": "4.3.2"
   },
   "devDependencies": {
     "@types/bun": "^1.3.5",

--- a/examples/command-routing-ts/services/api/src/index.ts
+++ b/examples/command-routing-ts/services/api/src/index.ts
@@ -9,6 +9,7 @@
 
 import { command, kv } from "@alienplatform/sdk"
 import { Hono } from "hono"
+import { z } from "zod"
 import { countDocs, searchIndex } from "../../../shared/scan-all"
 
 const RESOURCE = "api"
@@ -24,7 +25,7 @@ command("status", async () => ({
 }))
 
 // Overlapping command #2: `search`. Reads the shared index the daemon builds.
-command("search", async ({ term }: { term: string }) => ({
+command("search", z.object({ term: z.string() }), async ({ term }) => ({
   resource: RESOURCE,
   term,
   hits: await searchIndex(kv("index"), term),

--- a/examples/command-routing-ts/services/indexer/src/index.ts
+++ b/examples/command-routing-ts/services/indexer/src/index.ts
@@ -43,7 +43,7 @@ const receiver = createCommandReceiver()
 
 // Overlapping command #1: `status`. Answered by the daemon, so `role` is
 // "daemon" and `model` is "pull".
-receiver.handle("status", async () => ({
+receiver.command("status", async () => ({
   resource: RESOURCE,
   role: "daemon",
   model: "pull",
@@ -52,8 +52,11 @@ receiver.handle("status", async () => ({
 }))
 
 // Overlapping command #2: `search`, reading the index this daemon maintains.
-receiver.handle("search", async ctx => {
-  const { term } = JSON.parse(new TextDecoder().decode(ctx.input)) as { term: string }
+receiver.command("search", async input => {
+  if (typeof input !== "object" || input === null || !("term" in input) || typeof input.term !== "string") {
+    throw new TypeError("term must be a string")
+  }
+  const { term } = input
   return { resource: RESOURCE, term, hits: await searchIndex(index, term) }
 })
 

--- a/examples/data-connector-ts/package.json
+++ b/examples/data-connector-ts/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@alienplatform/sdk": "^1.0.0",
-    "@alienplatform/core": "^1.0.1"
+    "@alienplatform/core": "^1.0.1",
+    "zod": "4.3.2"
   },
   "devDependencies": {
     "@alienplatform/testing": "^0.1.0",

--- a/examples/data-connector-ts/src/index.ts
+++ b/examples/data-connector-ts/src/index.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto"
 import { command, kv, vault } from "@alienplatform/sdk"
+import { z } from "zod"
 
 // --- Sample data ---
 // In production, replace this with a real database client (pg, mysql2, etc.).
@@ -46,27 +47,31 @@ command("test-connection", async () => {
   }
 })
 
-command("query", async ({ sql, useCache }: { sql: string; useCache?: boolean }) => {
-  const c = await kv("cache")
-  const cacheKey = `query:${createHash("sha256").update(sql).digest("hex").slice(0, 16)}`
+command(
+  "query",
+  z.object({ sql: z.string(), useCache: z.boolean().optional() }),
+  async ({ sql, useCache }) => {
+    const c = await kv("cache")
+    const cacheKey = `query:${createHash("sha256").update(sql).digest("hex").slice(0, 16)}`
 
-  if (useCache) {
-    const cached = await c.get(cacheKey)
-    if (cached) {
-      return { ...JSON.parse(new TextDecoder().decode(cached)), cached: true }
+    if (useCache) {
+      const cached = await c.get(cacheKey)
+      if (cached) {
+        return { ...JSON.parse(new TextDecoder().decode(cached)), cached: true }
+      }
     }
-  }
 
-  // In production, use the connection config to connect to the actual database
-  await getConnectionConfig()
-  const result = simulateQuery(sql)
+    // In production, use the connection config to connect to the actual database
+    await getConnectionConfig()
+    const result = simulateQuery(sql)
 
-  if (useCache) {
-    await c.set(cacheKey, JSON.stringify(result))
-  }
+    if (useCache) {
+      await c.set(cacheKey, JSON.stringify(result))
+    }
 
-  return { ...result, cached: false }
-})
+    return { ...result, cached: false }
+  },
+)
 
 command("list-tables", async () => {
   return { tables: Object.keys(SAMPLE_DATA) }

--- a/examples/endpoint-agent/src/commands.rs
+++ b/examples/endpoint-agent/src/commands.rs
@@ -8,8 +8,7 @@ use crate::monitor;
 
 /// Register all command handlers on the app-owned pull command receiver.
 ///
-/// Each handler deserializes its params from the command context
-/// (`ctx.input_json()`) and returns a JSON value that the receiver submits as
+/// Each handler receives typed JSON params and returns a JSON value that the receiver submits as
 /// the command's success response. Handler errors are submitted as
 /// `HANDLER_ERROR` responses — both our `Error` and the receiver's own errors
 /// reach the `?` boundary as `std::error::Error`, so no manual conversion is
@@ -18,36 +17,33 @@ pub fn register(receiver: &mut Receiver, db: EncryptedDb) {
     // get-events command
     {
         let db = db.clone();
-        receiver.handle("get-events", move |ctx| {
+        receiver.command("get-events", move |params: GetEventsParams, _ctx| {
             let db = db.clone();
-            async move {
-                let params: GetEventsParams = ctx.input_json()?;
-                Ok(handle_get_events(db, params).await?)
-            }
+            async move { Ok(handle_get_events(db, params).await?) }
         });
     }
 
     // get-config command
-    receiver.handle("get-config", move |_ctx| async move {
+    receiver.command("get-config", move |_: serde_json::Value, _ctx| async move {
         Ok(handle_get_config().await?)
     });
 
     // scan-path command
-    receiver.handle("scan-path", move |ctx| async move {
-        let params: ScanPathParams = ctx.input_json()?;
-        Ok(handle_scan_path(params).await?)
-    });
+    receiver.command(
+        "scan-path",
+        move |params: ScanPathParams, _ctx| async move { Ok(handle_scan_path(params).await?) },
+    );
 
     // simulate-clipboard command (for testing)
     {
         let db = db.clone();
-        receiver.handle("simulate-clipboard", move |ctx| {
-            let db = db.clone();
-            async move {
-                let params: SimulateClipboardParams = ctx.input_json()?;
-                Ok(handle_simulate_clipboard(db, params).await?)
-            }
-        });
+        receiver.command(
+            "simulate-clipboard",
+            move |params: SimulateClipboardParams, _ctx| {
+                let db = db.clone();
+                async move { Ok(handle_simulate_clipboard(db, params).await?) }
+            },
+        );
     }
 }
 

--- a/examples/endpoint-agent/src/main.rs
+++ b/examples/endpoint-agent/src/main.rs
@@ -3,7 +3,7 @@
 //!
 //! Its only interface is Alien commands, so it drives the app-owned pull
 //! command receiver (`alien_commands::Receiver`) directly:
-//! `Receiver::from_env()` → register handlers with `receiver.handle(...)` →
+//! `Receiver::from_env()` → register typed handlers with `receiver.command(...)` →
 //! `receiver.run().await`. There are no resource bindings to load — the
 //! encrypted store is a local Turso database, not a linked binding.
 

--- a/examples/event-pipeline-ts/package.json
+++ b/examples/event-pipeline-ts/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@alienplatform/sdk": "^1.0.0",
     "@alienplatform/core": "^1.0.1",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "zod": "4.3.2"
   },
   "devDependencies": {
     "@alienplatform/testing": "^0.1.0",

--- a/examples/event-pipeline-ts/src/index.ts
+++ b/examples/event-pipeline-ts/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "@alienplatform/sdk"
 import type { Kv } from "@alienplatform/sdk"
 import { Hono } from "hono"
+import { z } from "zod"
 
 /** Iterate every key under a prefix, following the scan cursor across pages. */
 async function* scanAll(store: Kv, prefix: string) {
@@ -67,21 +68,25 @@ onCronEvent("*", async event => {
 
 // --- Commands for querying processed events ---
 
-command("get-events", async ({ type, limit }: { type?: string; limit?: number }) => {
-  const ev = kv("events")
-  const prefix = type ? `${type}:` : ""
-  const results: { key: string; value: unknown }[] = []
+command(
+  "get-events",
+  z.object({ type: z.string().optional(), limit: z.number().optional() }),
+  async ({ type, limit }) => {
+    const ev = kv("events")
+    const prefix = type ? `${type}:` : ""
+    const results: { key: string; value: unknown }[] = []
 
-  for await (const entry of scanAll(ev, prefix)) {
-    results.push({
-      key: entry.key,
-      value: JSON.parse(new TextDecoder().decode(entry.value)),
-    })
-    if (limit && results.length >= limit) break
-  }
+    for await (const entry of scanAll(ev, prefix)) {
+      results.push({
+        key: entry.key,
+        value: JSON.parse(new TextDecoder().decode(entry.value)),
+      })
+      if (limit && results.length >= limit) break
+    }
 
-  return { events: results, count: results.length }
-})
+    return { events: results, count: results.length }
+  },
+)
 
 command("get-stats", async () => {
   const ev = kv("events")
@@ -98,7 +103,7 @@ command("get-stats", async () => {
 
 // --- Send a test message (useful during development) ---
 
-command("send-test-message", async ({ message }: { message: string }) => {
+command("send-test-message", z.object({ message: z.string() }), async ({ message }) => {
   const q = queue("inbox")
   await q.send(message)
   return { sent: true }

--- a/examples/full-stack-microservices/services/worker/src/index.ts
+++ b/examples/full-stack-microservices/services/worker/src/index.ts
@@ -25,8 +25,11 @@ const files = storage(process.env.FILES_BUCKET ?? "files")
 // the Redis job loop still runs.
 if (process.env.ALIEN_COMMANDS_URL) {
   const receiver = createCommandReceiver()
-  receiver.handle("reprocess", async ctx => {
-    const { issueId } = JSON.parse(new TextDecoder().decode(ctx.input)) as { issueId: string }
+  receiver.command("reprocess", async input => {
+    if (typeof input !== "object" || input === null || !("issueId" in input) || typeof input.issueId !== "string") {
+      throw new TypeError("issueId must be a string")
+    }
+    const { issueId } = input
     await redis.lpush("work:issues", JSON.stringify({ issueId, requestedAt: Date.now() }))
     return { requeued: true, issueId }
   })

--- a/examples/github-agent/packages/remote-agent/src/commands.ts
+++ b/examples/github-agent/packages/remote-agent/src/commands.ts
@@ -1,20 +1,18 @@
 import { command } from "@alienplatform/sdk"
+import { z } from "zod"
 import { applyLabels, classifyPullRequests, computeMetrics, fetchPullRequests } from "./github.js"
 import { loadIntegrationConfig, saveIntegrationConfig } from "./integrations.js"
-import type { IntegrationConfig, LabelResult } from "./types.js"
+import type { IntegrationConfig } from "./types.js"
 
-type SetIntegrationParams = {
-  integrationId: string
-  config: IntegrationConfig
-}
-
-type AnalyzeParams = {
-  integrationId: string
-}
-
-type LabelParams = {
-  integrationId: string
-}
+const integrationIdSchema = z.object({ integrationId: z.string() })
+const setIntegrationSchema = integrationIdSchema.extend({
+  config: z.object({
+    owner: z.string(),
+    repo: z.string(),
+    token: z.string().optional(),
+    baseUrl: z.string().optional(),
+  }),
+})
 
 function normalizeConfig(config: IntegrationConfig): IntegrationConfig {
   const owner = config.owner?.trim()
@@ -41,34 +39,28 @@ function ensureIntegrationId(integrationId?: string): string {
 }
 
 export function registerCommands(): void {
-  command<SetIntegrationParams, { ok: boolean }>(
-    "set-integration",
-    async ({ integrationId, config }) => {
-      const id = ensureIntegrationId(integrationId)
-      const normalized = normalizeConfig(config)
-      console.log(`Saving integration config for ${id}: ${normalized.owner}/${normalized.repo}`)
-      await saveIntegrationConfig(id, normalized)
-      return { ok: true }
-    },
-  )
+  command("set-integration", setIntegrationSchema, async ({ integrationId, config }) => {
+    const id = ensureIntegrationId(integrationId)
+    const normalized = normalizeConfig(config)
+    console.log(`Saving integration config for ${id}: ${normalized.owner}/${normalized.repo}`)
+    await saveIntegrationConfig(id, normalized)
+    return { ok: true }
+  })
 
-  command<AnalyzeParams, ReturnType<typeof computeMetrics>>(
-    "analyze-repository",
-    async ({ integrationId }) => {
-      const id = ensureIntegrationId(integrationId)
-      console.log(`Analyzing repository for integration ${id}`)
-      const config = await loadIntegrationConfig(id)
-      const prs = await fetchPullRequests(config)
-      const classified = classifyPullRequests(prs)
-      const metrics = computeMetrics(classified)
-      console.log(
-        `Analysis complete: ${metrics.totalPRs} PRs, review throughput score ${metrics.reviewThroughputScore}`,
-      )
-      return metrics
-    },
-  )
+  command("analyze-repository", integrationIdSchema, async ({ integrationId }) => {
+    const id = ensureIntegrationId(integrationId)
+    console.log(`Analyzing repository for integration ${id}`)
+    const config = await loadIntegrationConfig(id)
+    const prs = await fetchPullRequests(config)
+    const classified = classifyPullRequests(prs)
+    const metrics = computeMetrics(classified)
+    console.log(
+      `Analysis complete: ${metrics.totalPRs} PRs, review throughput score ${metrics.reviewThroughputScore}`,
+    )
+    return metrics
+  })
 
-  command<LabelParams, LabelResult>("label-pull-requests", async ({ integrationId }) => {
+  command("label-pull-requests", integrationIdSchema, async ({ integrationId }) => {
     const id = ensureIntegrationId(integrationId)
     const config = await loadIntegrationConfig(id)
 

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   basic-worker-ts:
     dependencies:
@@ -58,7 +58,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   byoc-database:
     devDependencies:
@@ -95,6 +95,9 @@ importers:
       hono:
         specifier: ^4.0.0
         version: 4.12.5
+      zod:
+        specifier: 4.3.2
+        version: 4.3.2
     devDependencies:
       '@types/bun':
         specifier: ^1.3.5
@@ -149,6 +152,9 @@ importers:
       '@alienplatform/sdk':
         specifier: file:../../packages/sdk
         version: file:../packages/sdk(@types/json-schema@7.0.15)(openapi-types@12.1.3)
+      zod:
+        specifier: 4.3.2
+        version: 4.3.2
     devDependencies:
       '@alienplatform/testing':
         specifier: file:../../packages/testing
@@ -161,7 +167,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   endpoint-agent:
     devDependencies:
@@ -192,6 +198,9 @@ importers:
       hono:
         specifier: ^4.0.0
         version: 4.12.5
+      zod:
+        specifier: 4.3.2
+        version: 4.3.2
     devDependencies:
       '@alienplatform/testing':
         specifier: file:../../packages/testing
@@ -204,7 +213,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   full-stack-microservices:
     devDependencies:
@@ -334,7 +343,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   nextjs-app:
     dependencies:
@@ -375,6 +384,9 @@ importers:
       hono:
         specifier: ^4.0.0
         version: 4.12.5
+      zod:
+        specifier: 4.3.2
+        version: 4.3.2
     devDependencies:
       '@alienplatform/testing':
         specifier: file:../../packages/testing
@@ -387,7 +399,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   webhook-api-ts:
     dependencies:
@@ -400,6 +412,9 @@ importers:
       hono:
         specifier: ^4.0.0
         version: 4.12.5
+      zod:
+        specifier: 4.3.2
+        version: 4.3.2
     devDependencies:
       '@alienplatform/testing':
         specifier: file:../../packages/testing
@@ -412,7 +427,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -1692,22 +1707,8 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
-
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
-
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@3.2.7':
     resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
@@ -1720,32 +1721,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
-
   '@vitest/pretty-format@3.2.7':
     resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
-
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/runner@3.2.7':
     resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
-
   '@vitest/snapshot@3.2.7':
     resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
-
   '@vitest/spy@3.2.7':
     resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
-
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
@@ -2752,34 +2738,6 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
-        optional: true
-
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/debug':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@3.2.7:
@@ -4594,14 +4552,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
-
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -4609,14 +4559,6 @@ snapshots:
       '@vitest/utils': 3.2.7
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/mocker@3.2.7(vite@7.3.1(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
@@ -4626,19 +4568,17 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/mocker@3.2.7(vite@7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
       tinyrainbow: 2.0.0
-
-  '@vitest/runner@3.2.4':
-    dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.1.0
 
   '@vitest/runner@3.2.7':
     dependencies:
@@ -4646,31 +4586,15 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
   '@vitest/snapshot@3.2.7':
     dependencies:
       '@vitest/pretty-format': 3.2.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
-
   '@vitest/spy@3.2.7':
     dependencies:
       tinyspy: 4.0.4
-
-  '@vitest/utils@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
 
   '@vitest/utils@3.2.7':
     dependencies:
@@ -5781,47 +5705,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
 
-  vitest@3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
-      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.12.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vitest@3.2.7(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
@@ -5849,6 +5732,47 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.7(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/examples/remote-worker-ts/package.json
+++ b/examples/remote-worker-ts/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@alienplatform/core": "^1.0.1",
     "@alienplatform/sdk": "^1.0.0",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "zod": "4.3.2"
   },
   "devDependencies": {
     "@alienplatform/testing": "^0.1.0",

--- a/examples/remote-worker-ts/src/index.ts
+++ b/examples/remote-worker-ts/src/index.ts
@@ -1,5 +1,6 @@
 import { command, storage } from "@alienplatform/sdk"
 import { Hono } from "hono"
+import { z } from "zod"
 
 const app = new Hono()
 
@@ -22,13 +23,17 @@ const tools: Record<string, { description: string; execute: (params: any) => Pro
   },
 }
 
-command("execute-tool", async ({ tool, params }: { tool: string; params: any }) => {
-  const handler = tools[tool]
-  if (!handler) {
-    throw new Error(`Unknown tool: ${tool}. Available: ${Object.keys(tools).join(", ")}`)
-  }
-  return handler.execute(params)
-})
+command(
+  "execute-tool",
+  z.object({ tool: z.string(), params: z.unknown() }),
+  async ({ tool, params }) => {
+    const handler = tools[tool]
+    if (!handler) {
+      throw new Error(`Unknown tool: ${tool}. Available: ${Object.keys(tools).join(", ")}`)
+    }
+    return handler.execute(params)
+  },
+)
 
 command("list-tools", async () =>
   Object.entries(tools).map(([name, t]) => ({ name, description: t.description })),

--- a/examples/webhook-api-ts/package.json
+++ b/examples/webhook-api-ts/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@alienplatform/sdk": "^1.0.0",
     "@alienplatform/core": "^1.0.1",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "zod": "4.3.2"
   },
   "devDependencies": {
     "@alienplatform/testing": "^0.1.0",

--- a/examples/webhook-api-ts/src/index.ts
+++ b/examples/webhook-api-ts/src/index.ts
@@ -1,6 +1,7 @@
 import { command, kv } from "@alienplatform/sdk"
 import type { Kv } from "@alienplatform/sdk"
 import { Hono } from "hono"
+import { z } from "zod"
 
 const app = new Hono()
 
@@ -58,23 +59,27 @@ app.get("/health", c => c.json({ status: "ok" }))
 // --- Commands ---
 // Query stored events from your control plane.
 
-command("get-events", async ({ source, limit }: { source?: string; limit?: number }) => {
-  const ev = kv("events")
-  const prefix = source ? `${source}:` : ""
-  const results: { key: string; value: unknown }[] = []
+command(
+  "get-events",
+  z.object({ source: z.string().optional(), limit: z.number().optional() }),
+  async ({ source, limit }) => {
+    const ev = kv("events")
+    const prefix = source ? `${source}:` : ""
+    const results: { key: string; value: unknown }[] = []
 
-  for await (const entry of scanAll(ev, prefix)) {
-    results.push({
-      key: entry.key,
-      value: JSON.parse(new TextDecoder().decode(entry.value)),
-    })
-    if (limit && results.length >= limit) break
-  }
+    for await (const entry of scanAll(ev, prefix)) {
+      results.push({
+        key: entry.key,
+        value: JSON.parse(new TextDecoder().decode(entry.value)),
+      })
+      if (limit && results.length >= limit) break
+    }
 
-  return { events: results, count: results.length }
-})
+    return { events: results, count: results.length }
+  },
+)
 
-command("get-stats", async ({ sources }: { sources: string[] }) => {
+command("get-stats", z.object({ sources: z.array(z.string()) }), async ({ sources }) => {
   const ev = kv("events")
   const counts: Record<string, number> = {}
 

--- a/packages/bindings/PACKAGE_LAYOUT.md
+++ b/packages/bindings/PACKAGE_LAYOUT.md
@@ -11,10 +11,10 @@ thin wrapper over a napi-rs native addon. The Rust crate `alien-bindings` is the
 single provider implementation (S3/GCS/Blob, DynamoDB/Firestore/Table Storage,
 SQS/Pub-Sub/Service Bus, the vaults, the local providers, and their credential
 chains). The TypeScript layer carries only types, the binding factories, and error
-mapping; every storage/kv/queue/vault operation runs the Rust provider in-process.
+mapping; every storage/kv/queue/vault/container operation runs the Rust provider in-process.
 
-The package exposes exactly the four app-facing binding kinds — **storage**, **kv**,
-**queue**, **vault**. It has no JS cloud SDK dependencies and no provider logic of
+The package exposes five app-facing binding kinds — **storage**, **kv**,
+**queue**, **vault**, and linked **container** discovery. It has no JS cloud SDK dependencies and no provider logic of
 its own.
 
 ## Public surface — all exports from `"."`
@@ -25,9 +25,11 @@ its own.
 | `kv` | function | `kv(name: string): Kv` | Factory. |
 | `queue` | function | `queue(name: string): Queue` | Factory. |
 | `vault` | function | `vault(name: string): Vault` | Factory. |
+| `container` | function | `container(name: string): Container` | Lazy, read-only linked-service discovery. |
 | `Storage` | type | resource handle | Instance type returned by `storage()`. Operation method signatures mirror the Rust `alien-bindings` storage handle. |
 | `Kv` | type | resource handle | Instance type returned by `kv()`. Method signatures mirror the Rust handle. |
 | `Queue` | type | resource handle | Instance type returned by `queue()`. Method signatures mirror the Rust handle. |
+| `Container` | type | resource handle | `getInternalUrl()` and nullable `getPublicUrl()`. |
 | `Vault` | type | resource handle | Instance type returned by `vault()`. Method signatures mirror the Rust handle. |
 | `BindingNotConfiguredError` | error | `defineError({ code: "BINDING_NOT_CONFIGURED", context: { binding, envVar } })` | Thrown on the first operation against an unconfigured binding. `binding` is the binding name; `envVar` is `ALIEN_<NAME>_BINDING`. |
 | shared error primitives | re-export | `AlienError`, `defineError` (from `@alienplatform/core`) | Re-exported so consumers handle bindings errors without a direct `@alienplatform/core` import. |

--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -1,9 +1,24 @@
 # `@alienplatform/bindings`
 
-Direct TypeScript bindings for Alien storage, kv, queue, and vault over an
+Direct TypeScript bindings for Alien storage, kv, queue, vault, and linked-container discovery over an
 in-process [napi-rs](https://napi.rs) addon. The addon itself lives in the Rust
 crate `crates/alien-bindings-node`; this package is the published JavaScript
 wrapper that loads it.
+
+The same factories are re-exported by `@alienplatform/sdk` for Worker apps.
+Long-running Container and Daemon apps can import this package directly. A
+linked container is read-only service discovery:
+
+```ts
+import { container } from "@alienplatform/bindings"
+
+const database = container("database")
+const internalUrl = await database.getInternalUrl()
+const publicUrl = await database.getPublicUrl() // string | null
+```
+
+Use the internal URL for calls between resources in the same deployment. Use
+the public URL only when the caller is outside that private network.
 
 ## Native addon resolution
 

--- a/packages/bindings/scripts/run-bun-tests.mjs
+++ b/packages/bindings/scripts/run-bun-tests.mjs
@@ -48,6 +48,12 @@ env[bindingEnvName("bun-process-env")] = JSON.stringify({
   service: "local-kv",
   dataDir: dataDir("bun-process-env"),
 })
+env[bindingEnvName("bun-container")] = JSON.stringify({
+  service: "local",
+  containerName: "database",
+  internalUrl: "http://database.internal:5432",
+  publicUrl: "http://localhost:15432",
+})
 const testFiles = readdirSync("tests")
   .filter(file => file.endsWith(".test.ts") && file !== "errors.test.ts")
   .map(file => `tests/${file}`)

--- a/packages/bindings/src/__tests__/factories.test.ts
+++ b/packages/bindings/src/__tests__/factories.test.ts
@@ -4,6 +4,7 @@ import { createFactories } from "../factories.js"
 import type {
   NativeAddon,
   RawBindingsHandle,
+  RawContainerHandle,
   RawKvHandle,
   RawQueueHandle,
   RawStorageHandle,
@@ -48,12 +49,17 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
     deleteSecret: async () => {},
     listSecrets: async () => [],
   }
+  const containerHandle: RawContainerHandle = {
+    getInternalUrl: async () => "http://service.internal:8080",
+    getPublicUrl: async () => null,
+  }
 
   const bindings: RawBindingsHandle = {
     storage: async () => storageHandle,
     kv: async () => kvHandle,
     queue: async () => queueHandle,
     vault: async () => vaultHandle,
+    container: async () => containerHandle,
   }
 
   class FakeBindingsHandle {
@@ -64,6 +70,7 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
     kv = bindings.kv
     queue = bindings.queue
     vault = bindings.vault
+    container = bindings.container
   }
 
   return {
@@ -88,6 +95,9 @@ function addonForKv(kvHandle: RawKvHandle): NativeAddon {
       throw new Error("unused")
     }
     async vault() {
+      throw new Error("unused")
+    }
+    async container() {
       throw new Error("unused")
     }
   }
@@ -218,7 +228,7 @@ describe("createFactories kv surface", () => {
 })
 
 describe("createFactories method mapping", () => {
-  it("serializes queue.send payloads as JSON via sendJson using the binding name", async () => {
+  it("serializes queue.send payloads as JSON via the bound queue handle", async () => {
     const sendJson = vi.fn(async () => {})
     const queueHandle: RawQueueHandle = {
       sendJson,
@@ -250,6 +260,16 @@ describe("createFactories method mapping", () => {
 
     await queue("events").send({ hello: "world" })
 
-    expect(sendJson).toHaveBeenCalledWith("events", JSON.stringify({ hello: "world" }))
+    expect(sendJson).toHaveBeenCalledWith(JSON.stringify({ hello: "world" }))
+  })
+
+  it("exposes linked-container URLs through the lazy handle", async () => {
+    const { addon } = fakeAddon()
+    const { container } = createFactories(() => addon)
+
+    await expect(container("database").getInternalUrl()).resolves.toBe(
+      "http://service.internal:8080",
+    )
+    await expect(container("database").getPublicUrl()).resolves.toBeNull()
   })
 })

--- a/packages/bindings/src/__tests__/loader.test.ts
+++ b/packages/bindings/src/__tests__/loader.test.ts
@@ -17,6 +17,9 @@ function addonReporting(version: string): NativeAddon {
       vault(): never {
         throw new Error("not used by version validation")
       }
+      container(): never {
+        throw new Error("not used by version validation")
+      }
     },
     version: () => version,
   }

--- a/packages/bindings/src/factories.ts
+++ b/packages/bindings/src/factories.ts
@@ -1,5 +1,5 @@
 /**
- * The four binding factories, parameterized over how the native addon is
+ * The binding factories, parameterized over how the native addon is
  * obtained. `index.ts` binds them to the lazy {@link loadAddon}; `native.ts`
  * binds them to a statically-embedded addon.
  *
@@ -17,12 +17,14 @@ import { unwrapNapiError } from "./errors.js"
 import type {
   NativeAddon,
   RawBindingsHandle,
+  RawContainerHandle,
   RawKvHandle,
   RawQueueHandle,
   RawStorageHandle,
   RawVaultHandle,
 } from "./loader.js"
 import type {
+  Container,
   Kv,
   KvScanResult,
   KvSetOptions,
@@ -136,14 +138,21 @@ function makeKv(handle: () => Promise<RawKvHandle>): Kv {
 
 // The napi queue methods take the queue name as their first argument; the
 // binding name is used for it (providers key the queue off the binding).
-function makeQueue(handle: () => Promise<RawQueueHandle>, name: string): Queue {
+function makeQueue(handle: () => Promise<RawQueueHandle>): Queue {
   return {
-    send: message => guard(handle, raw => raw.sendJson(name, JSON.stringify(message))),
-    sendText: text => guard(handle, raw => raw.sendText(name, text)),
-    receive: (max): Promise<QueueMessage[]> => guard(handle, raw => raw.receive(name, max)),
-    ack: receipt => guard(handle, raw => raw.ack(name, receipt)),
-    nack: receipt => guard(handle, raw => raw.nack(name, receipt)),
-    purge: () => guard(handle, raw => raw.purge(name)),
+    send: message => guard(handle, raw => raw.sendJson(JSON.stringify(message))),
+    sendText: text => guard(handle, raw => raw.sendText(text)),
+    receive: (max): Promise<QueueMessage[]> => guard(handle, raw => raw.receive(max)),
+    ack: receipt => guard(handle, raw => raw.ack(receipt)),
+    nack: receipt => guard(handle, raw => raw.nack(receipt)),
+    purge: () => guard(handle, raw => raw.purge()),
+  }
+}
+
+function makeContainer(handle: () => Promise<RawContainerHandle>): Container {
+  return {
+    getInternalUrl: () => guard(handle, raw => raw.getInternalUrl()),
+    getPublicUrl: () => guard(handle, raw => raw.getPublicUrl()),
   }
 }
 
@@ -165,18 +174,16 @@ export interface Factories {
   kv(name: string): Kv
   queue(name: string): Queue
   vault(name: string): Vault
+  container(name: string): Container
 }
 
-/** Build the four factories bound to a given addon provider. */
+/** Build the factories bound to a given addon provider. */
 export function createFactories(getAddon: () => NativeAddon): Factories {
   return {
     storage: name => makeStorage(lazyHandle(getAddon, name, (b, n) => b.storage(n))),
     kv: name => makeKv(lazyHandle(getAddon, name, (b, n) => b.kv(n))),
-    queue: name =>
-      makeQueue(
-        lazyHandle(getAddon, name, (b, n) => b.queue(n)),
-        name,
-      ),
+    queue: name => makeQueue(lazyHandle(getAddon, name, (b, n) => b.queue(n))),
     vault: name => makeVault(lazyHandle(getAddon, name, (b, n) => b.vault(n))),
+    container: name => makeContainer(lazyHandle(getAddon, name, (b, n) => b.container(n))),
   }
 }

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * `@alienplatform/bindings` — direct TypeScript bindings for Alien storage, kv,
- * queue, and vault, backed by an in-process napi-rs addon over the Rust
+ * queue, vault, and linked containers, backed by an in-process napi-rs addon over the Rust
  * `alien-bindings` crate.
  *
  * Constructing a factory (`storage("x")`, `kv("y")`, …) does no I/O and needs no
@@ -22,10 +22,13 @@ export const kv = factories.kv
 export const queue = factories.queue
 /** Resolve the vault binding named `name`. */
 export const vault = factories.vault
+/** Resolve the linked-container binding named `name`. */
+export const container = factories.container
 
 export { AlienError, BindingNotConfiguredError, defineError } from "./errors.js"
 
 export type {
+  Container,
   Kv,
   KvScanItem,
   KvScanResult,

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -98,12 +98,17 @@ export interface RawKvHandle {
 
 /** Raw napi queue handle. Every method takes the queue name as its first arg. */
 export interface RawQueueHandle {
-  sendJson(queue: string, jsonString: string): Promise<void>
-  sendText(queue: string, text: string): Promise<void>
-  receive(queue: string, max: number): Promise<RawQueueMessage[]>
-  ack(queue: string, receipt: string): Promise<void>
-  nack(queue: string, receipt: string): Promise<void>
-  purge(queue: string): Promise<void>
+  sendJson(jsonString: string): Promise<void>
+  sendText(text: string): Promise<void>
+  receive(max: number): Promise<RawQueueMessage[]>
+  ack(receipt: string): Promise<void>
+  nack(receipt: string): Promise<void>
+  purge(): Promise<void>
+}
+
+export interface RawContainerHandle {
+  getInternalUrl(): Promise<string>
+  getPublicUrl(): Promise<string | null>
 }
 
 /** Raw napi vault handle. */
@@ -120,6 +125,7 @@ export interface RawBindingsHandle {
   kv(name: string): Promise<RawKvHandle>
   queue(name: string): Promise<RawQueueHandle>
   vault(name: string): Promise<RawVaultHandle>
+  container(name: string): Promise<RawContainerHandle>
 }
 
 /** The complete napi addon module surface consumed by the wrapper. */

--- a/packages/bindings/src/native.ts
+++ b/packages/bindings/src/native.ts
@@ -46,10 +46,13 @@ export const kv = factories.kv
 export const queue = factories.queue
 /** Resolve the vault binding named `name`. */
 export const vault = factories.vault
+/** Resolve the linked-container binding named `name`. */
+export const container = factories.container
 
 export { AlienError, BindingNotConfiguredError, defineError } from "./errors.js"
 
 export type {
+  Container,
   Kv,
   KvScanItem,
   KvScanResult,

--- a/packages/bindings/src/types.ts
+++ b/packages/bindings/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Public types for `@alienplatform/bindings`: the four resource handle
+ * Public types for `@alienplatform/bindings`: the app-facing resource handle
  * interfaces and their operation option/result shapes. These mirror the Rust
  * `alien-bindings` handles; the native (napi) surface is an internal detail.
  */
@@ -142,6 +142,14 @@ export interface Queue {
   nack(receipt: string): Promise<void>
   /** Delete every message in the queue. */
   purge(): Promise<void>
+}
+
+/** Read-only service discovery for a linked container. */
+export interface Container {
+  /** Get the URL reachable from the deployment's private network. */
+  getInternalUrl(): Promise<string>
+  /** Get the public URL when the container is publicly exposed. */
+  getPublicUrl(): Promise<string | null>
 }
 
 /** A resolved vault (secrets) binding. */

--- a/packages/bindings/tests/container.test.ts
+++ b/packages/bindings/tests/container.test.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from "node:crypto"
+import { afterAll, describe, expect, it } from "vitest"
+import { container } from "../src/index.js"
+import { cleanupTempDirs, localContainerBindingEnv } from "./helpers/local-binding-env.js"
+
+describe("linked container", () => {
+  afterAll(cleanupTempDirs)
+
+  it("returns internal and optional public URLs through the real addon", async () => {
+    const isBun = process.env.BUN_EXPECTED === "1"
+    const name = isBun ? "bun-container" : `container-${randomUUID()}`
+    if (!isBun) localContainerBindingEnv(name)
+    const database = container(name)
+
+    await expect(database.getInternalUrl()).resolves.toBe("http://database.internal:5432")
+    await expect(database.getPublicUrl()).resolves.toBe("http://localhost:15432")
+  })
+})

--- a/packages/bindings/tests/helpers/local-binding-env.ts
+++ b/packages/bindings/tests/helpers/local-binding-env.ts
@@ -174,6 +174,19 @@ export function localVaultBindingEnv(
   return fixture
 }
 
+/** Build the env for a local linked-container binding. */
+export function localContainerBindingEnv(bindingName: string): void {
+  installBindingEnv({
+    ...LOCAL_DEPLOYMENT_ENV,
+    [bindingEnvVarName(bindingName)]: JSON.stringify({
+      service: "local",
+      containerName: "database",
+      internalUrl: "http://database.internal:5432",
+      publicUrl: "http://localhost:15432",
+    }),
+  })
+}
+
 /** Return the sole element of `items`, throwing (with a useful message) if there isn't exactly one. */
 export function only<T>(items: T[]): T {
   if (items.length !== 1) {

--- a/packages/commands/PACKAGE_LAYOUT.md
+++ b/packages/commands/PACKAGE_LAYOUT.md
@@ -25,7 +25,7 @@ the same wire protocol.
 | `CommandsClient#invoke` | method | `.invoke(name: string, input, options?)` | Invokes a command and resolves to its response. See the API details below. |
 | `createCommandReceiver` | function | `createCommandReceiver(options?: CommandReceiverOptions): CommandReceiver` | Constructs the pull receiver from environment configuration. |
 | `CommandReceiverOptions` | type | constructor options | `{ env?, fetch?, pollIntervalMs?, pollMaxIntervalMs?, pollJitter?, leaseSeconds?, maxLeases?, drainTimeoutMs? }`. Constructor values override environment values. |
-| `CommandReceiver` | type | receiver handle | `.handle(name: string, handler)` registers a handler; `.run(): Promise<void>` leases and dispatches. Handler context includes input, cancellation, deadline, command identity, attempt, target identity, and optional W3C trace context. |
+| `CommandReceiver` | type | receiver handle | `.command(name, handler)` parses JSON as `unknown`; `.command(name, schema, handler)` also validates with Standard Schema and infers the validated type. `.handleRaw(name, handler)` is the byte-level escape hatch. `.run()` leases and dispatches until stopped. |
 | `CommandReceiverConfigInvalidError` | error | `defineError({ code: "COMMAND_RECEIVER_CONFIG_INVALID", context: { … } })` | Thrown when receiver env config is empty or invalid. Context names the offending identity, token-source, or tuning variable. |
 | sender error types | error | migrated from the former `@alienplatform/sdk/commands` error set | The seven exported sender errors are listed in the API details below. |
 | shared error primitives | re-export | `AlienError`, `defineError` (from `@alienplatform/core`) | Re-exported for consumer error handling. |
@@ -77,7 +77,6 @@ Single entry point. Every condition carries `types`. No deep imports.
 MUST NOT depend on, import, or reference:
 
 - Worker app protocol files.
-- gRPC packages — `@grpc/grpc-js`, `nice-grpc`.
 - [`@alienplatform/bindings`](../bindings/PACKAGE_LAYOUT.md) (large payloads use
   presigned HTTP, not the bindings addon).
 
@@ -158,9 +157,11 @@ MAY depend on:
   budget `min(envelope.deadline, leaseExpiresAt − 5 seconds)`, always present.
   `traceContext` carries the envelope's optional W3C `traceparent` and
   `tracestate`. A
-  `CommandHandler` is `(ctx: CommandContext) => unknown | Promise<unknown>`; its
-  return value is the JSON success body. `createCommandReceiver()` returns a
-  `CommandReceiver` (`.handle` / `.run` / `.stop`); `.stop()` is the exposed
+  `CommandHandler<T>` is `(input: T, ctx: CommandContext) => unknown | Promise<unknown>`;
+  its return value is the JSON success body. Schema-less commands use `unknown`;
+  Standard Schema commands infer `T`. `RawCommandHandler` receives only the
+  context and reads `ctx.input`. `createCommandReceiver()` returns a
+  `CommandReceiver` (`.command` / `.handleRaw` / `.run` / `.stop`); `.stop()` is the exposed
   drain-and-return mechanism (twin of the Rust `ShutdownHandle`).
 
 - **`CommandReceiverOptions`** (constructor options for `createCommandReceiver`,

--- a/packages/commands/src/client.ts
+++ b/packages/commands/src/client.ts
@@ -1,7 +1,7 @@
 /**
  * Command sender — invoke commands on remote Alien deployments.
  *
- * Migrated from the former `@alienplatform/sdk/commands` subpath. Pure `fetch`; no gRPC, no
+ * Migrated from the former `@alienplatform/sdk/commands` subpath. Pure `fetch`; no
  * bindings. Handles:
  * - Base64 encoding/decoding of input and responses
  * - Large payload download via storage presigned transfers
@@ -78,14 +78,17 @@ export interface InvokeOptions {
 }
 
 /**
- * Serialize `data` (JSON-stringifying anything that isn't already a string) and
+ * Serialize `data` as JSON and
  * base64-encode it. This is the one place the send-side serialize decision
  * lives. `@alienplatform/commands` is a Node-only package — the receiver decodes
  * with `Buffer` too — so this uses `Buffer` directly rather than branching on a
  * browser `btoa`.
  */
 function base64Encode(data: unknown): string {
-  const json = typeof data === "string" ? data : JSON.stringify(data)
+  const json = JSON.stringify(data)
+  if (json === undefined) {
+    throw new TypeError("Command input must be JSON-serializable")
+  }
   return Buffer.from(json, "utf-8").toString("base64")
 }
 

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -4,7 +4,7 @@
  * Pure `fetch` over the command wire protocol: the command **sender**
  * ({@link CommandsClient}, with {@link CommandsClient.target}) and the
  * non-Worker pull **receiver** (`createCommandReceiver`).
- * No native code, no gRPC, no bindings.
+ * No native code or bindings.
  *
  * @example
  * ```typescript
@@ -38,6 +38,9 @@ export type {
   CommandHandler,
   CommandReceiver,
   CommandReceiverOptions,
+  RawCommandHandler,
+  StandardSchema,
+  StandardSchemaOutput,
 } from "./receiver.js"
 
 // Error set

--- a/packages/commands/src/receiver.ts
+++ b/packages/commands/src/receiver.ts
@@ -3,11 +3,11 @@
  *
  * Behavior-identical twin of the Rust `alien_commands::Receiver`. It leases
  * commands addressed to its own target resource from the command server over
- * outbound HTTPS (no inbound connections, no gRPC), dispatches them to
+ * outbound HTTPS (no inbound connections), dispatches them to
  * in-process handlers, and submits responses through the envelope's
  * response-handling flow (inline or presigned storage upload).
  *
- * Pure `fetch`; no bindings, no gRPC. The receiver implements these public
+ * Pure `fetch`; no bindings. The receiver implements these public
  * command-delivery semantics:
  * - required identity plus token-or-token-file env, with fail-fast validation
  * - execution budget = `min(envelope.deadline, leaseExpiresAt − safety margin)`;
@@ -27,8 +27,7 @@
  * import { createCommandReceiver } from "@alienplatform/commands"
  *
  * const receiver = createCommandReceiver()
- * receiver.handle("generate-report", async ctx => {
- *   const params = JSON.parse(new TextDecoder().decode(ctx.input))
+ * receiver.command("generate-report", async params => {
  *   return { report: params }
  * })
  * await receiver.run() // call receiver.stop() to drain and return
@@ -162,16 +161,53 @@ export interface CommandContext {
  * (`JSON.stringify`-encoded). Throwing/rejecting submits the error's non-empty
  * string `code` when present, otherwise `HANDLER_ERROR`.
  */
-export type CommandHandler = (ctx: CommandContext) => unknown | Promise<unknown>
+export type RawCommandHandler = (ctx: CommandContext) => unknown | Promise<unknown>
+
+/** The part of Standard Schema v1 used to validate command inputs. */
+export interface StandardSchema<Input = unknown, Output = Input> {
+  readonly "~standard": {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | { readonly value: Output; readonly issues?: undefined }
+      | { readonly issues: ReadonlyArray<{ readonly message: string }> }
+      | Promise<
+          | { readonly value: Output; readonly issues?: undefined }
+          | { readonly issues: ReadonlyArray<{ readonly message: string }> }
+        >
+    readonly types?: { readonly input: Input; readonly output: Output }
+  }
+}
+
+/** Infer the validated output type of a Standard Schema. */
+export type StandardSchemaOutput<Schema extends StandardSchema> = NonNullable<
+  Schema["~standard"]["types"]
+>["output"]
+
+/** A JSON command handler. */
+export type CommandHandler<Input = unknown> = (
+  input: Input,
+  context: CommandContext,
+) => unknown | Promise<unknown>
 
 /**
- * The pull receiver handle. Register handlers with {@link CommandReceiver.handle},
+ * The pull receiver handle. Register handlers with {@link CommandReceiver.command},
  * drive the lease loop with {@link CommandReceiver.run}, and stop it with
  * {@link CommandReceiver.stop}.
  */
 export interface CommandReceiver {
-  /** Register a handler for a command name. Registering a name twice replaces it. */
-  handle(name: string, handler: CommandHandler): CommandReceiver
+  /** Register a schema-less JSON command. Its input is deliberately `unknown`. */
+  command(name: string, handler: CommandHandler<unknown>): CommandReceiver
+  /** Register a JSON command validated by a Standard Schema v1 validator. */
+  command<Schema extends StandardSchema>(
+    name: string,
+    schema: Schema,
+    handler: CommandHandler<StandardSchemaOutput<Schema>>,
+  ): CommandReceiver
+  /** Register an advanced handler that receives the encoded input bytes. */
+  handleRaw(name: string, handler: RawCommandHandler): CommandReceiver
   /**
    * Drive the lease loop until {@link CommandReceiver.stop} is called. No new
    * lease poll *starts* once draining begins; a poll already in flight
@@ -449,7 +485,7 @@ class PullCommandReceiver implements CommandReceiver {
   private readonly pollJitter: number
   private readonly drainTimeoutMs: number
   private readonly tokenSource: TokenSource
-  private readonly handlers = new Map<string, CommandHandler>()
+  private readonly handlers = new Map<string, RawCommandHandler>()
   private readonly shutdown = new AbortController()
   private readonly active = new Map<string, ActiveLease>()
 
@@ -465,7 +501,39 @@ class PullCommandReceiver implements CommandReceiver {
     this.tokenSource = new TokenSource(config.token, config.tokenFile)
   }
 
-  handle(name: string, handler: CommandHandler): CommandReceiver {
+  command(name: string, handler: CommandHandler<unknown>): CommandReceiver
+  command<Schema extends StandardSchema>(
+    name: string,
+    schema: Schema,
+    handler: CommandHandler<StandardSchemaOutput<Schema>>,
+  ): CommandReceiver
+  command<Schema extends StandardSchema>(
+    name: string,
+    schemaOrHandler: Schema | CommandHandler<unknown>,
+    validatedHandler?: CommandHandler<StandardSchemaOutput<Schema>>,
+  ): CommandReceiver {
+    const schema = validatedHandler === undefined ? undefined : (schemaOrHandler as Schema)
+    const handler = (validatedHandler ?? schemaOrHandler) as CommandHandler<unknown>
+    return this.handleRaw(name, async context => {
+      let input: unknown
+      try {
+        input = JSON.parse(new TextDecoder().decode(context.input))
+      } catch {
+        throw new Error("Command input is not valid JSON")
+      }
+      if (schema !== undefined) {
+        const result = await schema["~standard"].validate(input)
+        if (result.issues !== undefined) {
+          const details = result.issues.map(issue => issue.message).join("; ")
+          throw new Error(`Command input failed validation${details ? `: ${details}` : ""}`)
+        }
+        input = result.value
+      }
+      return await handler(input, context)
+    })
+  }
+
+  handleRaw(name: string, handler: RawCommandHandler): CommandReceiver {
     this.handlers.set(name, handler)
     return this
   }
@@ -1034,7 +1102,7 @@ function handlerTimeoutResponse(command: string, budget: Date): CommandResponse 
 
 /** Invoke and JSON-encode a handler without creating a new execution budget. */
 async function invokeHandler(
-  handler: CommandHandler,
+  handler: RawCommandHandler,
   ctx: CommandContext,
 ): Promise<CommandResponse> {
   let value: unknown

--- a/packages/commands/tests/commands-client.test.ts
+++ b/packages/commands/tests/commands-client.test.ts
@@ -112,6 +112,19 @@ describe("CommandsClient.invoke", () => {
     expect(alien.context).toMatchObject({ errorCode: "BOOM", errorMessage: "handler blew up" })
   })
 
+  it("encodes string input as a JSON string", async () => {
+    server = await startStubServer(req => {
+      if (req.method === "POST") return { json: createResponse() }
+      return { json: successStatus("cmd_1", null) }
+    })
+
+    await client(server.baseUrl).invoke("echo", "hello", FAST_POLL)
+
+    const create = server.requests.find(request => request.method === "POST") as CapturedRequest
+    const body = create.body as Record<string, unknown>
+    expect(body.params).toEqual({ mode: "inline", inlineBase64: encodeInlineJson("hello") })
+  })
+
   it("maps an EXPIRED terminal state to CommandExpiredError", async () => {
     server = await startStubServer((req): RouteResult => {
       if (req.method === "POST") return { json: createResponse() }

--- a/packages/commands/tests/integration.real-server.test.ts
+++ b/packages/commands/tests/integration.real-server.test.ts
@@ -275,7 +275,7 @@ describe("real-wire command twins", () => {
       pollIntervalMs: 25,
       leaseSeconds: 60,
     })
-    receiver.handle("echo", ctx => {
+    receiver.handleRaw("echo", ctx => {
       seen = ctx
       const params = JSON.parse(new TextDecoder().decode(ctx.input)) as Record<string, unknown>
       return { echoed: params, attempt: ctx.attempt }
@@ -313,7 +313,7 @@ describe("real-wire command twins", () => {
       pollIntervalMs: 25,
       leaseSeconds: 6,
     })
-    receiver.handle("slow", async ctx => {
+    receiver.handleRaw("slow", async ctx => {
       // Deliberately ignore the abort signal (only record it) and outlive the
       // budget so the receiver must time it out on us.
       ctx.signal.addEventListener("abort", () => {
@@ -369,7 +369,7 @@ describe("real-wire command twins", () => {
       pollIntervalMs: 25,
       leaseSeconds: 60,
     })
-    receiver.handle("redeliver", ctx => ({ ok: true, attempt: ctx.attempt }))
+    receiver.handleRaw("redeliver", ctx => ({ ok: true, attempt: ctx.attempt }))
     const running = receiver.run()
 
     const result = await invoked
@@ -389,7 +389,7 @@ describe("real-wire command twins", () => {
       pollIntervalMs: 25,
       leaseSeconds: 60,
     })
-    receiver.handle("something-else", () => ({}))
+    receiver.handleRaw("something-else", () => ({}))
     const running = receiver.run()
 
     const err = await makeSender(server)

--- a/packages/commands/tests/receiver.test.ts
+++ b/packages/commands/tests/receiver.test.ts
@@ -295,7 +295,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", (ctx: CommandContext) => {
+    r.handleRaw("echo", (ctx: CommandContext) => {
       seen = {
         input: new TextDecoder().decode(ctx.input),
         deadline: ctx.deadline.getTime(),
@@ -360,7 +360,7 @@ describe("CommandReceiver.run", () => {
         env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
         pollIntervalMs: 5,
       })
-      r.handle("echo", () => ({ ok: true }))
+      r.handleRaw("echo", () => ({ ok: true }))
       receiverStop = () => r.stop()
       running = r.run()
 
@@ -397,7 +397,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => {
+    r.handleRaw("echo", () => {
       throw new Error("database on fire")
     })
     receiverStop = () => r.stop()
@@ -419,7 +419,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => {
+    r.handleRaw("echo", () => {
       throw Object.assign(new Error("upstream unavailable"), { code: "UPSTREAM_UNAVAILABLE" })
     })
     receiverStop = () => r.stop()
@@ -452,7 +452,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", async (ctx: CommandContext) => {
+    r.handleRaw("echo", async (ctx: CommandContext) => {
       ctx.signal.addEventListener("abort", () => {
         signalFired = true
       })
@@ -487,7 +487,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", (ctx: CommandContext) => ({ attempt: ctx.attempt }))
+    r.handleRaw("echo", (ctx: CommandContext) => ({ attempt: ctx.attempt }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -522,13 +522,71 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", (ctx: CommandContext) => JSON.parse(new TextDecoder().decode(ctx.input)))
+    r.command("echo", params => params)
     receiverStop = () => r.stop()
     running = r.run()
 
     await waitFor(() => submitBody("cmd_1") !== undefined)
     const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "success" }>
     expect(decodeInline(body)).toEqual(params)
+  })
+
+  it("validates JSON with an asynchronous Standard Schema before running the handler", async () => {
+    server = await openServer()
+    const env = envelope({ baseUrl: server.baseUrl, params: inlineParams({ count: 3 }) })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+    const schema = {
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        types: undefined as unknown as { input: unknown; output: { count: number } },
+        validate: async (value: unknown) =>
+          typeof value === "object" &&
+          value !== null &&
+          "count" in value &&
+          typeof value.count === "number"
+            ? { value: { count: value.count } }
+            : { issues: [{ message: "count must be a number" }] },
+      },
+    }
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.command("echo", schema, input => ({ doubled: input.count * 2 }))
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    const body = submitBody("cmd_1") as Extract<CommandResponse, { status: "success" }>
+    expect(decodeInline(body)).toEqual({ doubled: 6 })
+  })
+
+  it("reports malformed JSON as a handler error without running the command", async () => {
+    server = await openServer()
+    const env = envelope({
+      baseUrl: server.baseUrl,
+      params: { mode: "inline", inlineBase64: Buffer.from("{").toString("base64") },
+    })
+    const serve = leaseOnce([lease(env)])
+    route = req => serve(req) ?? { status: 200 }
+    const handler = vi.fn()
+    const r = createCommandReceiver({
+      env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
+      pollIntervalMs: 5,
+    })
+    r.command("echo", handler)
+    receiverStop = () => r.stop()
+    running = r.run()
+
+    await waitFor(() => submitBody("cmd_1") !== undefined)
+    expect(submitBody("cmd_1")).toMatchObject({
+      status: "error",
+      code: "HANDLER_ERROR",
+      message: "Command input is not valid JSON",
+    })
+    expect(handler).not.toHaveBeenCalled()
   })
 
   it("counts a slow storage GET against the same budget as the handler", async () => {
@@ -563,7 +621,7 @@ describe("CommandReceiver.run", () => {
       pollIntervalMs: 5,
       pollJitter: 0,
     })
-    r.handle("echo", () => {
+    r.handleRaw("echo", () => {
       handlerCalled = true
       return { shouldNotRun: true }
     })
@@ -598,7 +656,7 @@ describe("CommandReceiver.run", () => {
       pollIntervalMs: 5,
       pollJitter: 0,
     })
-    r.handle("echo", () => {
+    r.handleRaw("echo", () => {
       handlerCalled = true
       return { shouldNotRun: true }
     })
@@ -626,7 +684,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => big)
+    r.handleRaw("echo", () => big)
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -677,7 +735,7 @@ describe("CommandReceiver.run", () => {
       pollIntervalMs: 5,
       pollJitter: 0,
     })
-    receiver.handle("echo", () => ({ payload: "x".repeat(64) }))
+    receiver.handleRaw("echo", () => ({ payload: "x".repeat(64) }))
     receiverStop = () => receiver.stop()
     running = receiver.run()
 
@@ -714,7 +772,7 @@ describe("CommandReceiver.run", () => {
       pollIntervalMs: 5,
     })
     let handlerStarted = false
-    r.handle("echo", async () => {
+    r.handleRaw("echo", async () => {
       handlerStarted = true
       await gate
       return { drained: true }
@@ -755,7 +813,7 @@ describe("CommandReceiver.run", () => {
       drainTimeoutMs: 10,
       pollJitter: 0,
     })
-    r.handle("echo", async ctx => {
+    r.handleRaw("echo", async ctx => {
       handlerStarted = true
       await new Promise<void>(resolve => {
         ctx.signal.addEventListener(
@@ -803,7 +861,7 @@ describe("CommandReceiver.run", () => {
       pollIntervalMs: 5,
       pollJitter: 0,
     })
-    r.handle("echo", async () => {
+    r.handleRaw("echo", async () => {
       calls += 1
       await gate
       return { ok: true }
@@ -843,7 +901,7 @@ describe("CommandReceiver.run", () => {
       pollIntervalMs: 5,
       pollJitter: 0,
     })
-    r.handle("echo", async () => {
+    r.handleRaw("echo", async () => {
       handlerStarted = true
       await gate
       return { ok: true }
@@ -899,7 +957,7 @@ describe("CommandReceiver.run", () => {
         pollIntervalMs: 5,
         pollJitter: 0,
       })
-      r.handle("echo", () => ({ ok: true }))
+      r.handleRaw("echo", () => ({ ok: true }))
       receiverStop = () => r.stop()
       running = r.run()
 
@@ -983,7 +1041,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => ({ ok: true }))
+    r.handleRaw("echo", () => ({ ok: true }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1006,7 +1064,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => ({ ok: true }))
+    r.handleRaw("echo", () => ({ ok: true }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1026,7 +1084,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => ({ ok: true }))
+    r.handleRaw("echo", () => ({ ok: true }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1066,7 +1124,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1?token=abc` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => ({ ok: true }))
+    r.handleRaw("echo", () => ({ ok: true }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1089,7 +1147,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => big)
+    r.handleRaw("echo", () => big)
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1125,7 +1183,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => big)
+    r.handleRaw("echo", () => big)
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1156,7 +1214,7 @@ describe("CommandReceiver.run", () => {
       env: { ...FULL_ENV, ALIEN_COMMANDS_URL: `${server.baseUrl}/v1/` },
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => ({ ok: true }))
+    r.handleRaw("echo", () => ({ ok: true }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1201,7 +1259,7 @@ describe("CommandReceiver.run", () => {
       fetch: failingFetch,
       pollIntervalMs: 5,
     })
-    r.handle("echo", () => ({ ok: true }))
+    r.handleRaw("echo", () => ({ ok: true }))
     receiverStop = () => r.stop()
     running = r.run()
 
@@ -1232,7 +1290,7 @@ describe("CommandReceiver.run", () => {
           pollIntervalMs: 5,
           pollJitter: 0,
         })
-        r.handle("echo", () => ({ ok: true }))
+        r.handleRaw("echo", () => ({ ok: true }))
         receiverStop = () => r.stop()
         running = r.run()
 

--- a/packages/sdk/PACKAGE_LAYOUT.md
+++ b/packages/sdk/PACKAGE_LAYOUT.md
@@ -28,13 +28,13 @@ in [`@alienplatform/bindings`](../bindings/PACKAGE_LAYOUT.md).
 
 | Export | Kind | Signature sketch | Notes |
 |---|---|---|---|
-| `command` | function | `command(name, handler): void` | Register a Worker command handler. |
+| `command` | function | `command(name, handler)` or `command(name, schema, handler)` | Register a Worker command handler. Schema-less input is `unknown`; Standard Schema validation infers the handler input. |
 | `onStorageEvent` | function | Worker storage-event handler registrar | Signature pinned by `src/worker-runtime`. |
 | `onCronEvent` | function | Worker cron-event handler registrar | Signature pinned by `src/worker-runtime`. |
 | `onQueueMessage` | function | Worker queue-message handler registrar | Signature pinned by `src/worker-runtime`. |
 | `waitUntil` | function | `waitUntil(promise): void` | Extend Worker task lifetime past the response. |
 | handler types | type | `StorageEvent`, `StorageEventType`, `CronEvent`, `QueueMessage`, `QueueMessageEvent`, `ScheduledEvent` | The event/handler types for the APIs above. |
-| `storage`, `kv`, `queue`, `vault` | function | re-export from `@alienplatform/bindings` | Facade re-export of the binding factories. |
+| `storage`, `kv`, `queue`, `vault`, `container` | function | re-export from `@alienplatform/bindings` | Facade re-export of the binding factories. |
 | `Storage`, `Kv`, `Queue`, `Vault` | type | re-export from `@alienplatform/bindings` | Facade re-export of the instance types. |
 | error re-exports | error | from `@alienplatform/bindings` and `@alienplatform/core` | Includes `BindingNotConfiguredError`; `AlienError`. |
 
@@ -132,7 +132,7 @@ No deep imports.
 
 ## Handler and runtime details
 
-- `command(name, handler): void`, `onStorageEvent(bucket, handler,
+- `command(name, handler): void`, `command(name, schema, handler): void`, `onStorageEvent(bucket, handler,
   options?): () => void`, `onCronEvent(schedule, handler): () => void`,
   `onQueueMessage(queue, handler): () => void`, `waitUntil(promise): void`. These
   are protocol-only registrars in `src/worker-runtime/registry.ts` (no gRPC); the

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,9 +13,10 @@
  *
  * @example
  * ```typescript
- * import { command, kv, storage, waitUntil } from "@alienplatform/sdk"
+ * import { command, kv } from "@alienplatform/sdk"
+ * import { z } from "zod"
  *
- * command("greet", async ({ name }: { name: string }) => {
+ * command("greet", z.object({ name: z.string() }), async ({ name }) => {
  *   const store = kv("greetings")
  *   await store.set(name, `Hello, ${name}!`)
  *   return { ok: true }
@@ -45,6 +46,8 @@ export type {
   QueueMessage,
   QueueMessageEvent,
   ScheduledEvent,
+  StandardSchema,
+  StandardSchemaOutput,
   WorkerCommandContext,
 } from "./worker-runtime/registry.js"
 
@@ -52,8 +55,8 @@ export type {
 // Binding factories — re-exported from @alienplatform/bindings
 // ============================================================================
 
-export { storage, kv, queue, vault } from "@alienplatform/bindings"
-export type { Storage, Kv, Queue, Vault } from "@alienplatform/bindings"
+export { storage, kv, queue, vault, container } from "@alienplatform/bindings"
+export type { Storage, Kv, Queue, Vault, Container } from "@alienplatform/bindings"
 
 // ============================================================================
 // Errors — re-exported from @alienplatform/bindings and @alienplatform/core

--- a/packages/sdk/src/worker-runtime/registry.ts
+++ b/packages/sdk/src/worker-runtime/registry.ts
@@ -68,6 +68,29 @@ export interface WorkerCommandContext {
   deadline?: Date
 }
 
+/** The part of Standard Schema v1 used to validate command inputs. */
+export interface StandardSchema<Input = unknown, Output = Input> {
+  readonly "~standard": {
+    readonly version: 1
+    readonly vendor: string
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | { readonly value: Output; readonly issues?: undefined }
+      | { readonly issues: ReadonlyArray<{ readonly message: string }> }
+      | Promise<
+          | { readonly value: Output; readonly issues?: undefined }
+          | { readonly issues: ReadonlyArray<{ readonly message: string }> }
+        >
+    readonly types?: { readonly input: Input; readonly output: Output }
+  }
+}
+
+/** Infer the validated output type of a Standard Schema. */
+export type StandardSchemaOutput<Schema extends StandardSchema> = NonNullable<
+  Schema["~standard"]["types"]
+>["output"]
+
 /**
  * Command definition.
  */
@@ -162,18 +185,49 @@ function registry(): RegistryState {
  * ```typescript
  * import { command } from "@alienplatform/sdk"
  *
- * command("echo", async ({ message }: { message: string }, { attempt }) => {
- *   return { message, attempt, timestamp: new Date().toISOString() }
+ * command("echo", schema, async ({ message }, { attempt }) => {
+ *   return { message, attempt }
  * })
  * ```
  */
-export function command<TParams = unknown, TResult = unknown>(
+export function command<TResult = unknown>(
   name: string,
-  handler: (params: TParams, context: WorkerCommandContext) => Promise<TResult>,
+  handler: (params: unknown, context: WorkerCommandContext) => TResult | Promise<TResult>,
+): void
+export function command<Schema extends StandardSchema, TResult = unknown>(
+  name: string,
+  schema: Schema,
+  handler: (
+    params: StandardSchemaOutput<Schema>,
+    context: WorkerCommandContext,
+  ) => TResult | Promise<TResult>,
+): void
+export function command<Schema extends StandardSchema, TResult = unknown>(
+  name: string,
+  schemaOrHandler:
+    | Schema
+    | ((params: unknown, context: WorkerCommandContext) => TResult | Promise<TResult>),
+  validatedHandler?: (
+    params: StandardSchemaOutput<Schema>,
+    context: WorkerCommandContext,
+  ) => TResult | Promise<TResult>,
 ): void {
+  const schema = validatedHandler === undefined ? undefined : (schemaOrHandler as Schema)
+  const handler = (validatedHandler ?? schemaOrHandler) as (
+    params: unknown,
+    context: WorkerCommandContext,
+  ) => TResult | Promise<TResult>
   registry().commands.set(name, {
     name,
-    handler: handler as (params: unknown, context: WorkerCommandContext) => Promise<unknown>,
+    handler: async (params, context) => {
+      if (schema === undefined) return await handler(params, context)
+      const result = await schema["~standard"].validate(params)
+      if (result.issues !== undefined) {
+        const details = result.issues.map(issue => issue.message).join("; ")
+        throw new Error(`Command input failed validation${details ? `: ${details}` : ""}`)
+      }
+      return await handler(result.value, context)
+    },
   })
 }
 

--- a/packages/sdk/tests/worker-command-schema.test.ts
+++ b/packages/sdk/tests/worker-command-schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+import { command, runCommand } from "../src/worker-runtime/registry.js"
+
+const context = { commandId: "command-1", attempt: 1 }
+
+describe("Worker command validation", () => {
+  it("passes schema-less input as unknown", async () => {
+    command("schema-less-test", input => ({ input }))
+    await expect(runCommand("schema-less-test", "hello", context)).resolves.toEqual({
+      input: "hello",
+    })
+  })
+
+  it("accepts a Zod Standard Schema and infers its output", async () => {
+    command("zod-test", z.object({ count: z.number() }), input => input.count * 2)
+    await expect(runCommand("zod-test", { count: 4 }, context)).resolves.toBe(8)
+  })
+
+  it("awaits Standard Schema validation and skips the handler on failure", async () => {
+    const handler = vi.fn((input: { name: string }) => input.name)
+    const schema = {
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        types: undefined as unknown as { input: unknown; output: { name: string } },
+        validate: async (value: unknown) =>
+          typeof value === "object" &&
+          value !== null &&
+          "name" in value &&
+          typeof value.name === "string"
+            ? { value: { name: value.name } }
+            : { issues: [{ message: "name must be a string" }] },
+      },
+    }
+    command("validated-test", schema, handler)
+
+    await expect(runCommand("validated-test", {}, context)).rejects.toThrow(
+      "Command input failed validation: name must be a string",
+    )
+    expect(handler).not.toHaveBeenCalled()
+    await expect(runCommand("validated-test", { name: "Ada" }, context)).resolves.toBe("Ada")
+  })
+})

--- a/tests/e2e/test-apps/container-rust/src/main.rs
+++ b/tests/e2e/test-apps/container-rust/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // App-owned pull receiver: leases only this container's commands.
     let mut receiver = alien_commands::receiver::Receiver::from_env()?;
-    receiver.handle("status", move |_ctx| {
+    receiver.command("status", move |_: serde_json::Value, _ctx| {
         let kv = kv.clone();
         async move {
             let mut documents = 0;

--- a/tests/e2e/test-apps/runtime-less-mixed/daemon/src/main.rs
+++ b/tests/e2e/test-apps/runtime-less-mixed/daemon/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut receiver = alien_commands::receiver::Receiver::from_env()?;
-    receiver.handle("status", move |_ctx| {
+    receiver.command("status", move |_: serde_json::Value, _ctx| {
         let kv = kv.clone();
         async move {
             Ok(serde_json::json!({

--- a/tests/e2e/test-apps/runtime-less-mixed/src/index.ts
+++ b/tests/e2e/test-apps/runtime-less-mixed/src/index.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
   }
 
   const receiver = createCommandReceiver()
-  receiver.handle("status", async () => ({
+  receiver.command("status", async () => ({
     resource: RESOURCE,
     role: "container",
     language: "typescript",


### PR DESCRIPTION
## Summary

- add typed JSON command registration in Rust and Standard Schema command registration in TypeScript
- make raw command handling explicit through `handle_raw` / `handleRaw`
- bind queue names once and add linked-container runtime bindings
- expose the same command and binding APIs through the Rust and TypeScript SDKs
- migrate public examples and runtimeless fixtures to the new API

## API notes

This intentionally removes the old receiver `handle` API before there are binding consumers to preserve. Schema-less TypeScript handlers receive `unknown`; schema-backed handlers infer their validated input type. Command results remain plain JSON success values, and handler or validation failures use the existing command failure path.

## Validation

- 79 command package tests
- 58 Node binding tests
- 54 Bun binding tests plus error-path subruns
- 10 TypeScript SDK tests
- Rust command, binding, native binding, SDK facade, and doc tests
- focused `cargo check`, formatting, and clippy
- public-repository boundary scan
