### PR TITLE
fix(ci): qualify Cargo package inputs before publish

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -41,6 +41,13 @@ Each destination is resumable:
 - an existing byte-for-byte match is accepted;
 - an existing same-version mismatch fails loudly.
 
+Cargo is the only format whose final archive cannot always be assembled during
+qualification: `cargo package` requires unpublished workspace dependency
+versions to already exist in crates.io. Qualification therefore records and
+hashes the exact source tree and each crate's package file list. Publication
+rechecks those inputs, assembles crates in dependency order, and accepts an
+existing version only when its crates.io checksum matches.
+
 If publication stops, fix the external failure and rerun the same publish
 action. Never prepare another version to recover a partial release.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,6 +490,35 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           mkdir -p qualified/crates
+          wait_for_crates_io_index() {
+            local crate=$1 expected_checksum=$2 index_path published_checksum
+            case "${#crate}" in
+              1) index_path="1/${crate}" ;;
+              2) index_path="2/${crate}" ;;
+              3) index_path="3/${crate:0:1}/${crate}" ;;
+              *) index_path="${crate:0:2}/${crate:2:2}/${crate}" ;;
+            esac
+            for attempt in $(seq 1 30); do
+              published_checksum=$(curl --fail --silent --show-error \
+                "https://index.crates.io/${index_path}" 2>/dev/null |
+                jq -s -r --arg version "$VERSION" \
+                  'map(select(.vers == $version)) | last | .cksum // empty' ||
+                true)
+              if [ "$published_checksum" = "$expected_checksum" ]; then
+                echo "${crate}@${VERSION} is available in the crates.io index"
+                return 0
+              fi
+              if [ -n "$published_checksum" ]; then
+                echo "::error::${crate}@${VERSION} reached the index with a different checksum"
+                return 1
+              fi
+              echo "Waiting for ${crate}@${VERSION} index propagation (${attempt}/30)..."
+              sleep 10
+            done
+            echo "::error::Timed out waiting for ${crate}@${VERSION} in the crates.io index"
+            return 1
+          }
+
           for crate in \
             alien-error-derive \
             alien-macros \
@@ -550,7 +579,7 @@ jobs:
 
             echo "Publishing $crate..."
             depot cargo publish -p "$crate" --no-verify
-            sleep 20
+            wait_for_crates_io_index "$crate" "$checksum"
           done
 
       - name: Upload qualified crates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -574,6 +574,7 @@ jobs:
                 exit 1
               fi
               echo "${crate}@${VERSION} already matches the qualified package"
+              wait_for_crates_io_index "$crate" "$checksum"
               continue
             fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -509,21 +509,33 @@ jobs:
             alien-sdk \
             alien-commands \
             alien-commands-client; do
-            echo "Packaging $crate..."
-            depot cargo package -p "$crate" --no-verify
-            package="target/package/${crate}-${VERSION}.crate"
-
             if [ "${{ inputs.stable_action }}" = "qualification" ]; then
-              cp "$package" qualified/crates/
+              echo "Recording package inputs for $crate..."
+              depot cargo package -p "$crate" --list |
+                LC_ALL=C sort > "qualified/crates/${crate}-${VERSION}.files"
               continue
             fi
 
-            checksum=$(sha256sum "$package" | awk '{print $1}')
-            qualified_checksum=$(sha256sum "qualified/crates/${crate}-${VERSION}.crate" | awk '{print $1}')
-            if [ "$checksum" != "$qualified_checksum" ]; then
-              echo "::error::${crate}@${VERSION} does not match its qualified package"
+            depot cargo package -p "$crate" --list |
+              LC_ALL=C sort > "${crate}-${VERSION}.files"
+            if ! cmp -s \
+              "${crate}-${VERSION}.files" \
+              "qualified/crates/${crate}-${VERSION}.files"; then
+              echo "::error::${crate}@${VERSION} package inputs differ from qualification"
+              diff -u \
+                "qualified/crates/${crate}-${VERSION}.files" \
+                "${crate}-${VERSION}.files" || true
               exit 1
             fi
+
+            # Cargo validates normalized registry dependencies while assembling
+            # the archive. A dependent crate cannot be packaged until the
+            # qualified prerequisite version exists in crates.io, so final
+            # assembly happens here in dependency order.
+            echo "Packaging $crate..."
+            depot cargo package -p "$crate" --no-verify
+            package="target/package/${crate}-${VERSION}.crate"
+            checksum=$(sha256sum "$package" | awk '{print $1}')
             published_checksum=$(curl --fail --silent --show-error \
               "https://crates.io/api/v1/crates/${crate}/${VERSION}" |
               jq -r '.version.checksum // empty' 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- qualify each Cargo package's exact file list without requiring unpublished workspace dependencies to exist in crates.io
- recheck the qualified inputs before publication, then assemble and publish in dependency order
- retain checksum-based idempotency for crates that already exist
- document the Cargo-specific registry constraint

## Root cause

`cargo package` validates the normalized upload manifest. A dependent workspace crate such as `alien-error@3.0.1` cannot be assembled until `alien-error-derive@3.0.1` exists in crates.io, even with `--no-verify`. Pre-merge qualification must not satisfy that condition by publishing.

The qualified Git tree plus per-crate package file lists captures the complete input. Final Cargo archive assembly remains an ordered promotion operation; retries compare locally assembled archive checksums with crates.io before skipping.

## Validation

- reproduced the failure in real v3.0.1 qualification run 30199183529
- verified `cargo package -p alien-error --list` records normalized package inputs without assembling the archive
- `actionlint -ignore 'label .* is unknown' .github/workflows/release.yml .github/workflows/release-qualification.yml`
- `git diff --check`
- after merge, rerun the complete v3.0.1 qualification on PR #215

Linear: ALIEN-346
