### PR TITLE
fix(terraform): bound the azurerm provider below the breaking major

### DIFF
--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -923,9 +923,12 @@ fn versions_body(
         ));
     }
     if matches!(target.cloud_platform(), alien_core::Platform::Azure) {
+        // Upper bound deliberate: an open-ended constraint promises every future
+        // major works, and azurerm 5 renamed arguments we emit. Raise it once the
+        // emitters are ported, rather than letting a release decide for us.
         provider_attrs.push(attr(
             "azurerm",
-            provider_decl_attr("hashicorp/azurerm", ">= 3.100"),
+            provider_decl_attr("hashicorp/azurerm", ">= 3.100, < 5.0"),
         ));
         if include_azapi_provider {
             provider_attrs.push(attr("azapi", provider_decl_attr("Azure/azapi", ">= 2.6")));

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aks_overlay_workload_identity.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aks_overlay_workload_identity.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_artifact_registry.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_artifact_registry.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_build.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_build.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_data_layer_full.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_data_layer_full.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_full_stack.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_basic.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_basic.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_public.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_function_public.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_kv_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_kv_minimal.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_byo_vnet.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_byo_vnet.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_create.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_network_create.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_queue_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_queue_minimal.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_stack_management.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_stack_management.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_service_account.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_service_account.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_minimal.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_public_read.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_public_read.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_versioning_and_lifecycle.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_storage_versioning_and_lifecycle.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_vault_minimal.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_vault_minimal.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_azure.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__enabled_gated_vault_azure.snap
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100"
+      version = ">= 3.100, < 5.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary

The azurerm provider constraint we generate had no upper bound, so Terraform resolved
whatever was newest. Version 5 renamed arguments we emit, and the module we generate
stopped passing `terraform validate`.

What happens when someone installs an Azure deployment:

1. We generate a module declaring `azurerm >= 3.100`.
2. `terraform init` resolves that to the newest matching version, now a 5.x release.
3. **`terraform validate` rejects our storage table**, because `storage_account_name`
   became `storage_account_id` in that major.

Existing deployments are unaffected: they resolved their provider once and kept it in
`.terraform.lock.hcl`. A fresh install has no lock file and resolves the new major.

This bounds the constraint to `>= 3.100, < 5.0` so we decide the supported range instead
of a release deciding it for us.

## What was broken

Every branch's `Rust crates` job went red at the same time, with no commit to blame. The
Azure generator tests render the real module and run `terraform validate`, so they failed
the moment the new provider shipped:

```
Error: Missing required argument
  on metadata.tf line 1, in resource "azurerm_storage_table" "metadata":
  The argument "storage_account_id" is required, but no definition was found.

Error: Unsupported argument
  on metadata.tf line 3:
    storage_account_name = azurerm_storage_account.default_storage_account.name
```

An unbounded major constraint claims we work with versions that do not exist yet, which
can never be true.

## What I did

Bounded the constraint, and left a note saying the ceiling is temporary so it is not read
later as a considered maximum. Porting the emitters to the new major is real work with a
support decision attached (anyone still on 3.x or 4.x breaks if we emit 5-only syntax),
so it belongs in its own change.

## Files touched

- `alien-terraform/src/generator.rs` - the constraint, plus why the bound exists
- 18 generator snapshots - the version string, nothing else

## How I tested

`cargo nextest run -p alien-terraform` - 158/158 pass. Before this change, four Azure
tests failed on `terraform validate`; they render the module and validate it for real, so
they are the same check a customer's `terraform init && terraform validate` performs.

Reviewed the snapshot diff line by line: 18 files, one line each, only the version string.

One caveat worth stating: a deployment that already applied successfully on the new major
would now see a constraint conflict and have to downgrade on its next `init`. That is only
reachable for a stack using none of the renamed resources, since anything with a storage
table could not have applied.
