### PR TITLE
feat: gate resources in the setup generators, not the emitters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-bindings",
  "alien-error",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "aegis",
  "alien-azure-clients",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error",
  "chrono",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "2.0.2"
+version = "2.1.6"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/crates/alien-cloudformation/src/emitter.rs
+++ b/crates/alien-cloudformation/src/emitter.rs
@@ -34,19 +34,6 @@ pub trait CfEmitter: Send + Sync {
     /// into the setup registration payload by the generator.
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<CfExpression>;
 
-    /// Whether this emitter renders correctly for a resource gated by
-    /// `.enabled(input)`.
-    ///
-    /// Opting in means the emitter leaves the generator free to stamp the gate's
-    /// `Condition` onto its resources, and folds its own import ref through
-    /// `Fn::If` so nothing references a resource the condition skipped. The
-    /// generator refuses to render a gated resource whose emitter has not, so a
-    /// half-converted emitter fails loudly instead of silently creating the
-    /// resource the deployer declined.
-    fn supports_enabled_when(&self) -> bool {
-        false
-    }
-
     /// Expression that resolves to this resource's runtime binding payload.
     /// Import data feeds the manager; binding data feeds user code.
     fn emit_binding_ref(&self, _ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {

--- a/crates/alien-cloudformation/src/emitters/aws/kv.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/kv.rs
@@ -76,10 +76,6 @@ impl CfEmitter for AwsKvEmitter {
         ]))
     }
 
-    fn supports_enabled_when(&self) -> bool {
-        true
-    }
-
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {
         let table_id = required_logical_id(ctx)?;
         Ok(Some(CfExpression::object([

--- a/crates/alien-cloudformation/src/emitters/aws/queue.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/queue.rs
@@ -66,10 +66,6 @@ impl CfEmitter for AwsQueueEmitter {
         ]))
     }
 
-    fn supports_enabled_when(&self) -> bool {
-        true
-    }
-
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {
         let queue_id = required_logical_id(ctx)?;
         Ok(Some(CfExpression::object([

--- a/crates/alien-cloudformation/src/emitters/aws/storage.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/storage.rs
@@ -122,7 +122,7 @@ impl CfEmitter for AwsStorageEmitter {
             bucket_policy_document(
                 bucket_id,
                 storage.public_read,
-                email_inbound_targets_bucket(ctx),
+                email_inbound_contribution(ctx).as_ref(),
             ),
         );
 
@@ -138,13 +138,6 @@ impl CfEmitter for AwsStorageEmitter {
             ("bucketName", CfExpression::ref_(bucket_id)),
             ("bucketArn", CfExpression::get_att(bucket_id, "Arn")),
         ]))
-    }
-
-    /// Every resource this emitter returns — bucket, policy, and the IAM
-    /// policies that name the bucket — is stamped with the gate's condition by
-    /// the generator, so they appear and disappear together.
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<CfExpression>> {
@@ -183,30 +176,38 @@ fn public_access_block(block_public_access: bool) -> CfExpression {
     ])
 }
 
-/// True when a setup-emitted Email resource delivers inbound mail into this
-/// bucket. The SES write grant must live in this bucket policy — S3 supports
-/// only one bucket policy resource per bucket, so the email emitter cannot
-/// attach its own.
-fn email_inbound_targets_bucket(ctx: &EmitContext<'_>) -> bool {
-    ctx.stack.resources().any(|(_id, entry)| {
+/// The setup-emitted Email resource delivering inbound mail into this bucket,
+/// if any, together with its gate. The SES write grant must live in this
+/// bucket policy — S3 supports only one bucket policy resource per bucket, so
+/// the email emitter cannot attach its own. That makes the grant a gated
+/// contribution: it belongs to the Email resource's gate, not the bucket's,
+/// and disappears with the Email when a deployer declines it.
+fn email_inbound_contribution(ctx: &EmitContext<'_>) -> Option<EmailInboundContribution> {
+    ctx.stack.resources().find_map(|(_id, entry)| {
         let ownership = ownership_policy_for_resource_type(entry.config.resource_type().as_ref());
         if !ownership.should_emit_in_setup(entry.lifecycle) {
-            return false;
+            return None;
         }
-        let Some(email) = entry.config.downcast_ref::<Email>() else {
-            return false;
-        };
+        let email = entry.config.downcast_ref::<Email>()?;
         email
             .inbound
             .as_ref()
             .is_some_and(|inbound| inbound.storage.id == ctx.resource_id)
+            .then(|| EmailInboundContribution {
+                enabled_when: entry.enabled_when.clone(),
+            })
     })
+}
+
+/// The Email contributor's gate, carried into the bucket policy statement.
+struct EmailInboundContribution {
+    enabled_when: Option<String>,
 }
 
 fn bucket_policy_document(
     bucket_id: &str,
     public_read: bool,
-    allow_ses_inbound: bool,
+    ses_inbound: Option<&EmailInboundContribution>,
 ) -> CfExpression {
     let bucket_arn = CfExpression::get_att(bucket_id, "Arn");
     let bucket_objects_arn =
@@ -240,10 +241,10 @@ fn bucket_policy_document(
         ]));
     }
 
-    if allow_ses_inbound {
+    if let Some(contribution) = ses_inbound {
         // SES delivers received mail via its service principal; scope the
         // grant to this account per the SES receiving documentation.
-        statements.push(CfExpression::object([
+        let statement = CfExpression::object([
             ("Sid", CfExpression::from("AllowSesInboundDelivery")),
             ("Effect", CfExpression::from("Allow")),
             (
@@ -262,7 +263,15 @@ fn bucket_policy_document(
                     )]),
                 )]),
             ),
-        ]));
+        ]);
+        // The grant follows the Email contributor's gate: a declined Email
+        // must not leave SES able to write into the bucket. `Fn::If` with
+        // `AWS::NoValue` removes the statement from the list outright.
+        statements.push(crate::emitters::enabled::when_enabled(
+            contribution.enabled_when.as_deref(),
+            statement,
+            CfExpression::no_value(),
+        ));
     }
 
     CfExpression::object([

--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -299,14 +299,17 @@ pub fn generate_cloudformation_template(
 
         let enabled_when = resource.enabled_when.as_deref();
         let declared_condition = if let Some(input_id) = enabled_when {
-            if !emitter.supports_enabled_when() {
+            // The same policy the compile-time check enforces, re-checked at
+            // render time so a caller that skips preflights cannot gate what
+            // the policy refuses.
+            if let Some(refusal) =
+                alien_core::gate_refusal(resource_type.as_ref(), resource_id.as_str())
+            {
                 return Err(AlienError::new(ErrorData::OperationNotSupported {
-                    operation: format!("enabled() on resource type '{resource_type}'"),
-                    reason: format!(
-                        "the CloudFormation emitter for '{resource_type}' does not render \
-                         conditionally yet, so resource '{resource_id}' would be created \
-                         regardless of the deployer's answer"
+                    operation: format!(
+                        "enabled() on resource '{resource_id}' of type '{resource_type}'"
                     ),
+                    reason: refusal.reason().to_string(),
                 }));
             }
             Some(declare_enabled_condition(
@@ -329,8 +332,9 @@ pub fn generate_cloudformation_template(
                 // and create the resource the deployer declined.
                 //
                 // No shipped emitter reaches this: the ones that set conditions
-                // (aws/network.rs, aws/kubernetes_cluster.rs) return false from
-                // `supports_enabled_when`, so they fail the check above first.
+                // (aws/network.rs, aws/kubernetes_cluster.rs) belong to types
+                // the gateability policy refuses, so they fail the check above
+                // first.
                 if let Some(existing) = &emitted.condition {
                     return Err(AlienError::new(ErrorData::OperationNotSupported {
                         operation: format!("enabled() on resource type '{resource_type}'"),

--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -256,7 +256,7 @@ pub fn generate_cloudformation_template(
         &stack_settings,
         supports_custom_domain,
     )?;
-    add_stack_input_parameters(&mut template, &stack_inputs);
+    add_stack_input_parameters(&mut template, &stack_inputs)?;
     add_supported_region_rule(&mut template, &options.registration);
     if supports_custom_domain {
         add_custom_domain_certificate_rule(&mut template);
@@ -457,13 +457,30 @@ pub(crate) fn stack_input_parameter_name_for_id(input_id: &str) -> String {
     format!("Input{}", sanitize_logical_id(input_id))
 }
 
-fn add_stack_input_parameters(template: &mut CfTemplate, inputs: &[StackInputDefinition]) {
+fn add_stack_input_parameters(
+    template: &mut CfTemplate,
+    inputs: &[StackInputDefinition],
+) -> Result<()> {
     for input in inputs {
-        template.parameters.insert(
-            stack_input_parameter_name(input),
-            stack_input_parameter(input),
-        );
+        let parameter_name = stack_input_parameter_name(input);
+        // Distinct ids can sanitize to the same logical id (`fooBar` and
+        // `foo_bar` both become `InputFooBar`); a silent overwrite would make
+        // both inputs — gates and their conditions included — read one
+        // parameter.
+        if template.parameters.contains_key(&parameter_name) {
+            return Err(AlienError::new(ErrorData::OperationNotSupported {
+                operation: "generate_cloudformation_template".to_string(),
+                reason: format!(
+                    "stack input '{}' normalizes to CloudFormation parameter                      '{parameter_name}', which another input already claimed; rename one so                      every input keeps its own parameter",
+                    input.id
+                ),
+            }));
+        }
+        template
+            .parameters
+            .insert(parameter_name, stack_input_parameter(input));
     }
+    Ok(())
 }
 
 fn stack_input_parameter(input: &StackInputDefinition) -> CfParameter {

--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -471,7 +471,9 @@ fn add_stack_input_parameters(
             return Err(AlienError::new(ErrorData::OperationNotSupported {
                 operation: "generate_cloudformation_template".to_string(),
                 reason: format!(
-                    "stack input '{}' normalizes to CloudFormation parameter                      '{parameter_name}', which another input already claimed; rename one so                      every input keeps its own parameter",
+                    "stack input '{}' normalizes to CloudFormation parameter \
+                     '{parameter_name}', which another input already claimed; rename one so \
+                     every input keeps its own parameter",
                     input.id
                 ),
             }));

--- a/crates/alien-cloudformation/src/registry.rs
+++ b/crates/alien-cloudformation/src/registry.rs
@@ -72,6 +72,15 @@ impl CfRegistry {
 
     /// Look up an emitter and produce a typed `ImportRegistrationMissing`
     /// error if none is registered.
+    /// Every registered `(resource type, platform)` pair. The gating test
+    /// matrix walks this so a newly registered emitter cannot ship without
+    /// either a policy refusal or a gated-render fixture.
+    pub fn registered_keys(&self) -> impl Iterator<Item = (&str, Platform)> {
+        self.emitters
+            .keys()
+            .map(|key| (key.resource_type.as_ref(), key.platform))
+    }
+
     pub fn require(
         &self,
         resource_type: &ResourceType,

--- a/crates/alien-cloudformation/src/registry.rs
+++ b/crates/alien-cloudformation/src/registry.rs
@@ -70,8 +70,6 @@ impl CfRegistry {
             .map(|boxed| boxed.as_ref())
     }
 
-    /// Look up an emitter and produce a typed `ImportRegistrationMissing`
-    /// error if none is registered.
     /// Every registered `(resource type, platform)` pair. The gating test
     /// matrix walks this so a newly registered emitter cannot ship without
     /// either a policy refusal or a gated-render fixture.
@@ -81,6 +79,8 @@ impl CfRegistry {
             .map(|key| (key.resource_type.as_ref(), key.platform))
     }
 
+    /// Look up an emitter and produce a typed `ImportRegistrationMissing`
+    /// error if none is registered.
     pub fn require(
         &self,
         resource_type: &ResourceType,

--- a/crates/alien-cloudformation/tests/generator.rs
+++ b/crates/alien-cloudformation/tests/generator.rs
@@ -16,6 +16,7 @@ mod generator {
     pub mod aws_full_stack_tests;
     pub mod aws_open_search_tests;
     pub mod enabled_queue_tests;
+    pub mod gating_matrix_tests;
     pub mod enabled_storage_tests;
     pub mod enabled_tests;
     pub mod kubernetes_cluster_tests;

--- a/crates/alien-cloudformation/tests/generator/gating_matrix_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/gating_matrix_tests.rs
@@ -185,3 +185,36 @@ fn a_gate_on_a_policy_refused_type_fails_at_render() {
     assert!(error.message.contains("email"), "{}", error.message);
     assert!(error.message.contains("mailer"), "{}", error.message);
 }
+
+/// Distinct ids can sanitize to the same CloudFormation parameter logical id;
+/// a silent overwrite would make both inputs read one parameter, so
+/// generation must refuse.
+#[test]
+fn inputs_colliding_after_normalization_are_refused() {
+    let stack = Stack::new("matrix-stack".to_string())
+        .inputs(vec![
+            gate_input("fooBar", "Input a", "First input."),
+            gate_input("foo_bar", "Input b", "Second input."),
+        ])
+        .add(
+            Kv::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let error = try_render_built_ins(
+        &stack,
+        StackSettings::default(),
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "colliding inputs",
+    )
+    .expect_err("colliding parameter names must refuse to render");
+    assert!(error.message.contains("InputFooBar"), "{}", error.message);
+    assert!(
+        !error.message.contains("  "),
+        "the message should render without space runs: {}",
+        error.message
+    );
+}

--- a/crates/alien-cloudformation/tests/generator/gating_matrix_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/gating_matrix_tests.rs
@@ -1,0 +1,187 @@
+//! The gating matrix: every registered CloudFormation emitter is either
+//! refused by the gateability policy or proven to render gated.
+//!
+//! Same contract as the Terraform matrix: registering a new emitter for a
+//! gateable type fails this test until a gated fixture exists, so a type can
+//! never become gateable without a validated gated render.
+
+use super::helpers::{
+    custom_resource_registration, gate_input, registration_payload, render_built_ins_template,
+    resolve, try_render_built_ins, Declined,
+};
+use alien_cloudformation::{CfRegistry, CloudFormationTarget};
+use alien_core::{Kv, Platform, Queue, ResourceLifecycle, Stack, StackSettings, Storage, Vault};
+use std::collections::HashMap;
+
+fn gated_fixture(resource_type: &str) -> Option<Stack> {
+    let base = || {
+        Stack::new("matrix-stack".to_string()).inputs(vec![gate_input(
+            "fixtureEnabled",
+            "Enable the fixture resource",
+            "Whether to create the gated matrix fixture.",
+        )])
+    };
+    let stack = match resource_type {
+        "kv" => base().add_enabled_when(
+            Kv::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        "storage" => base().add_enabled_when(
+            Storage::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        "queue" => base().add_enabled_when(
+            Queue::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        "vault" => base().add_enabled_when(
+            Vault::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        _ => return None,
+    };
+    Some(stack.build())
+}
+
+/// Rendered, linted, and resolved with the gate declined: the fixture must
+/// leave no registration entry, and every resource the fixture contributed
+/// must carry the gate's condition.
+fn assert_gated_render(resource_type: &str, stack: &Stack) {
+    let (template, _yaml) = render_built_ins_template(
+        stack,
+        StackSettings::default(),
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        &format!("gating matrix {resource_type}"),
+    );
+
+    let condition_name = "InputFixtureEnabledIsTrue";
+    assert!(
+        template.conditions.contains_key(condition_name),
+        "{resource_type}: the gate condition should be declared"
+    );
+
+    let unconditional: Vec<&str> = template
+        .resources
+        .iter()
+        .filter(|(logical_id, resource)| {
+            resource.condition.is_none()
+                && logical_id.to_ascii_lowercase().contains("fixture")
+        })
+        .map(|(logical_id, _)| logical_id.as_str())
+        .collect();
+    assert!(
+        unconditional.is_empty(),
+        "{resource_type}: every resource the fixture contributed should carry the gate's \
+         condition, but these are unconditional: {unconditional:?}"
+    );
+
+    let payload = registration_payload(&template);
+    let declined = resolve(
+        &payload,
+        &HashMap::from([(condition_name, false)]),
+        Declined::Removed,
+    )
+    .expect("registration payload should survive resolution");
+    let text = serde_json::to_string(&declined).expect("resolved payload serializes");
+    assert!(
+        !text.contains("\"fixture\""),
+        "{resource_type}: a declined fixture must leave no registration entry:\n{text}"
+    );
+}
+
+#[test]
+fn every_registered_emitter_is_policy_refused_or_renders_gated() {
+    let registry = CfRegistry::built_in();
+    let mut allowed_without_fixture = Vec::new();
+
+    for (resource_type, platform) in registry.registered_keys() {
+        if platform != Platform::Aws {
+            continue;
+        }
+        if alien_core::gate_refusal(resource_type, "matrix-fixture").is_some() {
+            continue;
+        }
+        match gated_fixture(resource_type) {
+            Some(stack) => assert_gated_render(resource_type, &stack),
+            None => allowed_without_fixture.push(resource_type.to_string()),
+        }
+    }
+
+    assert!(
+        allowed_without_fixture.is_empty(),
+        "these registered CloudFormation emitters belong to policy-allowed types but have no \
+         gated fixture; add one to this matrix (or refuse the type in \
+         alien_core::gateability) before the type silently becomes gateable: \
+         {allowed_without_fixture:?}"
+    );
+}
+
+/// Vault gates purely through the generator — its emitter never carried
+/// gating code. On AWS the vault's secrets are created lazily at runtime by
+/// name prefix, so a granting-profile-free vault contributes no template
+/// resources at all; its gated render is exactly the registration splice,
+/// asserted through both deploy-time answers and locked by a snapshot.
+#[test]
+fn a_gated_vault_renders_conditionally() {
+    let stack = gated_fixture("vault").expect("vault fixture");
+    let (template, yaml) = render_built_ins_template(
+        &stack,
+        StackSettings::default(),
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "gated vault stack",
+    );
+    assert_gated_render("vault", &stack);
+
+    let payload = registration_payload(&template);
+    let accepted = resolve(
+        &payload,
+        &HashMap::from([("InputFixtureEnabledIsTrue", true)]),
+        Declined::Removed,
+    )
+    .expect("payload resolves");
+    let text = serde_json::to_string(&accepted).expect("resolved payload serializes");
+    assert!(
+        text.contains("\"fixture\""),
+        "an accepted vault must keep its registration entry:\n{text}"
+    );
+    insta::assert_snapshot!("enabled_gated_vault", yaml);
+}
+
+/// The render-side policy check: a gate the policy refuses fails without
+/// preflights ever running, naming type and resource.
+#[test]
+fn a_gate_on_a_policy_refused_type_fails_at_render() {
+    let stack = Stack::new("matrix-stack".to_string())
+        .inputs(vec![gate_input(
+            "emailEnabled",
+            "Enable email",
+            "Whether to create the email resource.",
+        )])
+        .add_enabled_when(
+            alien_core::Email::new("mailer".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "emailEnabled",
+        )
+        .build();
+
+    let error = try_render_built_ins(
+        &stack,
+        StackSettings::default(),
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "gated email stack",
+    )
+    .expect_err("the policy should refuse a gated email at render");
+    assert_eq!(error.code, "OPERATION_NOT_SUPPORTED");
+    assert!(error.message.contains("email"), "{}", error.message);
+    assert!(error.message.contains("mailer"), "{}", error.message);
+}

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__gating_matrix_tests__enabled_gated_vault.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__gating_matrix_tests__enabled_gated_vault.snap
@@ -1,0 +1,144 @@
+---
+source: crates/alien-cloudformation/tests/generator/gating_matrix_tests.rs
+expression: yaml
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: gated vault stack
+Transform:
+- AWS::LanguageExtensions
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Registration
+      Parameters:
+      - Token
+      - ManagingRoleArn
+      - ManagingAccountId
+    - Label:
+        default: Application inputs
+      Parameters:
+      - InputFixtureEnabled
+    - Label:
+        default: Operations
+      Parameters:
+      - UpdatesMode
+      - TelemetryMode
+      - HeartbeatsMode
+    ParameterLabels:
+      HeartbeatsMode:
+        default: Heartbeats
+      InputFixtureEnabled:
+        default: Enable the fixture resource
+      ManagingAccountId:
+        default: Image account ID
+      ManagingRoleArn:
+        default: Management role ARN
+      TelemetryMode:
+        default: Telemetry
+      Token:
+        default: Install token
+      UpdatesMode:
+        default: Updates
+Parameters:
+  Token:
+    Type: String
+    Description: Install token from the application setup page.
+    NoEcho: true
+  ManagingRoleArn:
+    Type: String
+    Description: ARN of the management identity allowed to assume setup-created roles.
+    Default: ''
+  ManagingAccountId:
+    Type: String
+    Description: AWS account ID for the management account that hosts application container images.
+    Default: ''
+  NetworkMode:
+    Type: String
+    Description: Choose create-new for a managed VPC, use-existing for your VPC, or use-default for the account default VPC.
+    Default: create-new
+    AllowedValues:
+    - create-new
+    - use-existing
+    - use-default
+  UpdatesMode:
+    Type: String
+    Description: How updates are applied after setup registration.
+    Default: auto
+    AllowedValues:
+    - auto
+    - approval-required
+  TelemetryMode:
+    Type: String
+    Description: Telemetry collection behavior.
+    Default: auto
+    AllowedValues:
+    - auto
+  HeartbeatsMode:
+    Type: String
+    Description: Heartbeat health-check behavior.
+    Default: "on"
+    AllowedValues:
+    - "off"
+    - "on"
+  InputFixtureEnabled:
+    Type: String
+    Description: Whether to create the gated matrix fixture.
+    Default: 'true'
+    AllowedValues:
+    - 'true'
+    - 'false'
+Conditions:
+  InputFixtureEnabledIsTrue:
+    Fn::Equals:
+    - Ref: InputFixtureEnabled
+    - 'true'
+Resources:
+  DeploymentRegistration:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: arn:aws:lambda:us-east-1:123456789012:function:register
+      Token:
+        Ref: Token
+      DeploymentName:
+        Ref: AWS::StackName
+      ResourcePrefix:
+        Ref: AWS::StackName
+      SourceKind: cloudformation
+      Platform: aws
+      Region:
+        Ref: AWS::Region
+      SetupTarget: aws
+      SetupImportFormatVersion: 1
+      SetupFingerprint: test
+      SetupFingerprintVersion: 1
+      ManagementConfig:
+        platform: aws
+        managingRoleArn:
+          Ref: ManagingRoleArn
+      StackSettings:
+        deploymentModel: push
+        updates:
+          Ref: UpdatesMode
+        telemetry:
+          Ref: TelemetryMode
+        heartbeats:
+          Ref: HeartbeatsMode
+        network:
+          Ref: AWS::NoValue
+      Resources:
+      - Fn::If:
+        - InputFixtureEnabledIsTrue
+        - id: fixture
+          type: vault
+          importData:
+            accountId:
+              Ref: AWS::AccountId
+            region:
+              Ref: AWS::Region
+            parameterPrefix:
+              Fn::Sub: ${AWS::StackName}-fixture
+        - Ref: AWS::NoValue
+      InputValues:
+        fixtureEnabled:
+          Ref: InputFixtureEnabled

--- a/crates/alien-core/src/bin/schema_exporter.rs
+++ b/crates/alien-core/src/bin/schema_exporter.rs
@@ -216,6 +216,9 @@ struct Args {
     /// Output path for the OpenAPI JSON file
     #[arg(short, long, default_value = "openapi.json")]
     output: String,
+    /// Output path for the gateability manifest the SDK surface test consumes
+    #[arg(long, default_value = "src/generated/gateability.json")]
+    gateability_output: String,
 }
 
 fn main() {
@@ -225,4 +228,16 @@ fn main() {
     file.write_all(ApiDoc::openapi().to_pretty_json().unwrap().as_bytes())
         .unwrap();
     println!("OpenAPI spec exported to {}", args.output);
+
+    let manifest: std::collections::BTreeMap<&str, TypeGateability> = MANIFEST_TYPES
+        .iter()
+        .map(|resource_type| (*resource_type, type_gateability(resource_type)))
+        .collect();
+    if let Some(parent) = std::path::Path::new(&args.gateability_output).parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut file = File::create(&args.gateability_output).unwrap();
+    file.write_all(serde_json::to_string_pretty(&manifest).unwrap().as_bytes())
+        .unwrap();
+    println!("Gateability manifest exported to {}", args.gateability_output);
 }

--- a/crates/alien-core/src/gateability.rs
+++ b/crates/alien-core/src/gateability.rs
@@ -21,15 +21,31 @@ use crate::ownership_policy_for_resource_type;
 /// constant.
 pub const SECRETS_VAULT_ID: &str = "secrets";
 
-/// Framework infrastructure Alien derives from the stack itself. A gate here
-/// is never a customer choice, and `ServiceAccountMutation` inserts
-/// profile-derived "{profile}-sa" entries unconditionally, which would
-/// silently overwrite a gated entry before any render guard could fire.
+/// Framework and auxiliary infrastructure Alien derives from the stack, the
+/// platform, or the deployment settings. A gate here is never a customer
+/// choice: `ServiceAccountMutation` inserts profile-derived "{profile}-sa"
+/// entries unconditionally, the Azure `default-*` resources are
+/// preflight-injected hosts other resources build on, and network presence is
+/// a StackSettings decision, not a stack-resource one. Both naming variants
+/// are listed where the ownership table accepts both.
 const STACK_DERIVED_TYPES: &[&str] = &[
     "build",
     "artifact-registry",
     "service-account",
     "compute-cluster",
+    "kubernetes-cluster",
+    "network",
+    "remote-stack-management",
+    "service_activation",
+    "service-activation",
+    "azure_resource_group",
+    "azure-resource-group",
+    "azure_storage_account",
+    "azure-storage-account",
+    "azure_container_apps_environment",
+    "azure-container-apps-environment",
+    "azure_service_bus_namespace",
+    "azure-service-bus-namespace",
 ];
 
 /// Types whose setup emitters have not been proven under the generic gating

--- a/crates/alien-core/src/gateability.rs
+++ b/crates/alien-core/src/gateability.rs
@@ -1,0 +1,213 @@
+//! The single authority on which resources may carry an `.enabled()` gate.
+//!
+//! Both the compile-time check (`ResourceEnabledValidCheck`) and the setup
+//! generators consult this module, so a caller that renders without running
+//! preflights hits the same refusals. The rules live here rather than in the
+//! preflight crate because the generators must not depend on preflights, and
+//! duplicating the rules would let them drift.
+//!
+//! Extension resource types registered outside this crate are gateable by
+//! default (their ownership policy is `user_choice`), matching how the emitter
+//! registries treat them: the generic gating post-pass needs nothing from the
+//! emitter, so there is nothing for an extension to opt into.
+
+use crate::ownership_policy_for_resource_type;
+
+/// Reserved id of the deployment secrets vault.
+///
+/// `SecretsVaultMutation` links this vault to Live Workers and compute
+/// clusters after compile-time checks run, so its presence can never be
+/// optional. Owned here so the gating rules and the mutation agree on one
+/// constant.
+pub const SECRETS_VAULT_ID: &str = "secrets";
+
+/// Framework infrastructure Alien derives from the stack itself. A gate here
+/// is never a customer choice, and `ServiceAccountMutation` inserts
+/// profile-derived "{profile}-sa" entries unconditionally, which would
+/// silently overwrite a gated entry before any render guard could fire.
+const STACK_DERIVED_TYPES: &[&str] = &[
+    "build",
+    "artifact-registry",
+    "service-account",
+    "compute-cluster",
+];
+
+/// Types whose setup emitters have not been proven under the generic gating
+/// post-pass yet. Emptied as each type's gated render is validated; the list
+/// exists so switching the mechanism cannot silently open gating for a type
+/// nobody has rendered gated before.
+const NOT_YET_GENERIC_TYPES: &[&str] = &["email", "experimental/aws-opensearch"];
+
+/// Why a resource cannot carry an `.enabled()` gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateRefusal {
+    /// The reserved deployment secrets vault (`SECRETS_VAULT_ID`).
+    ReservedSecretsVault,
+    /// Framework infrastructure derived from the stack itself.
+    DerivedFromStack,
+    /// Code-carrying compute ships with every release; whether it runs is a
+    /// rollout question, not a data-plane opt-out.
+    CodeCarryingCompute,
+    /// The type's gated setup render has not been validated yet.
+    NotYetGeneric,
+}
+
+impl GateRefusal {
+    /// The reason clause, phrased to follow "Resource 'x' is enabled by input
+    /// 'y', but ...". Callers compose the full message so the preflight and
+    /// the generators report identically.
+    pub fn reason(self) -> &'static str {
+        match self {
+            GateRefusal::ReservedSecretsVault => {
+                "it is the deployment secrets vault. Workers and compute clusters are wired to \
+                 it automatically after compile-time checks run, so a deployer who says no would \
+                 leave them resolving a binding for a vault that was never created. Its presence \
+                 cannot be optional. Give a vault you want to gate a different id"
+            }
+            GateRefusal::DerivedFromStack => {
+                "Alien derives this resource from the stack itself, so it cannot be optional"
+            }
+            GateRefusal::CodeCarryingCompute => {
+                "code-carrying compute ships with every release, so it cannot be optional"
+            }
+            GateRefusal::NotYetGeneric => {
+                "this resource type's conditional setup render has not been validated yet, so \
+                 the resource would be created regardless of the deployer's answer"
+            }
+        }
+    }
+}
+
+/// Whether a resource may carry an `.enabled()` gate at all. `None` means
+/// gateable. Lifecycle legality is not decided here — a lifecycle the type
+/// does not allow is refused by the lifecycle rules regardless of gating.
+pub fn gate_refusal(resource_type: &str, resource_id: &str) -> Option<GateRefusal> {
+    if resource_id == SECRETS_VAULT_ID {
+        return Some(GateRefusal::ReservedSecretsVault);
+    }
+    if STACK_DERIVED_TYPES.contains(&resource_type) {
+        return Some(GateRefusal::DerivedFromStack);
+    }
+    // Live-only ownership is the compute classification, read from the one
+    // table that defines it so a new compute type cannot silently become
+    // gateable.
+    if !ownership_policy_for_resource_type(resource_type).allows_frozen() {
+        return Some(GateRefusal::CodeCarryingCompute);
+    }
+    if NOT_YET_GENERIC_TYPES.contains(&resource_type) {
+        return Some(GateRefusal::NotYetGeneric);
+    }
+    None
+}
+
+/// Per-lifecycle gateability of one resource type, derived from the ownership
+/// table and the gate refusals. Serialized into the generated manifest the
+/// TypeScript SDK's surface test consumes.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TypeGateability {
+    /// The gate may appear on a Frozen entry of this type.
+    pub frozen: bool,
+    /// The gate may appear on a Live entry of this type.
+    pub live: bool,
+}
+
+/// Gateability of one built-in user resource type, keyed for the manifest.
+pub fn type_gateability(resource_type: &str) -> TypeGateability {
+    let policy = ownership_policy_for_resource_type(resource_type);
+    // The id-based rule cannot be evaluated per type; the manifest describes
+    // types, and the reserved vault id is refused per entry.
+    let gateable = gate_refusal(resource_type, "").is_none();
+    TypeGateability {
+        frozen: gateable && policy.allows_frozen(),
+        live: gateable && policy.allows_live(),
+    }
+}
+
+/// The built-in user resource types listed in the generated manifest. The SDK
+/// builder surface is asserted against exactly this set.
+pub const MANIFEST_TYPES: &[&str] = &[
+    "kv",
+    "storage",
+    "queue",
+    "vault",
+    "postgres",
+    "worker",
+    "daemon",
+    "container",
+    "email",
+    "experimental/aws-opensearch",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_are_gateable_in_both_lifecycles() {
+        for store in ["kv", "storage", "queue", "vault"] {
+            assert_eq!(gate_refusal(store, "analytics"), None, "{store}");
+            let gateability = type_gateability(store);
+            assert!(gateability.frozen && gateability.live, "{store}");
+        }
+    }
+
+    #[test]
+    fn postgres_is_live_gateable_only() {
+        assert_eq!(gate_refusal("postgres", "db"), None);
+        let gateability = type_gateability("postgres");
+        // Frozen postgres has no setup emitter today; the gate rule allows it
+        // and the missing emitter refuses the render, exactly as for an
+        // ungated frozen postgres.
+        assert!(gateability.live);
+    }
+
+    #[test]
+    fn compute_is_refused() {
+        for compute in ["worker", "daemon", "container"] {
+            assert_eq!(
+                gate_refusal(compute, "api"),
+                Some(GateRefusal::CodeCarryingCompute),
+                "{compute}"
+            );
+        }
+    }
+
+    #[test]
+    fn stack_derived_types_are_refused() {
+        for framework in STACK_DERIVED_TYPES {
+            assert_eq!(
+                gate_refusal(framework, "x"),
+                Some(GateRefusal::DerivedFromStack),
+                "{framework}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_reserved_secrets_vault_is_refused_by_id() {
+        assert_eq!(
+            gate_refusal("vault", SECRETS_VAULT_ID),
+            Some(GateRefusal::ReservedSecretsVault)
+        );
+        assert_eq!(gate_refusal("vault", "app-tokens"), None);
+    }
+
+    #[test]
+    fn unproven_setup_types_are_refused_until_validated() {
+        for pending in NOT_YET_GENERIC_TYPES {
+            assert_eq!(
+                gate_refusal(pending, "x"),
+                Some(GateRefusal::NotYetGeneric),
+                "{pending}"
+            );
+        }
+    }
+
+    #[test]
+    fn extension_types_default_to_gateable() {
+        assert_eq!(gate_refusal("acme-widgets", "widgets"), None);
+        let gateability = type_gateability("acme-widgets");
+        assert!(gateability.frozen && gateability.live);
+    }
+}

--- a/crates/alien-core/src/lib.rs
+++ b/crates/alien-core/src/lib.rs
@@ -30,6 +30,9 @@ pub use resource::*;
 mod ownership;
 pub use ownership::*;
 
+mod gateability;
+pub use gateability::*;
+
 mod tags;
 pub use tags::*;
 

--- a/crates/alien-preflights/src/compile_time/resource_enabled_valid.rs
+++ b/crates/alien-preflights/src/compile_time/resource_enabled_valid.rs
@@ -13,7 +13,6 @@
 //! and a dependent of a gated resource looks up outputs that will not be there.
 
 use crate::error::Result;
-use crate::mutations::secrets_vault::SECRETS_VAULT_ID;
 use crate::{CheckResult, CompileTimeCheck};
 use alien_core::{Platform, Stack, StackInputKind, StackInputProvider};
 use std::collections::HashMap;
@@ -209,6 +208,7 @@ fn dependents_of_gated_resources(stack: &Stack) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mutations::secrets_vault::SECRETS_VAULT_ID;
     use alien_core::{
         permissions::PermissionProfile, Kv, Storage, ResourceLifecycle, StackInputDefinition,
         Vault, Worker, WorkerCode,

--- a/crates/alien-preflights/src/compile_time/resource_enabled_valid.rs
+++ b/crates/alien-preflights/src/compile_time/resource_enabled_valid.rs
@@ -41,54 +41,25 @@ impl CompileTimeCheck for ResourceEnabledValidCheck {
                 continue;
             };
 
-            // `SecretsVaultMutation` links this vault to Live Workers and compute clusters
-            // after every compile-time check has run, so `dependents_of_gated_resources`
-            // below reads a stack where those links do not exist yet and lets the gate pass.
-            if resource_id == SECRETS_VAULT_ID {
-                errors.push(format!(
-                    "Resource '{resource_id}' is enabled by input '{input_id}', but \
-                     '{SECRETS_VAULT_ID}' is the deployment secrets vault. Workers and compute \
-                     clusters are wired to it automatically after this check runs, so a deployer \
-                     who says no would leave them resolving a binding for a vault that was never \
-                     created. Its presence cannot be optional. Give a vault you want to gate a \
-                     different id"
-                ));
-            }
-
             let resource_type = entry.config.resource_type();
 
-            // Framework infrastructure Alien derives from the stack itself. A gate
-            // here is never a customer choice, and ServiceAccountMutation inserts
-            // profile-derived "{profile}-sa" entries unconditionally, which would
-            // silently overwrite a gated entry before any render guard could fire.
-            // The SDK does not offer .enabled() on these; this keeps hand-authored
-            // stacks to the same rule.
-            if matches!(
-                resource_type.as_ref(),
-                "build" | "artifact-registry" | "service-account" | "compute-cluster"
-            ) {
-                errors.push(format!(
-                    "Resource '{resource_id}' of type '{resource_type}' is enabled by input \
-                     '{input_id}', but Alien derives this resource from the stack itself, so \
-                     it cannot be optional"
-                ));
-                continue;
-            }
-
-            // Code-carrying compute ships with every release; whether it runs
-            // is a rollout question, not a data-plane opt-out, so gating it is
-            // a different feature than this one. Live-only ownership is the
-            // compute classification, read from the one table that defines it
-            // so a new compute type cannot silently become gateable.
-            if !alien_core::ownership_policy_for_resource_type(resource_type.as_ref())
-                .allows_frozen()
+            // The type/id rules live in `alien_core::gateability` so the setup
+            // generators enforce the same refusals for callers that render
+            // without preflights. Only the reserved-vault refusal falls
+            // through: `dependents_of_gated_resources` below reads a stack
+            // where the vault's auto-wired links do not exist yet, and the
+            // input rules further down still apply to it.
+            if let Some(refusal) =
+                alien_core::gate_refusal(resource_type.as_ref(), resource_id.as_str())
             {
                 errors.push(format!(
                     "Resource '{resource_id}' of type '{resource_type}' is enabled by input \
-                     '{input_id}', but code-carrying compute ships with every release, so it \
-                     cannot be optional"
+                     '{input_id}', but {}",
+                    refusal.reason()
                 ));
-                continue;
+                if refusal != alien_core::GateRefusal::ReservedSecretsVault {
+                    continue;
+                }
             }
 
             // `ServiceAccount::from_permission_profile` builds the runtime role from the

--- a/crates/alien-preflights/src/mutations/secrets_vault.rs
+++ b/crates/alien-preflights/src/mutations/secrets_vault.rs
@@ -27,10 +27,10 @@ pub struct SecretsVaultMutation;
 
 /// Resource id this mutation reserves for the deployment secrets vault.
 ///
-/// `ResourceEnabledValidCheck` reads it to reject `.enabled()` on this vault:
-/// the links below are attached after every compile-time check has run, so no
-/// check can see that gating it would strand its dependents.
-pub const SECRETS_VAULT_ID: &str = "secrets";
+/// Owned by `alien_core::gateability` so the gating rules the generators
+/// enforce agree with this mutation on one constant; re-exported here for the
+/// preflight callers that always read it from this module.
+pub use alien_core::SECRETS_VAULT_ID;
 
 #[async_trait]
 impl StackMutation for SecretsVaultMutation {

--- a/crates/alien-terraform/src/emitter.rs
+++ b/crates/alien-terraform/src/emitter.rs
@@ -24,6 +24,14 @@ pub struct TfFragment {
     /// Extra `locals { ... }` entries the emitter contributed. Merged across
     /// all emitters into a single `locals` block in `main.tf`.
     pub locals: IndexMap<String, Expression>,
+    /// Addresses (`type`, `label`) of blocks in [`Self::resource_blocks`] that
+    /// are shared support infrastructure rather than owned by this fragment's
+    /// resource — a project-wide custom role several resources reference.
+    /// Shared blocks outlive any single resource: the gating post-pass never
+    /// gates them, and the generator deduplicates body-identical copies across
+    /// fragments. Keyed by address, not index, so removals and reordering in
+    /// later passes cannot desynchronize the classification.
+    shared_addresses: std::collections::HashSet<(String, String)>,
 }
 
 impl TfFragment {
@@ -51,13 +59,42 @@ impl TfFragment {
         self
     }
 
+    /// Append a resource block classified as shared support infrastructure.
+    /// It renders in place like any other block, but the gating post-pass
+    /// leaves it ungated even when this fragment's resource is gated.
+    pub fn push_shared_resource(&mut self, block: Block) {
+        if let Some(address) = block_address(&block) {
+            self.shared_addresses.insert(address);
+        }
+        self.resource_blocks.push(block);
+    }
+
+    /// Whether a block of this fragment is shared support infrastructure.
+    pub fn is_shared(&self, block: &Block) -> bool {
+        block_address(block)
+            .map(|address| self.shared_addresses.contains(&address))
+            .unwrap_or(false)
+    }
+
     /// Merge another fragment into this one (used by the K8s identity overlay
     /// layer to append on top of cloud emitters).
     pub fn extend(&mut self, other: TfFragment) {
         self.resource_blocks.extend(other.resource_blocks);
         self.data_blocks.extend(other.data_blocks);
         self.locals.extend(other.locals);
+        self.shared_addresses.extend(other.shared_addresses);
     }
+}
+
+/// (`type`, `label`) address of a `resource` block, `None` for anything that
+/// is not a two-label resource block.
+fn block_address(block: &Block) -> Option<(String, String)> {
+    if block.identifier.as_str() != "resource" {
+        return None;
+    }
+    let provider_type = block.labels.first()?.as_str().to_string();
+    let label = block.labels.get(1)?.as_str().to_string();
+    Some((provider_type, label))
 }
 
 /// Generator-side trait \u2014 emit the raw `resource`/`data` blocks for one stack

--- a/crates/alien-terraform/src/emitter.rs
+++ b/crates/alien-terraform/src/emitter.rs
@@ -122,18 +122,6 @@ pub trait TfEmitter: Send + Sync {
     /// references.
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression>;
 
-    /// Whether this emitter renders correctly when its resource is gated on a
-    /// deployer input via `.enabled()`.
-    ///
-    /// Opting in means the emitter puts `count` on its blocks, indexes its own
-    /// references, and nulls out its import ref when the gate is off. The
-    /// generator refuses to render a gated resource whose emitter has not, so a
-    /// half-converted emitter fails loudly instead of silently creating the
-    /// resource the deployer declined.
-    fn supports_enabled_when(&self) -> bool {
-        false
-    }
-
     /// Apply-time expression that resolves to this resource's runtime binding
     /// payload. This is intentionally separate from [`Self::emit_import_ref`]:
     /// import data feeds the manager, while binding data feeds user code.

--- a/crates/alien-terraform/src/emitters/aws/kv.rs
+++ b/crates/alien-terraform/src/emitters/aws/kv.rs
@@ -6,7 +6,6 @@ use crate::{
     emitters::aws::helpers::{
         downcast, nested_block, required_label, resource_prefix_template, tags,
     },
-    emitters::enabled,
     expr,
 };
 use alien_core::{import::EmitContext, Kv, Result};
@@ -20,7 +19,7 @@ impl TfEmitter for AwsKvEmitter {
         let kv = downcast::<Kv>(ctx, Kv::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
 
-        let mut table = resource_block(
+        let table = resource_block(
             "aws_dynamodb_table",
             label,
             [
@@ -67,7 +66,6 @@ impl TfEmitter for AwsKvEmitter {
                 )),
             ],
         );
-        enabled::gate_own(ctx, &mut table)?;
 
         Ok(TfFragment::default().with_resource(table))
     }
@@ -77,17 +75,13 @@ impl TfEmitter for AwsKvEmitter {
         Ok(expr::object([
             (
                 "tableName",
-                enabled::self_attribute(ctx, "aws_dynamodb_table", label, "name"),
+                expr::traversal(["aws_dynamodb_table", label, "name"]),
             ),
             (
                 "tableArn",
-                enabled::self_attribute(ctx, "aws_dynamodb_table", label, "arn"),
+                expr::traversal(["aws_dynamodb_table", label, "arn"]),
             ),
         ]))
-    }
-
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
@@ -96,7 +90,7 @@ impl TfEmitter for AwsKvEmitter {
             ("service", Expression::String("dynamodb".to_string())),
             (
                 "tableName",
-                enabled::self_attribute(ctx, "aws_dynamodb_table", label, "name"),
+                expr::traversal(["aws_dynamodb_table", label, "name"]),
             ),
             ("region", expr::raw("data.aws_region.current.region")),
         ])))

--- a/crates/alien-terraform/src/emitters/aws/queue.rs
+++ b/crates/alien-terraform/src/emitters/aws/queue.rs
@@ -4,7 +4,6 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::aws::helpers::{downcast, required_label, resource_prefix_template, tags},
-    emitters::enabled,
     expr,
 };
 use alien_core::{import::EmitContext, Queue, Result, Worker, WorkerTrigger};
@@ -17,9 +16,8 @@ impl TfEmitter for AwsQueueEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
 
-        let mut q = resource_block(
+        let q = resource_block(
             "aws_sqs_queue",
             label,
             [
@@ -36,43 +34,24 @@ impl TfEmitter for AwsQueueEmitter {
                 attr("tags", tags(ctx, "queue")),
             ],
         );
-        enabled::gate(&mut q, enabled_when)?;
 
         Ok(TfFragment::default().with_resource(q))
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
-            (
-                "queueName",
-                enabled::attribute(enabled_when, "aws_sqs_queue", label, "name"),
-            ),
-            (
-                "queueUrl",
-                enabled::attribute(enabled_when, "aws_sqs_queue", label, "url"),
-            ),
-            (
-                "queueArn",
-                enabled::attribute(enabled_when, "aws_sqs_queue", label, "arn"),
-            ),
+            ("queueName", expr::traversal(["aws_sqs_queue", label, "name"])),
+            ("queueUrl", expr::traversal(["aws_sqs_queue", label, "url"])),
+            ("queueArn", expr::traversal(["aws_sqs_queue", label, "arn"])),
         ]))
-    }
-
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("sqs".to_string())),
-            (
-                "queueUrl",
-                enabled::attribute(enabled_when, "aws_sqs_queue", label, "url"),
-            ),
+            ("queueUrl", expr::traversal(["aws_sqs_queue", label, "url"])),
         ])))
     }
 }

--- a/crates/alien-terraform/src/emitters/aws/storage.rs
+++ b/crates/alien-terraform/src/emitters/aws/storage.rs
@@ -11,7 +11,6 @@ use crate::{
         aws_terraform_permission_context, downcast, emit_iam_role_policy_for_target_with_label,
         iam_policy_name_sanitize, required_label, resource_prefix_template, tags,
     },
-    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -31,85 +30,56 @@ impl TfEmitter for AwsStorageEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let storage = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         let mut fragment = TfFragment::default();
 
-        // The bucket's configuration siblings only describe a bucket that
-        // exists, so they carry the same gate rather than outliving it.
+        fragment.resource_blocks.push(bucket(label, ctx, storage));
+        fragment.resource_blocks.push(encryption(label));
+        fragment.resource_blocks.push(ownership_controls(label));
         fragment
             .resource_blocks
-            .push(bucket(label, ctx, storage, enabled_when)?);
+            .push(public_access_block(label, !storage.public_read));
         fragment
             .resource_blocks
-            .push(encryption(label, enabled_when)?);
-        fragment
-            .resource_blocks
-            .push(ownership_controls(label, enabled_when)?);
-        fragment.resource_blocks.push(public_access_block(
-            label,
-            !storage.public_read,
-            enabled_when,
-        )?);
-        fragment
-            .resource_blocks
-            .push(bucket_policy(label, storage, enabled_when)?);
+            .push(bucket_policy(label, storage));
 
         if storage.versioning {
-            fragment
-                .resource_blocks
-                .push(versioning(label, enabled_when)?);
+            fragment.resource_blocks.push(versioning(label));
         }
         if !storage.lifecycle_rules.is_empty() {
-            fragment.resource_blocks.push(lifecycle(
-                label,
-                &storage.lifecycle_rules,
-                enabled_when,
-            )?);
+            fragment
+                .resource_blocks
+                .push(lifecycle(label, &storage.lifecycle_rules));
         }
-        emit_storage_iam(ctx, &mut fragment, label, enabled_when)?;
+        emit_storage_iam(ctx, &mut fragment, label)?;
 
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             (
                 "bucketName",
-                enabled::attribute(enabled_when, "aws_s3_bucket", label, "bucket"),
+                expr::traversal(["aws_s3_bucket", label, "bucket"]),
             ),
-            (
-                "bucketArn",
-                enabled::attribute(enabled_when, "aws_s3_bucket", label, "arn"),
-            ),
+            ("bucketArn", expr::traversal(["aws_s3_bucket", label, "arn"])),
         ]))
-    }
-
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("s3".to_string())),
             (
                 "bucketName",
-                enabled::attribute(enabled_when, "aws_s3_bucket", label, "bucket"),
+                expr::traversal(["aws_s3_bucket", label, "bucket"]),
             ),
         ])))
     }
 }
 
-fn bucket(
-    label: &str,
-    ctx: &EmitContext<'_>,
-    storage: &Storage,
-    enabled_when: Option<&str>,
-) -> Result<Block> {
-    let mut bucket = resource_block(
+fn bucket(label: &str, ctx: &EmitContext<'_>, storage: &Storage) -> Block {
+    resource_block(
         "aws_s3_bucket",
         label,
         [
@@ -117,12 +87,10 @@ fn bucket(
             attr("force_destroy", Expression::Bool(true)),
             attr("tags", tags(ctx, "storage")),
         ],
-    );
-    enabled::gate(&mut bucket, enabled_when)?;
-    Ok(bucket)
+    )
 }
 
-fn encryption(label: &str, enabled_when: Option<&str>) -> Result<Block> {
+fn encryption(label: &str) -> Block {
     let inner = block(
         "apply_server_side_encryption_by_default",
         [attr(
@@ -131,16 +99,14 @@ fn encryption(label: &str, enabled_when: Option<&str>) -> Result<Block> {
         )],
     );
     let rule = block("rule", [nested(inner)]);
-    let mut encryption = resource_block(
+    resource_block(
         "aws_s3_bucket_server_side_encryption_configuration",
         label,
-        [attr("bucket", bucket_id(label, enabled_when)), nested(rule)],
-    );
-    enabled::gate(&mut encryption, enabled_when)?;
-    Ok(encryption)
+        [attr("bucket", bucket_id(label)), nested(rule)],
+    )
 }
 
-fn ownership_controls(label: &str, enabled_when: Option<&str>) -> Result<Block> {
+fn ownership_controls(label: &str) -> Block {
     let rule = block(
         "rule",
         [attr(
@@ -148,43 +114,30 @@ fn ownership_controls(label: &str, enabled_when: Option<&str>) -> Result<Block> 
             Expression::String("BucketOwnerEnforced".to_string()),
         )],
     );
-    let mut controls = resource_block(
+    resource_block(
         "aws_s3_bucket_ownership_controls",
         label,
-        [attr("bucket", bucket_id(label, enabled_when)), nested(rule)],
-    );
-    enabled::gate(&mut controls, enabled_when)?;
-    Ok(controls)
+        [attr("bucket", bucket_id(label)), nested(rule)],
+    )
 }
 
-fn public_access_block(
-    label: &str,
-    block_public: bool,
-    enabled_when: Option<&str>,
-) -> Result<Block> {
+fn public_access_block(label: &str, block_public: bool) -> Block {
     let value = Expression::Bool(block_public);
-    let mut access_block = resource_block(
+    resource_block(
         "aws_s3_bucket_public_access_block",
         label,
         [
-            attr("bucket", bucket_id(label, enabled_when)),
+            attr("bucket", bucket_id(label)),
             attr("block_public_acls", value.clone()),
             attr("block_public_policy", value.clone()),
             attr("ignore_public_acls", value.clone()),
             attr("restrict_public_buckets", value),
         ],
-    );
-    enabled::gate(&mut access_block, enabled_when)?;
-    Ok(access_block)
+    )
 }
 
-fn bucket_policy(label: &str, storage: &Storage, enabled_when: Option<&str>) -> Result<Block> {
-    let objects_arn = || {
-        expr::raw(format!(
-            "\"${{{}}}/*\"",
-            bucket_path(label, "arn", enabled_when)
-        ))
-    };
+fn bucket_policy(label: &str, storage: &Storage) -> Block {
+    let objects_arn = || expr::raw(format!("\"${{{}}}/*\"", bucket_path(label, "arn")));
 
     let mut statements = vec![expr::object([
         (
@@ -197,7 +150,7 @@ fn bucket_policy(label: &str, storage: &Storage, enabled_when: Option<&str>) -> 
         (
             "Resource",
             Expression::Array(vec![
-                enabled::attribute(enabled_when, "aws_s3_bucket", label, "arn"),
+                expr::traversal(["aws_s3_bucket", label, "arn"]),
                 objects_arn(),
             ]),
         ),
@@ -228,37 +181,30 @@ fn bucket_policy(label: &str, storage: &Storage, enabled_when: Option<&str>) -> 
         ("Statement", Expression::Array(statements)),
     ]);
 
-    let mut bucket_policy = resource_block(
+    resource_block(
         "aws_s3_bucket_policy",
         label,
         [
-            attr("bucket", bucket_id(label, enabled_when)),
+            attr("bucket", bucket_id(label)),
             attr("policy", crate::emitters::aws::helpers::jsonencode(policy)),
         ],
-    );
-    enabled::gate(&mut bucket_policy, enabled_when)?;
-    Ok(bucket_policy)
+    )
 }
 
-fn versioning(label: &str, enabled_when: Option<&str>) -> Result<Block> {
+fn versioning(label: &str) -> Block {
     let inner = block(
         "versioning_configuration",
         [attr("status", Expression::String("Enabled".to_string()))],
     );
-    let mut versioning = resource_block(
+    resource_block(
         "aws_s3_bucket_versioning",
         label,
-        [
-            attr("bucket", bucket_id(label, enabled_when)),
-            nested(inner),
-        ],
-    );
-    enabled::gate(&mut versioning, enabled_when)?;
-    Ok(versioning)
+        [attr("bucket", bucket_id(label)), nested(inner)],
+    )
 }
 
-fn lifecycle(label: &str, rules: &[LifecycleRule], enabled_when: Option<&str>) -> Result<Block> {
-    let mut body: Vec<Structure> = vec![attr("bucket", bucket_id(label, enabled_when))];
+fn lifecycle(label: &str, rules: &[LifecycleRule]) -> Block {
+    let mut body: Vec<Structure> = vec![attr("bucket", bucket_id(label))];
     for (index, rule) in rules.iter().enumerate() {
         let prefix = rule.prefix.clone().unwrap_or_default();
         let filter = block("filter", [attr("prefix", Expression::String(prefix))]);
@@ -280,35 +226,23 @@ fn lifecycle(label: &str, rules: &[LifecycleRule], enabled_when: Option<&str>) -
         );
         body.push(nested(rule_block));
     }
-    let mut lifecycle = resource_block("aws_s3_bucket_lifecycle_configuration", label, body);
-    enabled::gate(&mut lifecycle, enabled_when)?;
-    Ok(lifecycle)
+    resource_block("aws_s3_bucket_lifecycle_configuration", label, body)
 }
 
-fn bucket_id(label: &str, enabled_when: Option<&str>) -> Expression {
-    enabled::attribute(enabled_when, "aws_s3_bucket", label, "id")
+fn bucket_id(label: &str) -> Expression {
+    expr::traversal(["aws_s3_bucket", label, "id"])
 }
 
 /// Reference path to one of the bucket's own attributes, for the places that
 /// interpolate it into a string rather than emitting an expression.
-fn bucket_path(label: &str, attribute: &str, enabled_when: Option<&str>) -> String {
-    match enabled_when {
-        Some(_) => format!("aws_s3_bucket.{label}[0].{attribute}"),
-        None => format!("aws_s3_bucket.{label}.{attribute}"),
-    }
+fn bucket_path(label: &str, attribute: &str) -> String {
+    format!("aws_s3_bucket.{label}.{attribute}")
 }
 
-fn emit_storage_iam(
-    ctx: &EmitContext<'_>,
-    fragment: &mut TfFragment,
-    label: &str,
-    enabled_when: Option<&str>,
-) -> Result<()> {
+fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
     for (owner_label, permission_refs) in storage_permission_owners(ctx) {
-        let context = aws_terraform_permission_context().with_resource_name(format!(
-            "${{{}}}",
-            bucket_path(label, "bucket", enabled_when)
-        ));
+        let context = aws_terraform_permission_context()
+            .with_resource_name(format!("${{{}}}", bucket_path(label, "bucket")));
 
         for (idx, permission_ref) in permission_refs.iter().enumerate() {
             let Some(permission_set) =
@@ -329,11 +263,6 @@ fn emit_storage_iam(
                 ctx.resource_id, permission_set.id
             ));
 
-            // The policy document names the bucket, so it cannot outlive it.
-            // The shared emitter is used by ungated resources too, so the gate
-            // goes on the blocks it just appended rather than into its
-            // signature.
-            let appended_from = fragment.resource_blocks.len();
             emit_iam_role_policy_for_target_with_label(
                 fragment,
                 &owner_label,
@@ -343,9 +272,6 @@ fn emit_storage_iam(
                 &context,
                 BindingTarget::Resource,
             )?;
-            for block in &mut fragment.resource_blocks[appended_from..] {
-                enabled::gate(block, enabled_when)?;
-            }
         }
     }
 

--- a/crates/alien-terraform/src/emitters/azure/helpers.rs
+++ b/crates/alien-terraform/src/emitters/azure/helpers.rs
@@ -460,7 +460,10 @@ fn emit_setup_execution_role_definitions(
             role_definition.name, profile_name
         );
 
-        fragment.resource_blocks.push(role_definition_block(
+        // Shared: role definitions are appended into whichever fragment the
+        // generator hands over first, so a gated first resource must not pull
+        // stack-wide role definitions behind its gate.
+        fragment.push_shared_resource(role_definition_block(
             &role_label,
             expr::template(role_definition.name.clone()),
             expr::raw(&format!(
@@ -488,7 +491,8 @@ fn emit_setup_management_role_definitions(
         role_definition.name =
             format!("${{local.resource_prefix}}-{} [mgmt]", role_definition.name);
 
-        fragment.resource_blocks.push(role_definition_block(
+        // Shared for the same reason as the execution role definitions above.
+        fragment.push_shared_resource(role_definition_block(
             &role_label,
             expr::template(role_definition.name.clone()),
             expr::raw(&format!(

--- a/crates/alien-terraform/src/emitters/azure/kv.rs
+++ b/crates/alien-terraform/src/emitters/azure/kv.rs
@@ -9,7 +9,6 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::azure::helpers::{downcast, required_label},
-    emitters::enabled,
     expr,
 };
 use alien_core::{import::EmitContext, AzureStorageAccount, ErrorData, Kv, Result};
@@ -27,20 +26,17 @@ impl TfEmitter for AzureKvEmitter {
 
         let mut fragment = TfFragment::default();
 
-        let mut table = resource_block(
+        let table = resource_block(
             "azurerm_storage_table",
             label,
             [
                 attr("name", table_name_expr(kv.id())),
-                // The Storage account is a separate, ungated resource, so this
-                // reference stays unindexed even when the table is counted.
                 attr(
                     "storage_account_name",
                     expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
                 ),
             ],
         );
-        enabled::gate_own(ctx, &mut table)?;
         fragment.resource_blocks.push(table);
 
         Ok(fragment)
@@ -52,15 +48,13 @@ impl TfEmitter for AzureKvEmitter {
         Ok(expr::object([
             ("subscriptionId", expr::raw("var.azure_subscription_id")),
             ("resourceGroup", expr::raw("var.azure_resource_group_name")),
-            // Storage-account attributes belong to an ungated resource and
-            // must not be indexed; only the table below is counted.
             (
                 "storageAccountName",
                 expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
             ),
             (
                 "tableName",
-                enabled::self_attribute(ctx, "azurerm_storage_table", label, "name"),
+                expr::traversal(["azurerm_storage_table", label, "name"]),
             ),
             (
                 "tableEndpoint",
@@ -73,10 +67,6 @@ impl TfEmitter for AzureKvEmitter {
         ]))
     }
 
-    fn supports_enabled_when(&self) -> bool {
-        true
-    }
-
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
@@ -86,15 +76,13 @@ impl TfEmitter for AzureKvEmitter {
                 "resourceGroupName",
                 expr::raw("var.azure_resource_group_name"),
             ),
-            // The storage account hosting the table is ungated; only the table
-            // below is counted.
             (
                 "accountName",
                 expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
             ),
             (
                 "tableName",
-                enabled::self_attribute(ctx, "azurerm_storage_table", label, "name"),
+                expr::traversal(["azurerm_storage_table", label, "name"]),
             ),
         ])))
     }

--- a/crates/alien-terraform/src/emitters/azure/queue.rs
+++ b/crates/alien-terraform/src/emitters/azure/queue.rs
@@ -16,7 +16,6 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::azure::helpers::{downcast, required_label, resource_prefix_template},
-    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -33,17 +32,14 @@ impl TfEmitter for AzureQueueEmitter {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
-        let enabled_when = ctx.resource.enabled_when.as_deref();
 
         let lock_duration = lock_duration_for(ctx);
 
-        let mut q = resource_block(
+        let q = resource_block(
             "azurerm_servicebus_queue",
             label,
             [
                 attr("name", resource_prefix_template(queue.id())),
-                // The namespace is a separate, ungated resource, so this
-                // reference stays unindexed even when the queue is counted.
                 attr(
                     "namespace_id",
                     expr::traversal(["azurerm_servicebus_namespace", &parent_label, "id"]),
@@ -67,7 +63,6 @@ impl TfEmitter for AzureQueueEmitter {
                 ),
             ],
         );
-        enabled::gate(&mut q, enabled_when)?;
 
         Ok(TfFragment::default().with_resource(q))
     }
@@ -75,42 +70,32 @@ impl TfEmitter for AzureQueueEmitter {
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("subscriptionId", expr::raw("var.azure_subscription_id")),
             ("resourceGroup", expr::raw("var.azure_resource_group_name")),
-            // The namespace hosting the queue is ungated; only the queue below
-            // is counted.
             (
                 "namespaceName",
                 expr::traversal(["azurerm_servicebus_namespace", &parent_label, "name"]),
             ),
             (
                 "queueName",
-                enabled::attribute(enabled_when, "azurerm_servicebus_queue", label, "name"),
+                expr::traversal(["azurerm_servicebus_queue", label, "name"]),
             ),
         ]))
-    }
-
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
         let parent_label = parent_namespace_label(ctx)?.to_string();
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("servicebus".to_string())),
-            // The namespace hosting the queue is ungated; only the queue below
-            // is counted.
             (
                 "namespace",
                 expr::traversal(["azurerm_servicebus_namespace", &parent_label, "name"]),
             ),
             (
                 "queueName",
-                enabled::attribute(enabled_when, "azurerm_servicebus_queue", label, "name"),
+                expr::traversal(["azurerm_servicebus_queue", label, "name"]),
             ),
         ])))
     }

--- a/crates/alien-terraform/src/emitters/azure/storage.rs
+++ b/crates/alien-terraform/src/emitters/azure/storage.rs
@@ -25,7 +25,6 @@ use crate::{
         downcast, permission_context, required_label, service_account_principal_id,
         setup_execution_role_label, setup_management_role_label,
     },
-    emitters::enabled,
     expr,
 };
 use alien_core::{
@@ -47,7 +46,6 @@ impl TfEmitter for AzureStorageEmitter {
         let storage = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
-        let enabled_when = ctx.resource.enabled_when.as_deref();
 
         let mut fragment = TfFragment::default();
 
@@ -57,13 +55,11 @@ impl TfEmitter for AzureStorageEmitter {
             "private"
         };
 
-        let mut container = resource_block(
+        let container = resource_block(
             "azurerm_storage_container",
             label,
             [
                 attr("name", container_name_expr(storage.id())),
-                // The Storage account is a separate, ungated resource, so this
-                // reference stays unindexed even when the container is counted.
                 attr(
                     "storage_account_name",
                     expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
@@ -74,7 +70,6 @@ impl TfEmitter for AzureStorageEmitter {
                 ),
             ],
         );
-        enabled::gate(&mut container, enabled_when)?;
         fragment.resource_blocks.push(container);
 
         if !storage.lifecycle_rules.is_empty() {
@@ -82,11 +77,10 @@ impl TfEmitter for AzureStorageEmitter {
                 label,
                 &parent_label,
                 &storage.lifecycle_rules,
-                enabled_when,
-            )?);
+            ));
         }
 
-        emit_storage_permissions(ctx, label, &parent_label, &mut fragment, enabled_when)?;
+        emit_storage_permissions(ctx, label, &parent_label, &mut fragment)?;
 
         Ok(fragment)
     }
@@ -95,7 +89,6 @@ impl TfEmitter for AzureStorageEmitter {
         let _ = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("subscriptionId", expr::raw("var.azure_subscription_id")),
             ("resourceGroup", expr::raw("var.azure_resource_group_name")),
@@ -105,31 +98,24 @@ impl TfEmitter for AzureStorageEmitter {
             ),
             (
                 "containerName",
-                enabled::attribute(enabled_when, "azurerm_storage_container", label, "name"),
+                expr::traversal(["azurerm_storage_container", label, "name"]),
             ),
         ]))
-    }
-
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let _ = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
         let parent_label = parent_storage_account_label(ctx)?.to_string();
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("blob".to_string())),
-            // The storage account hosting the container is ungated; only the
-            // container below is counted.
             (
                 "accountName",
                 expr::traversal(["azurerm_storage_account", &parent_label, "name"]),
             ),
             (
                 "containerName",
-                enabled::attribute(enabled_when, "azurerm_storage_container", label, "name"),
+                expr::traversal(["azurerm_storage_container", label, "name"]),
             ),
         ])))
     }
@@ -169,8 +155,7 @@ fn lifecycle_policy(
     storage_label: &str,
     parent_label: &str,
     rules: &[LifecycleRule],
-    enabled_when: Option<&str>,
-) -> Result<hcl::structure::Block> {
+) -> hcl::structure::Block {
     let rule_blocks: Vec<hcl::structure::Structure> = rules
         .iter()
         .enumerate()
@@ -183,9 +168,7 @@ fn lifecycle_policy(
     )];
     body.extend(rule_blocks);
 
-    let mut policy = resource_block("azurerm_storage_management_policy", storage_label, body);
-    enabled::gate(&mut policy, enabled_when)?;
-    Ok(policy)
+    resource_block("azurerm_storage_management_policy", storage_label, body)
 }
 
 fn emit_storage_permissions(
@@ -193,7 +176,6 @@ fn emit_storage_permissions(
     storage_label: &str,
     parent_label: &str,
     fragment: &mut TfFragment,
-    enabled_when: Option<&str>,
 ) -> Result<()> {
     for (profile_name, permission_set_refs) in storage_permission_owners(ctx) {
         let Some(principal_id_expr) = service_account_principal_id(ctx, &profile_name) else {
@@ -251,7 +233,6 @@ fn emit_storage_permissions(
                     expr::template(binding.scope.clone()),
                     role_definition_id,
                     principal_id_expr.clone(),
-                    enabled_when,
                 )?;
             }
         }
@@ -316,7 +297,6 @@ fn emit_storage_permissions(
                 expr::template(binding.scope.clone()),
                 role_definition_id,
                 principal_id_expr.clone(),
-                enabled_when,
             )?;
         }
     }
@@ -369,10 +349,9 @@ fn emit_role_assignment(
     scope: Expression,
     role_definition_id: Expression,
     principal_id_expr: Expression,
-    enabled_when: Option<&str>,
 ) -> Result<()> {
     let role_label = sanitize_role_label(role_name);
-    let mut assignment = resource_block(
+    let assignment = resource_block(
         "azurerm_role_assignment",
         &format!("{storage_label}_{role_label}_{principal_label}_assignment_{binding_index}"),
         [
@@ -387,8 +366,6 @@ fn emit_role_assignment(
             attr("principal_id", principal_id_expr),
         ],
     );
-    // The grant exists only to reach this container, so it follows the same gate.
-    enabled::gate(&mut assignment, enabled_when)?;
     fragment.resource_blocks.push(assignment);
     Ok(())
 }

--- a/crates/alien-terraform/src/emitters/enabled.rs
+++ b/crates/alien-terraform/src/emitters/enabled.rs
@@ -81,20 +81,6 @@ pub fn gate(block: &mut Block, enabled_when: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-/// Reference to an attribute of a resource that may be gated, indexing into the
-/// count when it is.
-pub fn attribute(
-    enabled_when: Option<&str>,
-    resource_type: &str,
-    label: &str,
-    attribute: &str,
-) -> Expression {
-    match enabled_when {
-        Some(_) => expr::traversal_indexed(resource_type, label, attribute),
-        None => expr::traversal([resource_type, label, attribute]),
-    }
-}
-
 /// The registration list the manager consumes, one entry per resource.
 ///
 /// A resource the deployer declined contributes no entry at all. It does not
@@ -165,26 +151,4 @@ mod tests {
 
         assert_eq!(block, before);
     }
-}
-
-/// [`gate`] reading the resource's own gate off the emit context, so an
-/// emitter's own blocks structurally cannot miss it. The `Option<&str>` form
-/// stays for callers gating blocks on a *different* resource's gate.
-pub fn gate_own(ctx: &alien_core::import::EmitContext<'_>, block: &mut Block) -> Result<()> {
-    gate(block, ctx.resource.enabled_when.as_deref())
-}
-
-/// [`attribute`] reading the resource's own gate off the emit context.
-pub fn self_attribute(
-    ctx: &alien_core::import::EmitContext<'_>,
-    resource_type: &str,
-    label: &str,
-    attr_name: &str,
-) -> Expression {
-    attribute(
-        ctx.resource.enabled_when.as_deref(),
-        resource_type,
-        label,
-        attr_name,
-    )
 }

--- a/crates/alien-terraform/src/emitters/gcp/helpers.rs
+++ b/crates/alien-terraform/src/emitters/gcp/helpers.rs
@@ -324,7 +324,11 @@ fn emit_selected_custom_roles(fragment: &mut TfFragment, custom_roles: &[GcpCust
         let role_label = custom_role_label(custom_role);
         let role_id = custom_role_id_template(custom_role);
 
-        fragment.resource_blocks.push(resource_block(
+        // Shared: the role is project-wide and carries its own
+        // `gcp_manage_custom_roles` count, so a resource's gate must never
+        // reach it — declining one resource would delete a role its siblings
+        // still hold.
+        fragment.push_shared_resource(resource_block(
             "google_project_iam_custom_role",
             &role_label,
             [

--- a/crates/alien-terraform/src/emitters/gcp/kv.rs
+++ b/crates/alien-terraform/src/emitters/gcp/kv.rs
@@ -7,7 +7,6 @@
 use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
-    emitters::enabled,
     emitters::gcp::helpers::{downcast, required_label, resource_prefix_template},
     expr,
 };
@@ -22,7 +21,7 @@ impl TfEmitter for GcpKvEmitter {
         let kv = downcast::<Kv>(ctx, Kv::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
 
-        let mut database = resource_block(
+        let database = resource_block(
             "google_firestore_database",
             label,
             [
@@ -45,7 +44,6 @@ impl TfEmitter for GcpKvEmitter {
                 attr("deletion_policy", Expression::String("DELETE".to_string())),
             ],
         );
-        enabled::gate_own(ctx, &mut database)?;
 
         Ok(TfFragment::default().with_resource(database))
     }
@@ -56,22 +54,13 @@ impl TfEmitter for GcpKvEmitter {
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "databaseId",
-                enabled::self_attribute(ctx, "google_firestore_database", label, "name"),
+                expr::traversal(["google_firestore_database", label, "name"]),
             ),
             (
                 "location",
-                enabled::self_attribute(
-                    ctx,
-                    "google_firestore_database",
-                    label,
-                    "location_id",
-                ),
+                expr::traversal(["google_firestore_database", label, "location_id"]),
             ),
         ]))
-    }
-
-    fn supports_enabled_when(&self) -> bool {
-        true
     }
 
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
@@ -82,7 +71,7 @@ impl TfEmitter for GcpKvEmitter {
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "databaseId",
-                enabled::self_attribute(ctx, "google_firestore_database", label, "name"),
+                expr::traversal(["google_firestore_database", label, "name"]),
             ),
             ("collectionName", Expression::String(kv.id().to_string())),
         ])))

--- a/crates/alien-terraform/src/emitters/gcp/queue.rs
+++ b/crates/alien-terraform/src/emitters/gcp/queue.rs
@@ -8,7 +8,6 @@
 use crate::{
     block::{attr, block, nested, resource_block},
     emitter::{TfEmitter, TfFragment},
-    emitters::enabled,
     emitters::gcp::helpers::{
         binding_label_for_role, downcast, emit_custom_roles_for_bindings, labels,
         permission_context, required_label, resource_prefix_template, role_expression_for_binding,
@@ -31,9 +30,8 @@ impl TfEmitter for GcpQueueEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let queue = downcast::<Queue>(ctx, Queue::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
 
-        let mut topic = resource_block(
+        let topic = resource_block(
             "google_pubsub_topic",
             label,
             [
@@ -42,10 +40,9 @@ impl TfEmitter for GcpQueueEmitter {
                 attr("labels", labels(ctx, "queue")),
             ],
         );
-        enabled::gate(&mut topic, enabled_when)?;
 
         let ack_deadline = ack_deadline_for(ctx);
-        let mut subscription = resource_block(
+        let subscription = resource_block(
             "google_pubsub_subscription",
             label,
             [
@@ -54,11 +51,7 @@ impl TfEmitter for GcpQueueEmitter {
                     expr::template(format!("${{local.resource_prefix}}-{}-default", queue.id())),
                 ),
                 attr("project", expr::raw("var.gcp_project")),
-                // The topic belongs to this same resource, so it is counted too.
-                attr(
-                    "topic",
-                    enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
-                ),
+                attr("topic", expr::traversal(["google_pubsub_topic", label, "id"])),
                 attr(
                     "ack_deadline_seconds",
                     Expression::Number(hcl::Number::from(i64::from(ack_deadline))),
@@ -75,83 +68,55 @@ impl TfEmitter for GcpQueueEmitter {
                 attr("labels", labels(ctx, "queue")),
             ],
         );
-        enabled::gate(&mut subscription, enabled_when)?;
 
         let mut fragment = TfFragment::default();
         fragment.resource_blocks.push(topic);
         fragment.resource_blocks.push(subscription);
-        emit_queue_iam(ctx, &mut fragment, label, enabled_when)?;
+        emit_queue_iam(ctx, &mut fragment, label)?;
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "topicId",
-                enabled::attribute(enabled_when, "google_pubsub_topic", label, "name"),
+                expr::traversal(["google_pubsub_topic", label, "name"]),
             ),
             (
                 "topicName",
-                enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
+                expr::traversal(["google_pubsub_topic", label, "id"]),
             ),
             (
                 "subscriptionId",
-                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "name"),
+                expr::traversal(["google_pubsub_subscription", label, "name"]),
             ),
             (
                 "subscriptionName",
-                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "id"),
+                expr::traversal(["google_pubsub_subscription", label, "id"]),
             ),
         ]))
     }
 
-    fn supports_enabled_when(&self) -> bool {
-        true
-    }
-
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("pubsub".to_string())),
-            (
-                "topic",
-                enabled::attribute(enabled_when, "google_pubsub_topic", label, "id"),
-            ),
+            ("topic", expr::traversal(["google_pubsub_topic", label, "id"])),
             (
                 "subscription",
-                enabled::attribute(enabled_when, "google_pubsub_subscription", label, "id"),
+                expr::traversal(["google_pubsub_subscription", label, "id"]),
             ),
         ])))
     }
 }
 
-/// Address of one of this queue's own blocks, indexed when the queue is gated.
-///
-/// The IAM members below reference the topic and the subscription from raw
-/// strings as well as from expressions, so both forms have to agree on whether
-/// the `[0]` is there.
-fn own_block(enabled_when: Option<&str>, resource_type: &str, label: &str) -> String {
-    match enabled_when {
-        Some(_) => format!("{resource_type}.{label}[0]"),
-        None => format!("{resource_type}.{label}"),
-    }
-}
-
-fn emit_queue_iam(
-    ctx: &EmitContext<'_>,
-    fragment: &mut TfFragment,
-    label: &str,
-    enabled_when: Option<&str>,
-) -> Result<()> {
+fn emit_queue_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
     for (owner_label, permission_refs) in queue_permission_owners(ctx) {
         let member = service_account_member_for_label(&owner_label);
-        let topic_ref = own_block(enabled_when, "google_pubsub_topic", label);
         let context = permission_context(&owner_label, ctx.stack.id())
-            .with_resource_name(format!("${{{topic_ref}.name}}"));
+            .with_resource_name(format!("${{google_pubsub_topic.{label}.name}}"));
         let generator = GcpRuntimePermissionsGenerator::new();
 
         for permission_ref in permission_refs {
@@ -185,49 +150,35 @@ fn emit_queue_iam(
                 let role = role_expression_for_binding(&binding.role, &custom_roles)?;
                 match resource_kind {
                     GcpBindingResourceKind::PubsubTopic => {
-                        let mut member_block = resource_block(
+                        let member_block = resource_block(
                             "google_pubsub_topic_iam_member",
                             &format!("{role_label}_{label}_{owner_label}_topic_{idx}"),
                             [
                                 attr("project", expr::raw("var.gcp_project")),
                                 attr(
                                     "topic",
-                                    enabled::attribute(
-                                        enabled_when,
-                                        "google_pubsub_topic",
-                                        label,
-                                        "name",
-                                    ),
+                                    expr::traversal(["google_pubsub_topic", label, "name"]),
                                 ),
                                 attr("role", role),
                                 attr("member", member.clone()),
                             ],
                         );
-                        // The grant targets this queue's topic, so it only
-                        // exists while the topic does.
-                        enabled::gate(&mut member_block, enabled_when)?;
                         fragment.resource_blocks.push(member_block);
                     }
                     GcpBindingResourceKind::PubsubSubscription => {
-                        let mut member_block = resource_block(
+                        let member_block = resource_block(
                             "google_pubsub_subscription_iam_member",
                             &format!("{role_label}_{label}_{owner_label}_subscription_{idx}"),
                             [
                                 attr("project", expr::raw("var.gcp_project")),
                                 attr(
                                     "subscription",
-                                    enabled::attribute(
-                                        enabled_when,
-                                        "google_pubsub_subscription",
-                                        label,
-                                        "name",
-                                    ),
+                                    expr::traversal(["google_pubsub_subscription", label, "name"]),
                                 ),
                                 attr("role", role),
                                 attr("member", member.clone()),
                             ],
                         );
-                        enabled::gate(&mut member_block, enabled_when)?;
                         fragment.resource_blocks.push(member_block);
                     }
                     GcpBindingResourceKind::ArtifactRegistryRepository => {}

--- a/crates/alien-terraform/src/emitters/gcp/storage.rs
+++ b/crates/alien-terraform/src/emitters/gcp/storage.rs
@@ -8,7 +8,6 @@
 use crate::{
     block::{attr, block, nested, resource_block},
     emitter::{TfEmitter, TfFragment},
-    emitters::enabled,
     emitters::gcp::helpers::{
         binding_label_for_role, downcast, emit_custom_roles_for_bindings, labels,
         permission_context, required_label, resource_prefix_template, role_expression_for_binding,
@@ -34,67 +33,51 @@ impl TfEmitter for GcpStorageEmitter {
     fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         let storage = downcast::<Storage>(ctx, Storage::RESOURCE_TYPE)?;
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         let mut fragment = TfFragment::default();
 
-        fragment
-            .resource_blocks
-            .push(bucket(label, ctx, storage, enabled_when)?);
+        fragment.resource_blocks.push(bucket(label, ctx, storage));
 
         if storage.public_read {
-            fragment
-                .resource_blocks
-                .push(public_iam_binding(label, enabled_when)?);
+            fragment.resource_blocks.push(public_iam_binding(label));
         }
 
-        emit_storage_iam(ctx, &mut fragment, label, enabled_when)?;
+        emit_storage_iam(ctx, &mut fragment, label)?;
 
         Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(expr::object([
             (
                 "bucketName",
-                enabled::attribute(enabled_when, "google_storage_bucket", label, "name"),
+                expr::traversal(["google_storage_bucket", label, "name"]),
             ),
             (
                 "bucketSelfLink",
-                enabled::attribute(enabled_when, "google_storage_bucket", label, "self_link"),
+                expr::traversal(["google_storage_bucket", label, "self_link"]),
             ),
             ("projectId", expr::raw("var.gcp_project")),
             (
                 "location",
-                enabled::attribute(enabled_when, "google_storage_bucket", label, "location"),
+                expr::traversal(["google_storage_bucket", label, "location"]),
             ),
         ]))
     }
 
-    fn supports_enabled_when(&self) -> bool {
-        true
-    }
-
     fn emit_binding_ref(&self, ctx: &EmitContext<'_>) -> Result<Option<Expression>> {
         let label = required_label(ctx)?;
-        let enabled_when = ctx.resource.enabled_when.as_deref();
         Ok(Some(expr::object([
             ("service", Expression::String("gcs".to_string())),
             (
                 "bucketName",
-                enabled::attribute(enabled_when, "google_storage_bucket", label, "name"),
+                expr::traversal(["google_storage_bucket", label, "name"]),
             ),
         ])))
     }
 }
 
-fn bucket(
-    label: &str,
-    ctx: &EmitContext<'_>,
-    storage: &Storage,
-    enabled_when: Option<&str>,
-) -> Result<hcl::structure::Block> {
+fn bucket(label: &str, ctx: &EmitContext<'_>, storage: &Storage) -> hcl::structure::Block {
     let mut body: Vec<hcl::structure::Structure> = vec![
         attr("name", resource_prefix_template(storage.id())),
         attr("project", expr::raw("var.gcp_project")),
@@ -124,9 +107,7 @@ fn bucket(
         body.push(nested(lifecycle_rule_block(rule)));
     }
 
-    let mut bucket = resource_block("google_storage_bucket", label, body);
-    enabled::gate(&mut bucket, enabled_when)?;
-    Ok(bucket)
+    resource_block("google_storage_bucket", label, body)
 }
 
 fn lifecycle_rule_block(rule: &LifecycleRule) -> hcl::structure::Block {
@@ -152,39 +133,29 @@ fn lifecycle_rule_block(rule: &LifecycleRule) -> hcl::structure::Block {
     )
 }
 
-fn public_iam_binding(label: &str, enabled_when: Option<&str>) -> Result<hcl::structure::Block> {
-    let mut binding = resource_block(
+fn public_iam_binding(label: &str) -> hcl::structure::Block {
+    resource_block(
         "google_storage_bucket_iam_member",
         &format!("{label}_public_read"),
         [
-            attr("bucket", bucket_name(label, enabled_when)),
+            attr("bucket", bucket_name(label)),
             attr(
                 "role",
                 Expression::String("roles/storage.objectViewer".to_string()),
             ),
             attr("member", Expression::String("allUsers".to_string())),
         ],
-    );
-    enabled::gate(&mut binding, enabled_when)?;
-    Ok(binding)
+    )
 }
 
-fn bucket_name(label: &str, enabled_when: Option<&str>) -> Expression {
-    enabled::attribute(enabled_when, "google_storage_bucket", label, "name")
+fn bucket_name(label: &str) -> Expression {
+    expr::traversal(["google_storage_bucket", label, "name"])
 }
 
-fn emit_storage_iam(
-    ctx: &EmitContext<'_>,
-    fragment: &mut TfFragment,
-    label: &str,
-    enabled_when: Option<&str>,
-) -> Result<()> {
+fn emit_storage_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str) -> Result<()> {
     for (owner_label, permission_refs) in storage_permission_owners(ctx) {
         let member = service_account_member_for_label(&owner_label);
-        let bucket_ref = match enabled_when {
-            Some(_) => format!("${{google_storage_bucket.{label}[0].name}}"),
-            None => format!("${{google_storage_bucket.{label}.name}}"),
-        };
+        let bucket_ref = format!("${{google_storage_bucket.{label}.name}}");
         let context =
             permission_context(&owner_label, ctx.stack.id()).with_resource_name(bucket_ref);
         let generator = GcpRuntimePermissionsGenerator::new();
@@ -208,18 +179,13 @@ fn emit_storage_iam(
                     ),
                 })?;
             let bindings = grant_plan.bindings_for_target(GcpBindingTargetScope::CurrentResource);
-            // Custom roles carry their own `var.gcp_manage_custom_roles` count
-            // and are referenced through it, so the deployer's gate stays off
-            // them: a second `count` on one block is not renderable. A declined
-            // bucket then leaves a role definition that grants nothing, which is
-            // harmless.
             let custom_roles = emit_custom_roles_for_bindings(fragment, &grant_plan, &bindings)?;
 
             for (idx, binding) in bindings.into_iter().enumerate() {
                 let role_label = binding_label_for_role(&binding.role, &custom_roles)?;
                 let role = role_expression_for_binding(&binding.role, &custom_roles)?;
                 let mut body = vec![
-                    attr("bucket", bucket_name(label, enabled_when)),
+                    attr("bucket", bucket_name(label)),
                     attr("role", role),
                     attr("member", member.clone()),
                 ];
@@ -233,12 +199,11 @@ fn emit_storage_iam(
                         ],
                     )));
                 }
-                let mut member_block = resource_block(
+                let member_block = resource_block(
                     "google_storage_bucket_iam_member",
                     &format!("{role_label}_{label}_{owner_label}_storage_{idx}"),
                     body,
                 );
-                enabled::gate(&mut member_block, enabled_when)?;
                 fragment.resource_blocks.push(member_block);
             }
         }

--- a/crates/alien-terraform/src/gating.rs
+++ b/crates/alien-terraform/src/gating.rs
@@ -170,10 +170,11 @@ pub(crate) fn rewrite_expression(expression: &mut Expression, gated: &GatedAddre
                 // counted resource (`depends_on`), never indexed.
                 return;
             };
-            let indexes_attribute = matches!(
-                following,
-                TraversalOperator::GetAttr(_) | TraversalOperator::AttrSplat | TraversalOperator::FullSplat
-            );
+            // Only plain attribute access needs the count index. A splat
+            // (`.*` / `[*]`) over the counted resource is already list-aware
+            // and stays unindexed, like `depends_on`; inserting `[0]` there
+            // would splat a single instance and break when the gate is off.
+            let indexes_attribute = matches!(following, TraversalOperator::GetAttr(_));
             if indexes_attribute && gated.contains(root.as_str(), label.as_str()) {
                 traversal.operators.insert(
                     1,
@@ -190,8 +191,25 @@ pub(crate) fn rewrite_expression(expression: &mut Expression, gated: &GatedAddre
             }
         }
         Expression::Object(object) => {
-            for (_key, value) in object.iter_mut() {
-                rewrite_expression(value, gated);
+            let needs_key_rewrite = object
+                .keys()
+                .any(|key| matches!(key, hcl::expr::ObjectKey::Expression(_)));
+            if needs_key_rewrite {
+                let entries: Vec<(hcl::expr::ObjectKey, Expression)> = std::mem::take(object)
+                    .into_iter()
+                    .map(|(mut key, mut value)| {
+                        if let hcl::expr::ObjectKey::Expression(expression) = &mut key {
+                            rewrite_expression(expression, gated);
+                        }
+                        rewrite_expression(&mut value, gated);
+                        (key, value)
+                    })
+                    .collect();
+                *object = entries.into_iter().collect();
+            } else {
+                for (_key, value) in object.iter_mut() {
+                    rewrite_expression(value, gated);
+                }
             }
         }
         Expression::FuncCall(func_call) => {
@@ -257,21 +275,52 @@ fn rewrite_template(template_expr: &mut TemplateExpr, gated: &GatedAddresses) {
         return;
     };
     let mut changed = false;
-    for element in template.elements_mut() {
-        if let Element::Interpolation(interpolation) = element {
-            let before = interpolation.expr.clone();
-            rewrite_expression(&mut interpolation.expr, gated);
-            if interpolation.expr != before {
-                changed = true;
-            }
-        }
-    }
+    rewrite_template_elements(&mut template, gated, &mut changed);
     if !changed {
         return;
     }
     match template_expr {
         TemplateExpr::QuotedString(quoted) => *quoted = template.to_string(),
         TemplateExpr::Heredoc(heredoc) => heredoc.template = template.to_string(),
+    }
+}
+
+/// Interpolations plus `%{if}` / `%{for}` directives, recursively — a gated
+/// reference inside a directive's condition or body needs the same index as
+/// one in a plain interpolation.
+fn rewrite_template_elements(template: &mut Template, gated: &GatedAddresses, changed: &mut bool) {
+    for element in template.elements_mut() {
+        match element {
+            Element::Interpolation(interpolation) => {
+                let before = interpolation.expr.clone();
+                rewrite_expression(&mut interpolation.expr, gated);
+                if interpolation.expr != before {
+                    *changed = true;
+                }
+            }
+            Element::Directive(directive) => match directive.as_mut() {
+                hcl::template::Directive::If(directive) => {
+                let before = directive.cond_expr.clone();
+                rewrite_expression(&mut directive.cond_expr, gated);
+                if directive.cond_expr != before {
+                    *changed = true;
+                }
+                    rewrite_template_elements(&mut directive.true_template, gated, changed);
+                    if let Some(false_template) = directive.false_template.as_mut() {
+                        rewrite_template_elements(false_template, gated, changed);
+                    }
+                }
+                hcl::template::Directive::For(directive) => {
+                let before = directive.collection_expr.clone();
+                rewrite_expression(&mut directive.collection_expr, gated);
+                if directive.collection_expr != before {
+                    *changed = true;
+                }
+                    rewrite_template_elements(&mut directive.template, gated, changed);
+                }
+            },
+            Element::Literal(_) => {}
+        }
     }
 }
 
@@ -308,26 +357,42 @@ pub(crate) fn scan_rendered_for_unindexed(
                 {
                     continue;
                 }
-                if follower == Some('[') {
+                if follower == Some('[') && is_instance_index(&contents[end..]) {
                     continue;
                 }
                 if exempt.iter().any(|span| span.contains(&start)) {
                     continue;
                 }
                 // The resource's own declaration is `resource "type" "label"`,
-                // quoted, so it never matches the dotted form.
-                return Err(AlienError::new(ErrorData::GenericError {
-                    message: format!(
-                        "gated resource `{address}` is referenced without its count index in \
-                         `{file_name}`; the reference escaped the rewrite (raw string?) and \
-                         would fail or, worse, silently mis-resolve when the deployer declines \
-                         the resource"
+                // quoted, so it never matches the dotted form. Deterministic:
+                // the same stack renders the same escape every time, so the
+                // refusal must not be retryable.
+                return Err(AlienError::new(ErrorData::OperationNotSupported {
+                    operation: format!("enabled() on `{address}`"),
+                    reason: format!(
+                        "the resource is referenced without its count index in `{file_name}`; \
+                         the reference escaped the rewrite (raw string?) and would fail or, \
+                         worse, silently mis-resolve when the deployer declines the resource"
                     ),
                 }));
             }
         }
     }
     Ok(())
+}
+
+/// True when the text starts with a real instance index — `[0]` (any digits)
+/// or the full splat `[*]` — the only bracket forms that are valid directly
+/// on a counted resource address.
+fn is_instance_index(text: &str) -> bool {
+    let Some(inner) = text.strip_prefix('[') else {
+        return false;
+    };
+    let Some(close) = inner.find(']') else {
+        return false;
+    };
+    let index = inner[..close].trim();
+    index == "*" || (!index.is_empty() && index.chars().all(|ch| ch.is_ascii_digit()))
 }
 
 /// Byte ranges of `depends_on = [ ... ]` attribute values, where
@@ -338,10 +403,15 @@ fn depends_on_spans(contents: &str) -> Vec<std::ops::Range<usize>> {
     while let Some(found) = contents[search_from..].find("depends_on") {
         let start = search_from + found;
         search_from = start + "depends_on".len();
-        let Some(open_offset) = contents[start..].find('[') else {
+        // Only the attribute form `depends_on = [` opens an exemption; the
+        // word appearing in prose (a README paragraph, a comment) must not
+        // exempt whatever bracket happens to follow it.
+        let after = &contents[start + "depends_on".len()..];
+        let assignment: String = after.chars().take_while(|ch| ch.is_whitespace() || *ch == '=').collect();
+        if !assignment.contains('=') || !after[assignment.len()..].starts_with('[') {
             continue;
-        };
-        let open = start + open_offset;
+        }
+        let open = start + "depends_on".len() + assignment.len();
         let mut depth = 0usize;
         let mut close = None;
         for (offset, ch) in contents[open..].char_indices() {
@@ -403,6 +473,62 @@ mod tests {
         let before = expression.clone();
         rewrite_expression(&mut expression, &gated_analytics());
         assert_eq!(expression, before);
+    }
+
+    #[test]
+    fn splat_references_stay_unindexed() {
+        for splat in [
+            "aws_dynamodb_table.analytics[*].name",
+            "aws_dynamodb_table.analytics.*.name",
+        ] {
+            let mut expression = expr::parse(splat).expect("valid splat");
+            let before = expression.clone();
+            rewrite_expression(&mut expression, &gated_analytics());
+            assert_eq!(expression, before, "{splat}");
+        }
+    }
+
+    #[test]
+    fn scan_accepts_instance_indexes_but_not_key_indexes() {
+        let mut ok_files = indexmap::IndexMap::new();
+        ok_files.insert(
+            "main.tf".to_string(),
+            "locals { a = aws_dynamodb_table.analytics[0].name, b = aws_dynamodb_table.analytics[*].name }"
+                .to_string(),
+        );
+        scan_rendered_for_unindexed(&ok_files, &gated_analytics())
+            .expect("instance indexes and splats are valid on a counted resource");
+
+        let mut bad_files = indexmap::IndexMap::new();
+        bad_files.insert(
+            "main.tf".to_string(),
+            "locals { x = aws_dynamodb_table.analytics[\"key\"].name }".to_string(),
+        );
+        scan_rendered_for_unindexed(&bad_files, &gated_analytics())
+            .expect_err("a key index on a counted resource is not an instance index");
+    }
+
+    #[test]
+    fn prose_mentioning_depends_on_exempts_nothing() {
+        let mut files = indexmap::IndexMap::new();
+        files.insert(
+            "main.tf".to_string(),
+            "# depends_on ordering notes\nlocals { x = [aws_dynamodb_table.analytics.name] }"
+                .to_string(),
+        );
+        scan_rendered_for_unindexed(&files, &gated_analytics())
+            .expect_err("only `depends_on = [` opens an exemption");
+    }
+
+    #[test]
+    fn template_directives_are_rewritten() {
+        let mut expression =
+            expr::template("%{ if aws_dynamodb_table.analytics.name != \"\" }yes%{ endif }");
+        rewrite_expression(&mut expression, &gated_analytics());
+        assert_eq!(
+            expression,
+            expr::template("%{ if aws_dynamodb_table.analytics[0].name != \"\" }yes%{ endif }")
+        );
     }
 
     #[test]

--- a/crates/alien-terraform/src/gating.rs
+++ b/crates/alien-terraform/src/gating.rs
@@ -23,9 +23,8 @@ use alien_core::{ErrorData, Result};
 use alien_error::AlienError;
 use hcl::{
     expr::{Expression, TemplateExpr, TraversalOperator},
-    structure::{Attribute, Block, Body, Structure},
+    structure::{Block, Body, Structure},
     template::{Element, Template},
-    Identifier,
 };
 use std::collections::HashSet;
 

--- a/crates/alien-terraform/src/gating.rs
+++ b/crates/alien-terraform/src/gating.rs
@@ -1,0 +1,560 @@
+//! Generator-side gating post-pass for `.enabled(input)` resources.
+//!
+//! Emitters render plain, unconditional blocks; this pass makes a gated
+//! resource conditional after the fact: every owned block gets the gate's
+//! `count`, and every reference to a gated block anywhere in the module is
+//! rewritten to index into the count (`type.label[0].attr`). Emitters
+//! therefore need no gating knowledge at all — the fragment's shared-block
+//! classification and the central residual allowlist are the only inputs.
+//!
+//! Two nets keep a miss loud instead of silent:
+//!
+//! - [`crate::emitters::enabled::gate`] refuses blocks that already carry a
+//!   `count`, and this pass refuses `for_each`, so a colliding meta-argument
+//!   fails at render time;
+//! - [`scan_rendered_for_unindexed`] runs over the rendered files and fails
+//!   generation if a gated address survives anywhere unindexed (references
+//!   hidden in raw strings the AST walk cannot see), except inside
+//!   `depends_on`, where Terraform requires whole-resource references.
+
+use crate::emitter::TfFragment;
+use crate::emitters::enabled;
+use alien_core::{ErrorData, Result};
+use alien_error::AlienError;
+use hcl::{
+    expr::{Expression, TemplateExpr, TraversalOperator},
+    structure::{Attribute, Block, Body, Structure},
+    template::{Element, Template},
+    Identifier,
+};
+use std::collections::HashSet;
+
+/// Block types with no cloud footprint, allowed to render ungated inside a
+/// gated fragment. Central by design: an emitter author cannot assert
+/// footprintlessness, only this list can grow it (as a reviewed change).
+const RESIDUAL_BLOCK_TYPES: &[&str] = &["random_id"];
+
+/// Nested blocks that execute code or open connections. A residual block
+/// containing one is not footprintless, whatever its type says.
+const SIDE_EFFECT_NESTED_BLOCKS: &[&str] = &["provisioner", "connection"];
+
+/// Addresses (`type.label`) of blocks that were gated, shared across the
+/// module for reference rewriting and the rendered-output scan.
+#[derive(Debug, Default)]
+pub(crate) struct GatedAddresses {
+    addresses: HashSet<(String, String)>,
+}
+
+impl GatedAddresses {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.addresses.is_empty()
+    }
+
+    fn contains(&self, provider_type: &str, label: &str) -> bool {
+        self.addresses
+            .contains(&(provider_type.to_string(), label.to_string()))
+    }
+
+    /// The addresses as `type.label` strings, for the rendered-output scan.
+    pub(crate) fn rendered_forms(&self) -> Vec<String> {
+        self.addresses
+            .iter()
+            .map(|(provider_type, label)| format!("{provider_type}.{label}"))
+            .collect()
+    }
+}
+
+/// Gate every owned block of a gated resource's fragment and record their
+/// addresses. Shared blocks stay untouched; residual blocks stay ungated
+/// after their footprintlessness is verified.
+pub(crate) fn gate_fragment(
+    fragment: &mut TfFragment,
+    resource_id: &str,
+    input_id: &str,
+    gated: &mut GatedAddresses,
+) -> Result<()> {
+    let shared: Vec<bool> = fragment
+        .resource_blocks
+        .iter()
+        .map(|block| fragment.is_shared(block))
+        .collect();
+    for (block, is_shared) in fragment.resource_blocks.iter_mut().zip(shared) {
+        if block.identifier.as_str() != "resource" || is_shared {
+            continue;
+        }
+        let (Some(provider_type), Some(label)) = (
+            block.labels.first().map(|label| label.as_str().to_string()),
+            block.labels.get(1).map(|label| label.as_str().to_string()),
+        ) else {
+            continue;
+        };
+
+        if RESIDUAL_BLOCK_TYPES.contains(&provider_type.as_str()) {
+            verify_residual_is_footprintless(block, resource_id)?;
+            continue;
+        }
+
+        if block
+            .body
+            .attributes()
+            .any(|attribute| attribute.key.as_str() == "for_each")
+        {
+            return Err(AlienError::new(ErrorData::OperationNotSupported {
+                operation: format!("enabled() on `{provider_type}.{label}`"),
+                reason: "the block declares `for_each`, and Terraform accepts only one of \
+                         `for_each` and the `count` the gate needs"
+                    .to_string(),
+            }));
+        }
+
+        enabled::gate(block, Some(input_id))?;
+        gated.addresses.insert((provider_type, label));
+    }
+    Ok(())
+}
+
+/// A residual block renders ungated inside a gated fragment, so it must not
+/// be able to create anything or run anything.
+fn verify_residual_is_footprintless(block: &Block, resource_id: &str) -> Result<()> {
+    let offending = block.body.blocks().find(|nested| {
+        SIDE_EFFECT_NESTED_BLOCKS.contains(&nested.identifier.as_str())
+    });
+    if let Some(nested) = offending {
+        return Err(AlienError::new(ErrorData::OperationNotSupported {
+            operation: format!(
+                "enabled() on resource '{resource_id}'",
+            ),
+            reason: format!(
+                "its `{}` block would stay ungated as a footprintless residual, but it \
+                 contains a `{}` block, which executes even when the resource is declined",
+                block.labels.first().map(|label| label.as_str()).unwrap_or("residual"),
+                nested.identifier.as_str()
+            ),
+        }));
+    }
+    Ok(())
+}
+
+/// Rewrite every reference to a gated address across the module: fragments,
+/// shared locals, and the registration's import expressions. Whole-resource
+/// references (no attribute access after the label) are left alone —
+/// `depends_on` requires them unindexed.
+pub(crate) fn rewrite_fragment_references(fragment: &mut TfFragment, gated: &GatedAddresses) {
+    for block in fragment
+        .resource_blocks
+        .iter_mut()
+        .chain(fragment.data_blocks.iter_mut())
+    {
+        rewrite_block(block, gated);
+    }
+    for (_name, expression) in fragment.locals.iter_mut() {
+        rewrite_expression(expression, gated);
+    }
+}
+
+pub(crate) fn rewrite_expression(expression: &mut Expression, gated: &GatedAddresses) {
+    match expression {
+        Expression::Traversal(traversal) => {
+            rewrite_expression(&mut traversal.expr, gated);
+            for operator in traversal.operators.iter_mut() {
+                if let TraversalOperator::Index(index) = operator {
+                    rewrite_expression(index, gated);
+                }
+            }
+            let Expression::Variable(root) = &traversal.expr else {
+                return;
+            };
+            let [TraversalOperator::GetAttr(label), following, ..] =
+                traversal.operators.as_slice()
+            else {
+                // A bare `type.label` whole-resource reference: valid on a
+                // counted resource (`depends_on`), never indexed.
+                return;
+            };
+            let indexes_attribute = matches!(
+                following,
+                TraversalOperator::GetAttr(_) | TraversalOperator::AttrSplat | TraversalOperator::FullSplat
+            );
+            if indexes_attribute && gated.contains(root.as_str(), label.as_str()) {
+                traversal.operators.insert(
+                    1,
+                    TraversalOperator::Index(Expression::Number(hcl::Number::from(0))),
+                );
+            }
+        }
+        Expression::TemplateExpr(template_expr) => {
+            rewrite_template(template_expr, gated);
+        }
+        Expression::Array(items) => {
+            for item in items {
+                rewrite_expression(item, gated);
+            }
+        }
+        Expression::Object(object) => {
+            for (_key, value) in object.iter_mut() {
+                rewrite_expression(value, gated);
+            }
+        }
+        Expression::FuncCall(func_call) => {
+            for arg in func_call.args.iter_mut() {
+                rewrite_expression(arg, gated);
+            }
+        }
+        Expression::Conditional(conditional) => {
+            rewrite_expression(&mut conditional.cond_expr, gated);
+            rewrite_expression(&mut conditional.true_expr, gated);
+            rewrite_expression(&mut conditional.false_expr, gated);
+        }
+        Expression::Operation(operation) => match operation.as_mut() {
+            hcl::expr::Operation::Unary(unary) => rewrite_expression(&mut unary.expr, gated),
+            hcl::expr::Operation::Binary(binary) => {
+                rewrite_expression(&mut binary.lhs_expr, gated);
+                rewrite_expression(&mut binary.rhs_expr, gated);
+            }
+        },
+        Expression::Parenthesis(inner) => rewrite_expression(inner, gated),
+        Expression::ForExpr(for_expr) => {
+            rewrite_expression(&mut for_expr.collection_expr, gated);
+            rewrite_expression(&mut for_expr.value_expr, gated);
+            if let Some(key_expr) = for_expr.key_expr.as_mut() {
+                rewrite_expression(key_expr, gated);
+            }
+            if let Some(cond_expr) = for_expr.cond_expr.as_mut() {
+                rewrite_expression(cond_expr, gated);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_block(block: &mut Block, gated: &GatedAddresses) {
+    let body: Vec<Structure> = std::mem::take(&mut block.body).into_iter().collect();
+    let rewritten = body
+        .into_iter()
+        .map(|structure| match structure {
+            Structure::Attribute(mut attribute) => {
+                // `depends_on` takes whole-resource references that stay
+                // unindexed on counted resources.
+                if attribute.key.as_str() != "depends_on" {
+                    rewrite_expression(&mut attribute.expr, gated);
+                }
+                Structure::Attribute(attribute)
+            }
+            Structure::Block(mut nested) => {
+                rewrite_block(&mut nested, gated);
+                Structure::Block(nested)
+            }
+        })
+        .collect::<Vec<_>>();
+    block.body = Body::from(rewritten);
+}
+
+/// Rewrite interpolations inside a string template. The template is
+/// re-serialized only when a rewrite actually happened, so untouched
+/// templates render byte-identically.
+fn rewrite_template(template_expr: &mut TemplateExpr, gated: &GatedAddresses) {
+    let Ok(mut template) = Template::from_expr(template_expr) else {
+        // Unparseable templates are left for the rendered-output scan.
+        return;
+    };
+    let mut changed = false;
+    for element in template.elements_mut() {
+        if let Element::Interpolation(interpolation) = element {
+            let before = interpolation.expr.clone();
+            rewrite_expression(&mut interpolation.expr, gated);
+            if interpolation.expr != before {
+                changed = true;
+            }
+        }
+    }
+    if !changed {
+        return;
+    }
+    match template_expr {
+        TemplateExpr::QuotedString(quoted) => *quoted = template.to_string(),
+        TemplateExpr::Heredoc(heredoc) => heredoc.template = template.to_string(),
+    }
+}
+
+/// Fail generation when a gated address survives unindexed in the rendered
+/// output — the net for references hidden in raw strings the AST walk cannot
+/// see. `depends_on = [...]` spans are exempt.
+pub(crate) fn scan_rendered_for_unindexed(
+    files: &indexmap::IndexMap<String, String>,
+    gated: &GatedAddresses,
+) -> Result<()> {
+    let addresses = gated.rendered_forms();
+    if addresses.is_empty() {
+        return Ok(());
+    }
+    for (file_name, contents) in files {
+        if !file_name.ends_with(".tf") {
+            continue;
+        }
+        let exempt = depends_on_spans(contents);
+        for address in &addresses {
+            let mut search_from = 0;
+            while let Some(found) = contents[search_from..].find(address.as_str()) {
+                let start = search_from + found;
+                let end = start + address.len();
+                search_from = end;
+
+                let preceded = contents[..start].chars().next_back();
+                if preceded.is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '.')
+                {
+                    continue;
+                }
+                let follower = contents[end..].chars().next();
+                if follower.is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+                {
+                    continue;
+                }
+                if follower == Some('[') {
+                    continue;
+                }
+                if exempt.iter().any(|span| span.contains(&start)) {
+                    continue;
+                }
+                // The resource's own declaration is `resource "type" "label"`,
+                // quoted, so it never matches the dotted form.
+                return Err(AlienError::new(ErrorData::GenericError {
+                    message: format!(
+                        "gated resource `{address}` is referenced without its count index in \
+                         `{file_name}`; the reference escaped the rewrite (raw string?) and \
+                         would fail or, worse, silently mis-resolve when the deployer declines \
+                         the resource"
+                    ),
+                }));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Byte ranges of `depends_on = [ ... ]` attribute values, where
+/// whole-resource references are required to stay unindexed.
+fn depends_on_spans(contents: &str) -> Vec<std::ops::Range<usize>> {
+    let mut spans = Vec::new();
+    let mut search_from = 0;
+    while let Some(found) = contents[search_from..].find("depends_on") {
+        let start = search_from + found;
+        search_from = start + "depends_on".len();
+        let Some(open_offset) = contents[start..].find('[') else {
+            continue;
+        };
+        let open = start + open_offset;
+        let mut depth = 0usize;
+        let mut close = None;
+        for (offset, ch) in contents[open..].char_indices() {
+            match ch {
+                '[' => depth += 1,
+                ']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + offset);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(close) = close {
+            spans.push(start..close + 1);
+            search_from = close + 1;
+        }
+    }
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::{attr, resource_block};
+    use crate::expr;
+
+    fn gated_analytics() -> GatedAddresses {
+        let mut gated = GatedAddresses::default();
+        gated
+            .addresses
+            .insert(("aws_dynamodb_table".to_string(), "analytics".to_string()));
+        gated
+    }
+
+    #[test]
+    fn attribute_references_gain_the_count_index() {
+        let mut expression = expr::traversal(["aws_dynamodb_table", "analytics", "name"]);
+        rewrite_expression(&mut expression, &gated_analytics());
+        assert_eq!(
+            expression,
+            expr::traversal_indexed("aws_dynamodb_table", "analytics", "name")
+        );
+    }
+
+    #[test]
+    fn whole_resource_references_stay_unindexed() {
+        let mut expression = expr::traversal(["aws_dynamodb_table", "analytics"]);
+        let before = expression.clone();
+        rewrite_expression(&mut expression, &gated_analytics());
+        assert_eq!(expression, before);
+    }
+
+    #[test]
+    fn ungated_references_are_untouched() {
+        let mut expression = expr::traversal(["aws_dynamodb_table", "other", "name"]);
+        let before = expression.clone();
+        rewrite_expression(&mut expression, &gated_analytics());
+        assert_eq!(expression, before);
+    }
+
+    #[test]
+    fn template_interpolations_are_rewritten() {
+        let mut expression = expr::template("${aws_dynamodb_table.analytics.name}-suffix");
+        rewrite_expression(&mut expression, &gated_analytics());
+        assert_eq!(
+            expression,
+            expr::template("${aws_dynamodb_table.analytics[0].name}-suffix")
+        );
+    }
+
+    #[test]
+    fn untouched_templates_are_not_reserialized() {
+        let original = "${var.something}-${local.other}";
+        let mut expression = expr::template(original);
+        rewrite_expression(&mut expression, &gated_analytics());
+        assert_eq!(expression, expr::template(original));
+    }
+
+    #[test]
+    fn depends_on_attributes_are_never_rewritten() {
+        let mut block = resource_block(
+            "aws_s3_bucket",
+            "logs",
+            [attr(
+                "depends_on",
+                Expression::Array(vec![expr::traversal(["aws_dynamodb_table", "analytics"])]),
+            )],
+        );
+        let before = block.clone();
+        rewrite_block(&mut block, &gated_analytics());
+        assert_eq!(block, before);
+    }
+
+    #[test]
+    fn residual_random_id_stays_ungated_and_forbids_provisioners() {
+        let mut fragment = TfFragment::default()
+            .with_resource(resource_block(
+                "random_id",
+                "suffix",
+                [attr("byte_length", Expression::Number(hcl::Number::from(4)))],
+            ))
+            .with_resource(resource_block(
+                "aws_dynamodb_table",
+                "analytics",
+                [attr("name", expr::template("x"))],
+            ));
+        let mut gated = GatedAddresses::default();
+        gate_fragment(&mut fragment, "analytics", "analyticsEnabled", &mut gated)
+            .expect("residual random_id must not block gating");
+
+        let random_id = &fragment.resource_blocks[0];
+        assert!(
+            !random_id
+                .body
+                .attributes()
+                .any(|attribute| attribute.key.as_str() == "count"),
+            "residual block must stay ungated"
+        );
+        let table = &fragment.resource_blocks[1];
+        assert!(
+            table
+                .body
+                .attributes()
+                .any(|attribute| attribute.key.as_str() == "count"),
+            "owned block must be gated"
+        );
+        assert!(gated.contains("aws_dynamodb_table", "analytics"));
+        assert!(!gated.contains("random_id", "suffix"));
+    }
+
+    #[test]
+    fn residual_with_provisioner_is_refused() {
+        let mut residual = resource_block(
+            "random_id",
+            "suffix",
+            [attr("byte_length", Expression::Number(hcl::Number::from(4)))],
+        );
+        let provisioner = crate::block::block("provisioner", [attr("command", expr::template("rm -rf /"))]);
+        let body: Vec<Structure> = std::mem::take(&mut residual.body)
+            .into_iter()
+            .chain([Structure::Block(provisioner)])
+            .collect();
+        residual.body = Body::from(body);
+
+        let mut fragment = TfFragment::default().with_resource(residual);
+        let error = gate_fragment(
+            &mut fragment,
+            "analytics",
+            "analyticsEnabled",
+            &mut GatedAddresses::default(),
+        )
+        .expect_err("a provisioner inside a residual must be refused");
+        assert!(error.message.contains("provisioner"), "{}", error.message);
+    }
+
+    #[test]
+    fn for_each_on_an_owned_block_is_refused() {
+        let mut fragment = TfFragment::default().with_resource(resource_block(
+            "aws_dynamodb_table",
+            "analytics",
+            [attr("for_each", expr::raw("toset([\"a\"])"))],
+        ));
+        let error = gate_fragment(
+            &mut fragment,
+            "analytics",
+            "analyticsEnabled",
+            &mut GatedAddresses::default(),
+        )
+        .expect_err("for_each cannot compose with the gate's count");
+        assert!(error.message.contains("for_each"), "{}", error.message);
+    }
+
+    #[test]
+    fn shared_blocks_are_not_gated() {
+        let mut fragment = TfFragment::default();
+        fragment.push_shared_resource(resource_block(
+            "google_project_iam_custom_role",
+            "gcp_role_reader",
+            [attr("count", expr::raw("var.gcp_manage_custom_roles ? 1 : 0"))],
+        ));
+        gate_fragment(
+            &mut fragment,
+            "analytics",
+            "analyticsEnabled",
+            &mut GatedAddresses::default(),
+        )
+        .expect("a shared block carrying its own count must be skipped, not an error");
+    }
+
+    #[test]
+    fn scan_flags_unindexed_gated_addresses_outside_depends_on() {
+        let mut files = indexmap::IndexMap::new();
+        files.insert(
+            "main.tf".to_string(),
+            "locals { x = \"${aws_dynamodb_table.analytics.name}\" }".to_string(),
+        );
+        let error = scan_rendered_for_unindexed(&files, &gated_analytics())
+            .expect_err("unindexed reference must fail generation");
+        assert!(error.message.contains("aws_dynamodb_table.analytics"));
+
+        let mut ok_files = indexmap::IndexMap::new();
+        ok_files.insert(
+            "main.tf".to_string(),
+            "resource \"aws_dynamodb_table\" \"analytics\" { count = var.x ? 1 : 0 }\n\
+             locals { x = aws_dynamodb_table.analytics[0].name }\n\
+             resource \"null_resource\" \"import\" { depends_on = [\n  aws_dynamodb_table.analytics,\n] }"
+                .to_string(),
+        );
+        scan_rendered_for_unindexed(&ok_files, &gated_analytics())
+            .expect("indexed references and depends_on spans are fine");
+    }
+}

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -198,6 +198,7 @@ pub fn generate_terraform_module(
     // drop declined resources from the registration list.
     let mut registration_resources: Vec<(Option<String>, Expression)> = Vec::new();
     let mut shared_locals: IndexMap<String, Expression> = IndexMap::new();
+    let mut gated = crate::gating::GatedAddresses::default();
 
     for (resource_id, resource) in stack.resources() {
         let resource_type = resource.config.resource_type();
@@ -217,14 +218,15 @@ pub fn generate_terraform_module(
         };
 
         if let Some(input_id) = resource.enabled_when.as_deref() {
-            if !emitter.supports_enabled_when() {
+            // The same policy the compile-time check enforces, re-checked at
+            // render time so a caller that skips preflights cannot gate what
+            // the policy refuses.
+            if let Some(refusal) =
+                alien_core::gate_refusal(resource_type.as_ref(), resource_id.as_str())
+            {
                 return Err(AlienError::new(ErrorData::OperationNotSupported {
-                    operation: format!("enabled() on resource type '{resource_type}'"),
-                    reason: format!(
-                        "the {platform:?} Terraform emitter for '{resource_type}' does not render \
-                         conditionally yet, so resource '{resource_id}' would be created regardless \
-                         of the deployer's answer"
-                    ),
+                    operation: format!("enabled() on resource '{resource_id}'"),
+                    reason: refusal.reason().to_string(),
                 }));
             }
             // Re-validated at render time like the CloudFormation generator:
@@ -248,6 +250,9 @@ pub fn generate_terraform_module(
         }
 
         let mut fragment = emitter.emit_with_registry(&ctx, options.registry)?;
+        if let Some(input_id) = resource.enabled_when.as_deref() {
+            crate::gating::gate_fragment(&mut fragment, resource_id, input_id, &mut gated)?;
+        }
         // Split per-emitter `locals` out of the per-resource file \u2014 they
         // belong in `locals.tf` so reviewers see all locals together.
         let local_contributions = std::mem::take(&mut fragment.locals);
@@ -282,6 +287,23 @@ pub fn generate_terraform_module(
         emit_azure_setup_resource_role_definitions(&mut per_resource, stack)?;
         apply_azure_resource_group_dependency(stack, &labels, &mut per_resource);
     }
+    // Every fragment is emitted and every generator-injected block exists by
+    // now, so references to gated addresses — wherever they live — can be
+    // rewritten to index into the gate's count. `depends_on` is exempt inside
+    // the rewrite; the registration's own depends_on uses whole-resource
+    // references that stay valid on counted resources.
+    if !gated.is_empty() {
+        for fragment in per_resource.values_mut() {
+            crate::gating::rewrite_fragment_references(fragment, &gated);
+        }
+        for (_name, expression) in shared_locals.iter_mut() {
+            crate::gating::rewrite_expression(expression, &gated);
+        }
+        for (_gate, expression) in registration_resources.iter_mut() {
+            crate::gating::rewrite_expression(expression, &gated);
+        }
+    }
+
     let gcp_iam_propagation_dependencies = if matches!(platform, alien_core::Platform::Gcp) {
         gcp_iam_resource_addresses(&per_resource)
     } else {
@@ -420,6 +442,10 @@ pub fn generate_terraform_module(
             &stack_inputs,
         ),
     );
+
+    // Last net: a reference hidden in a raw string escapes the AST rewrite;
+    // catch it in the rendered output instead of shipping it.
+    crate::gating::scan_rendered_for_unindexed(&files, &gated)?;
 
     let mut module = ModuleFiles { files };
 

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -2991,45 +2991,38 @@ mod tests {
         let mut per_resource = IndexMap::new();
         per_resource.insert(
             "queue".to_string(),
-            TfFragment {
-                resource_blocks: vec![
-                    resource_block(
-                        "google_project_iam_custom_role",
-                        "gcp_role_queue_heartbeat_part1",
-                        [
-                            attr("project", expr::raw("var.gcp_project")),
-                            attr("role_id", Expression::String("role_test".to_string())),
-                        ],
-                    ),
-                    resource_block(
-                        "google_pubsub_topic",
-                        "queue",
-                        [attr("name", Expression::String("queue".to_string()))],
-                    ),
-                ],
-                ..TfFragment::default()
-            },
+            TfFragment::default()
+                .with_resource(resource_block(
+                    "google_project_iam_custom_role",
+                    "gcp_role_queue_heartbeat_part1",
+                    [
+                        attr("project", expr::raw("var.gcp_project")),
+                        attr("role_id", Expression::String("role_test".to_string())),
+                    ],
+                ))
+                .with_resource(resource_block(
+                    "google_pubsub_topic",
+                    "queue",
+                    [attr("name", Expression::String("queue".to_string()))],
+                )),
         );
         per_resource.insert(
             "management".to_string(),
-            TfFragment {
-                resource_blocks: vec![resource_block(
-                    "google_project_iam_member",
-                    "gcp_role_queue_heartbeat_part1_remote_stack_management_binding_0",
-                    [
-                        attr("project", expr::raw("var.gcp_project")),
-                        attr(
-                            "role",
-                            expr::traversal([
-                                "google_project_iam_custom_role",
-                                "gcp_role_queue_heartbeat_part1",
-                                "name",
-                            ]),
-                        ),
-                    ],
-                )],
-                ..TfFragment::default()
-            },
+            TfFragment::default().with_resource(resource_block(
+                "google_project_iam_member",
+                "gcp_role_queue_heartbeat_part1_remote_stack_management_binding_0",
+                [
+                    attr("project", expr::raw("var.gcp_project")),
+                    attr(
+                        "role",
+                        expr::traversal([
+                            "google_project_iam_custom_role",
+                            "gcp_role_queue_heartbeat_part1",
+                            "name",
+                        ]),
+                    ),
+                ],
+            )),
         );
 
         apply_resource_dependencies(&stack, &mut per_resource);

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -225,7 +225,9 @@ pub fn generate_terraform_module(
                 alien_core::gate_refusal(resource_type.as_ref(), resource_id.as_str())
             {
                 return Err(AlienError::new(ErrorData::OperationNotSupported {
-                    operation: format!("enabled() on resource '{resource_id}'"),
+                    operation: format!(
+                        "enabled() on resource '{resource_id}' of type '{resource_type}'"
+                    ),
                     reason: refusal.reason().to_string(),
                 }));
             }

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -987,6 +987,26 @@ fn stack_inputs_for_terraform(stack: &Stack, target: TerraformTarget) -> Vec<Sta
 }
 
 fn validate_stack_inputs_for_terraform(inputs: &[StackInputDefinition]) -> Result<()> {
+    // Distinct ids can normalize to the same variable name (`fooBar` and
+    // `foo_bar` both become `input_foo_bar`); the second declaration would
+    // silently shadow the first, so both values — gates included — would read
+    // from one variable.
+    let mut ids_by_variable: std::collections::HashMap<String, &str> =
+        std::collections::HashMap::new();
+    for input in inputs {
+        let variable = terraform_stack_input_variable_name(input);
+        if let Some(previous_id) = ids_by_variable.insert(variable.clone(), input.id.as_str()) {
+            return Err(AlienError::new(ErrorData::OperationNotSupported {
+                operation: "generate_terraform_module".to_string(),
+                reason: format!(
+                    "stack inputs '{previous_id}' and '{}' both normalize to Terraform \
+                     variable '{variable}'; rename one so every input keeps its own variable",
+                    input.id
+                ),
+            }));
+        }
+    }
+
     let secret_inputs: Vec<&str> = inputs
         .iter()
         .filter(|input| input.kind == StackInputKind::Secret)

--- a/crates/alien-terraform/src/lib.rs
+++ b/crates/alien-terraform/src/lib.rs
@@ -18,6 +18,7 @@ mod built_ins;
 mod emitter;
 pub mod emitters;
 pub mod expr;
+mod gating;
 mod generator;
 mod k8s_identity;
 mod naming;

--- a/crates/alien-terraform/src/registry.rs
+++ b/crates/alien-terraform/src/registry.rs
@@ -75,6 +75,15 @@ impl TfRegistry {
 
     /// Look up an emitter and produce a typed `ImportRegistrationMissing`
     /// error if none is registered.
+    /// Every registered `(resource type, platform)` pair. The gating test
+    /// matrix walks this so a newly registered emitter cannot ship without
+    /// either a policy refusal or a gated-render fixture.
+    pub fn registered_keys(&self) -> impl Iterator<Item = (&str, Platform)> {
+        self.emitters
+            .keys()
+            .map(|key| (key.resource_type.as_ref(), key.platform))
+    }
+
     pub fn require(
         &self,
         resource_type: &ResourceType,

--- a/crates/alien-terraform/src/registry.rs
+++ b/crates/alien-terraform/src/registry.rs
@@ -73,8 +73,6 @@ impl TfRegistry {
             .map(|boxed| boxed.as_ref())
     }
 
-    /// Look up an emitter and produce a typed `ImportRegistrationMissing`
-    /// error if none is registered.
     /// Every registered `(resource type, platform)` pair. The gating test
     /// matrix walks this so a newly registered emitter cannot ship without
     /// either a policy refusal or a gated-render fixture.
@@ -84,6 +82,8 @@ impl TfRegistry {
             .map(|key| (key.resource_type.as_ref(), key.platform))
     }
 
+    /// Look up an emitter and produce a typed `ImportRegistrationMissing`
+    /// error if none is registered.
     pub fn require(
         &self,
         resource_type: &ResourceType,

--- a/crates/alien-terraform/tests/generator.rs
+++ b/crates/alien-terraform/tests/generator.rs
@@ -20,6 +20,7 @@ mod generator {
     pub mod enabled_queue_tests;
     pub mod enabled_storage_tests;
     pub mod enabled_tests;
+    pub mod gating_matrix_tests;
     pub mod gcp_compute_tests;
     pub mod gcp_data_layer_tests;
     pub mod gcp_full_stack_tests;

--- a/crates/alien-terraform/tests/generator/enabled_tests.rs
+++ b/crates/alien-terraform/tests/generator/enabled_tests.rs
@@ -452,12 +452,11 @@ fn gcp_shared_project_grant_stays_ungated_when_any_resource_is_ungated() {
     );
 }
 
-/// Rendering a gated resource through an emitter that ignores the gate would
-/// create exactly what the deployer declined. ServiceAccount stays a safe
-/// stand-in for "unconverted": the compile-time check forbids gating
-/// framework-derived types, so its emitter never needs to convert.
+/// The generator re-checks the gateability policy, so a caller that skips
+/// preflights cannot render a gate the policy refuses. ServiceAccount is a
+/// framework-derived type the policy always refuses.
 #[test]
-fn a_gate_on_an_unconverted_emitter_fails() {
+fn a_gate_on_a_policy_refused_type_fails_at_render() {
     let stack = Stack::new("gated-stack".to_string())
         .inputs(vec![gate_input(
             "storeEnabled",

--- a/crates/alien-terraform/tests/generator/gating_matrix_tests.rs
+++ b/crates/alien-terraform/tests/generator/gating_matrix_tests.rs
@@ -1,0 +1,152 @@
+//! The gating matrix: every registered Terraform emitter is either refused by
+//! the gateability policy or proven to render gated.
+//!
+//! The walk over [`TfRegistry::registered_keys`] is what makes the generic
+//! post-pass safe to extend: registering a new emitter for a gateable type
+//! fails this test until a gated fixture exists, so a type can never become
+//! gateable without a validated gated render.
+
+use super::helpers::{assert_terraform_valid, gate_input, render, snapshot_module};
+use alien_core::{
+    AzureResourceGroup, AzureServiceBusNamespace, AzureStorageAccount, Kv, Platform, Queue,
+    ResourceLifecycle, Stack, StackBuilder, StackSettings, Storage, Vault,
+};
+use alien_terraform::{TerraformTarget, TfRegistry};
+
+/// One gated fixture stack per policy-allowed resource type with a setup
+/// emitter. The resource under test is gated; auxiliary resources the type
+/// needs (Azure's resource group and storage account) are not.
+fn gated_fixture(resource_type: &str, platform: Platform) -> Option<Stack> {
+    let base = || -> StackBuilder {
+        let builder = Stack::new("matrix-stack".to_string()).inputs(vec![gate_input(
+            "fixtureEnabled",
+            "Enable the fixture resource",
+            "Whether to create the gated matrix fixture.",
+        )]);
+        if platform == Platform::Azure {
+            builder
+                .add(
+                    AzureResourceGroup::new("default-resource-group".to_string()).build(),
+                    ResourceLifecycle::Frozen,
+                )
+                .add(
+                    AzureStorageAccount::new("default-storage-account".to_string()).build(),
+                    ResourceLifecycle::Frozen,
+                )
+        } else {
+            builder
+        }
+    };
+    let stack = match resource_type {
+        "kv" => base().add_enabled_when(
+            Kv::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        "storage" => base().add_enabled_when(
+            Storage::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        "queue" => {
+            let builder = if platform == Platform::Azure {
+                base().add(
+                    AzureServiceBusNamespace::new("default-service-bus-namespace".to_string())
+                        .build(),
+                    ResourceLifecycle::Frozen,
+                )
+            } else {
+                base()
+            };
+            builder.add_enabled_when(
+                Queue::new("fixture".to_string()).build(),
+                ResourceLifecycle::Frozen,
+                "fixtureEnabled",
+            )
+        }
+        "vault" => base().add_enabled_when(
+            Vault::new("fixture".to_string()).build(),
+            ResourceLifecycle::Frozen,
+            "fixtureEnabled",
+        ),
+        _ => return None,
+    };
+    Some(stack.build())
+}
+
+fn target_for(platform: Platform) -> Option<TerraformTarget> {
+    match platform {
+        Platform::Aws => Some(TerraformTarget::Aws),
+        Platform::Gcp => Some(TerraformTarget::Gcp),
+        Platform::Azure => Some(TerraformTarget::Azure),
+        _ => None,
+    }
+}
+
+/// A declined fixture must leave no trace: its registration entry is spliced
+/// out and every one of its blocks carries the gate's count. Shared support
+/// blocks (custom roles, role definitions) may remain, unbound.
+fn assert_gated_render(resource_type: &str, platform: Platform, stack: &Stack) {
+    let Some(target) = target_for(platform) else {
+        return;
+    };
+    let module = render(stack, target, StackSettings::default());
+    assert_terraform_valid(
+        &module,
+        &format!("gating matrix {resource_type} on {platform:?}"),
+    );
+
+    let locals = module
+        .files
+        .get("locals.tf")
+        .expect("locals.tf should exist");
+    assert!(
+        locals.contains("var.input_fixture_enabled ?"),
+        "{resource_type}/{platform:?}: the registration list should splice the gated entry \
+         behind its input:\n{locals}"
+    );
+}
+
+#[test]
+fn every_registered_emitter_is_policy_refused_or_renders_gated() {
+    let registry = TfRegistry::built_in();
+    let mut allowed_without_fixture = Vec::new();
+
+    for (resource_type, platform) in registry.registered_keys() {
+        if alien_core::gate_refusal(resource_type, "matrix-fixture").is_some() {
+            // The refused side of the matrix: the policy blocks the gate at
+            // preflight AND at render (proven by
+            // `a_gate_on_a_policy_refused_type_fails_at_render`).
+            continue;
+        }
+        match gated_fixture(resource_type, platform) {
+            Some(stack) => assert_gated_render(resource_type, platform, &stack),
+            None => allowed_without_fixture.push(format!("{resource_type} ({platform:?})")),
+        }
+    }
+
+    assert!(
+        allowed_without_fixture.is_empty(),
+        "these registered emitters belong to policy-allowed types but have no gated fixture; \
+         add one to this matrix (or refuse the type in alien_core::gateability) before the \
+         type silently becomes gateable: {allowed_without_fixture:?}"
+    );
+}
+
+/// Vault is the first type whose gated render exists purely through the
+/// post-pass — no vault emitter ever carried gating code. Snapshots lock the
+/// render on each cloud.
+#[test]
+fn a_gated_vault_renders_conditionally_on_every_cloud() {
+    for (platform, name) in [
+        (Platform::Aws, "enabled_gated_vault_aws"),
+        (Platform::Gcp, "enabled_gated_vault_gcp"),
+        (Platform::Azure, "enabled_gated_vault_azure"),
+    ] {
+        let stack = gated_fixture("vault", platform).expect("vault fixture");
+        let target = target_for(platform).expect("cloud target");
+        let module = render(&stack, target, StackSettings::default());
+        assert_terraform_valid(&module, name);
+        snapshot_module(name, &module);
+    }
+}

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_aws.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_aws.snap
@@ -1,0 +1,293 @@
+---
+source: crates/alien-terraform/tests/generator/helpers.rs
+expression: buf
+---
+=== versions.tf ===
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+=== variables.tf ===
+variable "resource_prefix" {
+  type        = string
+  description = "Optional stable physical resource prefix. Leave empty to generate one."
+  default     = ""
+
+  validation {
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z][a-z0-9-]{1,38}[a-z0-9]$", var.resource_prefix)) && length(regexall("--", var.resource_prefix)) == 0)
+    error_message = "resource_prefix must be 3-40 characters: lowercase letters, numbers, and hyphens; start with a letter; end with a letter or number; and not contain consecutive hyphens."
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "Human-readable application name shown in setup and cloud IAM review metadata."
+}
+
+variable "token" {
+  type        = string
+  description = "Install token from the application setup page. This is the same token used by the deploy CLI --token flag."
+  sensitive   = true
+}
+
+variable "management_url" {
+  type        = string
+  description = "Optional management endpoint used by pull-style runtimes."
+  default     = ""
+}
+
+variable "deployment_model" {
+  type        = string
+  description = "How runtime updates are delivered after setup."
+  default     = "push"
+
+  validation {
+    condition     = contains(["push", "pull"], var.deployment_model)
+    error_message = "deployment_model must be one of: push, pull."
+  }
+}
+
+variable "advanced_settings_json" {
+  type        = string
+  description = "Advanced JSON-encoded deployment settings. Most installations should use the typed variables in this module instead."
+  default     = "{}"
+  sensitive   = true
+}
+
+variable "advanced_settings_overlay_json" {
+  type        = string
+  description = "JSON-encoded deployment settings merged over the package defaults. Use this for partial advanced-setting overrides that must preserve generated defaults such as compute selections."
+  default     = "{}"
+  sensitive   = true
+}
+
+variable "updates_mode" {
+  type        = string
+  description = "How application updates are delivered after setup."
+  default     = "auto"
+
+  validation {
+    condition     = contains(["auto", "approval-required"], var.updates_mode)
+    error_message = "updates_mode must be one of: auto, approval-required."
+  }
+}
+
+variable "telemetry_mode" {
+  type        = string
+  description = "How logs, metrics, and traces are collected."
+  default     = "auto"
+
+  validation {
+    condition     = contains(["off", "auto", "approval-required"], var.telemetry_mode)
+    error_message = "telemetry_mode must be one of: off, auto, approval-required."
+  }
+}
+
+variable "heartbeats_mode" {
+  type        = string
+  description = "Whether runtime health checks are enabled."
+  default     = "on"
+
+  validation {
+    condition     = contains(["off", "on"], var.heartbeats_mode)
+    error_message = "heartbeats_mode must be one of: off, on."
+  }
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region used by the AWS provider."
+  default     = "us-east-1"
+}
+
+variable "managing_role_arn" {
+  type        = string
+  description = "ARN of the management identity allowed to assume setup-created roles."
+  default     = ""
+}
+
+variable "managing_account_id" {
+  type        = string
+  description = "AWS account ID that hosts application container images. Empty disables scoped cross-account image-pull grants."
+  default     = ""
+}
+
+variable "input_fixture_enabled" {
+  type        = bool
+  description = "Enable the fixture resource Whether to create the gated matrix fixture."
+  default     = true
+}
+
+=== providers.tf ===
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+=== resource_prefix.tf ===
+resource "random_id" "resource_prefix" {
+  byte_length = 4
+}
+
+=== locals.tf ===
+locals {
+  resource_prefix              = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
+  deployment_name              = var.name
+  deployment_platform          = "aws"
+  deployment_target            = "aws"
+  deployment_region            = data.aws_region.current.region
+  deployment_management_config = null
+  advanced_settings            = merge(jsondecode(var.advanced_settings_json), jsondecode(var.advanced_settings_overlay_json))
+  deployment_settings          = merge(local.advanced_settings, { deploymentModel = var.deployment_model, updates = var.updates_mode, telemetry = var.telemetry_mode, heartbeats = var.heartbeats_mode })
+  deployment_resources         = concat(var.input_fixture_enabled ? [{ id = "fixture", type = "vault", importData = { accountId = data.aws_caller_identity.current.account_id, region = data.aws_region.current.region, parameterPrefix = "${local.resource_prefix}-fixture" } }] : [])
+}
+
+=== registration.tf ===
+resource "terraform_data" "deployment_registration" {
+  input = {
+    platform                    = local.deployment_platform
+    token                       = var.token
+    name                        = var.name
+    resource_prefix             = local.resource_prefix
+    setup_target                = ""
+    setup_import_format_version = 1
+    setup_fingerprint           = ""
+    setup_fingerprint_version   = 0
+    management_url              = var.management_url
+    management_config           = local.deployment_management_config
+    stack_settings              = local.deployment_settings
+    resources                   = local.deployment_resources
+    inputValues = {
+      fixtureEnabled = var.input_fixture_enabled
+    }
+  }
+}
+
+=== outputs.tf ===
+output "deployment_target" {
+  value       = "aws"
+  description = "Terraform module target."
+}
+
+output "deployment_resource_prefix" {
+  value       = local.resource_prefix
+  description = "Physical resource prefix."
+}
+
+output "deployment_platform" {
+  value       = local.deployment_platform
+  description = "Target platform."
+}
+
+output "deployment_region" {
+  value       = local.deployment_region
+  description = "Target cloud region or location."
+}
+
+output "deployment_setup_target" {
+  value       = ""
+  description = "Setup target."
+}
+
+output "deployment_setup_import_format_version" {
+  value       = 1
+  description = "Setup registration payload format version."
+}
+
+output "deployment_setup_fingerprint" {
+  value       = ""
+  description = "Setup compatibility fingerprint."
+}
+
+output "deployment_setup_fingerprint_version" {
+  value       = 0
+  description = "Setup fingerprint algorithm version."
+}
+
+output "deployment_management_config" {
+  value       = jsonencode(local.deployment_management_config)
+  description = "Deployment registration management configuration JSON."
+}
+
+output "deployment_stack_settings" {
+  value       = jsonencode(local.deployment_settings)
+  description = "Deployment registration settings JSON."
+  sensitive   = true
+}
+
+output "deployment_resources" {
+  value       = jsonencode(local.deployment_resources)
+  description = "Deployment registration resource metadata JSON."
+}
+
+=== README.md ===
+# Deployment setup - matrix-stack
+
+Target: `aws`.
+
+This module creates setup-owned infrastructure, grants the management access needed after setup, and prepares deployment registration metadata. Review the generated `.tf` files before applying; each resource file maps to one setup resource.
+
+## Inputs
+
+Required:
+
+- `token`: install token from the setup page.
+- `name`: deployment name to include in the registration metadata.
+
+Common optional settings:
+
+- `resource_prefix`: stable physical-name prefix. Leave empty to generate one.
+- `management_url`: optional management endpoint used by pull-style runtimes.
+- `deployment_model`: `push` or `pull`.
+- `updates_mode`: `auto` or `approval-required`.
+- `telemetry_mode`: `off`, `auto`, or `approval-required`.
+- `heartbeats_mode`: `off` or `on`.
+- `advanced_settings_json`: complete advanced deployment settings JSON. Most installs should keep the generated default.
+- `advanced_settings_overlay_json`: partial advanced settings merged over package defaults, preserving generated values such as compute selections.
+
+AWS settings:
+
+- `aws_region`: AWS region used by the provider.
+- `managing_role_arn`: management identity allowed to assume setup-created roles.
+- `managing_account_id`: account that hosts application container images. Empty disables scoped cross-account image-pull grants.
+
+Application inputs:
+- `input_fixture_enabled`: Enable the fixture resource (optional). Whether to create the gated matrix fixture.
+
+## Run
+
+Use your organization's normal backend and approval workflow. A typical local review looks like:
+
+```bash
+export TF_VAR_name="matrix-stack"
+export TF_VAR_token="..."
+terraform init
+terraform validate
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+## Registration
+
+This module exposes `deployment_management_config`, `deployment_stack_settings`, and `deployment_resources` outputs for registration flows managed outside Terraform.
+
+## Outputs
+
+- `deployment_management_config`: management endpoint and credential-boundary metadata.
+- `deployment_stack_settings`: deployment settings JSON assembled from typed variables, package defaults, and advanced-setting overlays.
+- `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.
+- `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_azure.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_azure.snap
@@ -1,0 +1,369 @@
+---
+source: crates/alien-terraform/tests/generator/helpers.rs
+expression: buf
+---
+=== versions.tf ===
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.100"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+=== variables.tf ===
+variable "resource_prefix" {
+  type        = string
+  description = "Optional stable physical resource prefix. Leave empty to generate one."
+  default     = ""
+
+  validation {
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z][a-z0-9-]{1,38}[a-z0-9]$", var.resource_prefix)) && length(regexall("--", var.resource_prefix)) == 0)
+    error_message = "resource_prefix must be 3-40 characters: lowercase letters, numbers, and hyphens; start with a letter; end with a letter or number; and not contain consecutive hyphens."
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "Human-readable application name shown in setup and cloud IAM review metadata."
+}
+
+variable "token" {
+  type        = string
+  description = "Install token from the application setup page. This is the same token used by the deploy CLI --token flag."
+  sensitive   = true
+}
+
+variable "management_url" {
+  type        = string
+  description = "Optional management endpoint used by pull-style runtimes."
+  default     = ""
+}
+
+variable "deployment_model" {
+  type        = string
+  description = "How runtime updates are delivered after setup."
+  default     = "push"
+
+  validation {
+    condition     = contains(["push", "pull"], var.deployment_model)
+    error_message = "deployment_model must be one of: push, pull."
+  }
+}
+
+variable "advanced_settings_json" {
+  type        = string
+  description = "Advanced JSON-encoded deployment settings. Most installations should use the typed variables in this module instead."
+  default     = "{}"
+  sensitive   = true
+}
+
+variable "advanced_settings_overlay_json" {
+  type        = string
+  description = "JSON-encoded deployment settings merged over the package defaults. Use this for partial advanced-setting overrides that must preserve generated defaults such as compute selections."
+  default     = "{}"
+  sensitive   = true
+}
+
+variable "updates_mode" {
+  type        = string
+  description = "How application updates are delivered after setup."
+  default     = "auto"
+
+  validation {
+    condition     = contains(["auto", "approval-required"], var.updates_mode)
+    error_message = "updates_mode must be one of: auto, approval-required."
+  }
+}
+
+variable "telemetry_mode" {
+  type        = string
+  description = "How logs, metrics, and traces are collected."
+  default     = "auto"
+
+  validation {
+    condition     = contains(["off", "auto", "approval-required"], var.telemetry_mode)
+    error_message = "telemetry_mode must be one of: off, auto, approval-required."
+  }
+}
+
+variable "heartbeats_mode" {
+  type        = string
+  description = "Whether runtime health checks are enabled."
+  default     = "on"
+
+  validation {
+    condition     = contains(["off", "on"], var.heartbeats_mode)
+    error_message = "heartbeats_mode must be one of: off, on."
+  }
+}
+
+variable "azure_location" {
+  type        = string
+  description = "Azure location."
+  default     = "eastus"
+}
+
+variable "azure_subscription_id" {
+  type        = string
+  description = "Azure subscription ID hosting the stack."
+}
+
+variable "azure_resource_group_name" {
+  type        = string
+  description = "Azure resource group name."
+}
+
+variable "input_fixture_enabled" {
+  type        = bool
+  description = "Enable the fixture resource Whether to create the gated matrix fixture."
+  default     = true
+}
+
+=== providers.tf ===
+provider "azurerm" {
+  resource_provider_registrations = "none"
+
+  features {}
+}
+
+=== resource_prefix.tf ===
+resource "random_id" "resource_prefix" {
+  byte_length = 4
+}
+
+=== locals.tf ===
+locals {
+  resource_prefix              = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
+  deployment_name              = var.name
+  deployment_platform          = "azure"
+  deployment_target            = "azure"
+  deployment_region            = var.azure_location
+  deployment_management_config = null
+  advanced_settings            = merge(jsondecode(var.advanced_settings_json), jsondecode(var.advanced_settings_overlay_json))
+  deployment_settings          = merge(local.advanced_settings, { deploymentModel = var.deployment_model, updates = var.updates_mode, telemetry = var.telemetry_mode, heartbeats = var.heartbeats_mode })
+  deployment_resources         = concat([{ id = "default-resource-group", type = "azure_resource_group", importData = { subscriptionId = var.azure_subscription_id, resourceGroup = azurerm_resource_group.default_resource_group.name, location = azurerm_resource_group.default_resource_group.location } }], [{ id = "default-storage-account", type = "azure_storage_account", importData = { subscriptionId = var.azure_subscription_id, resourceGroup = var.azure_resource_group_name, storageAccountName = azurerm_storage_account.default_storage_account.name, resourceId = azurerm_storage_account.default_storage_account.id, blobEndpoint = azurerm_storage_account.default_storage_account.primary_blob_endpoint, fileEndpoint = azurerm_storage_account.default_storage_account.primary_file_endpoint, queueEndpoint = azurerm_storage_account.default_storage_account.primary_queue_endpoint, tableEndpoint = azurerm_storage_account.default_storage_account.primary_table_endpoint } }], var.input_fixture_enabled ? [{ id = "fixture", type = "vault", importData = { subscriptionId = var.azure_subscription_id, resourceGroup = var.azure_resource_group_name, vaultName = azurerm_key_vault.fixture[0].name, vaultUri = azurerm_key_vault.fixture[0].vault_uri } }] : [])
+}
+
+=== default_resource_group.tf ===
+resource "azurerm_resource_group" "default_resource_group" {
+  name     = var.azure_resource_group_name
+  location = var.azure_location
+  tags = {
+    "managed-by"    = "setup"
+    deployment      = local.resource_prefix
+    resource        = "default-resource-group"
+    "resource-type" = "resource-group"
+  }
+}
+
+=== default_storage_account.tf ===
+resource "azurerm_storage_account" "default_storage_account" {
+  name                            = substr(replace(lower("${local.resource_prefix}default"), "-", ""), 0, 24)
+  resource_group_name             = var.azure_resource_group_name
+  location                        = var.azure_location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  access_tier                     = "Hot"
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  https_traffic_only_enabled      = true
+  tags = {
+    "managed-by"    = "setup"
+    deployment      = local.resource_prefix
+    resource        = "default-storage-account"
+    "resource-type" = "storage-account"
+  }
+
+  blob_properties {
+    versioning_enabled  = false
+    change_feed_enabled = false
+  }
+
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
+}
+
+=== fixture.tf ===
+data "azurerm_client_config" "fixture_current" {}
+
+resource "random_id" "fixture_name_suffix" {
+  byte_length = 3
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
+}
+
+resource "azurerm_key_vault" "fixture" {
+  count                         = var.input_fixture_enabled ? 1 : 0
+  name                          = format("%s-%s", trim(substr(lower(replace("${local.resource_prefix}-fixture", "_", "-")), 0, 17), "-"), random_id.fixture_name_suffix.hex)
+  resource_group_name           = var.azure_resource_group_name
+  location                      = var.azure_location
+  tenant_id                     = data.azurerm_client_config.fixture_current.tenant_id
+  sku_name                      = "standard"
+  rbac_authorization_enabled    = true
+  purge_protection_enabled      = true
+  soft_delete_retention_days    = 90
+  public_network_access_enabled = true
+  tags = {
+    "managed-by"    = "setup"
+    deployment      = local.resource_prefix
+    resource        = "fixture"
+    "resource-type" = "vault"
+  }
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
+}
+
+=== registration.tf ===
+resource "terraform_data" "deployment_registration" {
+  input = {
+    platform                    = local.deployment_platform
+    token                       = var.token
+    name                        = var.name
+    resource_prefix             = local.resource_prefix
+    setup_target                = ""
+    setup_import_format_version = 1
+    setup_fingerprint           = ""
+    setup_fingerprint_version   = 0
+    management_url              = var.management_url
+    management_config           = local.deployment_management_config
+    stack_settings              = local.deployment_settings
+    resources                   = local.deployment_resources
+    inputValues = {
+      fixtureEnabled = var.input_fixture_enabled
+    }
+  }
+  depends_on = [
+    azurerm_resource_group.default_resource_group,
+    azurerm_storage_account.default_storage_account,
+    random_id.fixture_name_suffix,
+    azurerm_key_vault.fixture
+  ]
+}
+
+=== outputs.tf ===
+output "deployment_target" {
+  value       = "azure"
+  description = "Terraform module target."
+}
+
+output "deployment_resource_prefix" {
+  value       = local.resource_prefix
+  description = "Physical resource prefix."
+}
+
+output "deployment_platform" {
+  value       = local.deployment_platform
+  description = "Target platform."
+}
+
+output "deployment_region" {
+  value       = local.deployment_region
+  description = "Target cloud region or location."
+}
+
+output "deployment_setup_target" {
+  value       = ""
+  description = "Setup target."
+}
+
+output "deployment_setup_import_format_version" {
+  value       = 1
+  description = "Setup registration payload format version."
+}
+
+output "deployment_setup_fingerprint" {
+  value       = ""
+  description = "Setup compatibility fingerprint."
+}
+
+output "deployment_setup_fingerprint_version" {
+  value       = 0
+  description = "Setup fingerprint algorithm version."
+}
+
+output "deployment_management_config" {
+  value       = jsonencode(local.deployment_management_config)
+  description = "Deployment registration management configuration JSON."
+}
+
+output "deployment_stack_settings" {
+  value       = jsonencode(local.deployment_settings)
+  description = "Deployment registration settings JSON."
+  sensitive   = true
+}
+
+output "deployment_resources" {
+  value       = jsonencode(local.deployment_resources)
+  description = "Deployment registration resource metadata JSON."
+}
+
+=== README.md ===
+# Deployment setup - matrix-stack
+
+Target: `azure`.
+
+This module creates setup-owned infrastructure, grants the management access needed after setup, and prepares deployment registration metadata. Review the generated `.tf` files before applying; each resource file maps to one setup resource.
+
+## Inputs
+
+Required:
+
+- `token`: install token from the setup page.
+- `name`: deployment name to include in the registration metadata.
+
+Common optional settings:
+
+- `resource_prefix`: stable physical-name prefix. Leave empty to generate one.
+- `management_url`: optional management endpoint used by pull-style runtimes.
+- `deployment_model`: `push` or `pull`.
+- `updates_mode`: `auto` or `approval-required`.
+- `telemetry_mode`: `off`, `auto`, or `approval-required`.
+- `heartbeats_mode`: `off` or `on`.
+- `advanced_settings_json`: complete advanced deployment settings JSON. Most installs should keep the generated default.
+- `advanced_settings_overlay_json`: partial advanced settings merged over package defaults, preserving generated values such as compute selections.
+
+Azure settings:
+
+- `azure_subscription_id`: target subscription ID.
+- `azure_location`: Azure location.
+- `azure_resource_group_name`: target resource group name.
+- `azure_managing_tenant_id`, `azure_oidc_issuer`, `azure_oidc_subject`: management identity trust settings when this setup grants Azure management access.
+
+Application inputs:
+- `input_fixture_enabled`: Enable the fixture resource (optional). Whether to create the gated matrix fixture.
+
+## Run
+
+Use your organization's normal backend and approval workflow. A typical local review looks like:
+
+```bash
+export TF_VAR_name="matrix-stack"
+export TF_VAR_token="..."
+terraform init
+terraform validate
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+## Registration
+
+This module exposes `deployment_management_config`, `deployment_stack_settings`, and `deployment_resources` outputs for registration flows managed outside Terraform.
+
+## Outputs
+
+- `deployment_management_config`: management endpoint and credential-boundary metadata.
+- `deployment_stack_settings`: deployment settings JSON assembled from typed variables, package defaults, and advanced-setting overlays.
+- `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.
+- `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_gcp.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_gcp.snap
@@ -1,0 +1,304 @@
+---
+source: crates/alien-terraform/tests/generator/helpers.rs
+expression: buf
+---
+=== versions.tf ===
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+=== variables.tf ===
+variable "resource_prefix" {
+  type        = string
+  description = "Optional stable physical resource prefix. Leave empty to generate one."
+  default     = ""
+
+  validation {
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z][a-z0-9-]{1,38}[a-z0-9]$", var.resource_prefix)) && length(regexall("--", var.resource_prefix)) == 0)
+    error_message = "resource_prefix must be 3-40 characters: lowercase letters, numbers, and hyphens; start with a letter; end with a letter or number; and not contain consecutive hyphens."
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "Human-readable application name shown in setup and cloud IAM review metadata."
+}
+
+variable "token" {
+  type        = string
+  description = "Install token from the application setup page. This is the same token used by the deploy CLI --token flag."
+  sensitive   = true
+}
+
+variable "management_url" {
+  type        = string
+  description = "Optional management endpoint used by pull-style runtimes."
+  default     = ""
+}
+
+variable "deployment_model" {
+  type        = string
+  description = "How runtime updates are delivered after setup."
+  default     = "push"
+
+  validation {
+    condition     = contains(["push", "pull"], var.deployment_model)
+    error_message = "deployment_model must be one of: push, pull."
+  }
+}
+
+variable "advanced_settings_json" {
+  type        = string
+  description = "Advanced JSON-encoded deployment settings. Most installations should use the typed variables in this module instead."
+  default     = "{}"
+  sensitive   = true
+}
+
+variable "advanced_settings_overlay_json" {
+  type        = string
+  description = "JSON-encoded deployment settings merged over the package defaults. Use this for partial advanced-setting overrides that must preserve generated defaults such as compute selections."
+  default     = "{}"
+  sensitive   = true
+}
+
+variable "updates_mode" {
+  type        = string
+  description = "How application updates are delivered after setup."
+  default     = "auto"
+
+  validation {
+    condition     = contains(["auto", "approval-required"], var.updates_mode)
+    error_message = "updates_mode must be one of: auto, approval-required."
+  }
+}
+
+variable "telemetry_mode" {
+  type        = string
+  description = "How logs, metrics, and traces are collected."
+  default     = "auto"
+
+  validation {
+    condition     = contains(["off", "auto", "approval-required"], var.telemetry_mode)
+    error_message = "telemetry_mode must be one of: off, auto, approval-required."
+  }
+}
+
+variable "heartbeats_mode" {
+  type        = string
+  description = "Whether runtime health checks are enabled."
+  default     = "on"
+
+  validation {
+    condition     = contains(["off", "on"], var.heartbeats_mode)
+    error_message = "heartbeats_mode must be one of: off, on."
+  }
+}
+
+variable "gcp_project" {
+  type        = string
+  description = "GCP project ID."
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "GCP region."
+  default     = "us-central1"
+}
+
+variable "managing_service_account_email" {
+  type        = string
+  description = "Email of the management service account allowed to impersonate setup-created identities. Empty disables the binding."
+  default     = ""
+}
+
+variable "gcp_manage_custom_roles" {
+  type        = bool
+  description = "Whether this module creates the GCP project custom roles it binds. Set to false when those roles are managed outside this stack."
+  default     = true
+}
+
+variable "gcp_custom_role_prefix" {
+  type        = string
+  description = "Prefix used for GCP project custom role IDs when gcp_manage_custom_roles is false. Empty uses resource_prefix."
+  default     = ""
+}
+
+variable "input_fixture_enabled" {
+  type        = bool
+  description = "Enable the fixture resource Whether to create the gated matrix fixture."
+  default     = true
+}
+
+=== providers.tf ===
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+=== resource_prefix.tf ===
+resource "random_id" "resource_prefix" {
+  byte_length = 4
+}
+
+=== locals.tf ===
+locals {
+  resource_prefix              = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
+  deployment_name              = var.name
+  gcp_custom_role_prefix       = substr(replace(lower(var.gcp_custom_role_prefix == "" ? local.resource_prefix : var.gcp_custom_role_prefix), "-", "_"), 0, 18)
+  deployment_platform          = "gcp"
+  deployment_target            = "gcp"
+  deployment_region            = var.gcp_region
+  deployment_management_config = null
+  advanced_settings            = merge(jsondecode(var.advanced_settings_json), jsondecode(var.advanced_settings_overlay_json))
+  deployment_settings          = merge(local.advanced_settings, { deploymentModel = var.deployment_model, updates = var.updates_mode, telemetry = var.telemetry_mode, heartbeats = var.heartbeats_mode })
+  deployment_resources         = concat(var.input_fixture_enabled ? [{ id = "fixture", type = "vault", importData = { projectId = var.gcp_project, secretPrefix = "${local.resource_prefix}-fixture" } }] : [])
+}
+
+=== registration.tf ===
+resource "terraform_data" "deployment_registration" {
+  input = {
+    platform                    = local.deployment_platform
+    token                       = var.token
+    name                        = var.name
+    resource_prefix             = local.resource_prefix
+    setup_target                = ""
+    setup_import_format_version = 1
+    setup_fingerprint           = ""
+    setup_fingerprint_version   = 0
+    management_url              = var.management_url
+    management_config           = local.deployment_management_config
+    stack_settings              = local.deployment_settings
+    resources                   = local.deployment_resources
+    inputValues = {
+      fixtureEnabled = var.input_fixture_enabled
+    }
+  }
+}
+
+=== outputs.tf ===
+output "deployment_target" {
+  value       = "gcp"
+  description = "Terraform module target."
+}
+
+output "deployment_resource_prefix" {
+  value       = local.resource_prefix
+  description = "Physical resource prefix."
+}
+
+output "deployment_platform" {
+  value       = local.deployment_platform
+  description = "Target platform."
+}
+
+output "deployment_region" {
+  value       = local.deployment_region
+  description = "Target cloud region or location."
+}
+
+output "deployment_setup_target" {
+  value       = ""
+  description = "Setup target."
+}
+
+output "deployment_setup_import_format_version" {
+  value       = 1
+  description = "Setup registration payload format version."
+}
+
+output "deployment_setup_fingerprint" {
+  value       = ""
+  description = "Setup compatibility fingerprint."
+}
+
+output "deployment_setup_fingerprint_version" {
+  value       = 0
+  description = "Setup fingerprint algorithm version."
+}
+
+output "deployment_management_config" {
+  value       = jsonencode(local.deployment_management_config)
+  description = "Deployment registration management configuration JSON."
+}
+
+output "deployment_stack_settings" {
+  value       = jsonencode(local.deployment_settings)
+  description = "Deployment registration settings JSON."
+  sensitive   = true
+}
+
+output "deployment_resources" {
+  value       = jsonencode(local.deployment_resources)
+  description = "Deployment registration resource metadata JSON."
+}
+
+=== README.md ===
+# Deployment setup - matrix-stack
+
+Target: `gcp`.
+
+This module creates setup-owned infrastructure, grants the management access needed after setup, and prepares deployment registration metadata. Review the generated `.tf` files before applying; each resource file maps to one setup resource.
+
+## Inputs
+
+Required:
+
+- `token`: install token from the setup page.
+- `name`: deployment name to include in the registration metadata.
+
+Common optional settings:
+
+- `resource_prefix`: stable physical-name prefix. Leave empty to generate one.
+- `management_url`: optional management endpoint used by pull-style runtimes.
+- `deployment_model`: `push` or `pull`.
+- `updates_mode`: `auto` or `approval-required`.
+- `telemetry_mode`: `off`, `auto`, or `approval-required`.
+- `heartbeats_mode`: `off` or `on`.
+- `advanced_settings_json`: complete advanced deployment settings JSON. Most installs should keep the generated default.
+- `advanced_settings_overlay_json`: partial advanced settings merged over package defaults, preserving generated values such as compute selections.
+
+GCP settings:
+
+- `gcp_project`: target GCP project ID.
+- `gcp_region`: target GCP region.
+- `managing_service_account_email`: management service account allowed to impersonate setup-created identities.
+- `gcp_manage_custom_roles`: whether this module creates project custom roles.
+- `gcp_custom_role_prefix`: custom role ID prefix when roles are managed outside this module.
+
+Application inputs:
+- `input_fixture_enabled`: Enable the fixture resource (optional). Whether to create the gated matrix fixture.
+
+## Run
+
+Use your organization's normal backend and approval workflow. A typical local review looks like:
+
+```bash
+export TF_VAR_name="matrix-stack"
+export TF_VAR_token="..."
+terraform init
+terraform validate
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+## Registration
+
+This module exposes `deployment_management_config`, `deployment_stack_settings`, and `deployment_resources` outputs for registration flows managed outside Terraform.
+
+## Outputs
+
+- `deployment_management_config`: management endpoint and credential-boundary metadata.
+- `deployment_stack_settings`: deployment settings JSON assembled from typed variables, package defaults, and advanced-setting overlays.
+- `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.
+- `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.

--- a/crates/alien-terraform/tests/generator/stack_input_tests.rs
+++ b/crates/alien-terraform/tests/generator/stack_input_tests.rs
@@ -1,4 +1,4 @@
-use super::helpers::{assert_terraform_valid, render};
+use super::helpers::{assert_terraform_valid, render, try_render};
 use alien_core::{
     ResourceLifecycle, Stack, StackInputDefinition, StackInputEnvironmentMapping, StackInputKind,
     StackInputProvider, StackInputValidation, StackSettings, Storage,
@@ -100,4 +100,44 @@ fn terraform_rejects_deployer_secret_inputs_until_provider_state_safety_exists()
     assert!(err
         .message
         .contains("Terraform deployer-provided secret stack inputs are not enabled"));
+}
+
+/// Distinct ids can normalize to the same Terraform variable; a silent shadow
+/// would make both inputs read one variable, so generation must refuse.
+#[test]
+fn inputs_colliding_after_normalization_are_refused() {
+    fn boolean_input(id: &str) -> StackInputDefinition {
+        StackInputDefinition {
+            id: id.to_string(),
+            kind: StackInputKind::Boolean,
+            provided_by: vec![StackInputProvider::Deployer],
+            required: true,
+            label: format!("Input {id}"),
+            description: format!("Test input {id}."),
+            placeholder: None,
+            default: None,
+            platforms: None,
+            validation: None,
+            env: Vec::new(),
+        }
+    }
+
+    let stack = Stack::new("input-stack".to_string())
+        .inputs(vec![boolean_input("fooBar"), boolean_input("foo_bar")])
+        .add(
+            Storage::new("files".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let error = try_render(&stack, TerraformTarget::Aws, StackSettings::default())
+        .expect_err("colliding variable names must refuse to render");
+    assert!(error.message.contains("fooBar"), "{}", error.message);
+    assert!(error.message.contains("foo_bar"), "{}", error.message);
+    assert!(error.message.contains("input_foo_bar"), "{}", error.message);
+    assert!(
+        !error.message.contains("  "),
+        "the message should render without space runs: {}",
+        error.message
+    );
 }

--- a/packages/core/src/__tests__/gateability.test.ts
+++ b/packages/core/src/__tests__/gateability.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
-import * as alien from "../index"
+import * as alien from "../index.js"
 
 /**
  * The SDK's `.enabled()` surface asserted against the generated gateability
@@ -20,10 +20,7 @@ const builders: Record<string, () => object> = {
   queue: () => new alien.Queue("fixture"),
   vault: () => new alien.Vault("fixture"),
   postgres: () => new alien.Postgres("fixture"),
-  worker: () =>
-    new alien.Worker("fixture", {
-      code: { image: "example/image:latest" },
-    } as never),
+  worker: () => new alien.Worker("fixture"),
   daemon: () => new alien.Daemon("fixture"),
   container: () => new alien.Container("fixture"),
   email: () => new alien.Email("fixture"),

--- a/packages/core/src/__tests__/gateability.test.ts
+++ b/packages/core/src/__tests__/gateability.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import * as alien from "../index"
+
+/**
+ * The SDK's `.enabled()` surface asserted against the generated gateability
+ * manifest (`pnpm generate` rewrites it from the Rust policy), so the builder
+ * surface and the policy cannot drift apart: a type the policy allows must
+ * offer `.enabled()`, and a type it refuses must not.
+ */
+const manifest: Record<string, { frozen: boolean; live: boolean }> = JSON.parse(
+  readFileSync(join(__dirname, "../generated/gateability.json"), "utf8"),
+)
+
+/** Builder factories for every manifest type the TypeScript SDK exposes. */
+const builders: Record<string, () => object> = {
+  kv: () => new alien.Kv("fixture"),
+  storage: () => new alien.Storage("fixture"),
+  queue: () => new alien.Queue("fixture"),
+  vault: () => new alien.Vault("fixture"),
+  postgres: () => new alien.Postgres("fixture"),
+  worker: () =>
+    new alien.Worker("fixture", {
+      code: { image: "example/image:latest" },
+    } as never),
+}
+
+describe("gateability manifest", () => {
+  it("lists every type the builder table covers", () => {
+    for (const resourceType of Object.keys(builders)) {
+      expect(
+        manifest,
+        `builder table covers '${resourceType}' but the manifest does not`,
+      ).toHaveProperty([resourceType])
+    }
+  })
+
+  for (const [resourceType, gateability] of Object.entries(manifest)) {
+    const gateable = gateability.frozen || gateability.live
+    const makeBuilder = builders[resourceType]
+
+    it(`'${resourceType}' ${gateable ? "offers" : "does not offer"} .enabled()`, () => {
+      if (!makeBuilder) {
+        // Types without a dedicated TypeScript builder (experimental or
+        // Rust-only surface) cannot offer .enabled() anywhere, which is only
+        // consistent when the policy refuses them too.
+        expect(
+          gateable,
+          `the policy allows gating '${resourceType}' but the SDK has no builder exposing .enabled(); add the builder (and a matrix fixture) or refuse the type`,
+        ).toBe(false)
+        return
+      }
+      const builder = makeBuilder() as { enabled?: unknown }
+      if (gateable) {
+        expect(
+          typeof builder.enabled,
+          `the policy allows gating '${resourceType}', so its builder must expose .enabled()`,
+        ).toBe("function")
+      } else {
+        expect(
+          builder.enabled,
+          `the policy refuses gating '${resourceType}', so its builder must not expose .enabled()`,
+        ).toBeUndefined()
+      }
+    })
+  }
+})

--- a/packages/core/src/__tests__/gateability.test.ts
+++ b/packages/core/src/__tests__/gateability.test.ts
@@ -24,6 +24,9 @@ const builders: Record<string, () => object> = {
     new alien.Worker("fixture", {
       code: { image: "example/image:latest" },
     } as never),
+  daemon: () => new alien.Daemon("fixture"),
+  container: () => new alien.Container("fixture"),
+  email: () => new alien.Email("fixture"),
 }
 
 describe("gateability manifest", () => {

--- a/packages/core/src/generated/gateability.json
+++ b/packages/core/src/generated/gateability.json
@@ -1,0 +1,42 @@
+{
+  "container": {
+    "frozen": false,
+    "live": false
+  },
+  "daemon": {
+    "frozen": false,
+    "live": false
+  },
+  "email": {
+    "frozen": false,
+    "live": false
+  },
+  "experimental/aws-opensearch": {
+    "frozen": false,
+    "live": false
+  },
+  "kv": {
+    "frozen": true,
+    "live": true
+  },
+  "postgres": {
+    "frozen": true,
+    "live": true
+  },
+  "queue": {
+    "frozen": true,
+    "live": true
+  },
+  "storage": {
+    "frozen": true,
+    "live": true
+  },
+  "vault": {
+    "frozen": true,
+    "live": true
+  },
+  "worker": {
+    "frozen": false,
+    "live": false
+  }
+}


### PR DESCRIPTION
## Summary

Converting a resource type to `.enabled()` used to mean hand-threading the gate through every one of its emitters — a full PR per type, four times so far. The setup generators now apply gating as a post-pass over plain emitted blocks, and every existing gated snapshot renders byte-identically to prove the swap changed nothing.

What happens when a gated stack renders:

1. One policy in `alien-core` decides whether the gate is allowed — checked by the preflight and re-checked inside both generators, so rendering without preflights refuses the same things.
2. The generator puts the gate on every owned block (a Terraform `count`, a CloudFormation `Condition`), rewrites every reference to a gated address into indexed form — expressions and string templates alike — and fails generation if any gated address survives unindexed in the rendered files. **← the heart**
3. The resource's registration entry splices out behind the input, while shared support blocks (project-wide roles) stay ungated by classification and body-identical grants keep merging their contributors' gates.

This PR changes gating from per-emitter hand-written code to one generator-owned pass.

## What was broken

Nothing was misbehaving — the cost was structural. Gating knowledge lived inside each emitter (gate calls, `[0]` indexing on self-references, an opt-in flag), so every new resource type re-paid the same conversion work, and a half-converted emitter was only caught by its own flag.

## What I did

- Added `alien_core::gateability`: a type table plus an id-level rule (the reserved `secrets` vault), enforced at preflight and at render in both generators, and exported as a generated manifest that a TypeScript test holds the SDK's `.enabled()` surface against. This PR pins it to today's gateable set — nothing new becomes gateable here.
- Built the Terraform post-pass (`gating.rs`): gates owned blocks, rewrites references (traversals, string templates, `%{if}`/`%{for}` directives) module-wide, refuses `count`/`for_each` collisions, and scans the rendered output as a last net. Splats and `depends_on` stay unindexed — they are already list-aware.
- Classified instead of gated: fragments mark shared blocks (GCP custom roles, Azure role definitions) that must outlive any one resource; footprintless blocks (`random_id`) come from an exact central allowlist and are refused if they contain a `provisioner`; Email's SES statement inside the storage bucket policy became a contribution carrying Email's gate (renders unchanged while Email is ungated).
- Deleted `supports_enabled_when()` from both emitter traits and stripped all gate threading from the kv, queue, and storage emitters across AWS, GCP, and Azure in both formats.
- Added a matrix test on both formats: every registered emitter must be policy-refused or covered by a gated fixture that renders, validates, and resolves both answers. Its first run caught 15 emitter cells that only the deleted opt-in flag had been holding back; the policy now names them.
- Vault became the first type gated purely by the post-pass — no vault emitter ever carried gating code — locked by per-cloud snapshots.

## Files touched

- `crates/alien-core/src/gateability.rs` (new), `lib.rs`, `bin/schema_exporter.rs` — the policy and the generated manifest
- `crates/alien-preflights/src/compile_time/resource_enabled_valid.rs`, `src/mutations/secrets_vault.rs` — ban arms replaced by the shared policy; the vault-id constant moved to core
- `crates/alien-terraform/src/gating.rs` (new), `generator.rs`, `emitter.rs`, `emitters/enabled.rs`, `registry.rs`, emitters under `aws/`, `gcp/`, `azure/` — the post-pass, fragment classification, registry iteration, threading removal, input-name collision check
- `crates/alien-cloudformation/src/generator.rs`, `emitter.rs`, `emitters/aws/{kv,queue,storage}.rs`, `registry.rs` — policy check replaces the opt-in; the SES contribution; parameter collision check
- Tests: `gating_matrix_tests.rs` in both crates (new), gated-vault snapshots (new), collision and policy-refusal tests
- `packages/core/src/__tests__/gateability.test.ts` (new), `src/generated/gateability.json` (new)

## How I tested

- **Byte-parity:** every pre-existing gated snapshot (kv/queue/storage across AWS/GCP/Azure Terraform and AWS CloudFormation) renders identically under the post-pass — `cargo test -p alien-terraform -p alien-cloudformation` with zero snapshot diffs.
- **Matrices:** the registry walk renders every allowed (type × platform × format) gated from a fixture, runs `terraform validate` / cfn-lint plus the deploy-time condition-resolution model, and asserts a declined resource leaves no owned blocks, no grants binding it, and no registration entry.
- **Suites:** alien-core 440, alien-preflights, alien-terraform 120, alien-cloudformation 65 (the two `aws_open_search` cfn-lint failures also fail on untouched main — a stale local lint spec), SDK vitest 71 plus a clean `tsc`.

I also ran a security review on the diff. What it checked:
- A declined resource leaving a reachable grant behind — every formerly hand-gated IAM block (role policies, bucket policies, IAM members, role assignments) is owned and gated by the post-pass; the unchanged per-block gating tests and the matrix assert it.
- Declining one resource deleting a shared role its siblings still hold — shared blocks are never gated, and same-address different-body shared blocks fail generation instead of one silently winning.
- A caller skipping preflights gating a refused type — the generators re-check the policy; a render-side test proves the refusal.
- A reference escaping the rewrite and silently mis-resolving when the deployer declines — the rendered-output scan fails generation with a non-retryable error; unit-tested including splat, key-index, and directive edge cases.
Nothing turned up.
