### PR TITLE
chore: remove stale SDK changeset

### DIFF
--- a/.changeset/calm-workers-log.md
+++ b/.changeset/calm-workers-log.md
@@ -1,6 +1,0 @@
----
-"@alienplatform/sdk": patch
----
-
-Keep TypeScript Worker console output on one readable line and classify
-SDK-owned event-loop diagnostics as system logs.


### PR DESCRIPTION
## Summary

Remove the SDK changeset added by #228. The current stable release workflow computes one repository-wide version from conventional commits and does not consume Changesets, so retaining this file could cause an obsolete second SDK bump if `changeset version` is run later.

## Verification

- only `.changeset/calm-workers-log.md` is removed
- no product or release-workflow code changes

Linear: ALIEN-362