### PR TITLE
fix: keep worker task errors readable

### DIFF
--- a/.changeset/calm-workers-log.md
+++ b/.changeset/calm-workers-log.md
@@ -1,0 +1,6 @@
+---
+"@alienplatform/sdk": patch
+---
+
+Keep TypeScript Worker console output on one readable line and classify
+SDK-owned event-loop diagnostics as system logs.

--- a/crates/alien-cli/src/commands/logs.rs
+++ b/crates/alien-cli/src/commands/logs.rs
@@ -895,8 +895,9 @@ fn build_logs_query(
         // explicitly requested. `NOT field:value` keeps documents that lack the
         // attribute entirely, so user workload logs are always shown.
         filters.push(format!(
-            "NOT {}:\"true\"",
-            system_resource_attribute_field()
+            "NOT {}:\"true\" AND NOT {}:\"true\"",
+            system_resource_attribute_field(),
+            system_log_attribute_field()
         ));
     }
 
@@ -938,6 +939,13 @@ fn system_resource_attribute_field() -> String {
     // `resource_attributes.` as a single field name.
     format!(
         "resource_attributes.{}",
+        alien_core::ALIEN_SYSTEM_RESOURCE_ATTRIBUTE.replace('.', "\\.")
+    )
+}
+
+fn system_log_attribute_field() -> String {
+    format!(
+        "attributes.{}",
         alien_core::ALIEN_SYSTEM_RESOURCE_ATTRIBUTE.replace('.', "\\.")
     )
 }
@@ -1016,7 +1024,7 @@ mod tests {
 
         assert_eq!(
             query,
-            "* AND NOT resource_attributes.alien\\.system:\"true\""
+            "* AND NOT resource_attributes.alien\\.system:\"true\" AND NOT attributes.alien\\.system:\"true\""
         );
     }
 
@@ -1039,7 +1047,7 @@ mod tests {
 
         assert_eq!(
             query,
-            "(service_name:api) AND ((severity_number:>=17 AND severity_number:<=20)) AND resource_attributes.alien\\.deployment_id:\"dep_123\" AND NOT resource_attributes.alien\\.system:\"true\""
+            "(service_name:api) AND ((severity_number:>=17 AND severity_number:<=20)) AND resource_attributes.alien\\.deployment_id:\"dep_123\" AND NOT resource_attributes.alien\\.system:\"true\" AND NOT attributes.alien\\.system:\"true\""
         );
     }
 

--- a/crates/alien-worker-runtime/src/log_text.rs
+++ b/crates/alien-worker-runtime/src/log_text.rs
@@ -1,4 +1,27 @@
-pub(crate) fn normalize_log_body(input: &str) -> String {
+const SYSTEM_LOG_PREFIX: &str = "\u{1e}ALIEN_SYSTEM\u{1f}";
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CapturedLogLine {
+    pub(crate) body: String,
+    pub(crate) is_system: bool,
+}
+
+pub(crate) fn decode_log_line(input: &str) -> CapturedLogLine {
+    let (body, is_system) = strip_system_log_prefix(input);
+
+    CapturedLogLine {
+        body: normalize_log_body(body),
+        is_system,
+    }
+}
+
+pub(crate) fn strip_system_log_prefix(input: &str) -> (&str, bool) {
+    input
+        .strip_prefix(SYSTEM_LOG_PREFIX)
+        .map_or((input, false), |body| (body, true))
+}
+
+fn normalize_log_body(input: &str) -> String {
     let prepared = input.replace('\t', "\u{e000}").replace(['\r', '\n'], " ");
     let stripped = strip_ansi_escapes::strip_str(prepared);
     let mut normalized = String::with_capacity(stripped.len());
@@ -16,7 +39,39 @@ pub(crate) fn normalize_log_body(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_log_body;
+    use super::{
+        decode_log_line, normalize_log_body, strip_system_log_prefix, CapturedLogLine,
+    };
+
+    #[test]
+    fn decodes_and_removes_system_marker() {
+        assert_eq!(
+            decode_log_line("\u{1e}ALIEN_SYSTEM\u{1f}[alien:event-loop] failed"),
+            CapturedLogLine {
+                body: "[alien:event-loop] failed".to_string(),
+                is_system: true,
+            }
+        );
+    }
+
+    #[test]
+    fn leaves_application_lines_unclassified() {
+        assert_eq!(
+            decode_log_line("application ready"),
+            CapturedLogLine {
+                body: "application ready".to_string(),
+                is_system: false,
+            }
+        );
+    }
+
+    #[test]
+    fn strips_only_the_marker_for_unstructured_forwarding() {
+        assert_eq!(
+            strip_system_log_prefix("\u{1e}ALIEN_SYSTEM\u{1f}\u{1b}[31mfailed\u{1b}[0m"),
+            ("\u{1b}[31mfailed\u{1b}[0m", true)
+        );
+    }
 
     #[test]
     fn strips_sgr_color_sequences() {

--- a/crates/alien-worker-runtime/src/otlp.rs
+++ b/crates/alien-worker-runtime/src/otlp.rs
@@ -175,7 +175,7 @@ impl OwnedOtlpLogger {
 
     /// Emits a captured stdout/stderr line through this logger's own provider.
     pub fn emit_log(&self, stream: &str, body: &str, timestamp_nanos: i64) {
-        emit_to_provider(&self.provider, stream, body, timestamp_nanos);
+        emit_to_provider(&self.provider, stream, body, timestamp_nanos, false);
     }
 
     /// Force-flushes this logger's own pending logs (used before shutdown).
@@ -301,6 +301,11 @@ pub fn init_otlp_logging_from_config(_config: OtlpConfig) -> Result<()> {
 /// This is used by embedded runtimes to send captured stdout/stderr from function processes.
 #[cfg(feature = "otlp")]
 pub fn emit_log(stream: &str, body: &str, timestamp_nanos: i64) {
+    emit_captured_log(stream, body, timestamp_nanos, false);
+}
+
+#[cfg(feature = "otlp")]
+pub(crate) fn emit_captured_log(stream: &str, body: &str, timestamp_nanos: i64, is_system: bool) {
     // Get the global provider (initialized by init_otlp_logging)
     let provider = {
         let guard = OTLP_PROVIDER.lock().expect("OTLP provider mutex poisoned");
@@ -313,13 +318,19 @@ pub fn emit_log(stream: &str, body: &str, timestamp_nanos: i64) {
         }
     };
 
-    emit_to_provider(&provider, stream, body, timestamp_nanos);
+    emit_to_provider(&provider, stream, body, timestamp_nanos, is_system);
 }
 
 /// Emits a single captured log line through a specific provider. Shared by the
 /// process-global [`emit_log`] and the per-caller [`OwnedOtlpLogger`].
 #[cfg(feature = "otlp")]
-fn emit_to_provider(provider: &SdkLoggerProvider, stream: &str, body: &str, timestamp_nanos: i64) {
+fn emit_to_provider(
+    provider: &SdkLoggerProvider,
+    stream: &str,
+    body: &str,
+    timestamp_nanos: i64,
+    is_system: bool,
+) {
     use opentelemetry::logs::{
         AnyValue, LogRecord as _, Logger as _, LoggerProvider as _, Severity,
     };
@@ -349,6 +360,12 @@ fn emit_to_provider(provider: &SdkLoggerProvider, stream: &str, body: &str, time
 
     // Add stream as attribute
     record.add_attribute("stream", AnyValue::String(stream.to_string().into()));
+    if is_system {
+        record.add_attribute(
+            alien_core::ALIEN_SYSTEM_RESOURCE_ATTRIBUTE,
+            AnyValue::String("true".into()),
+        );
+    }
 
     // Emit the log record (batched by BatchLogProcessor)
     logger.emit(record);
@@ -358,6 +375,15 @@ fn emit_to_provider(provider: &SdkLoggerProvider, stream: &str, body: &str, time
 #[cfg(not(feature = "otlp"))]
 pub fn emit_log(_stream: &str, _body: &str, _timestamp_nanos: i64) {
     // No-op
+}
+
+#[cfg(not(feature = "otlp"))]
+pub(crate) fn emit_captured_log(
+    _stream: &str,
+    _body: &str,
+    _timestamp_nanos: i64,
+    _is_system: bool,
+) {
 }
 
 /// Flush all pending OTLP logs

--- a/crates/alien-worker-runtime/src/runtime.rs
+++ b/crates/alien-worker-runtime/src/runtime.rs
@@ -879,17 +879,22 @@ async fn stream_output(
 
             while let Ok(Some(line)) = lines.next_line().await {
                 let timestamp_nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+                let captured = crate::log_text::decode_log_line(&line);
 
                 // Print to local stdout/stderr for debugging
                 if is_stdout {
-                    println!("{}", line);
+                    println!("{}", captured.body);
                 } else {
-                    eprintln!("{}", line);
+                    eprintln!("{}", captured.body);
                 }
 
                 // Emit normalized text via OpenTelemetry SDK (batched, proper protobuf format).
-                let body = crate::log_text::normalize_log_body(&line);
-                crate::otlp::emit_log(stream_name, &body, timestamp_nanos);
+                crate::otlp::emit_captured_log(
+                    stream_name,
+                    &captured.body,
+                    timestamp_nanos,
+                    captured.is_system,
+                );
             }
 
             tracing::debug!("OTLP log streaming ended");
@@ -900,10 +905,11 @@ async fn stream_output(
             tracing::debug!("Starting forwarded log streaming");
 
             while let Ok(Some(line)) = lines.next_line().await {
+                let (body, _) = crate::log_text::strip_system_log_prefix(&line);
                 if is_stdout {
-                    println!("{}", line);
+                    println!("{}", body);
                 } else {
-                    eprintln!("{}", line);
+                    eprintln!("{}", body);
                 }
             }
 

--- a/packages/sdk/src/worker-runtime/console.ts
+++ b/packages/sdk/src/worker-runtime/console.ts
@@ -1,0 +1,40 @@
+import { formatWithOptions } from "node:util"
+
+const FORMAT_OPTIONS = {
+  breakLength: Number.POSITIVE_INFINITY,
+  colors: false,
+  compact: true,
+} as const
+
+let installed = false
+
+/** @internal exported for tests */
+export function formatWorkerConsoleLine(args: unknown[]): string {
+  try {
+    return formatWithOptions(FORMAT_OPTIONS, ...args).replace(/\s*\r?\n\s*/g, " ")
+  } catch {
+    return "[alien:console] Log arguments could not be formatted"
+  }
+}
+
+/**
+ * Keep every console call within one stdout/stderr record.
+ *
+ * The generated Worker bootstrap imports this runtime before it dynamically
+ * imports the application, so the console contract covers application module
+ * initialization as well as task handling.
+ */
+export function installWorkerConsole(): void {
+  if (installed) return
+  installed = true
+
+  const log = console.log.bind(console)
+  const info = console.info.bind(console)
+  const warn = console.warn.bind(console)
+  const error = console.error.bind(console)
+
+  console.log = (...args: unknown[]) => log(formatWorkerConsoleLine(args))
+  console.info = (...args: unknown[]) => info(formatWorkerConsoleLine(args))
+  console.warn = (...args: unknown[]) => warn(formatWorkerConsoleLine(args))
+  console.error = (...args: unknown[]) => error(formatWorkerConsoleLine(args))
+}

--- a/packages/sdk/src/worker-runtime/event-loop.ts
+++ b/packages/sdk/src/worker-runtime/event-loop.ts
@@ -24,6 +24,22 @@ import {
   runCommand,
 } from "./registry.js"
 import type { getControlServiceDefinition } from "./service-definitions.js"
+import { logSystemError, logSystemWarn } from "./system-log.js"
+
+const MAX_LOG_ERROR_LENGTH = 1_000
+
+/** @internal exported for tests */
+export function formatEventLoopError(error: unknown): string {
+  try {
+    const raw = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    const singleLine = raw.replace(/\s+/g, " ").trim()
+    return singleLine.length > MAX_LOG_ERROR_LENGTH
+      ? `${singleLine.slice(0, MAX_LOG_ERROR_LENGTH)}…`
+      : singleLine
+  } catch {
+    return "Unformattable thrown value"
+  }
+}
 
 /**
  * Handlers register by the resource's logical name (the name given in the
@@ -133,7 +149,9 @@ export class EventLoop {
       try {
         await this.processTasks()
       } catch (error) {
-        console.error("[alien:event-loop] processTasks threw:", error)
+        logSystemError(
+          `[alien:event-loop] processTasks threw: error=${formatEventLoopError(error)}`,
+        )
         await new Promise(resolve => setTimeout(resolve, 1000))
       }
     }
@@ -145,8 +163,8 @@ export class EventLoop {
       try {
         await this.handleTask(task)
       } catch (error) {
-        console.error(
-          `[alien:event-loop] handleTask threw (task will not break stream): id=${task.taskId} error=${error instanceof Error ? error.message : String(error)}`,
+        logSystemError(
+          `[alien:event-loop] handleTask threw (task will not break stream): id=${task.taskId} error=${formatEventLoopError(error)}`,
         )
       }
     }
@@ -185,7 +203,7 @@ export class EventLoop {
         // Report the miss as a failed result — without it the runtime waits
         // for the task until its event timeout (a 2-minute hang per event on
         // Lambda) instead of failing loudly.
-        console.warn(`No handler found for task: ${task.taskId}`)
+        logSystemWarn(`No handler found for task: ${task.taskId}`)
         await this.sendTaskResult(task.taskId, {
           success: false,
           error: `No handler registered for task ${task.taskId}`,
@@ -203,17 +221,16 @@ export class EventLoop {
 
       await this.sendTaskResult(task.taskId, { success: true })
     } catch (error) {
-      console.error(
-        `[alien:event-loop] Task error: id=${task.taskId} error=${error instanceof Error ? error.message : String(error)}`,
-      )
+      const formattedError = formatEventLoopError(error)
+      logSystemError(`[alien:event-loop] Task error: id=${task.taskId} error=${formattedError}`)
       try {
         await this.sendTaskResult(task.taskId, {
           success: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: formattedError,
         })
       } catch (sendError) {
-        console.error(
-          `[alien:event-loop] Failed to send error result: id=${task.taskId} sendError=${sendError instanceof Error ? sendError.message : String(sendError)}`,
+        logSystemError(
+          `[alien:event-loop] Failed to send error result: id=${task.taskId} sendError=${formatEventLoopError(sendError)}`,
         )
       }
     }

--- a/packages/sdk/src/worker-runtime/index.ts
+++ b/packages/sdk/src/worker-runtime/index.ts
@@ -15,6 +15,7 @@
 
 import { createClient } from "nice-grpc"
 import { getGrpcEndpointConfig, getOrCreateChannel } from "./channel.js"
+import { installWorkerConsole } from "./console.js"
 import { EventLoop } from "./event-loop.js"
 import { wrapGrpcCall } from "./grpc-utils.js"
 import {
@@ -22,6 +23,8 @@ import {
   getWaitUntilServiceDefinition,
 } from "./service-definitions.js"
 import { WaitUntilManager } from "./wait-until-manager.js"
+
+installWorkerConsole()
 
 // Minimal ambient declaration for the Bun runtime global. Worker binaries run
 // under Bun; the SDK is type-checked by tsc, which has no Bun types. We use

--- a/packages/sdk/src/worker-runtime/registry.ts
+++ b/packages/sdk/src/worker-runtime/registry.ts
@@ -22,6 +22,7 @@ import type {
   StorageEvent,
   StorageEventType,
 } from "@alienplatform/core"
+import { logSystemError } from "./system-log.js"
 
 // Re-export the canonical core event types for the facade to re-export.
 export type { StorageEvent, StorageEventType, ScheduledEvent, QueueMessage }
@@ -369,7 +370,7 @@ export function waitUntil(promise: Promise<unknown>): void {
   try {
     state.onTaskRegistered?.(tracker)
   } catch (error) {
-    console.error("[alien:wait-until] onTaskRegistered hook failed:", error)
+    logSystemError("[alien:wait-until] onTaskRegistered hook failed:", error)
   }
 }
 

--- a/packages/sdk/src/worker-runtime/system-log.ts
+++ b/packages/sdk/src/worker-runtime/system-log.ts
@@ -1,0 +1,15 @@
+/**
+ * Private wire marker understood by alien-worker-runtime.
+ *
+ * The runtime removes this marker before forwarding the message and, when the
+ * log path supports structured metadata, records `alien.system=true`.
+ */
+const SYSTEM_LOG_PREFIX = "\u001eALIEN_SYSTEM\u001f"
+
+export function logSystemError(message: string, ...args: unknown[]): void {
+  console.error(`${SYSTEM_LOG_PREFIX}${message}`, ...args)
+}
+
+export function logSystemWarn(message: string, ...args: unknown[]): void {
+  console.warn(`${SYSTEM_LOG_PREFIX}${message}`, ...args)
+}

--- a/packages/sdk/src/worker-runtime/wait-until-manager.ts
+++ b/packages/sdk/src/worker-runtime/wait-until-manager.ts
@@ -16,6 +16,7 @@ import type { WaitUntilServiceClient as GeneratedClient } from "./generated/wait
 import { wrapGrpcCall } from "./grpc-utils.js"
 import { setOnTaskRegistered } from "./registry.js"
 import type { getWaitUntilServiceDefinition } from "./service-definitions.js"
+import { logSystemError } from "./system-log.js"
 
 /**
  * WaitUntil manager for coordinating background tasks with the runtime.
@@ -42,7 +43,7 @@ export class WaitUntilManager {
   install(): void {
     setOnTaskRegistered(() => {
       this.notifyTaskRegistered().catch(error => {
-        console.error("[alien:wait-until] notifyTaskRegistered failed:", error)
+        logSystemError("[alien:wait-until] notifyTaskRegistered failed:", error)
       })
     })
   }

--- a/packages/sdk/tests/worker-runtime-console.test.ts
+++ b/packages/sdk/tests/worker-runtime-console.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { formatWorkerConsoleLine } from "../src/worker-runtime/console.js"
+
+describe("Worker console formatting", () => {
+  it("preserves ordinary messages", () => {
+    expect(formatWorkerConsoleLine(["worker ready"])).toBe("worker ready")
+  })
+
+  it("keeps object and Error output on one line without truncating it", () => {
+    const line = formatWorkerConsoleLine([
+      "request failed:",
+      {
+        id: "task_1",
+        error: new Error(`first\nsecond ${"x".repeat(5_000)}`),
+      },
+    ])
+
+    expect(line).not.toContain("\n")
+    expect(line.startsWith("request failed: { id: 'task_1', error: Error: first second ")).toBe(
+      true,
+    )
+    expect(line).toContain("x".repeat(5_000))
+  })
+
+  it("never throws when inspection fails", () => {
+    const value = {
+      [Symbol.for("nodejs.util.inspect.custom")]() {
+        throw new Error("inspect failed")
+      },
+    }
+
+    expect(formatWorkerConsoleLine([value])).toBe(
+      "[alien:console] Log arguments could not be formatted",
+    )
+  })
+})

--- a/packages/sdk/tests/worker-runtime-event-dispatch.test.ts
+++ b/packages/sdk/tests/worker-runtime-event-dispatch.test.ts
@@ -1,5 +1,34 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { physicalSourceNames, sourceMatches } from "../src/worker-runtime/event-loop.js"
+import {
+  formatEventLoopError,
+  physicalSourceNames,
+  sourceMatches,
+} from "../src/worker-runtime/event-loop.js"
+
+describe("event-loop error formatting", () => {
+  it("keeps error logs on one bounded line", () => {
+    const formatted = formatEventLoopError(new TypeError(`first\nsecond ${"x".repeat(2_000)}`))
+
+    expect(formatted).not.toContain("\n")
+    expect(formatted.startsWith("TypeError: first second ")).toBe(true)
+    expect(formatted).toHaveLength(1_001)
+    expect(formatted.endsWith("…")).toBe(true)
+  })
+
+  it("formats non-Error throws", () => {
+    expect(formatEventLoopError("failed\nbadly")).toBe("failed badly")
+  })
+
+  it("never throws while formatting a thrown value", () => {
+    const value = {
+      [Symbol.toPrimitive]() {
+        throw new Error("coercion failed")
+      },
+    }
+
+    expect(formatEventLoopError(value)).toBe("Unformattable thrown value")
+  })
+})
 
 // Cloud transports deliver tasks keyed by the provider's physical identifier
 // (S3 bucket name, SQS queue name) while handlers register by the resource's

--- a/packages/sdk/tests/worker-runtime-system-log.test.ts
+++ b/packages/sdk/tests/worker-runtime-system-log.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { logSystemError } from "../src/worker-runtime/system-log.js"
+
+describe("worker runtime system logs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("marks SDK-owned messages for the worker runtime", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    logSystemError("[alien:event-loop] Task error: id=task_123")
+
+    expect(error).toHaveBeenCalledWith(
+      "\u001eALIEN_SYSTEM\u001f[alien:event-loop] Task error: id=task_123",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- normalize TypeScript Worker console calls at the generated runtime boundary so one console call becomes one physical record
- preserve application log content without a platform-wide length cap
- bound only SDK event-loop diagnostic summaries and make both formatting and failed-task recovery exception-safe
- mark SDK-owned diagnostics with a private runtime signal; remove it before forwarding and attach per-record `alien.system=true` on OTLP paths
- preserve plain container output byte-for-byte apart from removing that private signal
- hide both resource-level and record-level system logs in the CLI unless `--system` is set
- add a patch changeset for `@alienplatform/sdk`

## Validation

- `pnpm --filter @alienplatform/sdk test` (17 passed)
- `pnpm --filter @alienplatform/sdk test:ts`
- `pnpm --filter @alienplatform/sdk format-and-lint`
- `pnpm --filter @alienplatform/sdk build`
- `cargo test -p alien-worker-runtime log_text --lib` (8 passed)
- `cargo test -p alien-cli commands::logs::tests --lib` (7 passed)
- verified the built Worker bundle installs the formatter and includes the system-log protocol

Linear: ALIEN-358