### PR TITLE
fix: make cloud observation opt-in

### DIFF
--- a/crates/alien-deployment/src/runner.rs
+++ b/crates/alien-deployment/src/runner.rs
@@ -399,25 +399,9 @@ async fn run_step_loop_body(
         let update_heartbeat = step_result.update_heartbeat;
         let suggested_delay_ms = step_result.suggested_delay_ms;
         let heartbeats = step_result.heartbeats.clone();
-        let mut observed_inventory_batches = step_result.observed_inventory_batches.clone();
+        let observed_inventory_batches = step_result.observed_inventory_batches.clone();
 
         *state = step_result.state;
-
-        if state.status == DeploymentStatus::Running {
-            let observe_service_provider = service_provider.clone().unwrap_or_else(|| {
-                Arc::new(alien_infra::DefaultPlatformServiceProvider::default())
-            });
-            let observe_report = run_observe_pass(
-                state.platform,
-                client_config,
-                &observe_service_provider,
-                deployment_id,
-                config.observe_label_selector.as_deref(),
-                config.observe_all_namespaces,
-            )
-            .await?;
-            observed_inventory_batches.extend(observe_report.inventory_batches);
-        }
 
         // Checkpoint after every step. This is a durability barrier: once a
         // cloud/API step has produced new state, the runner must not execute

--- a/crates/alien-observer/src/aws.rs
+++ b/crates/alien-observer/src/aws.rs
@@ -71,7 +71,7 @@ impl AwsObserver {
                     "aws-cloudwatch",
                     HeartbeatCollectionIssueReason::Forbidden,
                     HeartbeatIssueSeverity::Warning,
-                    "CloudWatch metrics are unavailable; grant cloudwatch:ListMetrics/GetMetricData",
+                    "CloudWatch metrics are unavailable; grant cloudwatch:ListMetrics",
                 ))
             }
         }

--- a/crates/alien-operator/src/cli.rs
+++ b/crates/alien-operator/src/cli.rs
@@ -385,6 +385,7 @@ async fn run(mut args: Args, init_hook: InitHook, debug_loop_hook: DebugLoopHook
         .platform(args.platform)
         .maybe_base_platform(args.base_platform)
         .maybe_agent_name(args.operator_name)
+        .maybe_operator_permission(operator_permission)
         .maybe_sync(sync_config)
         .data_dir(data_dir)
         .encryption_key(encryption_key)

--- a/crates/alien-operator/src/config.rs
+++ b/crates/alien-operator/src/config.rs
@@ -36,6 +36,11 @@ pub struct OperatorConfig {
     /// Human-readable deployment name configured for this agent.
     pub agent_name: Option<String>,
 
+    /// Explicit permission tier assigned to this Operator installation.
+    ///
+    /// Only `observe` enables raw environment inventory collection.
+    pub operator_permission: Option<String>,
+
     /// Sync configuration (None = airgapped mode)
     pub sync: Option<SyncConfig>,
 
@@ -114,6 +119,11 @@ pub struct OperatorConfig {
 }
 
 impl OperatorConfig {
+    /// Whether this Operator is an explicit observe-only installation.
+    pub fn observes_environment(&self) -> bool {
+        self.operator_permission.as_deref() == Some("observe")
+    }
+
     /// Check if running in airgapped mode (no sync configuration)
     pub fn is_airgapped(&self) -> bool {
         self.sync.is_none()
@@ -215,6 +225,22 @@ mod tests {
             .build();
 
         assert!(config.is_airgapped());
+    }
+
+    #[test]
+    fn observation_requires_explicit_observe_permission() {
+        let application = OperatorConfig::builder()
+            .platform(Platform::Aws)
+            .encryption_key("key")
+            .build();
+        let observer = OperatorConfig::builder()
+            .platform(Platform::Aws)
+            .operator_permission("observe")
+            .encryption_key("key")
+            .build();
+
+        assert!(!application.observes_environment());
+        assert!(observer.observes_environment());
     }
 
     #[test]

--- a/crates/alien-operator/src/loops/sync.rs
+++ b/crates/alien-operator/src/loops/sync.rs
@@ -137,7 +137,7 @@ async fn sync_with_manager(
         .expect("deployment_id must be set in online mode");
     let heartbeats = state.db.get_pending_heartbeats().await?;
     let mut observed_inventory_batches = state.db.get_pending_observed_inventory_batches().await?;
-    if deployment_state.status == DeploymentStatus::Running {
+    if deployment_state.status == DeploymentStatus::Running && state.config.observes_environment() {
         observed_inventory_batches.extend(observe_running_deployment(state, &deployment_id).await?);
     }
 
@@ -147,7 +147,7 @@ async fn sync_with_manager(
     // uses (where the deploy loop sets `current_release.release_id`). The version is
     // the vendor-configured override if set, else the single version observed on the
     // workloads (e.g. `app.kubernetes.io/version`), so it tracks upgrades.
-    if deployment_state.current_release.is_none() {
+    if state.config.observes_environment() && deployment_state.current_release.is_none() {
         let app_version = state
             .config
             .app_version

--- a/crates/alien-permissions/permission-sets/observe/observe.jsonc
+++ b/crates/alien-permissions/permission-sets/observe/observe.jsonc
@@ -7,7 +7,7 @@
         "label": "discover-resources",
         "description": "Discover tagged resources across the account (required for inventory).",
         "grant": {
-          "actions": ["tag:GetResources", "tag:GetTagKeys", "tag:GetTagValues"]
+          "actions": ["tag:GetResources"]
         },
         "binding": {
           "stack": {
@@ -19,11 +19,7 @@
         "label": "read-metrics",
         "description": "Read CloudWatch metrics for resource health.",
         "grant": {
-          "actions": [
-            "cloudwatch:GetMetricData",
-            "cloudwatch:ListMetrics",
-            "cloudwatch:GetMetricStatistics"
-          ]
+          "actions": ["cloudwatch:ListMetrics"]
         },
         "binding": {
           "stack": {

--- a/crates/alien-permissions/tests/operation_coverage.rs
+++ b/crates/alien-permissions/tests/operation_coverage.rs
@@ -235,11 +235,7 @@ fn critical_e2e_provider_operations_are_declared() {
         },
         OperationCoverage {
             permission_set_id: "observe/observe",
-            aws_actions: &[
-                "tag:GetResources",
-                "cloudwatch:GetMetricData",
-                "cloudwatch:ListMetrics",
-            ],
+            aws_actions: &["tag:GetResources", "cloudwatch:ListMetrics"],
             gcp_permissions: &[
                 "cloudasset.assets.searchAllResources",
                 "monitoring.timeSeries.list",

--- a/crates/alien-permissions/tests/snapshots/aws_runtime__aws_observe_account_wide_read_policy.snap
+++ b/crates/alien-permissions/tests/snapshots/aws_runtime__aws_observe_account_wide_read_policy.snap
@@ -9,9 +9,7 @@ expression: result
       "Sid": "DiscoverResources",
       "Effect": "Allow",
       "Action": [
-        "tag:GetResources",
-        "tag:GetTagKeys",
-        "tag:GetTagValues"
+        "tag:GetResources"
       ],
       "Resource": [
         "*"
@@ -21,9 +19,7 @@ expression: result
       "Sid": "ReadMetrics",
       "Effect": "Allow",
       "Action": [
-        "cloudwatch:GetMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:GetMetricStatistics"
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"

--- a/crates/alien-preflights/src/mutations/management_permission_profile.rs
+++ b/crates/alien-preflights/src/mutations/management_permission_profile.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{ErrorData, Result};
 use crate::StackMutation;
 use alien_core::permissions::{ManagementPermissions, PermissionProfile, PermissionSetReference};
 use alien_core::{
@@ -7,6 +7,7 @@ use alien_core::{
     KubernetesIngressRouteProfile, KubernetesRouteProfile, KubernetesRouteProviderOptions,
     Platform, ResourceLifecycle, Stack, StackState, Storage, Worker, WorkerTrigger,
 };
+use alien_error::AlienError;
 use alien_permissions::get_permission_set;
 use indexmap::IndexMap;
 use std::collections::BTreeSet;
@@ -50,6 +51,14 @@ impl StackMutation for ManagementPermissionProfileMutation {
         config: &DeploymentConfig,
     ) -> Result<Stack> {
         let current_management = stack.management().clone();
+        if management_profile_contains(&current_management, OBSERVE_PERMISSION_SET_ID) {
+            return Err(AlienError::new(ErrorData::StackMutationFailed {
+                mutation_name: self.description().to_string(),
+                message: "Account-wide observation is available only through a dedicated observe-only deployment; remove 'observe/observe' from the application stack"
+                    .to_string(),
+                resource_id: None,
+            }));
+        }
 
         match current_management {
             ManagementPermissions::Auto => {
@@ -86,8 +95,7 @@ impl StackMutation for ManagementPermissionProfileMutation {
                     stack.permissions.management = ManagementPermissions::Extend(extend_profile);
                 }
             }
-            ManagementPermissions::Override(mut override_profile) => {
-                ensure_observe_permission(&mut override_profile);
+            ManagementPermissions::Override(override_profile) => {
                 stack.permissions.management = ManagementPermissions::Override(override_profile);
             }
         }
@@ -96,15 +104,22 @@ impl StackMutation for ManagementPermissionProfileMutation {
     }
 }
 
-fn ensure_observe_permission(profile: &mut PermissionProfile) {
-    let global_permissions = profile.0.entry("*".to_string()).or_default();
-    let observe_ref = PermissionSetReference::from_name(OBSERVE_PERMISSION_SET_ID);
-    if !global_permissions.contains(&observe_ref) {
-        // TODO: move observe permissions to a dedicated read-only role, or gate
-        // this mandatory management grant once observe-only deployments have
-        // their own role model.
-        global_permissions.push(observe_ref);
-    }
+fn management_profile_contains(
+    management: &ManagementPermissions,
+    permission_set_id: &str,
+) -> bool {
+    let profile = match management {
+        ManagementPermissions::Auto => return false,
+        ManagementPermissions::Extend(profile) | ManagementPermissions::Override(profile) => {
+            profile
+        }
+    };
+
+    profile
+        .0
+        .values()
+        .flatten()
+        .any(|permission| permission.id() == permission_set_id)
 }
 
 /// Generates the default management permission profile from resource ownership
@@ -117,8 +132,6 @@ fn generate_auto_management_profile(
     let mut permission_set_ids = BTreeSet::new();
     let mut resource_permission_set_ids: IndexMap<String, BTreeSet<String>> = IndexMap::new();
     let platform = stack_state.platform;
-
-    permission_set_ids.insert(OBSERVE_PERMISSION_SET_ID.to_string());
 
     // Iterate through all resources in the stack to determine required management permissions
     for (resource_id, resource_entry) in stack.resources() {
@@ -202,8 +215,6 @@ fn generate_auto_management_profile(
         );
     }
 
-    // Always include the observe grant. It is read-only and lets the management
-    // role populate cloud inventory in Operate mode.
     if permission_set_ids.is_empty() && resource_permission_set_ids.is_empty() {
         return Ok(None);
     }
@@ -660,13 +671,13 @@ mod tests {
         let global_permission_names: Vec<String> = profile
             .0
             .get("*")
-            .unwrap()
-            .iter()
+            .into_iter()
+            .flatten()
             .map(|perm_ref| perm_ref.id().to_string())
             .collect();
         assert!(
-            global_permission_names == vec![OBSERVE_PERMISSION_SET_ID.to_string()],
-            "Only observe should be global; KubernetesCluster heartbeat should be resource-scoped because existing clusters do not necessarily use the deployment prefix"
+            global_permission_names.is_empty(),
+            "KubernetesCluster heartbeat should be resource-scoped because existing clusters do not necessarily use the deployment prefix"
         );
         let permission_names: Vec<String> = profile
             .0
@@ -935,7 +946,6 @@ mod tests {
 
                 // Should have auto-generated live provision and extended storage/data-write.
                 assert!(permission_names.contains(&"worker/provision".to_string()));
-                assert!(permission_names.contains(&OBSERVE_PERMISSION_SET_ID.to_string()));
                 assert!(!permission_names.contains(&"worker/management".to_string()));
                 assert!(permission_names.contains(&"storage/data-write".to_string()));
             }
@@ -944,7 +954,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_override_management_profile_keeps_user_grants_and_adds_observe() {
+    async fn test_override_management_profile_is_unchanged() {
         let worker = Worker::new("test-worker".to_string())
             .code(WorkerCode::Image {
                 image: "test:latest".to_string(),
@@ -989,12 +999,11 @@ mod tests {
         let mutation = ManagementPermissionProfileMutation;
         let result_stack = mutation.mutate(stack, &stack_state, &config).await.unwrap();
 
-        // Check that override profile keeps user grants, gets mandatory observe,
-        // and does not receive other auto-generated permissions.
+        // Override profiles are authored explicitly and are not mutated.
         match result_stack.management() {
             ManagementPermissions::Override(profile) => {
                 let global_permissions = profile.0.get("*").unwrap();
-                assert_eq!(global_permissions.len(), 3);
+                assert_eq!(global_permissions.len(), 2);
 
                 let permission_names: Vec<String> = global_permissions
                     .iter()
@@ -1003,12 +1012,36 @@ mod tests {
 
                 assert!(permission_names.contains(&"storage/management".to_string()));
                 assert!(permission_names.contains(&"worker/management".to_string()));
-                assert!(permission_names.contains(&OBSERVE_PERMISSION_SET_ID.to_string()));
                 // Should NOT have auto-generated worker/provision
                 assert!(!permission_names.contains(&"worker/provision".to_string()));
             }
             _ => panic!("Expected Override management permissions"),
         }
+    }
+
+    #[tokio::test]
+    async fn application_stack_cannot_request_account_wide_observation() {
+        let stack = Stack::new("test-stack".to_string())
+            .management(ManagementPermissions::Extend(
+                PermissionProfile::new().global([OBSERVE_PERMISSION_SET_ID]),
+            ))
+            .build();
+        let stack_state = StackState::new(Platform::Aws);
+        let config = DeploymentConfig::builder()
+            .stack_settings(StackSettings::default())
+            .environment_variables(empty_env_snapshot())
+            .allow_frozen_changes(false)
+            .external_bindings(ExternalBindings::default())
+            .build();
+
+        let error = ManagementPermissionProfileMutation
+            .mutate(stack, &stack_state, &config)
+            .await
+            .expect_err("application observation grant should be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("dedicated observe-only deployment"));
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/mutations/management_permission_profile.rs
+++ b/crates/alien-preflights/src/mutations/management_permission_profile.rs
@@ -533,7 +533,7 @@ mod tests {
                     .collect();
 
                 assert!(permission_names.contains(&"worker/provision".to_string()));
-                assert!(permission_names.contains(&OBSERVE_PERMISSION_SET_ID.to_string()));
+                assert!(!permission_names.contains(&OBSERVE_PERMISSION_SET_ID.to_string()));
                 assert!(!permission_names.contains(&"worker/management".to_string()));
                 assert!(!permission_names.contains(&"storage/management".to_string()));
                 assert!(!permission_names.contains(&"aws/tag-tamper-protection".to_string()));
@@ -716,23 +716,9 @@ mod tests {
             .await
             .unwrap();
 
-        let ManagementPermissions::Extend(profile) = result_stack.management() else {
-            panic!("Expected Extend management permissions");
-        };
-        let global_permission_names: Vec<String> = profile
-            .0
-            .get("*")
-            .unwrap()
-            .iter()
-            .map(|perm_ref| perm_ref.id().to_string())
-            .collect();
-        assert_eq!(
-            global_permission_names,
-            vec![OBSERVE_PERMISSION_SET_ID.to_string()]
-        );
         assert!(
-            !profile.0.contains_key("kubernetes"),
-            "API-only Kubernetes heartbeat should not author Kubernetes cloud metadata permissions"
+            matches!(result_stack.management(), ManagementPermissions::Auto),
+            "an application with no management grants should remain Auto"
         );
     }
 

--- a/crates/alien-test/src/distribution.rs
+++ b/crates/alien-test/src/distribution.rs
@@ -4576,7 +4576,6 @@ mod tests {
             "azure-resource-group/heartbeat",
             "azure-storage-account/heartbeat",
             "azure-service-bus-namespace/heartbeat",
-            "observe/observe",
             "service-account/heartbeat",
             "service-activation/heartbeat",
         ] {

--- a/infra/aws/observe-read-role/cloudformation.yaml
+++ b/infra/aws/observe-read-role/cloudformation.yaml
@@ -46,27 +46,11 @@ Resources:
             Effect: Allow
             Action:
               - tag:GetResources
-              - tag:GetTagKeys
-              - tag:GetTagValues
             Resource: "*"
           - Sid: HealthMetrics
             Effect: Allow
             Action:
-              - cloudwatch:GetMetricData
               - cloudwatch:ListMetrics
-            Resource: "*"
-          - Sid: DescribeReadOnly
-            Effect: Allow
-            Action:
-              - ec2:Describe*
-              - rds:Describe*
-              - ecs:Describe*
-              - ecs:List*
-              - elasticloadbalancing:Describe*
-              - s3:ListAllMyBuckets
-              - s3:GetBucketLocation
-              - lambda:List*
-              - lambda:GetFunctionConfiguration
             Resource: "*"
 
 Outputs:

--- a/infra/aws/observe-read-role/main.tf
+++ b/infra/aws/observe-read-role/main.tf
@@ -36,36 +36,13 @@ data "aws_iam_policy_document" "assume" {
 data "aws_iam_policy_document" "read" {
   statement {
     sid = "Discovery"
-    actions = [
-      "tag:GetResources",
-      "tag:GetTagKeys",
-      "tag:GetTagValues",
-    ]
+    actions   = ["tag:GetResources"]
     resources = ["*"]
   }
 
   statement {
     sid = "HealthMetrics"
-    actions = [
-      "cloudwatch:GetMetricData",
-      "cloudwatch:ListMetrics",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "DescribeReadOnly"
-    actions = [
-      "ec2:Describe*",
-      "rds:Describe*",
-      "ecs:Describe*",
-      "ecs:List*",
-      "elasticloadbalancing:Describe*",
-      "s3:ListAllMyBuckets",
-      "s3:GetBucketLocation",
-      "lambda:List*",
-      "lambda:GetFunctionConfiguration",
-    ]
+    actions   = ["cloudwatch:ListMetrics"]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
## Summary

- stop running account-wide observation from normal deployment reconciliation
- require an explicit `operatorPermission: "observe"` for Operator inventory collection
- stop automatically adding `observe/observe` to application management profiles and reject explicit application use
- reduce the AWS observer role to `tag:GetResources` and `cloudwatch:ListMetrics`

## Why

Normal AWS application deployments were scanning the whole target account and surfacing unrelated resources. Observation is now a dedicated opt-in capability instead of an implicit part of deployment management.

## Validation

- `cargo nextest run -p alien-preflights -E "test(application_stack_cannot_request_account_wide_observation) | test(test_override_management_profile_is_unchanged) | test(kubernetes_cluster_cloud_metadata_heartbeat_is_explicit)"`
- `cargo nextest run -p alien-permissions -E "test(test_aws_observe_generates_account_wide_read_policy) | test(critical_e2e_provider_operations_are_declared)"`
- `cargo nextest run -p alien-operator -p alien-deployment -E "test(observe) | test(sync) | test(observation_requires_explicit_observe_permission)"`
- targeted `rustfmt` and `git diff --check`

Repository-wide `cargo fmt --all -- --check` remains noisy on unrelated files already present on `main`.

Linear: [ALIEN-380](https://linear.app/alienplatform/issue/ALIEN-380/make-cloud-resource-observation-explicitly-opt-in)