### PR TITLE
fix(ci): create release tags through GitHub API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1754,7 +1754,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           ref: ${{ needs.prepare.outputs.release_commit }}
           fetch-depth: 0
 
@@ -1767,21 +1766,41 @@ jobs:
           path: .
 
       - name: Tag qualified release commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           TAG="v${VERSION}"
           COMMIT="${{ needs.prepare.outputs.release_commit }}"
-          if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
-            TAG_COMMIT=$(git rev-list -n1 "$TAG")
-            if [ "$TAG_COMMIT" != "$COMMIT" ]; then
-              echo "::error::${TAG} already points to ${TAG_COMMIT}, expected ${COMMIT}"
-              exit 1
-            fi
-            echo "${TAG} already points to the qualified release commit"
-          else
-            git tag "$TAG" "$COMMIT"
-            git push origin "$TAG"
+
+          REF_JSON=$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/dev/null || true)
+          if [ -z "$REF_JSON" ]; then
+            gh api \
+              --method POST \
+              "/repos/${GITHUB_REPOSITORY}/git/refs" \
+              --raw-field "ref=refs/tags/${TAG}" \
+              --raw-field "sha=${COMMIT}" >/dev/null || true
+            REF_JSON=$(gh api \
+              "/repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}")
           fi
+
+          TAG_TYPE=$(jq -r '.object.type' <<< "$REF_JSON")
+          TAG_COMMIT=$(jq -r '.object.sha' <<< "$REF_JSON")
+          if [ "$TAG_TYPE" = "tag" ]; then
+            TAG_COMMIT=$(gh api \
+              "/repos/${GITHUB_REPOSITORY}/git/tags/${TAG_COMMIT}" \
+              --jq '.object.sha')
+          elif [ "$TAG_TYPE" != "commit" ]; then
+            echo "::error::${TAG} points to unsupported Git object type ${TAG_TYPE}"
+            exit 1
+          fi
+
+          if [ "$TAG_COMMIT" != "$COMMIT" ]; then
+            echo "::error::${TAG} already points to ${TAG_COMMIT}, expected ${COMMIT}"
+            exit 1
+          fi
+          echo "${TAG} points to the qualified release commit"
 
       - name: Verify existing GitHub release assets
         env:


### PR DESCRIPTION
## Summary

- create lightweight release refs through the GitHub Git Refs API using the scoped workflow token
- verify existing lightweight or annotated tags resolve to the exact qualified release commit
- stop persisting the broader repository token in the release checkout
- tolerate a concurrent creator only when the resulting ref passes the exact commit check

## Evidence

The v3.0.1 promotion published qualified artifact surfaces and then Git rejected the OAuth-backed tag push because it lacked OAuth `workflow` scope: https://github.com/alienplatform/alien/actions/runs/30201552668/job/89792537745

## Validation

- `git diff --check`
- `actionlint .github/workflows/release.yml` parses the workflow; it reports only pre-existing Depot custom-runner label warnings
- next promotion rerun will exercise both exact tag creation and idempotent re-promotion of already-published artifacts

Linear: [ALIEN-350](https://linear.app/alienplatform/issue/ALIEN-350)