### PR TITLE
fix(ci): disable unused CLI package caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1910,6 +1910,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@v7
@@ -1947,6 +1948,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Validate npm auth
         env:


### PR DESCRIPTION
## Summary

- disable setup-node's automatic package-manager cache in the CLI qualification job
- apply the same setting to the publish-existing CLI job

These jobs package existing binaries with npm and do not install pnpm. The repository lockfile otherwise makes setup-node require a pnpm executable before the job begins.

## Validation

- reproduced in v3.0.1 qualification run 30199183529
- `actionlint -ignore 'label .* is unknown' .github/workflows/release.yml .github/workflows/release-qualification.yml`
- `git diff --check`
- after merge, rerun complete v3.0.1 qualification on PR #215

Linear: ALIEN-348
