### PR TITLE
feat(storage): gate the storage bucket on a deployer input

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/queue.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/queue.rs
@@ -66,6 +66,10 @@ impl CfEmitter for AwsQueueEmitter {
         ]))
     }
 
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {
         let queue_id = required_logical_id(ctx)?;
         Ok(Some(CfExpression::object([

--- a/crates/alien-cloudformation/src/emitters/aws/storage.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/storage.rs
@@ -140,6 +140,13 @@ impl CfEmitter for AwsStorageEmitter {
         ]))
     }
 
+    /// Every resource this emitter returns — bucket, policy, and the IAM
+    /// policies that name the bucket — is stamped with the gate's condition by
+    /// the generator, so they appear and disappear together.
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {
         resource_config::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let bucket_id = required_logical_id(ctx)?;

--- a/crates/alien-cloudformation/tests/generator.rs
+++ b/crates/alien-cloudformation/tests/generator.rs
@@ -15,6 +15,7 @@ mod generator {
     pub mod aws_email_tests;
     pub mod aws_full_stack_tests;
     pub mod aws_open_search_tests;
+    pub mod enabled_queue_tests;
     pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod kubernetes_cluster_tests;

--- a/crates/alien-cloudformation/tests/generator.rs
+++ b/crates/alien-cloudformation/tests/generator.rs
@@ -15,6 +15,7 @@ mod generator {
     pub mod aws_email_tests;
     pub mod aws_full_stack_tests;
     pub mod aws_open_search_tests;
+    pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod kubernetes_cluster_tests;
     pub mod network_tests;

--- a/crates/alien-cloudformation/tests/generator/enabled_queue_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/enabled_queue_tests.rs
@@ -1,0 +1,278 @@
+//! `.enabled(input)` for `Queue` on CloudFormation.
+//!
+//! `enabled_tests.rs` covers the mechanics on `Kv`. A queue is where the
+//! registration payload gets exercised against a stack that mixes a gated
+//! resource with an ungated neighbour, on both of the paths that publish it.
+
+use super::helpers::{
+    custom_resource_registration, gate_input, render_built_ins_template, resolve, Declined,
+};
+use alien_cloudformation::{CfExpression, CfTemplate, CloudFormationTarget, RegistrationMode};
+use alien_core::{
+    PermissionProfile, Queue, ResourceLifecycle, ServiceAccount, Stack, StackBuilder,
+    StackInputDefinition, StackSettings,
+};
+use std::collections::HashMap;
+
+fn render_as(stack: &Stack, registration: RegistrationMode, description: &str) -> CfTemplate {
+    render_built_ins_template(
+        stack,
+        StackSettings::default(),
+        registration,
+        CloudFormationTarget::Aws,
+        "aws",
+        description,
+    )
+    .0
+}
+
+fn render(stack: &Stack, description: &str) -> CfTemplate {
+    render_as(stack, custom_resource_registration(), description)
+}
+
+const QUEUE_CONDITION: &str = "InputQueueEnabledIsTrue";
+
+fn gate_inputs() -> Vec<StackInputDefinition> {
+    vec![gate_input(
+        "queueEnabled",
+        "queue",
+        "Whether to create the queue.",
+    )]
+}
+
+/// The service account gives the "off" answer an ungated neighbour to leave
+/// behind, so the payload assertions say something about which entries survive
+/// rather than about the payload being empty.
+fn base() -> StackBuilder {
+    Stack::new("gated-stack".to_string())
+        .inputs(gate_inputs())
+        .permission(
+            "execution",
+            PermissionProfile::new().resource("jobs", ["queue/data-write"]),
+        )
+        .add(
+            ServiceAccount::new("execution-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn stack(gated: bool) -> Stack {
+    let queue = Queue::new("jobs".to_string()).build();
+    let builder = base();
+    if gated {
+        builder
+            .add_enabled_when(queue, ResourceLifecycle::Frozen, "queueEnabled")
+            .build()
+    } else {
+        builder.add(queue, ResourceLifecycle::Frozen).build()
+    }
+}
+
+fn registration_entry_ids(template: &CfTemplate, conditions: &HashMap<&str, bool>) -> Vec<String> {
+    let payload = template
+        .resources
+        .get("DeploymentRegistration")
+        .expect("registration custom resource")
+        .properties
+        .get("Resources")
+        .expect("registration resource list")
+        .clone();
+    let CfExpression::List(entries) = resolve(&payload, conditions, Declined::Removed)
+        .expect("payload survives condition resolution")
+    else {
+        panic!("registration payload should resolve to a list");
+    };
+    entries
+        .iter()
+        .map(|entry| {
+            let CfExpression::Object(fields) = entry else {
+                panic!("registration entry should be an object: {entry:?}");
+            };
+            match fields.get("id").expect("registration entry id") {
+                CfExpression::String(id) => id.clone(),
+                other => panic!("registration entry id should be a string: {other:?}"),
+            }
+        })
+        .collect()
+}
+
+/// The `DeploymentResources` output, resolved and parsed the way the registering
+/// consumer reads it.
+///
+/// Returns the raw text alongside the parsed value so a caller can assert on the
+/// exact bytes CloudFormation would hand over, not just on what survived
+/// `serde_json`.
+fn resolved_outputs_payload(
+    template: &CfTemplate,
+    conditions: &HashMap<&str, bool>,
+) -> (String, serde_json::Value) {
+    let value = &template
+        .outputs
+        .get("DeploymentResources")
+        .expect("outputs fallback should carry the resources payload")
+        .value;
+    let resolved = resolve(value, conditions, Declined::Removed)
+        .expect("the resources output survives condition resolution");
+    let CfExpression::String(text) = resolved else {
+        panic!("the resources output should resolve to JSON text: {resolved:?}");
+    };
+    let parsed = serde_json::from_str(&text)
+        .unwrap_or_else(|error| panic!("resources output should be valid JSON: {error}\n{text}"));
+    (text, parsed)
+}
+
+/// Extract ids from the Outputs payload, verifying that every entry is a
+/// well-formed object.
+fn outputs_entry_ids(template: &CfTemplate, conditions: &HashMap<&str, bool>) -> Vec<String> {
+    let (text, parsed) = resolved_outputs_payload(template, conditions);
+    let serde_json::Value::Array(entries) = parsed else {
+        panic!("resources output should be a JSON array: {text}");
+    };
+    entries
+        .iter()
+        .map(|entry| {
+            let id = entry
+                .get("id")
+                .unwrap_or_else(|| panic!("registration entry has no id: {entry}\n{text}"));
+            id.as_str()
+                .unwrap_or_else(|| panic!("registration entry id should be a string: {id}"))
+                .to_string()
+        })
+        .collect()
+}
+
+/// Logical ids of every resource carrying `condition`.
+fn resources_conditioned_on(template: &CfTemplate, condition: &str) -> Vec<String> {
+    let mut ids = template
+        .resources
+        .iter()
+        .filter(|(_, resource)| resource.condition.as_deref() == Some(condition))
+        .map(|(logical_id, _)| logical_id.clone())
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+#[test]
+fn a_gated_queue_is_created_only_when_the_deployer_says_yes() {
+    let template = render(&stack(true), "gated queue");
+
+    let queue = template
+        .resources
+        .get("Jobs")
+        .expect("gated queue should still be declared");
+    assert_eq!(queue.resource_type, "AWS::SQS::Queue");
+    assert_eq!(queue.condition.as_deref(), Some(QUEUE_CONDITION));
+    assert_eq!(
+        resources_conditioned_on(&template, QUEUE_CONDITION),
+        vec![
+            "Jobs".to_string(),
+            "JobsExecutionSaRoleQueuePermission00".to_string(),
+        ],
+        "the queue owns the SQS queue and its resource-scoped grant, both gated"
+    );
+}
+
+/// Registration runs the typed importer over every entry it receives, so a
+/// declined resource must be absent, not present-and-null.
+#[test]
+fn declined_resources_leave_no_registration_entry() {
+    let template = render(&stack(true), "gated queue");
+
+    let queue_on = HashMap::from([(QUEUE_CONDITION, true)]);
+    assert_eq!(
+        registration_entry_ids(&template, &queue_on),
+        vec!["execution-sa".to_string(), "jobs".to_string()],
+        "everything registers when the deployer says yes"
+    );
+
+    let queue_off = HashMap::from([(QUEUE_CONDITION, false)]);
+    assert_eq!(
+        registration_entry_ids(&template, &queue_off),
+        vec!["execution-sa".to_string()],
+        "declined resources must be absent from the payload, not null"
+    );
+}
+
+/// The same invariant on the Outputs fallback, which is the path `alien render`
+/// picks whenever no notification lambda is configured.
+///
+/// It carries the payload as JSON text rather than as a list, and the intrinsic
+/// that produces that text renders a declined entry as a literal `null` instead
+/// of dropping it. Nothing about that is visible in the rendered template — it
+/// only happens once CloudFormation resolves the conditions — so this asserts on
+/// the resolved text.
+#[test]
+fn the_outputs_fallback_omits_declined_resources() {
+    let template = render_as(
+        &stack(true),
+        RegistrationMode::OutputsFallback,
+        "gated queue, outputs fallback",
+    );
+
+    let queue_on = HashMap::from([(QUEUE_CONDITION, true)]);
+    assert_eq!(
+        outputs_entry_ids(&template, &queue_on),
+        vec!["execution-sa".to_string(), "jobs".to_string()],
+        "everything registers when the deployer says yes"
+    );
+
+    let queue_off = HashMap::from([(QUEUE_CONDITION, false)]);
+    let (text, _) = resolved_outputs_payload(&template, &queue_off);
+    assert!(
+        !text.contains("null"),
+        "a declined resource must leave nothing behind, but the payload still \
+         carries a null: {text}"
+    );
+    assert_eq!(
+        outputs_entry_ids(&template, &queue_off),
+        vec!["execution-sa".to_string()],
+        "only the ungated resource registers"
+    );
+}
+
+/// Declining every gated resource must still leave a payload the consumer can
+/// read, rather than a malformed array or a stray delimiter.
+#[test]
+fn the_outputs_fallback_survives_every_resource_being_declined() {
+    let template = render_as(
+        &Stack::new("gated-stack".to_string())
+            .inputs(gate_inputs())
+            .add_enabled_when(
+                Queue::new("jobs".to_string()).build(),
+                ResourceLifecycle::Frozen,
+                "queueEnabled",
+            )
+            .build(),
+        RegistrationMode::OutputsFallback,
+        "every resource gated, outputs fallback",
+    );
+
+    let all_off = HashMap::from([(QUEUE_CONDITION, false)]);
+    let (text, parsed) = resolved_outputs_payload(&template, &all_off);
+    assert_eq!(text, "[]", "an all-declined payload is an empty array");
+    assert_eq!(parsed, serde_json::json!([]));
+}
+
+/// Ungated stacks gain no conditions: opt-in means no `.enabled(...)`, so no gating.
+#[test]
+fn an_ungated_stack_gains_no_conditions() {
+    let template = render(&stack(false), "ungated queue");
+
+    assert!(
+        template.conditions.is_empty(),
+        "nothing is gated, so no condition belongs in the template: {:?}",
+        template.conditions
+    );
+    assert!(
+        template
+            .resources
+            .values()
+            .all(|resource| resource.condition.is_none()),
+        "no resource may carry a condition when nothing is gated"
+    );
+    assert_eq!(
+        registration_entry_ids(&template, &HashMap::new()),
+        vec!["execution-sa".to_string(), "jobs".to_string()],
+    );
+}

--- a/crates/alien-cloudformation/tests/generator/enabled_storage_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/enabled_storage_tests.rs
@@ -1,0 +1,275 @@
+//! `.enabled(input)` on `storage` — the multi-resource case.
+//!
+//! `kv` emits one resource, so the generator stamping the gate's condition onto
+//! it is the whole story. `storage` emits a bucket, a bucket policy, and one IAM
+//! policy per grant, and every one of them names the bucket. The failure mode is
+//! an ungated resource left holding a `Ref` to a bucket the deployer declined:
+//! that template still lints and still renders, and fails at deploy time.
+//!
+//! So the assertions below are about the whole resource set, not the bucket.
+
+use super::helpers::{
+    custom_resource_registration, entry_ids, gate_input, registration_payload,
+    render_built_ins_template, resolve, Declined,
+};
+use alien_cloudformation::{CfExpression, CfTemplate, CloudFormationTarget};
+use alien_core::{
+    LifecycleRule, PermissionProfile, ResourceLifecycle, ServiceAccount, Stack, StackBuilder,
+    StackSettings, Storage,
+};
+use std::collections::HashMap;
+
+const GATE_CONDITION: &str = "InputFilesEnabledIsTrue";
+const BUCKET_ID: &str = "Files";
+
+fn gate() -> alien_core::StackInputDefinition {
+    gate_input(
+        "filesEnabled",
+        "Enable the bucket",
+        "Whether to create the object-storage bucket.",
+    )
+}
+
+/// Renders and lints, so every assertion below is made about a template
+/// `cfn-lint` already accepted.
+fn render(stack: &Stack, description: &str) -> CfTemplate {
+    render_built_ins_template(
+        stack,
+        StackSettings::default(),
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        description,
+    )
+    .0
+}
+
+/// Versioning and lifecycle rules fill in the bucket's optional properties, and
+/// the permission profile is what makes the emitter produce the IAM policies
+/// that name the bucket — the resources most likely to be left ungated.
+fn storage() -> Storage {
+    Storage::new("files".to_string())
+        .versioning(true)
+        .lifecycle_rules(vec![LifecycleRule {
+            days: 30,
+            prefix: Some("tmp/".to_string()),
+        }])
+        .build()
+}
+
+fn stack_base() -> StackBuilder {
+    Stack::new("gated-storage".to_string())
+        .inputs(vec![gate()])
+        .permission(
+            "app",
+            PermissionProfile::new().resource("files", ["storage/data-write"]),
+        )
+        .add(
+            ServiceAccount::new("app-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn gated_stack() -> Stack {
+    stack_base()
+        .add_enabled_when(storage(), ResourceLifecycle::Frozen, "filesEnabled")
+        .build()
+}
+
+fn ungated_stack() -> Stack {
+    stack_base()
+        .add(storage(), ResourceLifecycle::Frozen)
+        .build()
+}
+
+/// Logical ids of every resource that names `logical_id` anywhere in its
+/// properties or `DependsOn` — the resources that would break if it vanished.
+fn resources_referencing(template: &CfTemplate, logical_id: &str) -> Vec<String> {
+    template
+        .resources
+        .iter()
+        .filter(|(id, _)| *id != logical_id)
+        .filter(|(_, resource)| {
+            resource.depends_on.iter().any(|dep| dep == logical_id)
+                || resource
+                    .properties
+                    .values()
+                    .any(|value| names_resource(value, logical_id))
+        })
+        .map(|(id, _)| id.clone())
+        .collect()
+}
+
+/// Whether an expression reaches `logical_id` through `Ref`, `Fn::GetAtt`, or a
+/// `Fn::Sub` template that interpolates it.
+fn names_resource(expression: &CfExpression, logical_id: &str) -> bool {
+    match expression {
+        CfExpression::String(value) => value.contains(&format!("${{{logical_id}}}")),
+        CfExpression::Object(fields) => fields.iter().any(|(key, value)| match key.as_str() {
+            "Ref" => value == &CfExpression::from(logical_id),
+            "Fn::GetAtt" => match value {
+                CfExpression::List(parts) => parts
+                    .first()
+                    .is_some_and(|part| part == &CfExpression::from(logical_id)),
+                other => names_resource(other, logical_id),
+            },
+            _ => names_resource(value, logical_id),
+        }),
+        CfExpression::List(items) => items.iter().any(|item| names_resource(item, logical_id)),
+        _ => false,
+    }
+}
+
+/// The invariant that matters at deploy time: nothing that survives the "no"
+/// answer may still point at the bucket. `cfn-lint` does not catch this — the
+/// template is well-formed either way.
+#[test]
+fn nothing_ungated_is_left_pointing_at_a_declined_bucket() {
+    let template = render(&gated_stack(), "gated storage stack");
+
+    let mut referrers = resources_referencing(&template, BUCKET_ID);
+    assert!(
+        referrers.len() > 1,
+        "the fixture must produce resources that name the bucket, or this proves nothing: \
+         {referrers:?}"
+    );
+
+    // The registration custom resource is the one referrer that handles the
+    // "no" answer itself: it reaches the bucket only from inside the gate's own
+    // `Fn::If`, which drops the whole entry. `a_declined_bucket_leaves_no_
+    // registration_entry` is what proves that.
+    let registration = referrers
+        .iter()
+        .position(|id| id == "DeploymentRegistration")
+        .expect("registration should carry the bucket's import data");
+    referrers.remove(registration);
+
+    for referrer in &referrers {
+        assert_eq!(
+            template.resources[referrer].condition.as_deref(),
+            Some(GATE_CONDITION),
+            "`{referrer}` names the bucket, so it must disappear with it; \
+             referrers were {referrers:?}"
+        );
+    }
+}
+
+/// The bucket and every resource the emitter derives from it, named explicitly,
+/// so a newly added sibling that forgets the gate shows up as a failure here
+/// rather than at a customer's deploy.
+#[test]
+fn the_bucket_and_its_policies_all_carry_the_gate() {
+    let template = render(&gated_stack(), "gated storage stack");
+
+    let bucket = template
+        .resources
+        .get(BUCKET_ID)
+        .expect("gated bucket should still be declared");
+    assert_eq!(bucket.resource_type, "AWS::S3::Bucket");
+    assert_eq!(bucket.condition.as_deref(), Some(GATE_CONDITION));
+
+    let policy = template
+        .resources
+        .get(&format!("{BUCKET_ID}BucketPolicy"))
+        .expect("bucket policy should still be declared");
+    assert_eq!(policy.resource_type, "AWS::S3::BucketPolicy");
+    assert_eq!(policy.condition.as_deref(), Some(GATE_CONDITION));
+
+    let iam_policies = template
+        .resources
+        .iter()
+        .filter(|(id, resource)| {
+            resource.resource_type == "AWS::IAM::Policy" && id.starts_with(BUCKET_ID)
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !iam_policies.is_empty(),
+        "the permission profile should produce at least one storage IAM policy"
+    );
+    for (id, resource) in iam_policies {
+        assert_eq!(
+            resource.condition.as_deref(),
+            Some(GATE_CONDITION),
+            "`{id}` embeds the bucket in its policy document"
+        );
+    }
+}
+
+/// The IAM policy attaches to a role this emitter does not own. Gating that role
+/// would take the service account's other grants down with the bucket.
+#[test]
+fn the_service_account_role_is_not_gated() {
+    let template = render(&gated_stack(), "gated storage stack");
+
+    let roles = template
+        .resources
+        .iter()
+        .filter(|(_, resource)| resource.resource_type == "AWS::IAM::Role")
+        .collect::<Vec<_>>();
+    assert!(!roles.is_empty(), "the stack should declare a role");
+    for (id, resource) in roles {
+        assert_eq!(
+            resource.condition.as_deref(),
+            None,
+            "`{id}` belongs to the service account, not the bucket"
+        );
+    }
+}
+
+/// Registration runs the typed importer over every entry it receives, so a
+/// declined bucket has to be absent from the payload rather than present with a
+/// null one.
+#[test]
+fn a_declined_bucket_leaves_no_registration_entry() {
+    let template = render(&gated_stack(), "gated storage stack");
+    let payload = registration_payload(&template);
+
+    let accepted = resolve(
+        &payload,
+        &HashMap::from([(GATE_CONDITION, true)]),
+        Declined::Removed,
+    )
+    .expect("payload survives when the gate is on");
+    assert!(
+        entry_ids(&accepted).contains(&"files".to_string()),
+        "the bucket registers when the deployer says yes: {:?}",
+        entry_ids(&accepted)
+    );
+
+    let declined = resolve(
+        &payload,
+        &HashMap::from([(GATE_CONDITION, false)]),
+        Declined::Removed,
+    )
+    .expect("payload survives when the gate is off");
+    assert!(
+        !entry_ids(&declined).contains(&"files".to_string()),
+        "the declined bucket must be absent from the payload, not null: {:?}",
+        entry_ids(&declined)
+    );
+    assert!(
+        entry_ids(&declined).contains(&"app-sa".to_string()),
+        "the ungated service account still registers: {:?}",
+        entry_ids(&declined)
+    );
+}
+
+/// Ungated stacks gain no conditions: opt-in means no `.enabled(...)`, so no gating.
+#[test]
+fn an_ungated_storage_stack_gains_no_conditions() {
+    let template = render(&ungated_stack(), "ungated storage stack");
+
+    assert!(
+        template.conditions.is_empty(),
+        "nothing is gated, so no condition belongs in the template: {:?}",
+        template.conditions
+    );
+    for (id, resource) in template.resources.iter() {
+        assert_eq!(
+            resource.condition.as_deref(),
+            None,
+            "`{id}` gained a condition on an ungated stack"
+        );
+    }
+    assert!(entry_ids(&registration_payload(&template)).contains(&"files".to_string()));
+}

--- a/crates/alien-terraform/src/emitters/aws/queue.rs
+++ b/crates/alien-terraform/src/emitters/aws/queue.rs
@@ -4,6 +4,7 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::aws::helpers::{downcast, required_label, resource_prefix_template, tags},
+    emitters::enabled,
     expr,
 };
 use alien_core::{import::EmitContext, Queue, Result, Worker, WorkerTrigger};
@@ -16,8 +17,9 @@ impl TfEmitter for AwsQueueEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
-        let q = resource_block(
+        let mut q = resource_block(
             "aws_sqs_queue",
             label,
             [
@@ -34,27 +36,43 @@ impl TfEmitter for AwsQueueEmitter {
                 attr("tags", tags(ctx, "queue")),
             ],
         );
+        enabled::gate(&mut q, enabled_when)?;
 
         Ok(TfFragment::default().with_resource(q))
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             (
                 "queueName",
-                expr::traversal(["aws_sqs_queue", label, "name"]),
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "name"),
             ),
-            ("queueUrl", expr::traversal(["aws_sqs_queue", label, "url"])),
-            ("queueArn", expr::traversal(["aws_sqs_queue", label, "arn"])),
+            (
+                "queueUrl",
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "url"),
+            ),
+            (
+                "queueArn",
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "arn"),
+            ),
         ]))
+    }
+
+    fn supports_enabled_when(&self) -> bool {
+        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("sqs".to_string())),
-            ("queueUrl", expr::traversal(["aws_sqs_queue", label, "url"])),
+            (
+                "queueUrl",
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "url"),
+            ),
         ])))
     }
 }

--- a/crates/alien-terraform/src/emitters/aws/storage.rs
+++ b/crates/alien-terraform/src/emitters/aws/storage.rs
@@ -11,6 +11,7 @@ use crate::{
         aws_terraform_permission_context, downcast, emit_iam_role_policy_for_target_with_label,
         iam_policy_name_sanitize, required_label, resource_prefix_template, tags,
     },
+    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -18,7 +19,10 @@ use alien_core::{
     RemoteStackManagement, Result, ServiceAccount, Storage,
 };
 use alien_permissions::BindingTarget;
-use hcl::expr::Expression;
+use hcl::{
+    expr::Expression,
+    structure::{Block, Structure},
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AwsStorageEmitter;
@@ -27,57 +31,85 @@ impl TfEmitter for AwsStorageEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let storage = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         let mut fragment = TfFragment::default();
 
-        fragment.resource_blocks.push(bucket(label, ctx, storage));
-        fragment.resource_blocks.push(encryption(label));
-        fragment.resource_blocks.push(ownership_controls(label));
+        // The bucket's configuration siblings only describe a bucket that
+        // exists, so they carry the same gate rather than outliving it.
         fragment
             .resource_blocks
-            .push(public_access_block(label, !storage.public_read));
-        fragment.resource_blocks.push(bucket_policy(label, storage));
+            .push(bucket(label, ctx, storage, enabled_when)?);
+        fragment
+            .resource_blocks
+            .push(encryption(label, enabled_when)?);
+        fragment
+            .resource_blocks
+            .push(ownership_controls(label, enabled_when)?);
+        fragment.resource_blocks.push(public_access_block(
+            label,
+            !storage.public_read,
+            enabled_when,
+        )?);
+        fragment
+            .resource_blocks
+            .push(bucket_policy(label, storage, enabled_when)?);
 
         if storage.versioning {
-            fragment.resource_blocks.push(versioning(label));
-        }
-        if !storage.lifecycle_rules.is_empty() {
             fragment
                 .resource_blocks
-                .push(lifecycle(label, &storage.lifecycle_rules));
+                .push(versioning(label, enabled_when)?);
         }
-        emit_storage_iam(ctx, &mut fragment, label)?;
+        if !storage.lifecycle_rules.is_empty() {
+            fragment.resource_blocks.push(lifecycle(
+                label,
+                &storage.lifecycle_rules,
+                enabled_when,
+            )?);
+        }
+        emit_storage_iam(ctx, &mut fragment, label, enabled_when)?;
 
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             (
                 "bucketName",
-                expr::traversal(["aws_s3_bucket", label, "bucket"]),
+                enabled::attribute(enabled_when, "aws_s3_bucket", label, "bucket"),
             ),
             (
                 "bucketArn",
-                expr::traversal(["aws_s3_bucket", label, "arn"]),
+                enabled::attribute(enabled_when, "aws_s3_bucket", label, "arn"),
             ),
         ]))
     }
 
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("s3".to_string())),
             (
                 "bucketName",
-                expr::traversal(["aws_s3_bucket", label, "bucket"]),
+                enabled::attribute(enabled_when, "aws_s3_bucket", label, "bucket"),
             ),
         ])))
     }
 }
 
-fn bucket(label: &str, ctx: &EmitContext<'_>, storage: &Storage) -> hcl::structure::Block {
-    resource_block(
+fn bucket(
+    label: &str,
+    ctx: &EmitContext<'_>,
+    storage: &Storage,
+    enabled_when: Option<&str>,
+) -> Result<Block> {
+    let mut bucket = resource_block(
         "aws_s3_bucket",
         label,
         [
@@ -85,10 +117,12 @@ fn bucket(label: &str, ctx: &EmitContext<'_>, storage: &Storage) -> hcl::structu
             attr("force_destroy", Expression::Bool(true)),
             attr("tags", tags(ctx, "storage")),
         ],
-    )
+    );
+    enabled::gate(&mut bucket, enabled_when)?;
+    Ok(bucket)
 }
 
-fn encryption(label: &str) -> hcl::structure::Block {
+fn encryption(label: &str, enabled_when: Option<&str>) -> Result<Block> {
     let inner = block(
         "apply_server_side_encryption_by_default",
         [attr(
@@ -97,14 +131,16 @@ fn encryption(label: &str) -> hcl::structure::Block {
         )],
     );
     let rule = block("rule", [nested(inner)]);
-    resource_block(
+    let mut encryption = resource_block(
         "aws_s3_bucket_server_side_encryption_configuration",
         label,
-        [attr("bucket", bucket_id(label)), nested(rule)],
-    )
+        [attr("bucket", bucket_id(label, enabled_when)), nested(rule)],
+    );
+    enabled::gate(&mut encryption, enabled_when)?;
+    Ok(encryption)
 }
 
-fn ownership_controls(label: &str) -> hcl::structure::Block {
+fn ownership_controls(label: &str, enabled_when: Option<&str>) -> Result<Block> {
     let rule = block(
         "rule",
         [attr(
@@ -112,29 +148,44 @@ fn ownership_controls(label: &str) -> hcl::structure::Block {
             Expression::String("BucketOwnerEnforced".to_string()),
         )],
     );
-    resource_block(
+    let mut controls = resource_block(
         "aws_s3_bucket_ownership_controls",
         label,
-        [attr("bucket", bucket_id(label)), nested(rule)],
-    )
+        [attr("bucket", bucket_id(label, enabled_when)), nested(rule)],
+    );
+    enabled::gate(&mut controls, enabled_when)?;
+    Ok(controls)
 }
 
-fn public_access_block(label: &str, block_public: bool) -> hcl::structure::Block {
+fn public_access_block(
+    label: &str,
+    block_public: bool,
+    enabled_when: Option<&str>,
+) -> Result<Block> {
     let value = Expression::Bool(block_public);
-    resource_block(
+    let mut access_block = resource_block(
         "aws_s3_bucket_public_access_block",
         label,
         [
-            attr("bucket", bucket_id(label)),
+            attr("bucket", bucket_id(label, enabled_when)),
             attr("block_public_acls", value.clone()),
             attr("block_public_policy", value.clone()),
             attr("ignore_public_acls", value.clone()),
             attr("restrict_public_buckets", value),
         ],
-    )
+    );
+    enabled::gate(&mut access_block, enabled_when)?;
+    Ok(access_block)
 }
 
-fn bucket_policy(label: &str, storage: &Storage) -> hcl::structure::Block {
+fn bucket_policy(label: &str, storage: &Storage, enabled_when: Option<&str>) -> Result<Block> {
+    let objects_arn = || {
+        expr::raw(format!(
+            "\"${{{}}}/*\"",
+            bucket_path(label, "arn", enabled_when)
+        ))
+    };
+
     let mut statements = vec![expr::object([
         (
             "Sid",
@@ -146,8 +197,8 @@ fn bucket_policy(label: &str, storage: &Storage) -> hcl::structure::Block {
         (
             "Resource",
             Expression::Array(vec![
-                expr::traversal(["aws_s3_bucket", label, "arn"]),
-                expr::raw(format!("\"${{aws_s3_bucket.{label}.arn}}/*\"")),
+                enabled::attribute(enabled_when, "aws_s3_bucket", label, "arn"),
+                objects_arn(),
             ]),
         ),
         (
@@ -168,10 +219,7 @@ fn bucket_policy(label: &str, storage: &Storage) -> hcl::structure::Block {
             ("Effect", Expression::String("Allow".to_string())),
             ("Principal", Expression::String("*".to_string())),
             ("Action", Expression::String("s3:GetObject".to_string())),
-            (
-                "Resource",
-                expr::raw(format!("\"${{aws_s3_bucket.{label}.arn}}/*\"")),
-            ),
+            ("Resource", objects_arn()),
         ]));
     }
 
@@ -180,30 +228,37 @@ fn bucket_policy(label: &str, storage: &Storage) -> hcl::structure::Block {
         ("Statement", Expression::Array(statements)),
     ]);
 
-    resource_block(
+    let mut bucket_policy = resource_block(
         "aws_s3_bucket_policy",
         label,
         [
-            attr("bucket", bucket_id(label)),
+            attr("bucket", bucket_id(label, enabled_when)),
             attr("policy", crate::emitters::aws::helpers::jsonencode(policy)),
         ],
-    )
+    );
+    enabled::gate(&mut bucket_policy, enabled_when)?;
+    Ok(bucket_policy)
 }
 
-fn versioning(label: &str) -> hcl::structure::Block {
+fn versioning(label: &str, enabled_when: Option<&str>) -> Result<Block> {
     let inner = block(
         "versioning_configuration",
         [attr("status", Expression::String("Enabled".to_string()))],
     );
-    resource_block(
+    let mut versioning = resource_block(
         "aws_s3_bucket_versioning",
         label,
-        [attr("bucket", bucket_id(label)), nested(inner)],
-    )
+        [
+            attr("bucket", bucket_id(label, enabled_when)),
+            nested(inner),
+        ],
+    );
+    enabled::gate(&mut versioning, enabled_when)?;
+    Ok(versioning)
 }
 
-fn lifecycle(label: &str, rules: &[LifecycleRule]) -> hcl::structure::Block {
-    let mut body: Vec<hcl::structure::Structure> = vec![attr("bucket", bucket_id(label))];
+fn lifecycle(label: &str, rules: &[LifecycleRule], enabled_when: Option<&str>) -> Result<Block> {
+    let mut body: Vec<Structure> = vec![attr("bucket", bucket_id(label, enabled_when))];
     for (index, rule) in rules.iter().enumerate() {
         let prefix = rule.prefix.clone().unwrap_or_default();
         let filter = block("filter", [attr("prefix", Expression::String(prefix))]);
@@ -225,17 +280,35 @@ fn lifecycle(label: &str, rules: &[LifecycleRule]) -> hcl::structure::Block {
         );
         body.push(nested(rule_block));
     }
-    resource_block("aws_s3_bucket_lifecycle_configuration", label, body)
+    let mut lifecycle = resource_block("aws_s3_bucket_lifecycle_configuration", label, body);
+    enabled::gate(&mut lifecycle, enabled_when)?;
+    Ok(lifecycle)
 }
 
-fn bucket_id(label: &str) -> Expression {
-    expr::traversal(["aws_s3_bucket", label, "id"])
+fn bucket_id(label: &str, enabled_when: Option<&str>) -> Expression {
+    enabled::attribute(enabled_when, "aws_s3_bucket", label, "id")
 }
 
-fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
+/// Reference path to one of the bucket's own attributes, for the places that
+/// interpolate it into a string rather than emitting an expression.
+fn bucket_path(label: &str, attribute: &str, enabled_when: Option<&str>) -> String {
+    match enabled_when {
+        Some(_) => format!("aws_s3_bucket.{label}[0].{attribute}"),
+        None => format!("aws_s3_bucket.{label}.{attribute}"),
+    }
+}
+
+fn emit_storage_iam(
+    ctx: &EmitContext<'_>,
+    fragment: &mut TfFragment,
+    label: &str,
+    enabled_when: Option<&str>,
+) -> Result<()> {
     for (owner_label, permission_refs) in storage_permission_owners(ctx) {
-        let context = aws_terraform_permission_context()
-            .with_resource_name(format!("${{aws_s3_bucket.{label}.bucket}}"));
+        let context = aws_terraform_permission_context().with_resource_name(format!(
+            "${{{}}}",
+            bucket_path(label, "bucket", enabled_when)
+        ));
 
         for (idx, permission_ref) in permission_refs.iter().enumerate() {
             let Some(permission_set) =
@@ -256,6 +329,11 @@ fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &st
                 ctx.resource_id, permission_set.id
             ));
 
+            // The policy document names the bucket, so it cannot outlive it.
+            // The shared emitter is used by ungated resources too, so the gate
+            // goes on the blocks it just appended rather than into its
+            // signature.
+            let appended_from = fragment.resource_blocks.len();
             emit_iam_role_policy_for_target_with_label(
                 fragment,
                 &owner_label,
@@ -265,6 +343,9 @@ fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &st
                 &context,
                 BindingTarget::Resource,
             )?;
+            for block in &mut fragment.resource_blocks[appended_from..] {
+                enabled::gate(block, enabled_when)?;
+            }
         }
     }
 

--- a/crates/alien-terraform/src/emitters/azure/queue.rs
+++ b/crates/alien-terraform/src/emitters/azure/queue.rs
@@ -16,6 +16,7 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::azure::helpers::{downcast, required_label, resource_prefix_template},
+    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -32,14 +33,17 @@ impl TfEmitter for AzureQueueEmitter {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
         let lock_duration = lock_duration_for(ctx);
 
-        let q = resource_block(
+        let mut q = resource_block(
             "azurerm_servicebus_queue",
             label,
             [
                 attr("name", resource_prefix_template(queue.id())),
+                // The namespace is a separate, ungated resource, so this
+                // reference stays unindexed even when the queue is counted.
                 attr(
                     "namespace_id",
                     expr::traversal(["azurerm_servicebus_namespace", &parent_label, "id"]),
@@ -63,6 +67,7 @@ impl TfEmitter for AzureQueueEmitter {
                 ),
             ],
         );
+        enabled::gate(&mut q, enabled_when)?;
 
         Ok(TfFragment::default().with_resource(q))
     }
@@ -70,32 +75,42 @@ impl TfEmitter for AzureQueueEmitter {
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("subscriptionId", expr::raw("var.azure_subscription_id")),
             ("resourceGroup", expr::raw("var.azure_resource_group_name")),
+            // The namespace hosting the queue is ungated; only the queue below
+            // is counted.
             (
                 "namespaceName",
                 expr::traversal(["azurerm_servicebus_namespace", &parent_label, "name"]),
             ),
             (
                 "queueName",
-                expr::traversal(["azurerm_servicebus_queue", label, "name"]),
+                enabled::attribute(enabled_when, "azurerm_servicebus_queue", label, "name"),
             ),
         ]))
+    }
+
+    fn supports_enabled_when(&self) -> bool {
+        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("servicebus".to_string())),
+            // The namespace hosting the queue is ungated; only the queue below
+            // is counted.
             (
                 "namespace",
                 expr::traversal(["azurerm_servicebus_namespace", &parent_label, "name"]),
             ),
             (
                 "queueName",
-                expr::traversal(["azurerm_servicebus_queue", label, "name"]),
+                enabled::attribute(enabled_when, "azurerm_servicebus_queue", label, "name"),
             ),
         ])))
     }

--- a/crates/alien-terraform/src/emitters/azure/storage.rs
+++ b/crates/alien-terraform/src/emitters/azure/storage.rs
@@ -25,6 +25,7 @@ use crate::{
         downcast, permission_context, required_label, service_account_principal_id,
         setup_execution_role_label, setup_management_role_label,
     },
+    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -46,6 +47,7 @@ impl TfEmitter for AzureStorageEmitter {
         let storage = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
         let mut fragment = TfFragment::default();
 
@@ -55,11 +57,13 @@ impl TfEmitter for AzureStorageEmitter {
             "private"
         };
 
-        fragment.resource_blocks.push(resource_block(
+        let mut container = resource_block(
             "azurerm_storage_container",
             label,
             [
                 attr("name", container_name_expr(storage.id())),
+                // The Storage account is a separate, ungated resource, so this
+                // reference stays unindexed even when the container is counted.
                 attr(
                     "storage_account_name",
                     expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
@@ -69,17 +73,20 @@ impl TfEmitter for AzureStorageEmitter {
                     Expression::String(access_type.to_string()),
                 ),
             ],
-        ));
+        );
+        enabled::gate(&mut container, enabled_when)?;
+        fragment.resource_blocks.push(container);
 
         if !storage.lifecycle_rules.is_empty() {
             fragment.resource_blocks.push(lifecycle_policy(
                 label,
                 &parent_label,
                 &storage.lifecycle_rules,
-            ));
+                enabled_when,
+            )?);
         }
 
-        emit_storage_permissions(ctx, label, &parent_label, &mut fragment)?;
+        emit_storage_permissions(ctx, label, &parent_label, &mut fragment, enabled_when)?;
 
         Ok(fragment)
     }
@@ -88,6 +95,7 @@ impl TfEmitter for AzureStorageEmitter {
         let _ = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("subscriptionId", expr::raw("var.azure_subscription_id")),
             ("resourceGroup", expr::raw("var.azure_resource_group_name")),
@@ -97,24 +105,31 @@ impl TfEmitter for AzureStorageEmitter {
             ),
             (
                 "containerName",
-                expr::traversal(["azurerm_storage_container", label, "name"]),
+                enabled::attribute(enabled_when, "azurerm_storage_container", label, "name"),
             ),
         ]))
+    }
+
+    fn supports_enabled_when(&self) -> bool {
+        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let _ = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("blob".to_string())),
+            // The storage account hosting the container is ungated; only the
+            // container below is counted.
             (
                 "accountName",
                 expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
             ),
             (
                 "containerName",
-                expr::traversal(["azurerm_storage_container", label, "name"]),
+                enabled::attribute(enabled_when, "azurerm_storage_container", label, "name"),
             ),
         ])))
     }
@@ -154,7 +169,8 @@ fn lifecycle_policy(
     storage_label: &str,
     parent_label: &str,
     rules: &[LifecycleRule],
-) -> hcl::structure::Block {
+    enabled_when: Option<&str>,
+) -> Result<hcl::structure::Block> {
     let rule_blocks: Vec<hcl::structure::Structure> = rules
         .iter()
         .enumerate()
@@ -167,7 +183,9 @@ fn lifecycle_policy(
     )];
     body.extend(rule_blocks);
 
-    resource_block("azurerm_storage_management_policy", storage_label, body)
+    let mut policy = resource_block("azurerm_storage_management_policy", storage_label, body);
+    enabled::gate(&mut policy, enabled_when)?;
+    Ok(policy)
 }
 
 fn emit_storage_permissions(
@@ -175,6 +193,7 @@ fn emit_storage_permissions(
     storage_label: &str,
     parent_label: &str,
     fragment: &mut TfFragment,
+    enabled_when: Option<&str>,
 ) -> Result<()> {
     for (profile_name, permission_set_refs) in storage_permission_owners(ctx) {
         let Some(principal_id_expr) = service_account_principal_id(ctx, &profile_name) else {
@@ -232,7 +251,8 @@ fn emit_storage_permissions(
                     expr::template(binding.scope.clone()),
                     role_definition_id,
                     principal_id_expr.clone(),
-                );
+                    enabled_when,
+                )?;
             }
         }
     }
@@ -296,7 +316,8 @@ fn emit_storage_permissions(
                 expr::template(binding.scope.clone()),
                 role_definition_id,
                 principal_id_expr.clone(),
-            );
+                enabled_when,
+            )?;
         }
     }
 
@@ -348,9 +369,10 @@ fn emit_role_assignment(
     scope: Expression,
     role_definition_id: Expression,
     principal_id_expr: Expression,
-) {
+    enabled_when: Option<&str>,
+) -> Result<()> {
     let role_label = sanitize_role_label(role_name);
-    fragment.resource_blocks.push(resource_block(
+    let mut assignment = resource_block(
         "azurerm_role_assignment",
         &format!("{storage_label}_{role_label}_{principal_label}_assignment_{binding_index}"),
         [
@@ -364,7 +386,11 @@ fn emit_role_assignment(
             attr("role_definition_id", role_definition_id),
             attr("principal_id", principal_id_expr),
         ],
-    ));
+    );
+    // The grant exists only to reach this container, so it follows the same gate.
+    enabled::gate(&mut assignment, enabled_when)?;
+    fragment.resource_blocks.push(assignment);
+    Ok(())
 }
 
 fn storage_permission_owners<'a>(

--- a/crates/alien-terraform/src/emitters/gcp/queue.rs
+++ b/crates/alien-terraform/src/emitters/gcp/queue.rs
@@ -8,6 +8,7 @@
 use crate::{
     block::{attr, block, nested, resource_block},
     emitter::{TfEmitter, TfFragment},
+    emitters::enabled,
     emitters::gcp::helpers::{
         binding_label_for_role, downcast, emit_custom_roles_for_bindings, labels,
         permission_context, required_label, resource_prefix_template, role_expression_for_binding,
@@ -30,8 +31,9 @@ impl TfEmitter for GcpQueueEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
-        let topic = resource_block(
+        let mut topic = resource_block(
             "google_pubsub_topic",
             label,
             [
@@ -40,9 +42,10 @@ impl TfEmitter for GcpQueueEmitter {
                 attr("labels", labels(ctx, "queue")),
             ],
         );
+        enabled::gate(&mut topic, enabled_when)?;
 
         let ack_deadline = ack_deadline_for(ctx);
-        let subscription = resource_block(
+        let mut subscription = resource_block(
             "google_pubsub_subscription",
             label,
             [
@@ -51,9 +54,10 @@ impl TfEmitter for GcpQueueEmitter {
                     expr::template(format!("${{local.resource_prefix}}-{}-default", queue.id())),
                 ),
                 attr("project", expr::raw("var.gcp_project")),
+                // The topic belongs to this same resource, so it is counted too.
                 attr(
                     "topic",
-                    expr::traversal(["google_pubsub_topic", label, "id"]),
+                    enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
                 ),
                 attr(
                     "ack_deadline_seconds",
@@ -71,58 +75,83 @@ impl TfEmitter for GcpQueueEmitter {
                 attr("labels", labels(ctx, "queue")),
             ],
         );
+        enabled::gate(&mut subscription, enabled_when)?;
 
         let mut fragment = TfFragment::default();
         fragment.resource_blocks.push(topic);
         fragment.resource_blocks.push(subscription);
-        emit_queue_iam(ctx, &mut fragment, label)?;
+        emit_queue_iam(ctx, &mut fragment, label, enabled_when)?;
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "topicId",
-                expr::traversal(["google_pubsub_topic", label, "name"]),
+                enabled::attribute(enabled_when, "google_pubsub_topic", label, "name"),
             ),
             (
                 "topicName",
-                expr::traversal(["google_pubsub_topic", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
             ),
             (
                 "subscriptionId",
-                expr::traversal(["google_pubsub_subscription", label, "name"]),
+                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "name"),
             ),
             (
                 "subscriptionName",
-                expr::traversal(["google_pubsub_subscription", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "id"),
             ),
         ]))
     }
 
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("pubsub".to_string())),
             (
                 "topic",
-                expr::traversal(["google_pubsub_topic", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
             ),
             (
                 "subscription",
-                expr::traversal(["google_pubsub_subscription", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "id"),
             ),
         ])))
     }
 }
 
-fn emit_queue_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
+/// Address of one of this queue's own blocks, indexed when the queue is gated.
+///
+/// The IAM members below reference the topic and the subscription from raw
+/// strings as well as from expressions, so both forms have to agree on whether
+/// the `[0]` is there.
+fn own_block(enabled_when: Option<&str>, resource_type: &str, label: &str) -> String {
+    match enabled_when {
+        Some(_) => format!("{resource_type}.{label}[0]"),
+        None => format!("{resource_type}.{label}"),
+    }
+}
+
+fn emit_queue_iam(
+    ctx: &EmitContext<'_>,
+    fragment: &mut TfFragment,
+    label: &str,
+    enabled_when: Option<&str>,
+) -> Result<()> {
     for (owner_label, permission_refs) in queue_permission_owners(ctx) {
         let member = service_account_member_for_label(&owner_label);
+        let topic_ref = own_block(enabled_when, "google_pubsub_topic", label);
         let context = permission_context(&owner_label, ctx.stack.id())
-            .with_resource_name(format!("${{google_pubsub_topic.{label}.name}}"));
+            .with_resource_name(format!("${{{topic_ref}.name}}"));
         let generator = GcpRuntimePermissionsGenerator::new();
 
         for permission_ref in permission_refs {
@@ -156,34 +185,50 @@ fn emit_queue_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str)
                 let role = role_expression_for_binding(&binding.role, &custom_roles)?;
                 match resource_kind {
                     GcpBindingResourceKind::PubsubTopic => {
-                        fragment.resource_blocks.push(resource_block(
+                        let mut member_block = resource_block(
                             "google_pubsub_topic_iam_member",
                             &format!("{role_label}_{label}_{owner_label}_topic_{idx}"),
                             [
                                 attr("project", expr::raw("var.gcp_project")),
                                 attr(
                                     "topic",
-                                    expr::traversal(["google_pubsub_topic", label, "name"]),
+                                    enabled::attribute(
+                                        enabled_when,
+                                        "google_pubsub_topic",
+                                        label,
+                                        "name",
+                                    ),
                                 ),
                                 attr("role", role),
                                 attr("member", member.clone()),
                             ],
-                        ));
+                        );
+                        // The grant targets this queue's topic, so it only
+                        // exists while the topic does.
+                        enabled::gate(&mut member_block, enabled_when)?;
+                        fragment.resource_blocks.push(member_block);
                     }
                     GcpBindingResourceKind::PubsubSubscription => {
-                        fragment.resource_blocks.push(resource_block(
+                        let mut member_block = resource_block(
                             "google_pubsub_subscription_iam_member",
                             &format!("{role_label}_{label}_{owner_label}_subscription_{idx}"),
                             [
                                 attr("project", expr::raw("var.gcp_project")),
                                 attr(
                                     "subscription",
-                                    expr::traversal(["google_pubsub_subscription", label, "name"]),
+                                    enabled::attribute(
+                                        enabled_when,
+                                        "google_pubsub_subscription",
+                                        label,
+                                        "name",
+                                    ),
                                 ),
                                 attr("role", role),
                                 attr("member", member.clone()),
                             ],
-                        ));
+                        );
+                        enabled::gate(&mut member_block, enabled_when)?;
+                        fragment.resource_blocks.push(member_block);
                     }
                     GcpBindingResourceKind::ArtifactRegistryRepository => {}
                 }

--- a/crates/alien-terraform/src/emitters/gcp/storage.rs
+++ b/crates/alien-terraform/src/emitters/gcp/storage.rs
@@ -8,6 +8,7 @@
 use crate::{
     block::{attr, block, nested, resource_block},
     emitter::{TfEmitter, TfFragment},
+    emitters::enabled,
     emitters::gcp::helpers::{
         binding_label_for_role, downcast, emit_custom_roles_for_bindings, labels,
         permission_context, required_label, resource_prefix_template, role_expression_for_binding,
@@ -33,51 +34,67 @@ impl TfEmitter for GcpStorageEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let storage = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         let mut fragment = TfFragment::default();
 
-        fragment.resource_blocks.push(bucket(label, ctx, storage));
+        fragment
+            .resource_blocks
+            .push(bucket(label, ctx, storage, enabled_when)?);
 
         if storage.public_read {
-            fragment.resource_blocks.push(public_iam_binding(label));
+            fragment
+                .resource_blocks
+                .push(public_iam_binding(label, enabled_when)?);
         }
 
-        emit_storage_iam(ctx, &mut fragment, label)?;
+        emit_storage_iam(ctx, &mut fragment, label, enabled_when)?;
 
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             (
                 "bucketName",
-                expr::traversal(["google_storage_bucket", label, "name"]),
+                enabled::attribute(enabled_when, "google_storage_bucket", label, "name"),
             ),
             (
                 "bucketSelfLink",
-                expr::traversal(["google_storage_bucket", label, "self_link"]),
+                enabled::attribute(enabled_when, "google_storage_bucket", label, "self_link"),
             ),
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "location",
-                expr::traversal(["google_storage_bucket", label, "location"]),
+                enabled::attribute(enabled_when, "google_storage_bucket", label, "location"),
             ),
         ]))
     }
 
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("gcs".to_string())),
             (
                 "bucketName",
-                expr::traversal(["google_storage_bucket", label, "name"]),
+                enabled::attribute(enabled_when, "google_storage_bucket", label, "name"),
             ),
         ])))
     }
 }
 
-fn bucket(label: &str, ctx: &EmitContext<'_>, storage: &Storage) -> hcl::structure::Block {
+fn bucket(
+    label: &str,
+    ctx: &EmitContext<'_>,
+    storage: &Storage,
+    enabled_when: Option<&str>,
+) -> Result<hcl::structure::Block> {
     let mut body: Vec<hcl::structure::Structure> = vec![
         attr("name", resource_prefix_template(storage.id())),
         attr("project", expr::raw("var.gcp_project")),
@@ -107,7 +124,9 @@ fn bucket(label: &str, ctx: &EmitContext<'_>, storage: &Storage) -> hcl::structu
         body.push(nested(lifecycle_rule_block(rule)));
     }
 
-    resource_block("google_storage_bucket", label, body)
+    let mut bucket = resource_block("google_storage_bucket", label, body);
+    enabled::gate(&mut bucket, enabled_when)?;
+    Ok(bucket)
 }
 
 fn lifecycle_rule_block(rule: &LifecycleRule) -> hcl::structure::Block {
@@ -133,29 +152,41 @@ fn lifecycle_rule_block(rule: &LifecycleRule) -> hcl::structure::Block {
     )
 }
 
-fn public_iam_binding(label: &str) -> hcl::structure::Block {
-    resource_block(
+fn public_iam_binding(label: &str, enabled_when: Option<&str>) -> Result<hcl::structure::Block> {
+    let mut binding = resource_block(
         "google_storage_bucket_iam_member",
         &format!("{label}_public_read"),
         [
-            attr(
-                "bucket",
-                expr::traversal(["google_storage_bucket", label, "name"]),
-            ),
+            attr("bucket", bucket_name(label, enabled_when)),
             attr(
                 "role",
                 Expression::String("roles/storage.objectViewer".to_string()),
             ),
             attr("member", Expression::String("allUsers".to_string())),
         ],
-    )
+    );
+    enabled::gate(&mut binding, enabled_when)?;
+    Ok(binding)
 }
 
-fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
+fn bucket_name(label: &str, enabled_when: Option<&str>) -> Expression {
+    enabled::attribute(enabled_when, "google_storage_bucket", label, "name")
+}
+
+fn emit_storage_iam(
+    ctx: &EmitContext<'_>,
+    fragment: &mut TfFragment,
+    label: &str,
+    enabled_when: Option<&str>,
+) -> Result<()> {
     for (owner_label, permission_refs) in storage_permission_owners(ctx) {
         let member = service_account_member_for_label(&owner_label);
-        let context = permission_context(&owner_label, ctx.stack.id())
-            .with_resource_name(format!("${{google_storage_bucket.{label}.name}}"));
+        let bucket_ref = match enabled_when {
+            Some(_) => format!("${{google_storage_bucket.{label}[0].name}}"),
+            None => format!("${{google_storage_bucket.{label}.name}}"),
+        };
+        let context =
+            permission_context(&owner_label, ctx.stack.id()).with_resource_name(bucket_ref);
         let generator = GcpRuntimePermissionsGenerator::new();
 
         for permission_ref in permission_refs {
@@ -177,16 +208,18 @@ fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &st
                     ),
                 })?;
             let bindings = grant_plan.bindings_for_target(GcpBindingTargetScope::CurrentResource);
+            // Custom roles carry their own `var.gcp_manage_custom_roles` count
+            // and are referenced through it, so the deployer's gate stays off
+            // them: a second `count` on one block is not renderable. A declined
+            // bucket then leaves a role definition that grants nothing, which is
+            // harmless.
             let custom_roles = emit_custom_roles_for_bindings(fragment, &grant_plan, &bindings)?;
 
             for (idx, binding) in bindings.into_iter().enumerate() {
                 let role_label = binding_label_for_role(&binding.role, &custom_roles)?;
                 let role = role_expression_for_binding(&binding.role, &custom_roles)?;
                 let mut body = vec![
-                    attr(
-                        "bucket",
-                        expr::traversal(["google_storage_bucket", label, "name"]),
-                    ),
+                    attr("bucket", bucket_name(label, enabled_when)),
                     attr("role", role),
                     attr("member", member.clone()),
                 ];
@@ -200,11 +233,13 @@ fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &st
                         ],
                     )));
                 }
-                fragment.resource_blocks.push(resource_block(
+                let mut member_block = resource_block(
                     "google_storage_bucket_iam_member",
                     &format!("{role_label}_{label}_{owner_label}_storage_{idx}"),
                     body,
-                ));
+                );
+                enabled::gate(&mut member_block, enabled_when)?;
+                fragment.resource_blocks.push(member_block);
             }
         }
     }

--- a/crates/alien-terraform/tests/generator.rs
+++ b/crates/alien-terraform/tests/generator.rs
@@ -17,6 +17,7 @@ mod generator {
     pub mod azure_data_layer_tests;
     pub mod azure_full_stack_tests;
     pub mod azure_identity_tests;
+    pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod gcp_compute_tests;
     pub mod gcp_data_layer_tests;

--- a/crates/alien-terraform/tests/generator.rs
+++ b/crates/alien-terraform/tests/generator.rs
@@ -17,6 +17,7 @@ mod generator {
     pub mod azure_data_layer_tests;
     pub mod azure_full_stack_tests;
     pub mod azure_identity_tests;
+    pub mod enabled_queue_tests;
     pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod gcp_compute_tests;

--- a/crates/alien-terraform/tests/generator/enabled_queue_tests.rs
+++ b/crates/alien-terraform/tests/generator/enabled_queue_tests.rs
@@ -1,0 +1,330 @@
+//! `.enabled(input)` for `Queue`.
+//!
+//! `enabled_tests.rs` covers the mechanics on `Kv`. A queue adds the shape `Kv`
+//! never had: it owns more than one block and grants IAM against them. The
+//! recurring failure mode is a self-reference that keeps rendering after its
+//! resource became a list — valid HCL, rejected by `terraform validate` — so
+//! every gated scenario here is linted.
+
+use super::helpers::{
+    assert_terraform_valid, assert_ungated_registration_list_is_a_plain_array,
+    declared_block_types, gate_input, gated_block_types, normalized, render,
+};
+use alien_core::{
+    AzureResourceGroup, AzureServiceBusNamespace, PermissionProfile, Queue, ResourceLifecycle,
+    ServiceAccount, Stack, StackBuilder, StackInputDefinition, StackSettings,
+};
+use alien_terraform::TerraformTarget;
+
+const QUEUE_GATE: &str = "count = var.input_queue_enabled ? 1 : 0";
+
+fn gate_inputs() -> Vec<StackInputDefinition> {
+    vec![gate_input(
+        "queueEnabled",
+        "queue",
+        "Whether to create the queue.",
+    )]
+}
+
+/// A gated resource has to keep rendering valid Terraform for everything that
+/// points at it, and IAM is where the pointers are. A stack without a permission
+/// profile emits no IAM blocks at all, so a missed index would never reach
+/// `terraform validate` — which is exactly how this bug ships.
+fn permissioned(builder: StackBuilder, resource_id: &str, permissions: &[&str]) -> StackBuilder {
+    builder
+        .permission(
+            "execution",
+            PermissionProfile::new().resource(resource_id, permissions.to_vec()),
+        )
+        .add(
+            ServiceAccount::new("execution-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn queue_stack(gated: bool) -> Stack {
+    let builder = permissioned(
+        Stack::new("gated-stack".to_string()).inputs(gate_inputs()),
+        "jobs",
+        &["queue/data-write"],
+    );
+    add_queue(builder, gated).build()
+}
+
+/// `queue/management` grants raw permissions, so the emitter defines a project
+/// custom role for it — the shared block a resource's gate must never reach.
+/// `queue/data-write` (used above) is only predefined roles, so it emits no
+/// custom role at all: the gate-exclusion test needs this fixture to have
+/// anything to check.
+fn custom_role_queue_stack(gated: bool) -> Stack {
+    let builder = permissioned(
+        Stack::new("gated-stack".to_string()).inputs(gate_inputs()),
+        "jobs",
+        &["queue/management"],
+    );
+    add_queue(builder, gated).build()
+}
+
+/// Azure realises the queue inside a shared Service Bus namespace. The rebuild
+/// preflight injects that namespace and its resource group at runtime; neither
+/// is gated, only what the tests add on top.
+fn azure_queue_stack(gated: bool) -> Stack {
+    let builder = Stack::new("gated-stack".to_string())
+        .inputs(gate_inputs())
+        .add(
+            AzureResourceGroup::new("default-resource-group".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            AzureServiceBusNamespace::new("default-service-bus-namespace".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        );
+    add_queue(builder, gated).build()
+}
+
+fn add_queue(builder: StackBuilder, gated: bool) -> StackBuilder {
+    let queue = Queue::new("jobs".to_string()).build();
+    if gated {
+        builder.add_enabled_when(queue, ResourceLifecycle::Frozen, "queueEnabled")
+    } else {
+        builder.add(queue, ResourceLifecycle::Frozen)
+    }
+}
+
+/// The registration list only changes shape once something in the stack is
+/// gated, and a declined resource contributes no entry rather than a null one.
+fn assert_gated_registration_list(main: &str, gate_variable: &str) {
+    assert!(
+        main.contains("deployment_resources = concat("),
+        "a gated stack splices its registration list together:\n{main}"
+    );
+    assert!(
+        main.contains(&format!("{gate_variable} ? [")) && main.contains("] : []"),
+        "the gated entry must collapse to an empty list, not to null:\n{main}"
+    );
+    assert!(
+        !main.contains(": null"),
+        "no null may reach the registration payload:\n{main}"
+    );
+}
+
+// ---------------------------------------------------------------- AWS queue
+
+#[test]
+fn a_gated_aws_queue_is_counted_and_indexed() {
+    let module = render(
+        &queue_stack(true),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("resource \"aws_sqs_queue\""),
+        "the queue block is still declared:\n{main}"
+    );
+    assert!(
+        main.contains(QUEUE_GATE),
+        "the queue must be created only when the deployer says yes:\n{main}"
+    );
+    for attribute in ["name", "url", "arn"] {
+        assert!(
+            main.contains(&format!("aws_sqs_queue.jobs[0].{attribute}")),
+            "every self-reference must be indexed, not just the first ({attribute}):\n{main}"
+        );
+    }
+    assert_gated_registration_list(main, "var.input_queue_enabled");
+    assert_terraform_valid(&module, "gated aws queue stack");
+}
+
+#[test]
+fn an_ungated_aws_queue_is_untouched() {
+    let module = render(
+        &queue_stack(false),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("aws_sqs_queue.jobs[0]"),
+        "no indexing on an ungated queue:\n{main}"
+    );
+    assert!(
+        main.contains("aws_sqs_queue.jobs.arn"),
+        "references stay unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains(QUEUE_GATE),
+        "nothing is gated, so no count belongs in the module:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+}
+
+// ---------------------------------------------------------------- GCP queue
+
+/// GCP is the only cloud where one Alien queue owns two blocks, and the
+/// subscription points at the topic. Gating one without the other renders fine
+/// and fails `terraform validate`.
+#[test]
+fn a_gated_gcp_queue_counts_both_of_its_blocks() {
+    let module = render(
+        &queue_stack(true),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert_eq!(
+        main.matches(QUEUE_GATE).count(),
+        5,
+        "topic, subscription and the three IAM members all follow the gate:\n{main}"
+    );
+    assert!(
+        main.contains("topic = google_pubsub_topic.jobs[0].id"),
+        "the subscription points at the counted topic:\n{main}"
+    );
+    assert_terraform_valid(&module, "gated gcp queue stack");
+}
+
+/// The IAM members grant against the topic and the subscription by name. They
+/// are the references most easily missed, because a stack without a permission
+/// profile does not render them at all.
+#[test]
+fn a_gated_gcp_queue_leaves_no_unindexed_self_reference() {
+    let module = render(
+        &queue_stack(true),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("google_pubsub_topic_iam_member"),
+        "the fixture must actually render queue IAM, or this test proves nothing:\n{main}"
+    );
+    assert!(
+        main.contains("topic = google_pubsub_topic.jobs[0].name")
+            && main.contains("subscription = google_pubsub_subscription.jobs[0].name"),
+        "IAM members address the counted instances:\n{main}"
+    );
+    for block in ["google_pubsub_topic", "google_pubsub_subscription"] {
+        assert!(
+            !main.contains(&format!("{block}.jobs.")),
+            "no attribute may be read off {block} without an index:\n{main}"
+        );
+    }
+    assert_gated_registration_list(main, "var.input_queue_enabled");
+}
+
+/// The project-wide custom roles are shared across resources and carry their own
+/// `var.gcp_manage_custom_roles` count. Tying them to one resource's gate would
+/// delete roles other resources still need.
+#[test]
+fn a_gated_gcp_queue_leaves_shared_custom_roles_alone() {
+    let module = render(
+        &custom_role_queue_stack(true),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        declared_block_types(main)
+            .iter()
+            .any(|found| found == "google_project_iam_custom_role"),
+        "the fixture must actually produce a custom role, or this proves nothing:\n{main}"
+    );
+    assert!(
+        !gated_block_types(main, QUEUE_GATE)
+            .iter()
+            .any(|found| found == "google_project_iam_custom_role"),
+        "a shared custom role must not follow one resource's gate:\n{main}"
+    );
+    assert!(
+        main.contains("var.gcp_manage_custom_roles ? 1 : 0"),
+        "the custom role keeps its own count:\n{main}"
+    );
+}
+
+#[test]
+fn an_ungated_gcp_queue_is_untouched() {
+    let module = render(
+        &queue_stack(false),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("google_pubsub_topic.jobs[0]")
+            && !main.contains("google_pubsub_subscription.jobs[0]"),
+        "no indexing on an ungated queue:\n{main}"
+    );
+    assert!(
+        main.contains("topic = google_pubsub_topic.jobs.id"),
+        "references stay unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains(QUEUE_GATE),
+        "nothing is gated, so no gate count belongs in the module:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+}
+
+// -------------------------------------------------------------- Azure queue
+
+/// The Azure payload mixes the gated queue with the ungated namespace hosting
+/// it. Indexing the latter would produce Terraform that does not validate.
+#[test]
+fn a_gated_azure_queue_indexes_only_its_own_references() {
+    let module = render(
+        &azure_queue_stack(true),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains(QUEUE_GATE),
+        "the queue must be created only when the deployer says yes:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_servicebus_queue.jobs[0].name"),
+        "references to the counted queue must be indexed:\n{main}"
+    );
+    assert!(
+        !main.contains("azurerm_servicebus_namespace.default_service_bus_namespace[0]"),
+        "the parent namespace is not counted, so it must stay unindexed:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_servicebus_namespace.default_service_bus_namespace.name"),
+        "the parent namespace name is still read directly:\n{main}"
+    );
+    assert_gated_registration_list(main, "var.input_queue_enabled");
+    assert_terraform_valid(&module, "gated azure queue stack");
+}
+
+#[test]
+fn an_ungated_azure_queue_is_untouched() {
+    let module = render(
+        &azure_queue_stack(false),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("azurerm_servicebus_queue.jobs[0]"),
+        "no indexing on an ungated queue:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_servicebus_queue.jobs.name"),
+        "references stay unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains(QUEUE_GATE),
+        "nothing is gated, so no count belongs in the module:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+}

--- a/crates/alien-terraform/tests/generator/enabled_storage_tests.rs
+++ b/crates/alien-terraform/tests/generator/enabled_storage_tests.rs
@@ -1,0 +1,497 @@
+//! `.enabled(input)` on `storage` — the multi-block case.
+//!
+//! `kv` renders one block, so gating it is one `count` and one indexed
+//! reference. `storage` renders a bucket plus a run of configuration siblings
+//! (encryption, ownership, public-access block, policy, versioning, lifecycle)
+//! and the IAM policies that name the bucket. Two ways to get that wrong:
+//!
+//! - a sibling without `count` outlives the bucket and, at apply time, points
+//!   at an element of an empty list
+//! - a self-reference without `[0]` does not survive `terraform validate` at all
+//!
+//! Every stack below therefore turns on versioning and lifecycle rules (so the
+//! optional blocks render) and grants a service account access to the bucket
+//! (so the IAM policies render), then runs the real `terraform validate`.
+
+use super::helpers::{
+    assert_terraform_valid, assert_ungated_registration_list_is_a_plain_array, gate_input,
+    normalized, render,
+};
+use alien_core::{
+    AzureResourceGroup, AzureStorageAccount, LifecycleRule, PermissionProfile, ResourceLifecycle,
+    ServiceAccount, Stack, StackBuilder, StackSettings, Storage,
+};
+use alien_terraform::TerraformTarget;
+
+const GATE: &str = "count = var.input_files_enabled ? 1 : 0";
+
+/// Versioning and lifecycle rules are on so the optional blocks render, and the
+/// permission profile is what makes the emitter produce IAM policies naming the
+/// bucket. Both are the parts a single-block resource never exercises.
+fn storage() -> Storage {
+    Storage::new("files".to_string())
+        .versioning(true)
+        .lifecycle_rules(vec![LifecycleRule {
+            days: 30,
+            prefix: Some("tmp/".to_string()),
+        }])
+        .build()
+}
+
+fn stack_base() -> StackBuilder {
+    Stack::new("gated-storage".to_string())
+        .inputs(vec![gate_input(
+            "filesEnabled",
+            "Enable the bucket",
+            "Whether to create the object-storage bucket.",
+        )])
+        .permission(
+            "app",
+            PermissionProfile::new().resource(
+                "files",
+                ["storage/data-write", "storage/trigger-management"],
+            ),
+        )
+        .add(
+            ServiceAccount::new("app-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn gated_stack() -> Stack {
+    stack_base()
+        .add_enabled_when(storage(), ResourceLifecycle::Frozen, "filesEnabled")
+        .build()
+}
+
+fn ungated_stack() -> Stack {
+    stack_base()
+        .add(storage(), ResourceLifecycle::Frozen)
+        .build()
+}
+
+/// Azure realises a bucket as a container inside a shared Storage account, so
+/// the stack needs the auxiliary resources the preflight pipeline injects.
+/// Neither of them is gated; only the container on top.
+fn azure_stack_base() -> StackBuilder {
+    stack_base()
+        .add(
+            AzureResourceGroup::new("default-resource-group".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            AzureStorageAccount::new("default-storage-account".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn gated_azure_stack() -> Stack {
+    azure_stack_base()
+        .add_enabled_when(storage(), ResourceLifecycle::Frozen, "filesEnabled")
+        .build()
+}
+
+fn ungated_azure_stack() -> Stack {
+    azure_stack_base()
+        .add(storage(), ResourceLifecycle::Frozen)
+        .build()
+}
+
+/// Count the `resource "<type>" "<label>"` headers that carry the gate, so the
+/// assertion is "all of them" rather than "at least the one I looked at".
+fn gated_block_types(main: &str) -> Vec<String> {
+    let mut types = Vec::new();
+    for (index, _) in main.match_indices("resource \"") {
+        let rest = &main[index + "resource \"".len()..];
+        let Some((block_type, tail)) = rest.split_once('"') else {
+            continue;
+        };
+        // The block body runs to the next `resource "` header.
+        let body_end = tail.find("resource \"").unwrap_or(tail.len());
+        if tail[..body_end].contains(GATE) {
+            types.push(block_type.to_string());
+        }
+    }
+    types
+}
+
+fn declared_block_types(main: &str) -> Vec<String> {
+    main.match_indices("resource \"")
+        .filter_map(|(index, _)| {
+            main[index + "resource \"".len()..]
+                .split_once('"')
+                .map(|(block_type, _)| block_type.to_string())
+        })
+        .collect()
+}
+
+/// The whole point: the bucket disappears together with every sibling that only
+/// describes it. A sibling left behind would reference an element of an empty
+/// list the moment the deployer says no.
+#[test]
+fn every_aws_storage_block_carries_the_gate() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    let expected = [
+        "aws_s3_bucket",
+        "aws_s3_bucket_server_side_encryption_configuration",
+        "aws_s3_bucket_ownership_controls",
+        "aws_s3_bucket_public_access_block",
+        "aws_s3_bucket_policy",
+        "aws_s3_bucket_versioning",
+        "aws_s3_bucket_lifecycle_configuration",
+    ];
+    let gated = gated_block_types(main);
+    for block_type in expected {
+        assert!(
+            gated.iter().any(|found| found == block_type),
+            "`{block_type}` must be created only when the deployer says yes:\n{main}"
+        );
+    }
+
+    // The IAM policy embeds the bucket name in its document, so it cannot
+    // outlive the bucket either.
+    assert!(
+        gated.iter().any(|found| found == "aws_iam_role_policy"),
+        "the bucket's IAM policy must follow the same gate:\n{main}"
+    );
+
+    assert_terraform_valid(&module, "gated aws storage stack");
+}
+
+/// The failure this guards against renders fine and only breaks at
+/// `terraform validate`: one sibling reading `aws_s3_bucket.files.id` while the
+/// bucket is a counted list.
+#[test]
+fn aws_storage_indexes_every_self_reference() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    for attribute in ["id", "bucket", "arn"] {
+        assert!(
+            !main.contains(&format!("aws_s3_bucket.files.{attribute}")),
+            "no unindexed `{attribute}` reference may survive:\n{main}"
+        );
+    }
+    assert!(
+        main.contains("aws_s3_bucket.files[0].id"),
+        "the siblings read the counted bucket by index:\n{main}"
+    );
+    assert!(
+        main.contains("aws_s3_bucket.files[0].arn"),
+        "the bucket policy reads the counted bucket by index:\n{main}"
+    );
+    assert!(
+        main.contains("aws_s3_bucket.files[0].bucket"),
+        "the import ref and IAM policy read the counted bucket by index:\n{main}"
+    );
+}
+
+/// The IAM policy is attached to a role this emitter does not own. Indexing that
+/// role would produce Terraform that does not validate.
+#[test]
+fn aws_storage_leaves_the_service_account_role_unindexed() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("aws_iam_role.app_sa.id"),
+        "the role the policy attaches to is ungated, so it stays unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains("aws_iam_role.app_sa[0]"),
+        "the service-account role is not counted:\n{main}"
+    );
+}
+
+/// The manager deserializes every registration entry into typed import data with
+/// required fields, so a declined bucket has to be absent from the list rather
+/// than present with a null payload.
+#[test]
+fn a_declined_aws_bucket_drops_out_of_the_registration_list() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("deployment_resources = concat("),
+        "a gated stack splices its registration list together:\n{main}"
+    );
+    assert!(
+        main.contains("var.input_files_enabled ? [") && main.contains("] : []"),
+        "the gated entry must collapse to an empty list, not to null:\n{main}"
+    );
+    assert!(
+        !main.contains(": null"),
+        "no null may reach the registration payload:\n{main}"
+    );
+}
+
+/// Ungated stacks are untouched: opt-in means no `.enabled(...)`, so no counts
+/// and no indexing.
+#[test]
+fn an_ungated_aws_storage_stack_is_untouched() {
+    let module = render(
+        &ungated_stack(),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        gated_block_types(main).is_empty(),
+        "nothing is gated, so no block gains a count:\n{main}"
+    );
+    assert!(
+        !main.contains("aws_s3_bucket.files[0]"),
+        "no indexing on an ungated bucket:\n{main}"
+    );
+    assert!(
+        main.contains("aws_s3_bucket.files.id"),
+        "references stay unindexed:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+    assert_terraform_valid(&module, "ungated aws storage stack");
+}
+
+#[test]
+fn every_gcp_storage_block_carries_the_gate() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    let gated = gated_block_types(main);
+    assert!(
+        gated.iter().any(|found| found == "google_storage_bucket"),
+        "the bucket must be created only when the deployer says yes:\n{main}"
+    );
+    assert!(
+        gated
+            .iter()
+            .any(|found| found == "google_storage_bucket_iam_member"),
+        "a grant on the bucket cannot outlive it:\n{main}"
+    );
+    assert!(
+        gated
+            .iter()
+            .any(|found| found == "google_project_iam_member"),
+        "the project-scoped signBlob grant renders through the service-account \
+         path, not this emitter, so it must still follow the bucket's gate:\n{main}"
+    );
+    assert!(
+        !main.contains("google_storage_bucket.files.name"),
+        "no unindexed reference may survive:\n{main}"
+    );
+    assert!(
+        main.contains("google_storage_bucket.files[0].name"),
+        "the grants read the counted bucket by index:\n{main}"
+    );
+    assert_terraform_valid(&module, "gated gcp storage stack");
+}
+
+/// `storage/trigger-management` grants raw GCP permissions at bucket scope, so
+/// this emitter defines a custom role for it. That block already carries its own
+/// `var.gcp_manage_custom_roles` count and is referenced through it, so the
+/// deployer's gate must stay off it — a second `count` on one block is not
+/// renderable, and re-pointing the reference is not this emitter's to do.
+#[test]
+fn gcp_custom_roles_keep_their_own_gate() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        declared_block_types(main)
+            .iter()
+            .any(|found| found == "google_project_iam_custom_role"),
+        "the fixture must actually produce a custom role, or this proves nothing:\n{main}"
+    );
+    assert!(
+        !gated_block_types(main)
+            .iter()
+            .any(|found| found == "google_project_iam_custom_role"),
+        "the custom role keeps its own count, not the deployer's:\n{main}"
+    );
+    assert!(
+        main.contains("var.gcp_manage_custom_roles ? 1 : 0"),
+        "the custom role's own count is still there:\n{main}"
+    );
+}
+
+/// Two `count` attributes in one block is the way a blanket "gate everything in
+/// the fragment" pass fails: it renders, and Terraform rejects it.
+#[test]
+fn no_block_carries_two_counts() {
+    for target in [
+        TerraformTarget::Aws,
+        TerraformTarget::Gcp,
+        TerraformTarget::Azure,
+    ] {
+        let stack = if matches!(target, TerraformTarget::Azure) {
+            gated_azure_stack()
+        } else {
+            gated_stack()
+        };
+        let module = render(&stack, target, StackSettings::default());
+        for (path, contents) in module.iter() {
+            for block in contents.split("\nresource \"").skip(1) {
+                // Match `count` as a token, not a prefix: a name like
+                // `account = …` must not read as a count, and `terraform fmt`
+                // pads the `=` for alignment so a raw `"count ="` never matches.
+                let counts = block
+                    .lines()
+                    .filter(|line| {
+                        let mut tokens = line.split_whitespace();
+                        tokens.next() == Some("count") && tokens.next() == Some("=")
+                    })
+                    .count();
+                assert!(
+                    counts <= 1,
+                    "{target:?} {path} declares a block with {counts} counts:\n{block}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn every_gcp_storage_self_reference_is_indexed() {
+    let module = render(
+        &gated_stack(),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    for attribute in ["name", "self_link", "location"] {
+        assert!(
+            !main.contains(&format!("google_storage_bucket.files.{attribute}")),
+            "no unindexed `{attribute}` reference may survive:\n{main}"
+        );
+    }
+    assert!(
+        main.contains("google_storage_bucket.files[0].self_link"),
+        "every import-ref attribute is indexed, not just the first:\n{main}"
+    );
+    assert!(
+        main.contains("google_storage_bucket.files[0].location"),
+        "every import-ref attribute is indexed, not just the first:\n{main}"
+    );
+}
+
+#[test]
+fn an_ungated_gcp_storage_stack_is_untouched() {
+    let module = render(
+        &ungated_stack(),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("google_storage_bucket.files[0]"),
+        "no indexing on an ungated bucket:\n{main}"
+    );
+    assert!(
+        main.contains("google_storage_bucket.files.name"),
+        "references stay unindexed:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+    assert_terraform_valid(&module, "ungated gcp storage stack");
+}
+
+#[test]
+fn every_azure_storage_block_carries_the_gate() {
+    let module = render(
+        &gated_azure_stack(),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    let gated = gated_block_types(main);
+    for block_type in [
+        "azurerm_storage_container",
+        "azurerm_storage_management_policy",
+        "azurerm_role_assignment",
+    ] {
+        assert!(
+            gated.iter().any(|found| found == block_type),
+            "`{block_type}` must be created only when the deployer says yes:\n{main}"
+        );
+    }
+    assert_terraform_valid(&module, "gated azure storage stack");
+}
+
+/// The Azure payload mixes references to the gated container with references to
+/// the ungated Storage account that hosts it. Indexing the latter would produce
+/// Terraform that does not validate.
+#[test]
+fn a_gated_azure_container_indexes_only_its_own_references() {
+    let module = render(
+        &gated_azure_stack(),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("azurerm_storage_container.files[0].name"),
+        "references to the counted container must be indexed:\n{main}"
+    );
+    assert!(
+        !main.contains("azurerm_storage_account.default_storage_account[0]"),
+        "the parent Storage account is not counted, so it must stay unindexed:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_storage_account.default_storage_account.name"),
+        "the parent account is still read directly:\n{main}"
+    );
+}
+
+#[test]
+fn an_ungated_azure_storage_stack_is_untouched() {
+    let module = render(
+        &ungated_azure_stack(),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        gated_block_types(main).is_empty(),
+        "nothing is gated, so no block gains a count:\n{main}"
+    );
+    assert!(
+        !main.contains("azurerm_storage_container.files[0]"),
+        "no indexing on an ungated container:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_storage_container.files.name"),
+        "references stay unindexed:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+    assert_terraform_valid(&module, "ungated azure storage stack");
+}

--- a/crates/alien-terraform/tests/generator/helpers.rs
+++ b/crates/alien-terraform/tests/generator/helpers.rs
@@ -36,6 +36,41 @@ pub fn normalized(module: &ModuleFiles) -> String {
         .join(" ")
 }
 
+/// The `resource "<type>"` headers whose block body carries `gate` (the
+/// `count = var.<input> ? 1 : 0` line), read off a `normalized` module. Lets a
+/// test assert "every block that must be gated is, and no other" by parsed
+/// structure instead of a brittle `starts_with` on the rendered string.
+#[allow(dead_code)]
+pub fn gated_block_types(main: &str, gate: &str) -> Vec<String> {
+    let mut types = Vec::new();
+    for (index, _) in main.match_indices("resource \"") {
+        let rest = &main[index + "resource \"".len()..];
+        let Some((block_type, tail)) = rest.split_once('"') else {
+            continue;
+        };
+        // The block body runs to the next `resource "` header.
+        let body_end = tail.find("resource \"").unwrap_or(tail.len());
+        if tail[..body_end].contains(gate) {
+            types.push(block_type.to_string());
+        }
+    }
+    types
+}
+
+/// Every `resource "<type>"` header the module declares, gated or not. Paired
+/// with `gated_block_types` so a gate-exclusion test first proves the block it
+/// expects to stay ungated is actually rendered.
+#[allow(dead_code)]
+pub fn declared_block_types(main: &str) -> Vec<String> {
+    main.match_indices("resource \"")
+        .filter_map(|(index, _)| {
+            main[index + "resource \"".len()..]
+                .split_once('"')
+                .map(|(block_type, _)| block_type.to_string())
+        })
+        .collect()
+}
+
 /// The registration list only changes shape once something in the stack is
 /// gated. Everything else must render exactly as it did before this feature.
 pub fn assert_ungated_registration_list_is_a_plain_array(main: &str) {


### PR DESCRIPTION
## Summary

The storage bucket gains `.enabled(input)`: a boolean deployer input decides whether
the bucket and the access it needs exist. Same treatment as kv (#174), extended to
storage across AWS, Azure, and GCP, both Terraform and CloudFormation.

When a stack renders a gated storage bucket:

1. The setup emitter puts the bucket behind its input — a Terraform `count` or a
   CloudFormation condition — so a bucket the deployer declined is never created.
2. **← the heart:** every block the bucket *owns* takes that same gate — not just
   the bucket, but its encryption, ownership controls, public-access block, bucket
   policy, versioning and lifecycle on AWS; the container and its management policy
   on Azure; and every IAM grant that names it. A sibling left ungated would
   reference `bucket[0]` of a resource that was never created — legal HCL that
   `terraform validate` accepts but that fails at apply — so the bucket and
   everything describing it live and die together.
3. Blocks the bucket does *not* own stay ungated: the shared service-account role,
   Azure's parent storage account, and GCP's project custom role (which already
   carries its own count and is deduped project-wide, so one bucket's gate must not
   reach it).

This turns storage creation from unconditional into opt-in through `.enabled()`, cloud by cloud.

## What I did

- Gated the storage bucket and every block it owns across AWS/Azure/GCP, Terraform
  and CloudFormation, indexing self-references `[0]` under the count.
- Kept the blocks a bucket doesn't own ungated, and added a test that fails if any
  block carries two counts (which is unrenderable HCL).

## Files touched

- `alien-terraform` / `alien-cloudformation` storage emitters — gate the bucket and
  its grants.
- Tests for gated storage on each cloud: per-block count coverage, self-reference
  indexing, the declined-registration payload, and the ungated-is-untouched path.

## How I tested

- `cargo test -p alien-terraform` and `cargo test -p alien-cloudformation` — 13 and 5
  gated-storage tests across AWS/Azure/GCP, with `terraform validate` / cfn-lint run
  through the test helpers.
- Because `terraform validate` accepts a childless block that references `bucket[0]`,
  the tests assert per-block count coverage directly rather than relying on validate.
- This touches IAM rendering, so:
  - A declined bucket leaving a data grant behind — every grant that names the bucket
    carries the bucket's gate, including the project-scoped GCP signBlob grant that
    renders through the service-account path (asserted in
    `every_gcp_storage_block_carries_the_gate`).
  - One bucket's gate reaching a block it doesn't own — the GCP project custom role
    keeps its own count; `no_block_carries_two_counts` fails if any block gets a
    second.
  - Nothing turned up.
