### PR TITLE
fix(ci): authenticate qualified image verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Login to GHCR for qualification verification
         if: ${{ inputs.stable_action == 'publish' && !inputs.dry_run }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,6 +313,14 @@ jobs:
             fi
           done
 
+      - name: Login to GHCR for qualification verification
+        if: ${{ inputs.stable_action == 'publish' && !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify release qualification
         id: verify_qualification
         if: ${{ inputs.stable_action == 'publish' && !inputs.dry_run }}


### PR DESCRIPTION
## Summary

- authenticate the stable release prepare job to GHCR before inspecting private qualification image tags
- retain exact digest comparison and fail-closed promotion behavior

## Evidence

The first v3.0.1 promotion run stopped before publication because the anonymous GHCR token request returned 401: https://github.com/alienplatform/alien/actions/runs/30200834974/job/89790370601

## Validation

- `git diff --check`
- `actionlint .github/workflows/release.yml` parses the workflow; it reports only the repository's pre-existing unconfigured Depot runner-label warnings

Linear: [ALIEN-349](https://linear.app/alienplatform/issue/ALIEN-349)