### PR TITLE
fix(ci): align qualification workflow permissions

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -11,7 +11,11 @@ on:
         required: true
 
 permissions:
-  contents: read
+  # The reusable release workflow also serves the prepare/publish entrypoint
+  # and declares contents: write. GitHub requires callers to grant at least the
+  # permissions declared by a called workflow, even when qualification itself
+  # only checks out source and uploads artifacts.
+  contents: write
   packages: write
   id-token: write
 


### PR DESCRIPTION
## Summary

- grant the qualification caller the permission ceiling declared by the reusable release workflow
- document why qualification needs this caller-level permission even though its selected jobs do not mutate repository contents

## Root cause

GitHub rejects a reusable workflow call at startup when the called workflow declares a permission the caller did not grant. The first real v3.0.1 qualification run exposed that `release.yml` declares `contents: write` while `release-qualification.yml` granted only `contents: read`.

The repository-owned, version-only diff gate still runs before any privileged qualification jobs.

## Validation

- `actionlint -ignore 'label .* is unknown' .github/workflows/release.yml .github/workflows/release-qualification.yml`
- `git diff --check`
- after merge, rerun qualification on release PR #215

Linear: ALIEN-345
