### PR TITLE
fix(ci): keep release lockfiles synchronized

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,10 @@ jobs:
             "
           done
 
+      - name: Regenerate Cargo lockfile
+        if: ${{ inputs.stable_action == 'prepare' || inputs.dry_run }}
+        run: cargo metadata --format-version 1 >/dev/null
+
       # Dry-run build jobs start from the untagged commit, so carry the exact
       # versioned manifests that a real release would commit into those fresh
       # checkouts. This keeps the addon binary, wrapper, and platform packages
@@ -180,6 +184,7 @@ jobs:
           retention-days: 1
           path: |
             Cargo.toml
+            Cargo.lock
             packages/core/package.json
             packages/commands/package.json
             packages/sdk/package.json
@@ -206,7 +211,7 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml packages/core/package.json packages/commands/package.json \
+          git add Cargo.toml Cargo.lock packages/core/package.json packages/commands/package.json \
             packages/sdk/package.json packages/testing/package.json \
             client-sdks/platform/typescript/package.json client-sdks/manager/typescript/package.json \
             packages/bindings/package.json crates/alien-bindings-node/package.json \
@@ -237,6 +242,7 @@ jobs:
           VERSION: ${{ steps.merged_version.outputs.version }}
         run: |
           git checkout --detach "${{ steps.merged_version.outputs.commit }}"
+          cargo metadata --format-version 1 --locked >/dev/null
           for pkg in packages/core packages/commands packages/sdk packages/testing \
             client-sdks/platform/typescript client-sdks/manager/typescript \
             packages/bindings crates/alien-bindings-node \


### PR DESCRIPTION
## Summary

- regenerate `Cargo.lock` with Cargo after bumping workspace manifests
- include the lockfile in dry-run artifacts and version-only release PRs
- reject publication when the exact merged release commit fails locked Cargo metadata resolution

This closes the release inconsistency found by exercising v3.0.0 preparation end to end.

## Validation

- `actionlint -shellcheck= -ignore 'label .* is unknown' .github/workflows/release.yml`\n- `git diff --check`\n- `cargo metadata --format-version 1 --offline` regenerated only 36 workspace package versions in the v3 release lockfile\n- `cargo check --workspace --locked --quiet` passed on the corrected v3 release branch\n\n[ALIEN-340](https://linear.app/alienplatform/issue/ALIEN-340/make-stable-releases-respect-protected-main)