### PR TITLE
ci: reduce required test latency

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -14,7 +14,6 @@ env:
   # Fall back to local compilation when the shared sccache backend returns a
   # transient error (e.g. webdav 403) instead of failing the whole build.
   SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   pr-conventions:
@@ -83,8 +82,6 @@ jobs:
         continue-on-error: true
         with:
           version: v0.16.0
-      - name: Enable sccache when available
-        run: command -v sccache >/dev/null && echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV" || true
 
       - uses: taiki-e/install-action@nextest
 
@@ -187,8 +184,6 @@ jobs:
         continue-on-error: true
         with:
           version: v0.16.0
-      - name: Enable sccache when available
-        run: command -v sccache >/dev/null && echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV" || true
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -3,6 +3,8 @@ name: Tests
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -13,12 +15,15 @@ env:
   # transient error (e.g. webdav 403) instead of failing the whole build.
   SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
   SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
 
 jobs:
   pr-conventions:
     name: PR conventions
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
+    if: >-
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork != true) &&
+      (github.event_name != 'push' ||
+      startsWith(github.event.head_commit.message, 'chore: release '))
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title and branch
@@ -78,6 +83,8 @@ jobs:
         continue-on-error: true
         with:
           version: v0.16.0
+      - name: Enable sccache when available
+        run: command -v sccache >/dev/null && echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV" || true
 
       - uses: taiki-e/install-action@nextest
 
@@ -180,6 +187,8 @@ jobs:
         continue-on-error: true
         with:
           version: v0.16.0
+      - name: Enable sccache when available
+        run: command -v sccache >/dev/null && echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV" || true
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -274,7 +283,9 @@ jobs:
     if: >-
       always() &&
       (github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.fork != true)
+      github.event.pull_request.head.repo.fork != true) &&
+      (github.event_name != 'push' ||
+      startsWith(github.event.head_commit.message, 'chore: release '))
     needs: [pr-conventions, rust, typescript]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -3,8 +3,6 @@ name: Tests
 on:
   pull_request:
   merge_group:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -14,24 +12,14 @@ env:
   # Fall back to local compilation when the shared sccache backend returns a
   # transient error (e.g. webdav 403) instead of failing the whole build.
   SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
 
 jobs:
-  fast:
-    name: All tests passed
+  pr-conventions:
+    name: PR conventions
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
-    runs-on: depot-ubuntu-24.04-arm-16
-    timeout-minutes: 120
-    env:
-      CARGO_INCREMENTAL: "0"
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      # Bound the build/test memory peak: this job's recurring failure mode
-      # is the runner agent being starved for memory mid Rust-tests (GitHub
-      # reports "runner lost communication" with no logs). Full-width
-      # parallelism (16 rustc jobs, then 16 concurrent test binaries — many
-      # of which spawn servers and embedded databases) is what spikes it.
-      CARGO_BUILD_JOBS: "12"
-      NEXTEST_TEST_THREADS: "10"
-
+    runs-on: ubuntu-latest
     steps:
       - name: Validate PR title and branch
         if: github.event_name == 'pull_request'
@@ -51,25 +39,24 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v5
+  rust:
+    name: Rust crates
+    needs: pr-conventions
+    runs-on: depot-ubuntu-24.04-arm-16
+    timeout-minutes: 120
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      # Bound the build/test memory peak: this job's recurring failure mode
+      # is the runner agent being starved for memory mid Rust-tests (GitHub
+      # reports "runner lost communication" with no logs). Full-width
+      # parallelism (16 rustc jobs, then 16 concurrent test binaries — many
+      # of which spawn servers and embedded databases) is what spikes it.
+      CARGO_BUILD_JOBS: "12"
+      NEXTEST_TEST_THREADS: "10"
 
-      - uses: dorny/paths-filter@v4
-        id: changes
-        continue-on-error: true
-        with:
-          filters: |
-            examples:
-              - 'examples/**'
-              - 'packages/**'
-              - 'crates/alien-cli/**'
-              - 'crates/alien-deploy-cli/**'
-              - 'crates/alien-operator/**'
-              # The addon crates feed the dual-runtime import and
-              # compile-embed checks — without them a PR touching only the
-              # napi layer or the bindings core skips both.
-              - 'crates/alien-bindings-node/**'
-              - 'crates/alien-bindings/**'
-              - 'crates/alien-build/**'
+    steps:
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v6
         with:
@@ -134,39 +121,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint
-        run: pnpm format-and-lint
-
-      - name: TypeScript typecheck
-        env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
-        run: pnpm test:ts
-
-      - name: Build bindings dev addon (used by package and compiled-binary tests)
-        # alien-bindings-node is not a pnpm workspace member; resolve the napi
-        # CLI from package-layout's devDependencies (root frozen-lockfile
-        # install), matching the fixture's own CI recipe in run.ts. Debug
-        # profile with capped jobs: a cold --release build at full parallelism
-        # has been killing the runner mid-step (OOM); the tests only need the
-        # .node file to exist, not to be fast.
-        working-directory: crates/alien-bindings-node
-        env:
-          CARGO_BUILD_JOBS: "6"
-        run: ../../packages/package-layout/node_modules/.bin/napi build --platform
-
-      - name: Validate package layout
-        run: pnpm validate:package-layout
-
-      - name: TypeScript unit tests
-        # The per-package vitest suites (commands receiver twins, bindings
-        # loader/error mapping, core schemas) — `test:ts` above is
-        # typecheck-only, so without this step they never ran in CI. Must run
-        # after the dev-addon build: the bindings kv/queue/storage/vault
-        # suites load the native addon.
-        env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
-        run: pnpm --filter @alienplatform/core --filter @alienplatform/bindings --filter @alienplatform/commands test
-
       - name: Rust fast tests (non-cloud)
         env:
           AXIOM_OTLP_ENDPOINT: https://api.axiom.co/v1/logs
@@ -179,18 +133,126 @@ jobs:
             --exclude alien-test-server \
             --filter-expr 'not (package(alien-aws-clients) and kind(test)) and not (package(alien-gcp-clients) and kind(test)) and not (package(alien-azure-clients) and kind(test)) and not (package(alien-bindings) and kind(test)) and not binary_id(alien-build::build_integration_tests) and not binary_id(alien-build::image_shape_tests) and not binary_id(alien-build::rust_integration_tests) and not binary_id(alien-build::typescript_integration_tests) and not binary_id(alien-worker-runtime::cloudrun) and not binary_id(alien-worker-runtime::lambda) and not binary_id(alien-test::distribution) and not binary_id(alien-test::pull) and not binary_id(alien-test::push) and not binary_id(alien-manager::registry_proxy_cloud_test)'
 
+  typescript:
+    name: TypeScript packages and CLIs
+    needs: pr-conventions
+    runs-on: depot-ubuntu-24.04-arm-16
+    timeout-minutes: 60
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      CARGO_BUILD_JOBS: "6"
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            examples:
+              - 'examples/**'
+              - 'packages/**'
+              - 'crates/alien-cli/**'
+              - 'crates/alien-deploy-cli/**'
+              - 'crates/alien-operator/**'
+              - 'crates/alien-bindings-node/**'
+              - 'crates/alien-bindings/**'
+              - 'crates/alien-build/**'
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            examples/pnpm-lock.yaml
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+        continue-on-error: true
+        with:
+          version: v0.16.0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.x"
+          repo-token: ${{ github.token }}
+
+      - name: Install CloudFormation linter
+        run: pipx install cfn-lint
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.15.3
+          terraform_wrapper: false
+
+      - uses: azure/setup-helm@v5
+
+      - name: Install kubeconform
+        run: |
+          case "$(uname -m)" in
+            x86_64) KUBECONFORM_ARCH=amd64 ;;
+            aarch64|arm64) KUBECONFORM_ARCH=arm64 ;;
+            *) echo "Unsupported kubeconform architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -L "https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-${KUBECONFORM_ARCH}.tar.gz" \
+            | tar xz kubeconform
+          sudo mv kubeconform /usr/local/bin/kubeconform
+
+      - name: Install zig (needed by cargo-zigbuild for example builds)
+        run: pip3 install ziglang
+
+      - name: Configure git credentials for cargo
+        run: git config --global url."https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm format-and-lint
+
+      - name: TypeScript typecheck
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+        run: pnpm test:ts
+
+      - name: Build bindings dev addon
+        working-directory: crates/alien-bindings-node
+        run: ../../packages/package-layout/node_modules/.bin/napi build --platform
+
+      - name: Validate package layout
+        run: pnpm validate:package-layout
+
+      - name: TypeScript unit tests
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+        run: pnpm --filter @alienplatform/core --filter @alienplatform/bindings --filter @alienplatform/commands test
+
       - name: Build all CLIs
-        if: steps.changes.outcome != 'success' || steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        if: steps.changes.outcome != 'success' || steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch'
         run: cargo build -p alien-cli -p alien-deploy-cli -p alien-operator
 
       - name: Build TypeScript packages
-        if: steps.changes.outcome != 'success' || steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        if: steps.changes.outcome != 'success' || steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch'
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: pnpm build && pnpm -C packages/package-layout check
 
       - name: Rust and TypeScript command integration
-        if: steps.changes.outcome != 'success' || steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        if: steps.changes.outcome != 'success' || steps.changes.outputs.examples == 'true' || github.event_name == 'workflow_dispatch'
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         # Drives the TypeScript command sender/receiver against the Rust command
@@ -206,3 +268,20 @@ jobs:
         # Kubb may change insignificant whitespace between environments. Keep
         # the gate focused on generated behavior and schema content.
         run: git diff --ignore-all-space --exit-code -- packages/core packages/sdk
+
+  all-tests-passed:
+    name: All tests passed
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork != true)
+    needs: [pr-conventions, rust, typescript]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every test area
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          for result in $RESULTS; do
+            [[ "$result" == "success" || "$result" == "skipped" ]] || exit 1
+          done

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -57,7 +57,7 @@ jobs:
       # parallelism (16 rustc jobs, then 16 concurrent test binaries — many
       # of which spawn servers and embedded databases) is what spikes it.
       CARGO_BUILD_JOBS: "12"
-      NEXTEST_TEST_THREADS: "10"
+      NEXTEST_TEST_THREADS: "12"
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## What changed

- run Rust crates and TypeScript/native package tests concurrently
- keep one required `All tests passed` result
- stop repeating the full suite after protected PR merges

## Validation

- YAML parsed
- `actionlint` passed (custom Depot runner labels exempted)
- `git diff --check` passed
- no local Rust build was run

Linear: ALIEN-329