### PR TITLE
chore: stop building packages during install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,6 +520,11 @@ jobs:
       - name: Install JavaScript dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build packages used by addon smoke test
+        run: |
+          pnpm --filter @alienplatform/core build
+          pnpm --filter @alienplatform/bindings build
+
       - name: Download staged addon (${{ matrix.triple }})
         uses: actions/download-artifact@v7
         with:

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -22,7 +22,6 @@
   "scripts": {
     "build": "tsdown && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:addon": "napi build --platform --release --cwd ../../crates/alien-bindings-node",
-    "prepare": "npm run build",
     "test": "vitest run",
     "test:bun": "bun scripts/run-bun-tests.mjs",
     "test:ts": "tsc --noEmit",

--- a/packages/bindings/turbo.json
+++ b/packages/bindings/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build:addon": {
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["$TURBO_EXTENDS$", "build:addon"]
+    }
+  }
+}

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "build": "tsdown && tsc -p tsconfig.build.json --emitDeclarationOnly",
-    "prepare": "npm run build",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:bun": "BUN_EXPECTED=1 bun test tests/runtime-canary.test.ts tests/commands-client.test.ts tests/receiver.test.ts tests/presigned.test.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,6 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepare": "npm run build",
     "test": "vitest run",
     "test:ts": "tsc --noEmit",
     "generate": "rm -rf src/generated && cargo run --quiet --bin schema_exporter --features=clap,openapi -p alien-core -- --output openapi.json && kubb generate",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,7 +19,6 @@
   },
   "scripts": {
     "build": "tsdown && tsc --emitDeclarationOnly",
-    "prepare": "npm run build",
     "test": "vitest run --passWithNoTests",
     "test:ts": "tsc --noEmit",
     "generate": "./scripts/generate-proto.sh",

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
       "cache": false
     },
     "test": {
+      "dependsOn": ["^build", "build"],
       "cache": false
     },
     "test:ts": {


### PR DESCRIPTION
## Summary

- remove the `prepare` build hook from the core, commands, bindings, and SDK packages
- keep package compilation behind the existing explicit `build` commands

## Why

A workspace `pnpm install` currently compiles all four packages as a lifecycle side effect. Bootstrap only needs dependencies installed, so that work is unnecessary and makes setup appear stuck.

The stable and dev npm release workflows already run `pnpm build` before publishing or packing. A `prepack` replacement would keep compilation implicit and duplicate those release build steps.

## Validation

- fresh and repeated `pnpm install --frozen-lockfile` complete without invoking the package builds
- explicit builds succeed for core, commands, bindings, and SDK
- package-layout fixture passes all 28 packed-artifact and consumer checks
- Biome passes for the changed manifests