### PR TITLE
fix(commands): restore deployment command execution

### DIFF
--- a/crates/alien-commands/src/server/command_registry.rs
+++ b/crates/alien-commands/src/server/command_registry.rs
@@ -445,7 +445,7 @@ impl CommandRegistry for InMemoryCommandRegistry {
             error: None,
             target: target.target.clone(),
             delivery_mode: target.delivery_mode,
-            project_id: "local-dev".to_string(),
+            project_id: "default".to_string(),
         };
 
         self.commands
@@ -457,7 +457,7 @@ impl CommandRegistry for InMemoryCommandRegistry {
             command_id,
             target: target.target.clone(),
             delivery_mode: target.delivery_mode,
-            project_id: "local-dev".to_string(),
+            project_id: "default".to_string(),
         })
     }
 
@@ -832,6 +832,34 @@ mod tests {
                 .unwrap()
                 .state,
             CommandState::Succeeded
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_command_access_uses_oss_tenant_context() {
+        let registry = InMemoryCommandRegistry::new();
+        registry
+            .register_target("worker-1", CommandTargetType::Worker)
+            .await
+            .unwrap();
+        let target = registry.resolve_target("dep-1", None).await.unwrap();
+        let command = registry
+            .create_command("dep-1", "run", &target, CommandState::Pending, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(command.project_id, "default");
+        assert_eq!(
+            registry
+                .get_command_access_context(&command.command_id)
+                .await
+                .unwrap()
+                .unwrap(),
+            CommandAccessContext {
+                workspace_id: "default".to_string(),
+                project_id: "default".to_string(),
+                deployment_id: "dep-1".to_string(),
+            }
         );
     }
 

--- a/crates/alien-manager/src/auth/authz.rs
+++ b/crates/alien-manager/src/auth/authz.rs
@@ -7,7 +7,7 @@
 //! impl inspect every field without re-querying. Create paths take a context
 //! struct instead because the entity does not exist yet.
 
-use crate::auth::{Role, Subject};
+use crate::auth::Subject;
 use crate::traits::{
     deployment_store::{DeploymentGroupRecord, DeploymentRecord},
     release_store::ReleaseRecord,
@@ -48,10 +48,11 @@ pub trait Authz: Send + Sync {
 
     // -- Commands ----------------------------------------------------------
     fn can_dispatch_command(&self, subject: &Subject, deployment: &DeploymentRecord) -> bool;
-    /// The target deployment may complete its own command execution lifecycle.
-    /// This is intentionally narrower than dispatch authorization.
+    /// Callers that may act on the target deployment may complete its command
+    /// execution lifecycle. This remains distinct from dispatch authorization:
+    /// deployment tokens can execute commands but cannot create them.
     fn can_execute_command(&self, subject: &Subject, deployment: &DeploymentRecord) -> bool {
-        subject.role == Role::DeploymentManager && self.can_read_command(subject, deployment)
+        self.can_act_on_deployment(subject, deployment)
     }
     fn can_read_command(&self, subject: &Subject, deployment: &DeploymentRecord) -> bool;
     /// Authorize a read from the canonical command record without loading its

--- a/crates/alien-manager/src/auth/authz.rs
+++ b/crates/alien-manager/src/auth/authz.rs
@@ -7,7 +7,7 @@
 //! impl inspect every field without re-querying. Create paths take a context
 //! struct instead because the entity does not exist yet.
 
-use crate::auth::Subject;
+use crate::auth::{Role, Subject};
 use crate::traits::{
     deployment_store::{DeploymentGroupRecord, DeploymentRecord},
     release_store::ReleaseRecord,
@@ -48,6 +48,11 @@ pub trait Authz: Send + Sync {
 
     // -- Commands ----------------------------------------------------------
     fn can_dispatch_command(&self, subject: &Subject, deployment: &DeploymentRecord) -> bool;
+    /// The target deployment may complete its own command execution lifecycle.
+    /// This is intentionally narrower than dispatch authorization.
+    fn can_execute_command(&self, subject: &Subject, deployment: &DeploymentRecord) -> bool {
+        subject.role == Role::DeploymentManager && self.can_read_command(subject, deployment)
+    }
     fn can_read_command(&self, subject: &Subject, deployment: &DeploymentRecord) -> bool;
     /// Authorize a read from the canonical command record without loading its
     /// deployment. Deployment-group scope is intentionally handled through

--- a/crates/alien-manager/src/providers/oss_authz.rs
+++ b/crates/alien-manager/src/providers/oss_authz.rs
@@ -329,6 +329,16 @@ mod tests {
     }
 
     #[test]
+    fn deployment_token_executes_but_does_not_dispatch_its_own_command() {
+        let dep = deployment("d1", "dg-a");
+        let subject = deployment_token("d1");
+
+        assert!(OssAuthz.can_execute_command(&subject, &dep));
+        assert!(!OssAuthz.can_dispatch_command(&subject, &dep));
+        assert!(!OssAuthz.can_execute_command(&deployment_token("d2"), &dep));
+    }
+
+    #[test]
     fn project_token_only_reads_commands_in_its_project() {
         let subject = Subject {
             kind: SubjectKind::ServiceAccount {

--- a/crates/alien-manager/src/providers/oss_authz.rs
+++ b/crates/alien-manager/src/providers/oss_authz.rs
@@ -329,13 +329,16 @@ mod tests {
     }
 
     #[test]
-    fn deployment_token_executes_but_does_not_dispatch_its_own_command() {
+    fn command_execution_follows_deployment_access_without_granting_dispatch() {
         let dep = deployment("d1", "dg-a");
-        let subject = deployment_token("d1");
 
-        assert!(OssAuthz.can_execute_command(&subject, &dep));
-        assert!(!OssAuthz.can_dispatch_command(&subject, &dep));
+        assert!(OssAuthz.can_execute_command(&admin(), &dep));
+        assert!(OssAuthz.can_execute_command(&dg_token("dg-a"), &dep));
+        assert!(OssAuthz.can_execute_command(&deployment_token("d1"), &dep));
+
+        assert!(!OssAuthz.can_execute_command(&dg_token("dg-b"), &dep));
         assert!(!OssAuthz.can_execute_command(&deployment_token("d2"), &dep));
+        assert!(!OssAuthz.can_dispatch_command(&deployment_token("d1"), &dep));
     }
 
     #[test]

--- a/crates/alien-manager/src/routes/commands.rs
+++ b/crates/alien-manager/src/routes/commands.rs
@@ -75,7 +75,7 @@ async fn require_command_read_access(
     require_command_access(state, subject, &command.deployment_id).await
 }
 
-async fn require_command_mutation_access(
+async fn require_command_execution_access(
     state: &AppState,
     subject: &crate::auth::Subject,
     deployment_id: &str,
@@ -86,7 +86,7 @@ async fn require_command_mutation_access(
         .await
         .map_err(|e| e.into_response())?
         .ok_or_else(|| ErrorData::not_found_deployment(deployment_id).into_response())?;
-    if state.authz.can_dispatch_command(subject, &deployment) {
+    if state.authz.can_execute_command(subject, &deployment) {
         Ok(())
     } else {
         Err(ErrorData::forbidden("Access denied").into_response())
@@ -281,7 +281,7 @@ async fn submit_response(
             Ok(None) => return ErrorData::not_found_deployment(&deployment_id).into_response(),
             Err(e) => return e.into_response(),
         };
-        if !state.authz.can_dispatch_command(&subject, &deployment) {
+        if !state.authz.can_execute_command(&subject, &deployment) {
             return ErrorData::forbidden(
                 "Access denied: only the target deployment can submit responses",
             )
@@ -485,7 +485,7 @@ async fn release_lease(
         }
         Err(e) => return e.into_response(),
     };
-    if let Err(e) = require_command_mutation_access(&state, &subject, &owner).await {
+    if let Err(e) = require_command_execution_access(&state, &subject, &owner).await {
         return e;
     }
 

--- a/crates/alien-manager/src/routes/commands.rs
+++ b/crates/alien-manager/src/routes/commands.rs
@@ -282,10 +282,8 @@ async fn submit_response(
             Err(e) => return e.into_response(),
         };
         if !state.authz.can_execute_command(&subject, &deployment) {
-            return ErrorData::forbidden(
-                "Access denied: only the target deployment can submit responses",
-            )
-            .into_response();
+            return ErrorData::forbidden("Access denied: cannot act on the target deployment")
+                .into_response();
         }
     } else {
         // No Bearer token — try presigned URL auth from query parameters.

--- a/crates/alien-manager/src/stores/sqlite/command_registry.rs
+++ b/crates/alien-manager/src/stores/sqlite/command_registry.rs
@@ -2,13 +2,13 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use sea_query::{Expr, Query, SqliteQueryBuilder};
+use sea_query::{Alias, Expr, JoinType, Query, SqliteQueryBuilder};
 use std::sync::Arc;
 
 use alien_commands::error::ErrorData as CommandErrorData;
 use alien_commands::server::{
-    delivery_mode_for, select_command_target, CommandEnvelopeData, CommandMetadata,
-    CommandRegistry, CommandStatus, ResolvedCommandTarget,
+    delivery_mode_for, select_command_target, CommandAccessContext, CommandEnvelopeData,
+    CommandMetadata, CommandRegistry, CommandStatus, ResolvedCommandTarget,
 };
 use alien_core::{
     CommandDeliveryMode, CommandState, CommandTarget, CommandTargetType, DeploymentModel, Platform,
@@ -16,7 +16,7 @@ use alien_core::{
 use alien_error::IntoAlienError;
 
 use super::database::{RowParser, SqliteDatabase};
-use super::migrations::Commands;
+use super::migrations::{Commands, Deployments};
 
 pub struct SqliteCommandRegistry {
     db: Arc<SqliteDatabase>,
@@ -410,6 +410,53 @@ impl CommandRegistry for SqliteCommandRegistry {
         }
     }
 
+    async fn get_command_access_context(
+        &self,
+        command_id: &str,
+    ) -> alien_commands::error::Result<Option<CommandAccessContext>> {
+        let sql = Query::select()
+            .expr_as(
+                Expr::col((Deployments::Table, Deployments::WorkspaceId)),
+                Alias::new("workspace_id"),
+            )
+            .expr_as(
+                Expr::col((Deployments::Table, Deployments::ProjectId)),
+                Alias::new("project_id"),
+            )
+            .expr_as(
+                Expr::col((Commands::Table, Commands::DeploymentId)),
+                Alias::new("deployment_id"),
+            )
+            .from(Commands::Table)
+            .join(
+                JoinType::InnerJoin,
+                Deployments::Table,
+                Expr::col((Commands::Table, Commands::DeploymentId))
+                    .equals((Deployments::Table, Deployments::Id)),
+            )
+            .and_where(Expr::col((Commands::Table, Commands::Id)).eq(command_id))
+            .to_string(SqliteQueryBuilder);
+
+        let conn = self.db.conn().lock().await;
+        let mut rows = conn
+            .query(&sql, ())
+            .await
+            .into_alien_error()
+            .map_err(to_cmd_err)?;
+
+        match rows.next().await.into_alien_error().map_err(to_cmd_err)? {
+            Some(row) => {
+                let p = RowParser::new(&row);
+                Ok(Some(CommandAccessContext {
+                    workspace_id: p.string(0, "workspace_id").map_err(to_cmd_err)?,
+                    project_id: p.string(1, "project_id").map_err(to_cmd_err)?,
+                    deployment_id: p.string(2, "deployment_id").map_err(to_cmd_err)?,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
     async fn update_command_state(
         &self,
         command_id: &str,
@@ -746,6 +793,40 @@ mod tests {
             err.message.contains("predates command-target columns"),
             "expected a loud legacy error, got: {}",
             err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn command_access_context_comes_from_owning_deployment() {
+        let (db, reg) = registry().await;
+        db.execute(
+            "INSERT INTO deployments \
+             (id, name, deployment_group_id, platform, status, stack_settings, workspace_id, project_id) \
+             VALUES ('dep-1', 'deployment', 'dg-1', 'local', 'running', '{}', 'workspace-a', 'project-a')",
+        )
+        .await
+        .unwrap();
+        db.execute(
+            "INSERT INTO commands \
+             (id, deployment_id, name, state, deployment_model, attempt, created_at) \
+             VALUES ('command-1', 'dep-1', 'run', 'PENDING', 'pull', 1, '2020-01-01T00:00:00Z')",
+        )
+        .await
+        .unwrap();
+
+        let context = reg
+            .get_command_access_context("command-1")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            context,
+            CommandAccessContext {
+                workspace_id: "workspace-a".to_string(),
+                project_id: "project-a".to_string(),
+                deployment_id: "dep-1".to_string(),
+            }
         );
     }
 

--- a/examples/command-routing-ts/services/indexer/src/index.ts
+++ b/examples/command-routing-ts/services/indexer/src/index.ts
@@ -53,7 +53,12 @@ receiver.command("status", async () => ({
 
 // Overlapping command #2: `search`, reading the index this daemon maintains.
 receiver.command("search", async input => {
-  if (typeof input !== "object" || input === null || !("term" in input) || typeof input.term !== "string") {
+  if (
+    typeof input !== "object" ||
+    input === null ||
+    !("term" in input) ||
+    typeof input.term !== "string"
+  ) {
     throw new TypeError("term must be a string")
   }
   const { term } = input

--- a/examples/full-stack-microservices/services/worker/src/index.ts
+++ b/examples/full-stack-microservices/services/worker/src/index.ts
@@ -26,7 +26,12 @@ const files = storage(process.env.FILES_BUCKET ?? "files")
 if (process.env.ALIEN_COMMANDS_URL) {
   const receiver = createCommandReceiver()
   receiver.command("reprocess", async input => {
-    if (typeof input !== "object" || input === null || !("issueId" in input) || typeof input.issueId !== "string") {
+    if (
+      typeof input !== "object" ||
+      input === null ||
+      !("issueId" in input) ||
+      typeof input.issueId !== "string"
+    ) {
       throw new TypeError("issueId must be a string")
     }
     const { issueId } = input


### PR DESCRIPTION
Follow-up to #167.

## What changed

- Separate deployment-side command execution from operator-side command dispatch authorization.
- Allow deployment managers to submit responses and release leases only for their own deployment, without granting dispatch permission.
- Derive SQLite command ownership from the canonical deployment row instead of synthetic tenant values.
- Align the in-memory OSS registry with the default single-tenant context.

## Validation

- cargo test -p alien-manager providers::oss_authz --lib
- cargo test -p alien-manager stores::sqlite::command_registry::tests --lib
- cargo test -p alien-commands server::command_registry::tests --lib
- cargo check -p alien-manager --tests
- cargo fmt --all -- --check
- git diff --check