### PR TITLE
fix(ci): compile every workspace package in CI Fast

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -141,8 +141,40 @@ jobs:
           # `alien-test-server` has no Rust unit tests; it is filtered out rather than
           # merely uncovered so that tests added to it later don't start running here by
           # accident — it is exercised by the e2e-cloud workflow against real clouds.
-          cargo nextest run --workspace \
-            --filter-expr 'not package(alien-test-server) and not (package(alien-aws-clients) and kind(test)) and not (package(alien-gcp-clients) and kind(test)) and not (package(alien-azure-clients) and kind(test)) and not (package(alien-bindings) and kind(test)) and not binary_id(alien-build::build_integration_tests) and not binary_id(alien-build::image_shape_tests) and not binary_id(alien-build::rust_integration_tests) and not binary_id(alien-build::typescript_integration_tests) and not binary_id(alien-worker-runtime::cloudrun) and not binary_id(alien-worker-runtime::lambda) and not binary_id(alien-test::distribution) and not binary_id(alien-test::pull) and not binary_id(alien-test::push) and not binary_id(alien-manager::registry_proxy_cloud_test)'
+          #
+          # One clause per line, joined with spaces into a single nextest filterset, so
+          # that a missing or mistyped clause is visible when reading the diff.
+          FILTER_CLAUSES=(
+            'not package(alien-test-server)'
+
+            # Cloud client and bindings crates: their `tests/` targets only — the unit
+            # tests under `src/` still run here. cloud-tests.yml runs these targets
+            # with real cloud credentials.
+            'and not (package(alien-aws-clients) and kind(test))'
+            'and not (package(alien-gcp-clients) and kind(test))'
+            'and not (package(alien-azure-clients) and kind(test))'
+            'and not (package(alien-bindings) and kind(test))'
+
+            # alien-build integration suites: they build real images, so they need
+            # Docker and network access to pull base images.
+            'and not binary_id(alien-build::build_integration_tests)'
+            'and not binary_id(alien-build::image_shape_tests)'
+            'and not binary_id(alien-build::rust_integration_tests)'
+            'and not binary_id(alien-build::typescript_integration_tests)'
+
+            # alien-worker-runtime platform transport suites (Lambda, Cloud Run).
+            'and not binary_id(alien-worker-runtime::cloudrun)'
+            'and not binary_id(alien-worker-runtime::lambda)'
+
+            # alien-test registry suites: e2e-cloud.yml runs them against real clouds.
+            'and not binary_id(alien-test::distribution)'
+            'and not binary_id(alien-test::pull)'
+            'and not binary_id(alien-test::push)'
+
+            # Manager registry proxy against a real cloud registry: cloud-tests.yml.
+            'and not binary_id(alien-manager::registry_proxy_cloud_test)'
+          )
+          cargo nextest run --workspace --filter-expr "${FILTER_CLAUSES[*]}"
 
   typescript:
     name: TypeScript packages and CLIs

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -136,7 +136,7 @@ jobs:
           # it. Skip tests with `--filter-expr` instead: the package still compiles, so
           # a break in it fails this job. `alien-test-server` (the default app for the
           # manually dispatched e2e-cloud workflow, and so not built anywhere else) sat
-          # broken for over a month behind `--exclude` exactly this way — see ALIEN-335.
+          # broken behind `--exclude` exactly this way from #169 until ALIEN-335 found it.
           #
           # `alien-test-server` has no Rust unit tests; it is filtered out rather than
           # merely uncovered so that tests added to it later don't start running here by

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -131,11 +131,18 @@ jobs:
           AXIOM_TOKEN: ${{ secrets.AXIOM_CI_API_KEY }}
           AXIOM_DATASET: dev
         run: |
+          # Never use `--exclude` here. It drops a package from *compilation*, not just
+          # from the test run, so the package rots silently until something else builds
+          # it. Skip tests with `--filter-expr` instead: the package still compiles, so
+          # a break in it fails this job. `alien-test-server` (the default app for the
+          # manually dispatched e2e-cloud workflow, and so not built anywhere else) sat
+          # broken for over a month behind `--exclude` exactly this way — see ALIEN-335.
+          #
+          # `alien-test-server` has no Rust unit tests; it is filtered out rather than
+          # merely uncovered so that tests added to it later don't start running here by
+          # accident — it is exercised by the e2e-cloud workflow against real clouds.
           cargo nextest run --workspace \
-            --exclude byocdb \
-            --exclude endpoint-agent \
-            --exclude alien-test-server \
-            --filter-expr 'not (package(alien-aws-clients) and kind(test)) and not (package(alien-gcp-clients) and kind(test)) and not (package(alien-azure-clients) and kind(test)) and not (package(alien-bindings) and kind(test)) and not binary_id(alien-build::build_integration_tests) and not binary_id(alien-build::image_shape_tests) and not binary_id(alien-build::rust_integration_tests) and not binary_id(alien-build::typescript_integration_tests) and not binary_id(alien-worker-runtime::cloudrun) and not binary_id(alien-worker-runtime::lambda) and not binary_id(alien-test::distribution) and not binary_id(alien-test::pull) and not binary_id(alien-test::push) and not binary_id(alien-manager::registry_proxy_cloud_test)'
+            --filter-expr 'not package(alien-test-server) and not (package(alien-aws-clients) and kind(test)) and not (package(alien-gcp-clients) and kind(test)) and not (package(alien-azure-clients) and kind(test)) and not (package(alien-bindings) and kind(test)) and not binary_id(alien-build::build_integration_tests) and not binary_id(alien-build::image_shape_tests) and not binary_id(alien-build::rust_integration_tests) and not binary_id(alien-build::typescript_integration_tests) and not binary_id(alien-worker-runtime::cloudrun) and not binary_id(alien-worker-runtime::lambda) and not binary_id(alien-test::distribution) and not binary_id(alien-test::pull) and not binary_id(alien-test::push) and not binary_id(alien-manager::registry_proxy_cloud_test)'
 
   typescript:
     name: TypeScript packages and CLIs

--- a/crates/alien-deploy-cli/src/commands/register.rs
+++ b/crates/alien-deploy-cli/src/commands/register.rs
@@ -463,7 +463,7 @@ mod tests {
     fn outputs_with_resources(payload: &str) -> CfnOutputs {
         CfnOutputs {
             resources_chunks: vec![
-                parse_json_output("DeploymentResources", payload).expect("payload is JSON"),
+                parse_json_output("DeploymentResources", payload).expect("payload is JSON")
             ],
             ..base_outputs()
         }
@@ -481,7 +481,10 @@ mod tests {
 
         assert_eq!(request.resources.len(), 1);
         assert_eq!(request.resources[0].id, "jobs");
-        assert_eq!(request.resources[0].resource_type, ResourceType::from("queue"));
+        assert_eq!(
+            request.resources[0].resource_type,
+            ResourceType::from("queue")
+        );
     }
 
     /// The reason the payload has to be correct at the source: there is no

--- a/crates/alien-deployment/src/pending.rs
+++ b/crates/alien-deployment/src/pending.rs
@@ -134,10 +134,9 @@ pub fn strip_declined_resources(
         let Some(input_id) = entry.enabled_when.as_deref() else {
             continue;
         };
-        let setup_created = alien_core::ownership_policy_for_resource_type(
-            entry.config.resource_type().as_ref(),
-        )
-        .should_emit_in_setup(entry.lifecycle);
+        let setup_created =
+            alien_core::ownership_policy_for_resource_type(entry.config.resource_type().as_ref())
+                .should_emit_in_setup(entry.lifecycle);
 
         let is_declined = if setup_created {
             !stack_state.resources.is_empty()
@@ -249,7 +248,7 @@ fn environment_collection_context(
 mod tests {
     use super::*;
     use alien_core::{
-        Kv, KubernetesClientConfig, Resource, ResourceLifecycle, ResourceStatus, ServiceAccount,
+        KubernetesClientConfig, Kv, Resource, ResourceLifecycle, ResourceStatus, ServiceAccount,
         StackInputDefinition, StackResourceState,
     };
 
@@ -364,7 +363,10 @@ mod tests {
         let stripped = strip_declined_resources(
             live_gated_stack(Some(true)),
             &StackState::new(Platform::Aws),
-            &std::collections::HashMap::from([("cacheEnabled".to_string(), serde_json::json!(false))]),
+            &std::collections::HashMap::from([(
+                "cacheEnabled".to_string(),
+                serde_json::json!(false),
+            )]),
         )
         .expect("resolvable gate");
         assert!(!stripped.resources.contains_key("cache"));
@@ -375,7 +377,10 @@ mod tests {
         let stripped = strip_declined_resources(
             live_gated_stack(Some(false)),
             &StackState::new(Platform::Aws),
-            &std::collections::HashMap::from([("cacheEnabled".to_string(), serde_json::json!(true))]),
+            &std::collections::HashMap::from([(
+                "cacheEnabled".to_string(),
+                serde_json::json!(true),
+            )]),
         )
         .expect("resolvable gate");
         assert!(stripped.resources.contains_key("cache"));
@@ -420,7 +425,10 @@ mod tests {
         let error = strip_declined_resources(
             live_gated_stack(Some(true)),
             &StackState::new(Platform::Aws),
-            &std::collections::HashMap::from([("cacheEnabled".to_string(), serde_json::json!("false"))]),
+            &std::collections::HashMap::from([(
+                "cacheEnabled".to_string(),
+                serde_json::json!("false"),
+            )]),
         )
         .expect_err("string values are not answers");
         assert!(error.message.contains("boolean"), "{}", error.message);

--- a/crates/alien-deployment/tests/test_platform.rs
+++ b/crates/alien-deployment/tests/test_platform.rs
@@ -1455,7 +1455,11 @@ async fn test_deleted_is_noop() {
 /// F) Live gating flow tests
 
 /// A deployer-provided boolean gate input with a declared default of true.
-fn boolean_gate_input(id: &str, label: &str, description: &str) -> alien_core::StackInputDefinition {
+fn boolean_gate_input(
+    id: &str,
+    label: &str,
+    description: &str,
+) -> alien_core::StackInputDefinition {
     alien_core::StackInputDefinition::deployer_boolean(id, label, description, Some(true))
 }
 
@@ -1483,8 +1487,7 @@ fn create_live_gated_stack(stack_id: &str, store_id: &str, function_id: &str) ->
 
 fn config_with_store_enabled(enabled: bool) -> DeploymentConfig {
     let mut config = create_test_config("hash_v1", false);
-    config.input_values =
-        HashMap::from([("storeEnabled".to_string(), serde_json::json!(enabled))]);
+    config.input_values = HashMap::from([("storeEnabled".to_string(), serde_json::json!(enabled))]);
     config
 }
 

--- a/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
+++ b/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
@@ -130,7 +130,10 @@ fn management_differs_outside_gates(
 ) -> bool {
     match (old_management, new_management) {
         (ManagementPermissions::Auto, ManagementPermissions::Auto) => false,
-        (ManagementPermissions::Extend(old_profile), ManagementPermissions::Extend(new_profile))
+        (
+            ManagementPermissions::Extend(old_profile),
+            ManagementPermissions::Extend(new_profile),
+        )
         | (
             ManagementPermissions::Override(old_profile),
             ManagementPermissions::Override(new_profile),
@@ -419,7 +422,10 @@ mod tests {
             .management(ManagementPermissions::Extend(
                 PermissionProfile::new().global(["kv/provision", "kv/data-write"]),
             ))
-            .add(Kv::new("cache".to_string()).build(), ResourceLifecycle::Live)
+            .add(
+                Kv::new("cache".to_string()).build(),
+                ResourceLifecycle::Live,
+            )
             .build();
 
         let result = PermissionProfilesUnchangedCheck
@@ -437,7 +443,10 @@ mod tests {
             .management(ManagementPermissions::Extend(
                 PermissionProfile::new().resource("cache", ["kv/provision"]),
             ))
-            .add(Kv::new("cache".to_string()).build(), ResourceLifecycle::Live)
+            .add(
+                Kv::new("cache".to_string()).build(),
+                ResourceLifecycle::Live,
+            )
             .build();
         let new_stack = Stack::new("s".to_string())
             .management(ManagementPermissions::Extend(PermissionProfile::new()))

--- a/crates/alien-preflights/src/compile_time/resource_enabled_valid.rs
+++ b/crates/alien-preflights/src/compile_time/resource_enabled_valid.rs
@@ -239,7 +239,7 @@ fn dependents_of_gated_resources(stack: &Stack) -> Vec<String> {
 mod tests {
     use super::*;
     use alien_core::{
-        permissions::PermissionProfile, Kv, Storage, ResourceLifecycle, StackInputDefinition,
+        permissions::PermissionProfile, Kv, ResourceLifecycle, StackInputDefinition, Storage,
         Vault, Worker, WorkerCode,
     };
 
@@ -371,7 +371,10 @@ mod tests {
         input.default = None;
         let errors = errors_for(stack_with(input)).await;
         assert_eq!(errors.len(), 1, "{errors:?}");
-        assert!(errors[0].contains("required or declare a default"), "{errors:?}");
+        assert!(
+            errors[0].contains("required or declare a default"),
+            "{errors:?}"
+        );
     }
 
     #[tokio::test]
@@ -520,9 +523,15 @@ mod tests {
     /// Two inputs mean two independent answers, and only one of them creates the store.
     #[tokio::test]
     async fn rejects_a_dependent_gated_on_a_different_input() {
-        let errors = errors_for(stack_with_bucket_depending_on_gated_store(Some("buildEnabled"))).await;
+        let errors = errors_for(stack_with_bucket_depending_on_gated_store(Some(
+            "buildEnabled",
+        )))
+        .await;
         assert_eq!(errors.len(), 1, "{errors:?}");
-        assert!(errors[0].contains("gated on different inputs"), "{errors:?}");
+        assert!(
+            errors[0].contains("gated on different inputs"),
+            "{errors:?}"
+        );
         assert!(
             errors[0].contains("'buildEnabled' and 'storeEnabled'"),
             "{errors:?}"
@@ -567,7 +576,10 @@ mod tests {
     #[tokio::test]
     async fn ungated_stacks_skip_the_check_entirely() {
         let stack = Stack::new("test-stack".to_string())
-            .add(Kv::new("store".to_string()).build(), ResourceLifecycle::Frozen)
+            .add(
+                Kv::new("store".to_string()).build(),
+                ResourceLifecycle::Frozen,
+            )
             .build();
         assert!(!ResourceEnabledValidCheck.should_run(&stack, Platform::Aws));
     }

--- a/crates/alien-terraform/src/emitters/gcp/kv.rs
+++ b/crates/alien-terraform/src/emitters/gcp/kv.rs
@@ -60,12 +60,7 @@ impl TfEmitter for GcpKvEmitter {
             ),
             (
                 "location",
-                enabled::self_attribute(
-                    ctx,
-                    "google_firestore_database",
-                    label,
-                    "location_id",
-                ),
+                enabled::self_attribute(ctx, "google_firestore_database", label, "location_id"),
             ),
         ]))
     }

--- a/crates/alien-terraform/tests/generator/helpers.rs
+++ b/crates/alien-terraform/tests/generator/helpers.rs
@@ -5,9 +5,7 @@
 //! `=== <path> ===` separators. Snapshots stay reviewable as a unit, the
 //! way a security team would actually read the module.
 
-use alien_core::{
-    Stack, StackInputDefinition, StackSettings,
-};
+use alien_core::{Stack, StackInputDefinition, StackSettings};
 use alien_terraform::{
     generate_terraform_module, ModuleFiles, TerraformOptions, TerraformTarget, TfRegistry,
 };

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/queue.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/queue.rs
@@ -49,7 +49,7 @@ pub async fn test_queue(
     let payload =
         MessagePayload::Json(serde_json::json!({ "hello": "world", "binding": binding_name }));
     queue
-        .send(&binding_name, payload)
+        .send(payload)
         .await
         .into_alien_error()
         .context(ErrorData::QueueOperationFailed {
@@ -57,16 +57,17 @@ pub async fn test_queue(
         })?;
 
     // Receive up to 1 message
-    let messages = queue
-        .receive(&binding_name, 1)
-        .await
-        .into_alien_error()
-        .context(ErrorData::QueueOperationFailed {
-            operation: "Failed to receive message".to_string(),
-        })?;
+    let messages =
+        queue
+            .receive(1)
+            .await
+            .into_alien_error()
+            .context(ErrorData::QueueOperationFailed {
+                operation: "Failed to receive message".to_string(),
+            })?;
     if let Some(msg) = messages.into_iter().next() {
         queue
-            .ack(&binding_name, &msg.receipt_handle)
+            .ack(&msg.receipt_handle)
             .await
             .into_alien_error()
             .context(ErrorData::QueueOperationFailed {
@@ -122,7 +123,7 @@ pub async fn send_queue_message(
 
     let payload = MessagePayload::Json(serde_json::json!({ "marker": request.marker }));
     queue
-        .send(&binding_name, payload)
+        .send(payload)
         .await
         .into_alien_error()
         .context(ErrorData::QueueOperationFailed {


### PR DESCRIPTION
Refs ALIEN-335

## The break

`tests/e2e/test-apps/comprehensive-rust` (package `alien-test-server`) has not compiled since **2026-07-21**.

`2a6cd640` ("feat!: simplify commands and runtime bindings", #169) removed the redundant binding-name argument from `BoundQueue::send/receive/ack` — the handle already carries its own name:

```rust
pub struct BoundQueue {
    inner: Arc<dyn Queue>,
    name: Arc<str>,
}

pub async fn send(&self, message: MessagePayload) -> Result<()> {
    self.inner.send(&self.name, message).await
}
```

Four call sites in `src/handlers/queue.rs` were never updated, so the package fails with `error[E0061]: this method takes 1 argument but 2 arguments were supplied`. `binding_name` stays a live local at every site (it is still used for the binding lookup, the log line, and the response), so this is a pure argument drop with no dead bindings left behind.

`alien-test-server` is the **default** `app` input of the manual `e2e-cloud` workflow and is deployed to AWS, GCP and Azure. Cloud Rust e2e has therefore been broken for over a month. Nobody noticed because that workflow is `workflow_dispatch`-only.

## Why CI Fast stayed green — the part that matters

CI Fast ran:

```
cargo nextest run --workspace \
  --exclude byocdb \
  --exclude endpoint-agent \
  --exclude alien-test-server \
  --filter-expr 'not (package(alien-bindings) and kind(test)) and ...'
```

**`--exclude` removes a package from compilation, not just from the test run.** Once a package is behind `--exclude`, nothing in CI Fast builds it, and it rots silently until something else happens to build it — which for an e2e-only app is "never, until someone dispatches the cloud workflow."

The `filter-expr` treatment already applied to `alien-bindings` in the same command — `not (package(alien-bindings) and kind(test))` — is the correct pattern: the package still compiles, only the selected tests are skipped, so a break fails the job even though the tests never run.

All three `--exclude` flags are now gone. `alien-test-server` moves to a filter clause, and a comment on the step records why `--exclude` must not come back.

## `byocdb` and `endpoint-agent`

Both were excluded for the same blunt reason — no rationale in the diff, and both flags date back to the initial import without ever being revisited. **Verified locally that neither needs to be excluded at all**, so they now compile *and* run:

```
$ cargo check -p byocdb --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 51.26s

$ cargo check -p endpoint-agent --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.41s
```

Their 9 unit tests are pure in-process checks — duration parsing, PII regexes, command-receiver env validation — with no network, credentials, or system dependencies:

```
$ cargo nextest run -p byocdb -p endpoint-agent
    Starting 9 tests across 2 binaries
        PASS [   0.022s] (1/9) byocdb::bin/byocdb tests::terminal_receiver_error_fails_the_service
        PASS [   0.025s] (2/9) byocdb::bin/byocdb tests::absent_command_environment_disables_receiver
        PASS [   0.025s] (3/9) endpoint-agent::bin/endpoint-agent pii::tests::test_ssn_detection
        PASS [   0.028s] (4/9) byocdb::bin/byocdb tests::invalid_command_environment_fails_startup
        PASS [   0.031s] (5/9) endpoint-agent::bin/endpoint-agent commands::tests::test_parse_duration
        PASS [   0.035s] (6/9) endpoint-agent::bin/endpoint-agent commands::tests::test_parse_duration_invalid
        PASS [   0.036s] (7/9) endpoint-agent::bin/endpoint-agent pii::tests::test_no_pii
        PASS [   0.039s] (8/9) byocdb::bin/byocdb tests::partial_command_environment_fails_startup
        PASS [   0.041s] (9/9) endpoint-agent::bin/endpoint-agent pii::tests::test_email_detection
────────────
     Summary [   0.043s] 9 tests run: 9 passed, 0 skipped
```

43 milliseconds of coverage that CI has been throwing away. Neither needs a filter clause.

`alien-test-server` keeps a filter clause rather than being left uncovered: it has no Rust unit tests today, and the clause stops any added later from silently starting to run in the fast job when they belong in `e2e-cloud`.

## fmt sweep

`cargo fmt --all -- --check` was already failing on `main` across 7 files in `alien-deploy-cli`, `alien-deployment`, `alien-preflights` and `alien-terraform`. `hk` only rustfmt-checks *changed* files, so this drift was invisible day to day while masking any real formatting failure in those crates.

Ran `cargo fmt --all`. The diff is import reordering and line wrapping only — no semantic change.

## Validation

Core proof — the package compiles again:

```
$ cargo check -p alien-test-server --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 18s
```

The exact CI Fast invocation with the edited flags, proving every included package builds:

```
$ cargo nextest run --workspace --filter-expr '<exactly as in the workflow>' --no-run
    Finished `test` profile [unoptimized + debuginfo] target(s) in 8m 31s
$ echo $status
0
```

No package other than `alien-test-server` was hiding a compile break.

Full run of the same command was also done locally, after `pnpm install --frozen-lockfile`. It is **not** a clean signal on this machine and I am not claiming it as one: `terraform`, `helm` and `kubeconform` are not installed here, and CI installs all three before this step. The generator does a best-effort `terraform fmt` pass and says so itself:

```rust
// Best-effort `terraform fmt` pass so output matches what
// `terraform fmt -check` expects. If terraform isn't installed we ship
// the hcl-rs output as-is — it parses identically; only attribute
// equals-sign alignment differs.
let _ = format_with_terraform(&mut module);
```

So every local failure is an `alien-terraform` insta snapshot or an `alien-test` assertion comparing against equals-sign-aligned HCL (e.g. `rendered.contains("id   = \"management\"")`). Diffing one snapshot against its `.new` shows nothing but alignment:

```
$ diff generator__generator__helpers__gcp_kv_minimal.snap{,.new}
11c12
<       source  = "hashicorp/google"
---
>       source = "hashicorp/google"
```

None of these touch anything this PR changes, and the two `alien-terraform` files in the fmt sweep are import re-wrapping plus one file `git diff` reports as "No syntactic changes". **The authoritative full-run signal is this PR's own CI Fast job**, which has the toolchain installed — and it is green:

```
PR conventions:                completed success
TypeScript packages and CLIs:  completed success
Rust crates:                   completed success
All tests passed:              completed success
```

That is the real proof: the whole workspace — now including `alien-test-server`, `byocdb` and `endpoint-agent` — compiles and passes under the edited flags.

Formatting and whitespace:

```
$ cargo fmt --all -- --check && echo "FMT CLEAN"
FMT CLEAN

$ git diff --check && echo "DIFF CHECK CLEAN"
DIFF CHECK CLEAN
```

The workflow file was also parsed with a YAML loader to confirm the edited `run` block is intact, and `cargo nextest list` under the new filter confirms it selects the 9 `byocdb`/`endpoint-agent` tests and zero `alien-test-server` entries.
