### PR TITLE
feat(queue): gate the queue on a deployer input

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/queue.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/queue.rs
@@ -66,6 +66,10 @@ impl CfEmitter for AwsQueueEmitter {
         ]))
     }
 
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {
         let queue_id = required_logical_id(ctx)?;
         Ok(Some(CfExpression::object([

--- a/crates/alien-cloudformation/tests/generator.rs
+++ b/crates/alien-cloudformation/tests/generator.rs
@@ -15,6 +15,7 @@ mod generator {
     pub mod aws_email_tests;
     pub mod aws_full_stack_tests;
     pub mod aws_open_search_tests;
+    pub mod enabled_queue_tests;
     pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod kubernetes_cluster_tests;

--- a/crates/alien-cloudformation/tests/generator/enabled_queue_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/enabled_queue_tests.rs
@@ -1,0 +1,278 @@
+//! `.enabled(input)` for `Queue` on CloudFormation.
+//!
+//! `enabled_tests.rs` covers the mechanics on `Kv`. A queue is where the
+//! registration payload gets exercised against a stack that mixes a gated
+//! resource with an ungated neighbour, on both of the paths that publish it.
+
+use super::helpers::{
+    custom_resource_registration, gate_input, render_built_ins_template, resolve, Declined,
+};
+use alien_cloudformation::{CfExpression, CfTemplate, CloudFormationTarget, RegistrationMode};
+use alien_core::{
+    PermissionProfile, Queue, ResourceLifecycle, ServiceAccount, Stack, StackBuilder,
+    StackInputDefinition, StackSettings,
+};
+use std::collections::HashMap;
+
+fn render_as(stack: &Stack, registration: RegistrationMode, description: &str) -> CfTemplate {
+    render_built_ins_template(
+        stack,
+        StackSettings::default(),
+        registration,
+        CloudFormationTarget::Aws,
+        "aws",
+        description,
+    )
+    .0
+}
+
+fn render(stack: &Stack, description: &str) -> CfTemplate {
+    render_as(stack, custom_resource_registration(), description)
+}
+
+const QUEUE_CONDITION: &str = "InputQueueEnabledIsTrue";
+
+fn gate_inputs() -> Vec<StackInputDefinition> {
+    vec![gate_input(
+        "queueEnabled",
+        "queue",
+        "Whether to create the queue.",
+    )]
+}
+
+/// The service account gives the "off" answer an ungated neighbour to leave
+/// behind, so the payload assertions say something about which entries survive
+/// rather than about the payload being empty.
+fn base() -> StackBuilder {
+    Stack::new("gated-stack".to_string())
+        .inputs(gate_inputs())
+        .permission(
+            "execution",
+            PermissionProfile::new().resource("jobs", ["queue/data-write"]),
+        )
+        .add(
+            ServiceAccount::new("execution-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn stack(gated: bool) -> Stack {
+    let queue = Queue::new("jobs".to_string()).build();
+    let builder = base();
+    if gated {
+        builder
+            .add_enabled_when(queue, ResourceLifecycle::Frozen, "queueEnabled")
+            .build()
+    } else {
+        builder.add(queue, ResourceLifecycle::Frozen).build()
+    }
+}
+
+fn registration_entry_ids(template: &CfTemplate, conditions: &HashMap<&str, bool>) -> Vec<String> {
+    let payload = template
+        .resources
+        .get("DeploymentRegistration")
+        .expect("registration custom resource")
+        .properties
+        .get("Resources")
+        .expect("registration resource list")
+        .clone();
+    let CfExpression::List(entries) = resolve(&payload, conditions, Declined::Removed)
+        .expect("payload survives condition resolution")
+    else {
+        panic!("registration payload should resolve to a list");
+    };
+    entries
+        .iter()
+        .map(|entry| {
+            let CfExpression::Object(fields) = entry else {
+                panic!("registration entry should be an object: {entry:?}");
+            };
+            match fields.get("id").expect("registration entry id") {
+                CfExpression::String(id) => id.clone(),
+                other => panic!("registration entry id should be a string: {other:?}"),
+            }
+        })
+        .collect()
+}
+
+/// The `DeploymentResources` output, resolved and parsed the way the registering
+/// consumer reads it.
+///
+/// Returns the raw text alongside the parsed value so a caller can assert on the
+/// exact bytes CloudFormation would hand over, not just on what survived
+/// `serde_json`.
+fn resolved_outputs_payload(
+    template: &CfTemplate,
+    conditions: &HashMap<&str, bool>,
+) -> (String, serde_json::Value) {
+    let value = &template
+        .outputs
+        .get("DeploymentResources")
+        .expect("outputs fallback should carry the resources payload")
+        .value;
+    let resolved = resolve(value, conditions, Declined::Removed)
+        .expect("the resources output survives condition resolution");
+    let CfExpression::String(text) = resolved else {
+        panic!("the resources output should resolve to JSON text: {resolved:?}");
+    };
+    let parsed = serde_json::from_str(&text)
+        .unwrap_or_else(|error| panic!("resources output should be valid JSON: {error}\n{text}"));
+    (text, parsed)
+}
+
+/// Extract ids from the Outputs payload, verifying that every entry is a
+/// well-formed object.
+fn outputs_entry_ids(template: &CfTemplate, conditions: &HashMap<&str, bool>) -> Vec<String> {
+    let (text, parsed) = resolved_outputs_payload(template, conditions);
+    let serde_json::Value::Array(entries) = parsed else {
+        panic!("resources output should be a JSON array: {text}");
+    };
+    entries
+        .iter()
+        .map(|entry| {
+            let id = entry
+                .get("id")
+                .unwrap_or_else(|| panic!("registration entry has no id: {entry}\n{text}"));
+            id.as_str()
+                .unwrap_or_else(|| panic!("registration entry id should be a string: {id}"))
+                .to_string()
+        })
+        .collect()
+}
+
+/// Logical ids of every resource carrying `condition`.
+fn resources_conditioned_on(template: &CfTemplate, condition: &str) -> Vec<String> {
+    let mut ids = template
+        .resources
+        .iter()
+        .filter(|(_, resource)| resource.condition.as_deref() == Some(condition))
+        .map(|(logical_id, _)| logical_id.clone())
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+#[test]
+fn a_gated_queue_is_created_only_when_the_deployer_says_yes() {
+    let template = render(&stack(true), "gated queue");
+
+    let queue = template
+        .resources
+        .get("Jobs")
+        .expect("gated queue should still be declared");
+    assert_eq!(queue.resource_type, "AWS::SQS::Queue");
+    assert_eq!(queue.condition.as_deref(), Some(QUEUE_CONDITION));
+    assert_eq!(
+        resources_conditioned_on(&template, QUEUE_CONDITION),
+        vec![
+            "Jobs".to_string(),
+            "JobsExecutionSaRoleQueuePermission00".to_string(),
+        ],
+        "the queue owns the SQS queue and its resource-scoped grant, both gated"
+    );
+}
+
+/// Registration runs the typed importer over every entry it receives, so a
+/// declined resource must be absent, not present-and-null.
+#[test]
+fn declined_resources_leave_no_registration_entry() {
+    let template = render(&stack(true), "gated queue");
+
+    let queue_on = HashMap::from([(QUEUE_CONDITION, true)]);
+    assert_eq!(
+        registration_entry_ids(&template, &queue_on),
+        vec!["execution-sa".to_string(), "jobs".to_string()],
+        "everything registers when the deployer says yes"
+    );
+
+    let queue_off = HashMap::from([(QUEUE_CONDITION, false)]);
+    assert_eq!(
+        registration_entry_ids(&template, &queue_off),
+        vec!["execution-sa".to_string()],
+        "declined resources must be absent from the payload, not null"
+    );
+}
+
+/// The same invariant on the Outputs fallback, which is the path `alien render`
+/// picks whenever no notification lambda is configured.
+///
+/// It carries the payload as JSON text rather than as a list, and the intrinsic
+/// that produces that text renders a declined entry as a literal `null` instead
+/// of dropping it. Nothing about that is visible in the rendered template — it
+/// only happens once CloudFormation resolves the conditions — so this asserts on
+/// the resolved text.
+#[test]
+fn the_outputs_fallback_omits_declined_resources() {
+    let template = render_as(
+        &stack(true),
+        RegistrationMode::OutputsFallback,
+        "gated queue, outputs fallback",
+    );
+
+    let queue_on = HashMap::from([(QUEUE_CONDITION, true)]);
+    assert_eq!(
+        outputs_entry_ids(&template, &queue_on),
+        vec!["execution-sa".to_string(), "jobs".to_string()],
+        "everything registers when the deployer says yes"
+    );
+
+    let queue_off = HashMap::from([(QUEUE_CONDITION, false)]);
+    let (text, _) = resolved_outputs_payload(&template, &queue_off);
+    assert!(
+        !text.contains("null"),
+        "a declined resource must leave nothing behind, but the payload still \
+         carries a null: {text}"
+    );
+    assert_eq!(
+        outputs_entry_ids(&template, &queue_off),
+        vec!["execution-sa".to_string()],
+        "only the ungated resource registers"
+    );
+}
+
+/// Declining every gated resource must still leave a payload the consumer can
+/// read, rather than a malformed array or a stray delimiter.
+#[test]
+fn the_outputs_fallback_survives_every_resource_being_declined() {
+    let template = render_as(
+        &Stack::new("gated-stack".to_string())
+            .inputs(gate_inputs())
+            .add_enabled_when(
+                Queue::new("jobs".to_string()).build(),
+                ResourceLifecycle::Frozen,
+                "queueEnabled",
+            )
+            .build(),
+        RegistrationMode::OutputsFallback,
+        "every resource gated, outputs fallback",
+    );
+
+    let all_off = HashMap::from([(QUEUE_CONDITION, false)]);
+    let (text, parsed) = resolved_outputs_payload(&template, &all_off);
+    assert_eq!(text, "[]", "an all-declined payload is an empty array");
+    assert_eq!(parsed, serde_json::json!([]));
+}
+
+/// Ungated stacks gain no conditions: opt-in means no `.enabled(...)`, so no gating.
+#[test]
+fn an_ungated_stack_gains_no_conditions() {
+    let template = render(&stack(false), "ungated queue");
+
+    assert!(
+        template.conditions.is_empty(),
+        "nothing is gated, so no condition belongs in the template: {:?}",
+        template.conditions
+    );
+    assert!(
+        template
+            .resources
+            .values()
+            .all(|resource| resource.condition.is_none()),
+        "no resource may carry a condition when nothing is gated"
+    );
+    assert_eq!(
+        registration_entry_ids(&template, &HashMap::new()),
+        vec!["execution-sa".to_string(), "jobs".to_string()],
+    );
+}

--- a/crates/alien-terraform/src/emitters/aws/queue.rs
+++ b/crates/alien-terraform/src/emitters/aws/queue.rs
@@ -4,6 +4,7 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::aws::helpers::{downcast, required_label, resource_prefix_template, tags},
+    emitters::enabled,
     expr,
 };
 use alien_core::{import::EmitContext, Queue, Result, Worker, WorkerTrigger};
@@ -16,8 +17,9 @@ impl TfEmitter for AwsQueueEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
-        let q = resource_block(
+        let mut q = resource_block(
             "aws_sqs_queue",
             label,
             [
@@ -34,27 +36,43 @@ impl TfEmitter for AwsQueueEmitter {
                 attr("tags", tags(ctx, "queue")),
             ],
         );
+        enabled::gate(&mut q, enabled_when)?;
 
         Ok(TfFragment::default().with_resource(q))
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             (
                 "queueName",
-                expr::traversal(["aws_sqs_queue", label, "name"]),
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "name"),
             ),
-            ("queueUrl", expr::traversal(["aws_sqs_queue", label, "url"])),
-            ("queueArn", expr::traversal(["aws_sqs_queue", label, "arn"])),
+            (
+                "queueUrl",
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "url"),
+            ),
+            (
+                "queueArn",
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "arn"),
+            ),
         ]))
+    }
+
+    fn supports_enabled_when(&self) -> bool {
+        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("sqs".to_string())),
-            ("queueUrl", expr::traversal(["aws_sqs_queue", label, "url"])),
+            (
+                "queueUrl",
+                enabled::attribute(enabled_when, "aws_sqs_queue", label, "url"),
+            ),
         ])))
     }
 }

--- a/crates/alien-terraform/src/emitters/azure/queue.rs
+++ b/crates/alien-terraform/src/emitters/azure/queue.rs
@@ -16,6 +16,7 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::azure::helpers::{downcast, required_label, resource_prefix_template},
+    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -32,14 +33,17 @@ impl TfEmitter for AzureQueueEmitter {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
         let lock_duration = lock_duration_for(ctx);
 
-        let q = resource_block(
+        let mut q = resource_block(
             "azurerm_servicebus_queue",
             label,
             [
                 attr("name", resource_prefix_template(queue.id())),
+                // The namespace is a separate, ungated resource, so this
+                // reference stays unindexed even when the queue is counted.
                 attr(
                     "namespace_id",
                     expr::traversal(["azurerm_servicebus_namespace", &parent_label, "id"]),
@@ -63,6 +67,7 @@ impl TfEmitter for AzureQueueEmitter {
                 ),
             ],
         );
+        enabled::gate(&mut q, enabled_when)?;
 
         Ok(TfFragment::default().with_resource(q))
     }
@@ -70,32 +75,42 @@ impl TfEmitter for AzureQueueEmitter {
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("subscriptionId", expr::raw("var.azure_subscription_id")),
             ("resourceGroup", expr::raw("var.azure_resource_group_name")),
+            // The namespace hosting the queue is ungated; only the queue below
+            // is counted.
             (
                 "namespaceName",
                 expr::traversal(["azurerm_servicebus_namespace", &parent_label, "name"]),
             ),
             (
                 "queueName",
-                expr::traversal(["azurerm_servicebus_queue", label, "name"]),
+                enabled::attribute(enabled_when, "azurerm_servicebus_queue", label, "name"),
             ),
         ]))
+    }
+
+    fn supports_enabled_when(&self) -> bool {
+        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("servicebus".to_string())),
+            // The namespace hosting the queue is ungated; only the queue below
+            // is counted.
             (
                 "namespace",
                 expr::traversal(["azurerm_servicebus_namespace", &parent_label, "name"]),
             ),
             (
                 "queueName",
-                expr::traversal(["azurerm_servicebus_queue", label, "name"]),
+                enabled::attribute(enabled_when, "azurerm_servicebus_queue", label, "name"),
             ),
         ])))
     }

--- a/crates/alien-terraform/src/emitters/gcp/queue.rs
+++ b/crates/alien-terraform/src/emitters/gcp/queue.rs
@@ -8,6 +8,7 @@
 use crate::{
     block::{attr, block, nested, resource_block},
     emitter::{TfEmitter, TfFragment},
+    emitters::enabled,
     emitters::gcp::helpers::{
         binding_label_for_role, downcast, emit_custom_roles_for_bindings, labels,
         permission_context, required_label, resource_prefix_template, role_expression_for_binding,
@@ -30,8 +31,9 @@ impl TfEmitter for GcpQueueEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
 
-        let topic = resource_block(
+        let mut topic = resource_block(
             "google_pubsub_topic",
             label,
             [
@@ -40,9 +42,10 @@ impl TfEmitter for GcpQueueEmitter {
                 attr("labels", labels(ctx, "queue")),
             ],
         );
+        enabled::gate(&mut topic, enabled_when)?;
 
         let ack_deadline = ack_deadline_for(ctx);
-        let subscription = resource_block(
+        let mut subscription = resource_block(
             "google_pubsub_subscription",
             label,
             [
@@ -51,9 +54,10 @@ impl TfEmitter for GcpQueueEmitter {
                     expr::template(format!("${{local.resource_prefix}}-{}-default", queue.id())),
                 ),
                 attr("project", expr::raw("var.gcp_project")),
+                // The topic belongs to this same resource, so it is counted too.
                 attr(
                     "topic",
-                    expr::traversal(["google_pubsub_topic", label, "id"]),
+                    enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
                 ),
                 attr(
                     "ack_deadline_seconds",
@@ -71,58 +75,83 @@ impl TfEmitter for GcpQueueEmitter {
                 attr("labels", labels(ctx, "queue")),
             ],
         );
+        enabled::gate(&mut subscription, enabled_when)?;
 
         let mut fragment = TfFragment::default();
         fragment.resource_blocks.push(topic);
         fragment.resource_blocks.push(subscription);
-        emit_queue_iam(ctx, &mut fragment, label)?;
+        emit_queue_iam(ctx, &mut fragment, label, enabled_when)?;
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "topicId",
-                expr::traversal(["google_pubsub_topic", label, "name"]),
+                enabled::attribute(enabled_when, "google_pubsub_topic", label, "name"),
             ),
             (
                 "topicName",
-                expr::traversal(["google_pubsub_topic", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
             ),
             (
                 "subscriptionId",
-                expr::traversal(["google_pubsub_subscription", label, "name"]),
+                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "name"),
             ),
             (
                 "subscriptionName",
-                expr::traversal(["google_pubsub_subscription", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "id"),
             ),
         ]))
     }
 
+    fn supports_enabled_when(&self) -> bool {
+        true
+    }
+
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
+        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("pubsub".to_string())),
             (
                 "topic",
-                expr::traversal(["google_pubsub_topic", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
             ),
             (
                 "subscription",
-                expr::traversal(["google_pubsub_subscription", label, "id"]),
+                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "id"),
             ),
         ])))
     }
 }
 
-fn emit_queue_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
+/// Address of one of this queue's own blocks, indexed when the queue is gated.
+///
+/// The IAM members below reference the topic and the subscription from raw
+/// strings as well as from expressions, so both forms have to agree on whether
+/// the `[0]` is there.
+fn own_block(enabled_when: Option<&str>, resource_type: &str, label: &str) -> String {
+    match enabled_when {
+        Some(_) => format!("{resource_type}.{label}[0]"),
+        None => format!("{resource_type}.{label}"),
+    }
+}
+
+fn emit_queue_iam(
+    ctx: &EmitContext<'_>,
+    fragment: &mut TfFragment,
+    label: &str,
+    enabled_when: Option<&str>,
+) -> Result<()> {
     for (owner_label, permission_refs) in queue_permission_owners(ctx) {
         let member = service_account_member_for_label(&owner_label);
+        let topic_ref = own_block(enabled_when, "google_pubsub_topic", label);
         let context = permission_context(&owner_label, ctx.stack.id())
-            .with_resource_name(format!("${{google_pubsub_topic.{label}.name}}"));
+            .with_resource_name(format!("${{{topic_ref}.name}}"));
         let generator = GcpRuntimePermissionsGenerator::new();
 
         for permission_ref in permission_refs {
@@ -156,34 +185,50 @@ fn emit_queue_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str)
                 let role = role_expression_for_binding(&binding.role, &custom_roles)?;
                 match resource_kind {
                     GcpBindingResourceKind::PubsubTopic => {
-                        fragment.resource_blocks.push(resource_block(
+                        let mut member_block = resource_block(
                             "google_pubsub_topic_iam_member",
                             &format!("{role_label}_{label}_{owner_label}_topic_{idx}"),
                             [
                                 attr("project", expr::raw("var.gcp_project")),
                                 attr(
                                     "topic",
-                                    expr::traversal(["google_pubsub_topic", label, "name"]),
+                                    enabled::attribute(
+                                        enabled_when,
+                                        "google_pubsub_topic",
+                                        label,
+                                        "name",
+                                    ),
                                 ),
                                 attr("role", role),
                                 attr("member", member.clone()),
                             ],
-                        ));
+                        );
+                        // The grant targets this queue's topic, so it only
+                        // exists while the topic does.
+                        enabled::gate(&mut member_block, enabled_when)?;
+                        fragment.resource_blocks.push(member_block);
                     }
                     GcpBindingResourceKind::PubsubSubscription => {
-                        fragment.resource_blocks.push(resource_block(
+                        let mut member_block = resource_block(
                             "google_pubsub_subscription_iam_member",
                             &format!("{role_label}_{label}_{owner_label}_subscription_{idx}"),
                             [
                                 attr("project", expr::raw("var.gcp_project")),
                                 attr(
                                     "subscription",
-                                    expr::traversal(["google_pubsub_subscription", label, "name"]),
+                                    enabled::attribute(
+                                        enabled_when,
+                                        "google_pubsub_subscription",
+                                        label,
+                                        "name",
+                                    ),
                                 ),
                                 attr("role", role),
                                 attr("member", member.clone()),
                             ],
-                        ));
+                        );
+                        enabled::gate(&mut member_block, enabled_when)?;
+                        fragment.resource_blocks.push(member_block);
                     }
                     GcpBindingResourceKind::ArtifactRegistryRepository => {}
                 }

--- a/crates/alien-terraform/tests/generator.rs
+++ b/crates/alien-terraform/tests/generator.rs
@@ -17,6 +17,7 @@ mod generator {
     pub mod azure_data_layer_tests;
     pub mod azure_full_stack_tests;
     pub mod azure_identity_tests;
+    pub mod enabled_queue_tests;
     pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod gcp_compute_tests;

--- a/crates/alien-terraform/tests/generator/enabled_queue_tests.rs
+++ b/crates/alien-terraform/tests/generator/enabled_queue_tests.rs
@@ -1,0 +1,330 @@
+//! `.enabled(input)` for `Queue`.
+//!
+//! `enabled_tests.rs` covers the mechanics on `Kv`. A queue adds the shape `Kv`
+//! never had: it owns more than one block and grants IAM against them. The
+//! recurring failure mode is a self-reference that keeps rendering after its
+//! resource became a list — valid HCL, rejected by `terraform validate` — so
+//! every gated scenario here is linted.
+
+use super::helpers::{
+    assert_terraform_valid, assert_ungated_registration_list_is_a_plain_array,
+    declared_block_types, gate_input, gated_block_types, normalized, render,
+};
+use alien_core::{
+    AzureResourceGroup, AzureServiceBusNamespace, PermissionProfile, Queue, ResourceLifecycle,
+    ServiceAccount, Stack, StackBuilder, StackInputDefinition, StackSettings,
+};
+use alien_terraform::TerraformTarget;
+
+const QUEUE_GATE: &str = "count = var.input_queue_enabled ? 1 : 0";
+
+fn gate_inputs() -> Vec<StackInputDefinition> {
+    vec![gate_input(
+        "queueEnabled",
+        "queue",
+        "Whether to create the queue.",
+    )]
+}
+
+/// A gated resource has to keep rendering valid Terraform for everything that
+/// points at it, and IAM is where the pointers are. A stack without a permission
+/// profile emits no IAM blocks at all, so a missed index would never reach
+/// `terraform validate` — which is exactly how this bug ships.
+fn permissioned(builder: StackBuilder, resource_id: &str, permissions: &[&str]) -> StackBuilder {
+    builder
+        .permission(
+            "execution",
+            PermissionProfile::new().resource(resource_id, permissions.to_vec()),
+        )
+        .add(
+            ServiceAccount::new("execution-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+}
+
+fn queue_stack(gated: bool) -> Stack {
+    let builder = permissioned(
+        Stack::new("gated-stack".to_string()).inputs(gate_inputs()),
+        "jobs",
+        &["queue/data-write"],
+    );
+    add_queue(builder, gated).build()
+}
+
+/// `queue/management` grants raw permissions, so the emitter defines a project
+/// custom role for it — the shared block a resource's gate must never reach.
+/// `queue/data-write` (used above) is only predefined roles, so it emits no
+/// custom role at all: the gate-exclusion test needs this fixture to have
+/// anything to check.
+fn custom_role_queue_stack(gated: bool) -> Stack {
+    let builder = permissioned(
+        Stack::new("gated-stack".to_string()).inputs(gate_inputs()),
+        "jobs",
+        &["queue/management"],
+    );
+    add_queue(builder, gated).build()
+}
+
+/// Azure realises the queue inside a shared Service Bus namespace. The rebuild
+/// preflight injects that namespace and its resource group at runtime; neither
+/// is gated, only what the tests add on top.
+fn azure_queue_stack(gated: bool) -> Stack {
+    let builder = Stack::new("gated-stack".to_string())
+        .inputs(gate_inputs())
+        .add(
+            AzureResourceGroup::new("default-resource-group".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            AzureServiceBusNamespace::new("default-service-bus-namespace".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        );
+    add_queue(builder, gated).build()
+}
+
+fn add_queue(builder: StackBuilder, gated: bool) -> StackBuilder {
+    let queue = Queue::new("jobs".to_string()).build();
+    if gated {
+        builder.add_enabled_when(queue, ResourceLifecycle::Frozen, "queueEnabled")
+    } else {
+        builder.add(queue, ResourceLifecycle::Frozen)
+    }
+}
+
+/// The registration list only changes shape once something in the stack is
+/// gated, and a declined resource contributes no entry rather than a null one.
+fn assert_gated_registration_list(main: &str, gate_variable: &str) {
+    assert!(
+        main.contains("deployment_resources = concat("),
+        "a gated stack splices its registration list together:\n{main}"
+    );
+    assert!(
+        main.contains(&format!("{gate_variable} ? [")) && main.contains("] : []"),
+        "the gated entry must collapse to an empty list, not to null:\n{main}"
+    );
+    assert!(
+        !main.contains(": null"),
+        "no null may reach the registration payload:\n{main}"
+    );
+}
+
+// ---------------------------------------------------------------- AWS queue
+
+#[test]
+fn a_gated_aws_queue_is_counted_and_indexed() {
+    let module = render(
+        &queue_stack(true),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("resource \"aws_sqs_queue\""),
+        "the queue block is still declared:\n{main}"
+    );
+    assert!(
+        main.contains(QUEUE_GATE),
+        "the queue must be created only when the deployer says yes:\n{main}"
+    );
+    for attribute in ["name", "url", "arn"] {
+        assert!(
+            main.contains(&format!("aws_sqs_queue.jobs[0].{attribute}")),
+            "every self-reference must be indexed, not just the first ({attribute}):\n{main}"
+        );
+    }
+    assert_gated_registration_list(main, "var.input_queue_enabled");
+    assert_terraform_valid(&module, "gated aws queue stack");
+}
+
+#[test]
+fn an_ungated_aws_queue_is_untouched() {
+    let module = render(
+        &queue_stack(false),
+        TerraformTarget::Aws,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("aws_sqs_queue.jobs[0]"),
+        "no indexing on an ungated queue:\n{main}"
+    );
+    assert!(
+        main.contains("aws_sqs_queue.jobs.arn"),
+        "references stay unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains(QUEUE_GATE),
+        "nothing is gated, so no count belongs in the module:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+}
+
+// ---------------------------------------------------------------- GCP queue
+
+/// GCP is the only cloud where one Alien queue owns two blocks, and the
+/// subscription points at the topic. Gating one without the other renders fine
+/// and fails `terraform validate`.
+#[test]
+fn a_gated_gcp_queue_counts_both_of_its_blocks() {
+    let module = render(
+        &queue_stack(true),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert_eq!(
+        main.matches(QUEUE_GATE).count(),
+        5,
+        "topic, subscription and the three IAM members all follow the gate:\n{main}"
+    );
+    assert!(
+        main.contains("topic = google_pubsub_topic.jobs[0].id"),
+        "the subscription points at the counted topic:\n{main}"
+    );
+    assert_terraform_valid(&module, "gated gcp queue stack");
+}
+
+/// The IAM members grant against the topic and the subscription by name. They
+/// are the references most easily missed, because a stack without a permission
+/// profile does not render them at all.
+#[test]
+fn a_gated_gcp_queue_leaves_no_unindexed_self_reference() {
+    let module = render(
+        &queue_stack(true),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains("google_pubsub_topic_iam_member"),
+        "the fixture must actually render queue IAM, or this test proves nothing:\n{main}"
+    );
+    assert!(
+        main.contains("topic = google_pubsub_topic.jobs[0].name")
+            && main.contains("subscription = google_pubsub_subscription.jobs[0].name"),
+        "IAM members address the counted instances:\n{main}"
+    );
+    for block in ["google_pubsub_topic", "google_pubsub_subscription"] {
+        assert!(
+            !main.contains(&format!("{block}.jobs.")),
+            "no attribute may be read off {block} without an index:\n{main}"
+        );
+    }
+    assert_gated_registration_list(main, "var.input_queue_enabled");
+}
+
+/// The project-wide custom roles are shared across resources and carry their own
+/// `var.gcp_manage_custom_roles` count. Tying them to one resource's gate would
+/// delete roles other resources still need.
+#[test]
+fn a_gated_gcp_queue_leaves_shared_custom_roles_alone() {
+    let module = render(
+        &custom_role_queue_stack(true),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        declared_block_types(main)
+            .iter()
+            .any(|found| found == "google_project_iam_custom_role"),
+        "the fixture must actually produce a custom role, or this proves nothing:\n{main}"
+    );
+    assert!(
+        !gated_block_types(main, QUEUE_GATE)
+            .iter()
+            .any(|found| found == "google_project_iam_custom_role"),
+        "a shared custom role must not follow one resource's gate:\n{main}"
+    );
+    assert!(
+        main.contains("var.gcp_manage_custom_roles ? 1 : 0"),
+        "the custom role keeps its own count:\n{main}"
+    );
+}
+
+#[test]
+fn an_ungated_gcp_queue_is_untouched() {
+    let module = render(
+        &queue_stack(false),
+        TerraformTarget::Gcp,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("google_pubsub_topic.jobs[0]")
+            && !main.contains("google_pubsub_subscription.jobs[0]"),
+        "no indexing on an ungated queue:\n{main}"
+    );
+    assert!(
+        main.contains("topic = google_pubsub_topic.jobs.id"),
+        "references stay unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains(QUEUE_GATE),
+        "nothing is gated, so no gate count belongs in the module:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+}
+
+// -------------------------------------------------------------- Azure queue
+
+/// The Azure payload mixes the gated queue with the ungated namespace hosting
+/// it. Indexing the latter would produce Terraform that does not validate.
+#[test]
+fn a_gated_azure_queue_indexes_only_its_own_references() {
+    let module = render(
+        &azure_queue_stack(true),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        main.contains(QUEUE_GATE),
+        "the queue must be created only when the deployer says yes:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_servicebus_queue.jobs[0].name"),
+        "references to the counted queue must be indexed:\n{main}"
+    );
+    assert!(
+        !main.contains("azurerm_servicebus_namespace.default_service_bus_namespace[0]"),
+        "the parent namespace is not counted, so it must stay unindexed:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_servicebus_namespace.default_service_bus_namespace.name"),
+        "the parent namespace name is still read directly:\n{main}"
+    );
+    assert_gated_registration_list(main, "var.input_queue_enabled");
+    assert_terraform_valid(&module, "gated azure queue stack");
+}
+
+#[test]
+fn an_ungated_azure_queue_is_untouched() {
+    let module = render(
+        &azure_queue_stack(false),
+        TerraformTarget::Azure,
+        StackSettings::default(),
+    );
+    let main = &normalized(&module);
+
+    assert!(
+        !main.contains("azurerm_servicebus_queue.jobs[0]"),
+        "no indexing on an ungated queue:\n{main}"
+    );
+    assert!(
+        main.contains("azurerm_servicebus_queue.jobs.name"),
+        "references stay unindexed:\n{main}"
+    );
+    assert!(
+        !main.contains(QUEUE_GATE),
+        "nothing is gated, so no count belongs in the module:\n{main}"
+    );
+    assert_ungated_registration_list_is_a_plain_array(main);
+}

--- a/crates/alien-terraform/tests/generator/helpers.rs
+++ b/crates/alien-terraform/tests/generator/helpers.rs
@@ -36,6 +36,41 @@ pub fn normalized(module: &ModuleFiles) -> String {
         .join(" ")
 }
 
+/// The `resource "<type>"` headers whose block body carries `gate` (the
+/// `count = var.<input> ? 1 : 0` line), read off a `normalized` module. Lets a
+/// test assert "every block that must be gated is, and no other" by parsed
+/// structure instead of a brittle `starts_with` on the rendered string.
+#[allow(dead_code)]
+pub fn gated_block_types(main: &str, gate: &str) -> Vec<String> {
+    let mut types = Vec::new();
+    for (index, _) in main.match_indices("resource \"") {
+        let rest = &main[index + "resource \"".len()..];
+        let Some((block_type, tail)) = rest.split_once('"') else {
+            continue;
+        };
+        // The block body runs to the next `resource "` header.
+        let body_end = tail.find("resource \"").unwrap_or(tail.len());
+        if tail[..body_end].contains(gate) {
+            types.push(block_type.to_string());
+        }
+    }
+    types
+}
+
+/// Every `resource "<type>"` header the module declares, gated or not. Paired
+/// with `gated_block_types` so a gate-exclusion test first proves the block it
+/// expects to stay ungated is actually rendered.
+#[allow(dead_code)]
+pub fn declared_block_types(main: &str) -> Vec<String> {
+    main.match_indices("resource \"")
+        .filter_map(|(index, _)| {
+            main[index + "resource \"".len()..]
+                .split_once('"')
+                .map(|(block_type, _)| block_type.to_string())
+        })
+        .collect()
+}
+
 /// The registration list only changes shape once something in the stack is
 /// gated. Everything else must render exactly as it did before this feature.
 pub fn assert_ungated_registration_list_is_a_plain_array(main: &str) {


### PR DESCRIPTION
## Summary

The queue gains `.enabled(input)`: a boolean deployer input decides whether the queue
and the access it needs exist. Same treatment as kv (#174) and storage (#175), extended
to the queue across AWS, Azure, and GCP, both Terraform and CloudFormation.

When a stack renders a gated queue:

1. The setup emitter puts the queue behind its input — a Terraform `count` or a
   CloudFormation condition — so a queue the deployer declined is never created.
2. **← the heart:** every block the queue *owns* takes that same gate — and a queue
   owns more than one. On GCP one queue is a topic *plus* a subscription that points at
   the topic, plus the IAM members that grant against both by name; on Azure the queue
   inside its namespace; on AWS the queue and its policy. Each self-reference is
   `[0]`-indexed under the count. A block left ungated would reference `topic[0]` of a
   resource that was never created — legal HCL that `terraform validate` accepts but
   that fails at apply — so the whole set lives and dies together.
3. Blocks the queue does *not* own stay ungated: Azure's shared Service Bus namespace,
   and GCP's project custom roles (which carry their own count and are shared across
   resources, so one queue's gate must not reach them).

This turns queue creation from unconditional into opt-in through `.enabled()`, cloud by cloud.

## What I did

- Gated the queue and every block it owns across AWS/Azure/GCP, Terraform and
  CloudFormation, indexing self-references (topic↔subscription, IAM-by-name) `[0]` under
  the count.
- Kept the blocks a queue doesn't own ungated: Azure's shared namespace and GCP's
  shared project custom roles.

## Files touched

- `alien-terraform` / `alien-cloudformation` queue emitters — gate the queue, its
  topic/subscription, and its grants.
- Tests for gated queue on each cloud: per-block count coverage, the topic↔subscription
  indexing, custom-role-stays-ungated, the declined-registration payload, and the
  ungated-is-untouched path.

## How I tested

- `cargo test -p alien-terraform` and `cargo test -p alien-cloudformation` — 8 and 5
  gated-queue tests across AWS/Azure/GCP, with `terraform validate` / cfn-lint run
  through the test helpers.
- Because `terraform validate` accepts a childless block that references `topic[0]`, the
  tests assert per-block count coverage directly. The CloudFormation tests resolve the
  rendered template the way CloudFormation would and assert on what registration
  receives (custom resource *and* Outputs fallback): a declined queue is absent from the
  payload, not present-and-null; declining everything still leaves an empty array a
  consumer can parse.
- This touches IAM rendering, so:
  - A declined queue leaving a grant behind — every IAM member that names the topic or
    subscription carries the queue's gate (asserted per cloud), and shared custom roles
    keep their own count, proven by `a_gated_gcp_queue_leaves_shared_custom_roles_alone`
    (which first asserts the fixture actually renders a custom role, so it can't pass
    vacuously).
  - A worker triggered by a gated queue rendering a reference to a queue that isn't
    created — rejected at manifest-write by the compile-time check, because a worker is
    live compute that can't share the gate. You cannot gate a queue a worker is
    triggered by; the check enforces it rather than emitting a broken template.
  - Nothing turned up.
