### PR TITLE
fix(ci): distinguish absent release refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1817,9 +1817,9 @@ jobs:
           COMMIT="${{ needs.prepare.outputs.release_commit }}"
           FULL_REF="refs/tags/${TAG}"
 
-          MATCHING_REFS=$(gh api \
+          MATCHING_REFS=$(gh api --paginate --slurp \
             "/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${TAG}" |
-            jq -c --arg ref "$FULL_REF" '[.[] | select(.ref == $ref)]')
+            jq -c --arg ref "$FULL_REF" '[add[] | select(.ref == $ref)]')
           if [ "$(jq 'length' <<< "$MATCHING_REFS")" = "0" ]; then
             if ! gh api \
               --method POST \
@@ -1828,9 +1828,9 @@ jobs:
               --raw-field "sha=${COMMIT}" >/dev/null; then
               echo "Tag creation failed; checking whether a concurrent release created it"
             fi
-            MATCHING_REFS=$(gh api \
+            MATCHING_REFS=$(gh api --paginate --slurp \
               "/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${TAG}" |
-              jq -c --arg ref "$FULL_REF" '[.[] | select(.ref == $ref)]')
+              jq -c --arg ref "$FULL_REF" '[add[] | select(.ref == $ref)]')
           fi
 
           if [ "$(jq 'length' <<< "$MATCHING_REFS")" != "1" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1815,19 +1815,29 @@ jobs:
           VERSION="${{ needs.prepare.outputs.version }}"
           TAG="v${VERSION}"
           COMMIT="${{ needs.prepare.outputs.release_commit }}"
+          FULL_REF="refs/tags/${TAG}"
 
-          REF_JSON=$(gh api \
-            "/repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/dev/null || true)
-          if [ -z "$REF_JSON" ]; then
-            gh api \
+          MATCHING_REFS=$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${TAG}" |
+            jq -c --arg ref "$FULL_REF" '[.[] | select(.ref == $ref)]')
+          if [ "$(jq 'length' <<< "$MATCHING_REFS")" = "0" ]; then
+            if ! gh api \
               --method POST \
               "/repos/${GITHUB_REPOSITORY}/git/refs" \
-              --raw-field "ref=refs/tags/${TAG}" \
-              --raw-field "sha=${COMMIT}" >/dev/null || true
-            REF_JSON=$(gh api \
-              "/repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}")
+              --raw-field "ref=${FULL_REF}" \
+              --raw-field "sha=${COMMIT}" >/dev/null; then
+              echo "Tag creation failed; checking whether a concurrent release created it"
+            fi
+            MATCHING_REFS=$(gh api \
+              "/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${TAG}" |
+              jq -c --arg ref "$FULL_REF" '[.[] | select(.ref == $ref)]')
           fi
 
+          if [ "$(jq 'length' <<< "$MATCHING_REFS")" != "1" ]; then
+            echo "::error::Expected exactly one ${FULL_REF} after tag creation"
+            exit 1
+          fi
+          REF_JSON=$(jq -c '.[0]' <<< "$MATCHING_REFS")
           TAG_TYPE=$(jq -r '.object.type' <<< "$REF_JSON")
           TAG_COMMIT=$(jq -r '.object.sha' <<< "$REF_JSON")
           if [ "$TAG_TYPE" = "tag" ]; then


### PR DESCRIPTION
## Summary

- use GitHub's matching-refs endpoint, which returns an empty array rather than a 404 body for an absent tag
- filter prefix matches to the exact release ref and require exactly one result after creation
- re-read and verify the exact ref after a failed create to safely handle a concurrent release
- let transport/auth/API lookup failures stop the job

## Root cause

The single-ref endpoint's 404 error JSON survived `|| true` and was parsed as though it were a ref, producing a null object type.

Evidence: https://github.com/alienplatform/alien/actions/runs/30203055819/job/89796515026

## Validation

- the real matching-refs endpoint returns exactly one filtered match for `v3.0.0`
- it returns zero filtered matches for the currently absent `v3.0.1`
- `git diff --check`
- `actionlint` parses the workflow with only pre-existing Depot custom-runner label warnings

Linear: [ALIEN-352](https://linear.app/alienplatform/issue/ALIEN-352)