### PR TITLE
chore: release v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-bindings",
  "alien-error",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aegis",
  "alien-azure-clients",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error",
  "chrono",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -61,38 +61,38 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.0.0", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.0.1", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.0.0", default-features = false }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.0.0" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.0.0", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.0.0" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.0.1", default-features = false }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.0.1" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.0.1", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.0.1" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.0.0" }
-alien-infra = { path = "crates/alien-infra", version = "3.0.0" }
-alien-build = { path = "crates/alien-build", version = "3.0.0" }
-alien-macros = { path = "crates/alien-macros", version = "3.0.0" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.0.0" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.0.0" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.0.0" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.0.0" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.0.0" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.0.0" }
-alien-error = { path = "crates/alien-error", version = "3.0.0", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.0.0" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.0.0" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.0.0" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.0.0" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.0.0" }
-alien-local = { path = "crates/alien-local", version = "3.0.0" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.0.0" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.0.0" }
-alien-helm = { path = "crates/alien-helm", version = "3.0.0" }
-alien-manager = { path = "crates/alien-manager", version = "3.0.0" }
-alien-observer = { path = "crates/alien-observer", version = "3.0.0" }
+alien-core = { path = "crates/alien-core", version = "3.0.1" }
+alien-infra = { path = "crates/alien-infra", version = "3.0.1" }
+alien-build = { path = "crates/alien-build", version = "3.0.1" }
+alien-macros = { path = "crates/alien-macros", version = "3.0.1" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.0.1" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.0.1" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.0.1" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.0.1" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.0.1" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.0.1" }
+alien-error = { path = "crates/alien-error", version = "3.0.1", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.0.1" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.0.1" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.0.1" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.0.1" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.0.1" }
+alien-local = { path = "crates/alien-local", version = "3.0.1" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.0.1" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.0.1" }
+alien-helm = { path = "crates/alien-helm", version = "3.0.1" }
+alien-manager = { path = "crates/alien-manager", version = "3.0.1" }
+alien-observer = { path = "crates/alien-observer", version = "3.0.1" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.0.0", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.0.0", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.0.1", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.0.1", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "cpu": ["arm64"],
   "main": "alien-bindings-node.darwin-arm64.node",
   "files": ["alien-bindings-node.darwin-arm64.node"],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "cpu": ["x64"],
   "main": "alien-bindings-node.darwin-x64.node",
   "files": ["alien-bindings-node.darwin-x64.node"],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "cpu": ["arm64"],
   "main": "alien-bindings-node.linux-arm64-gnu.node",
   "files": ["alien-bindings-node.linux-arm64-gnu.node"],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "cpu": ["x64"],
   "main": "alien-bindings-node.linux-x64-gnu.node",
   "files": ["alien-bindings-node.linux-x64-gnu.node"],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "files": ["dist"],
   "exports": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "files": ["dist"],
   "exports": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Version-only release PR generated by the stable release workflow. The **Release qualification** check builds and records the exact artifact set. After every required check passes and this merges, run the stable **publish** action from `main` to promote those qualified artifacts.