### PR TITLE
fix: publish draft before verifying release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1949,6 +1949,39 @@ jobs:
           draft: true
           prerelease: false
 
+      - name: Publish staged GitHub Release
+        if: ${{ steps.verify_release.outputs.complete != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          TAG="v${VERSION}"
+          COMMIT="${{ needs.prepare.outputs.release_commit }}"
+
+          staged_release=$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/releases/${{ steps.stage_release.outputs.id }}")
+          if ! jq -e \
+            --arg tag "$TAG" \
+            --arg commit "$COMMIT" \
+            '.draft == true and
+             .tag_name == $tag and
+             .target_commitish == $commit' \
+            <<< "$staged_release" >/dev/null; then
+            echo "::error::Staged release does not target the qualified commit"
+            exit 1
+          fi
+
+          published_release=$(gh api \
+            --method PATCH \
+            "/repos/${GITHUB_REPOSITORY}/releases/${{ steps.stage_release.outputs.id }}" \
+            --field draft=false \
+            --raw-field make_latest=true)
+          if ! jq -e '.draft == false and .immutable == true' \
+            <<< "$published_release" >/dev/null; then
+            echo "::error::GitHub did not publish an immutable release"
+            exit 1
+          fi
+
       - name: Verify published release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1962,7 +1995,7 @@ jobs:
             "/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${TAG}" |
             jq -c --arg ref "$FULL_REF" '[add[] | select(.ref == $ref)]')
           if [ "$(jq 'length' <<< "$MATCHING_REFS")" != "1" ]; then
-            echo "::error::Expected exactly one ${FULL_REF} after release creation"
+            echo "::error::Expected exactly one ${FULL_REF} after release publication"
             exit 1
           fi
 
@@ -1983,51 +2016,6 @@ jobs:
             exit 1
           fi
           echo "${TAG} points to the qualified release commit"
-
-      - name: Publish staged GitHub Release
-        if: ${{ steps.verify_release.outputs.complete != 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          TAG="v${VERSION}"
-          COMMIT="${{ needs.prepare.outputs.release_commit }}"
-          FULL_REF="refs/tags/${TAG}"
-
-          MATCHING_REFS=$(gh api --paginate --slurp \
-            "/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${TAG}" |
-            jq -c --arg ref "$FULL_REF" '[add[] | select(.ref == $ref)]')
-          if [ "$(jq 'length' <<< "$MATCHING_REFS")" != "1" ]; then
-            echo "::error::Expected exactly one ${FULL_REF} before publication"
-            exit 1
-          fi
-
-          REF_JSON=$(jq -c '.[0]' <<< "$MATCHING_REFS")
-          TAG_TYPE=$(jq -r '.object.type' <<< "$REF_JSON")
-          TAG_COMMIT=$(jq -r '.object.sha' <<< "$REF_JSON")
-          if [ "$TAG_TYPE" = "tag" ]; then
-            TAG_COMMIT=$(gh api \
-              "/repos/${GITHUB_REPOSITORY}/git/tags/${TAG_COMMIT}" \
-              --jq '.object.sha')
-          elif [ "$TAG_TYPE" != "commit" ]; then
-            echo "::error::${TAG} points to unsupported Git object type ${TAG_TYPE}"
-            exit 1
-          fi
-          if [ "$TAG_COMMIT" != "$COMMIT" ]; then
-            echo "::error::${TAG} points to ${TAG_COMMIT}, expected ${COMMIT}"
-            exit 1
-          fi
-
-          published_release=$(gh api \
-            --method PATCH \
-            "/repos/${GITHUB_REPOSITORY}/releases/${{ steps.stage_release.outputs.id }}" \
-            --field draft=false \
-            --raw-field make_latest=true)
-          if ! jq -e '.draft == false and .immutable == true' \
-            <<< "$published_release" >/dev/null; then
-            echo "::error::GitHub did not publish an immutable release"
-            exit 1
-          fi
 
   # ─── Homebrew tap ──────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes stable release finalization after v3.1.0 exposed that GitHub does not create a tag for a draft release.

The workflow now:
- validates the staged draft targets the qualified commit
- publishes the draft, creating the protected immutable tag
- verifies the published tag points to the qualified commit

Validation:
- `actionlint -ignore 'label "depot-' .github/workflows/release.yml`\n- validated the new staged-release assertion against the live v3.1.0 draft\n- `git diff --check`