### PR TITLE
fix(ci): pack bindings from local path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -998,7 +998,7 @@ jobs:
         run: node packages/bindings/scripts/inject-optional-deps.mjs
 
       - name: Pack bindings wrapper
-        run: npm pack packages/bindings --pack-destination "$PWD/qualified/bindings"
+        run: npm pack ./packages/bindings --pack-destination "$PWD/qualified/bindings"
 
       - name: Upload qualified bindings packages
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- pass an explicit local directory to `npm pack` for the qualified native bindings wrapper
- prevent npm from interpreting `packages/bindings` as a GitHub repository shorthand

## Validation

- reproduced in v3.0.1 qualification run 30199183529 after all four native addons built and passed smoke tests
- `actionlint -ignore 'label .* is unknown' .github/workflows/release.yml .github/workflows/release-qualification.yml`
- `git diff --check`
- after merge, rerun complete v3.0.1 qualification on PR #215

Linear: ALIEN-347
