### PR TITLE
refactor: remove legacy observe compatibility

### DIFF
--- a/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
+++ b/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
@@ -1,7 +1,5 @@
 use crate::error::Result;
-use crate::mutations::management_permission_profile::{
-    GATE_DERIVED_GLOBAL_SUFFIXES, OBSERVE_PERMISSION_SET_ID,
-};
+use crate::mutations::management_permission_profile::GATE_DERIVED_GLOBAL_SUFFIXES;
 use crate::{CheckResult, StackCompatibilityCheck};
 use alien_core::permissions::{ManagementPermissions, PermissionProfile, PermissionSetReference};
 use alien_core::Stack;
@@ -62,32 +60,15 @@ fn gated_contributions(old_stack: &Stack, new_stack: &Stack) -> GatedContributio
 /// data-capable grant here would let it slip through as soon as any resource
 /// of its type is gated. Full references are compared (not their ids), so an
 /// inline set whose body changed under a stable id still reads as drift.
-///
-/// Older managers also inserted the named `observe/observe` grant into every
-/// prepared management profile. Application stacks no longer receive that
-/// account-wide grant. Compatibility may therefore omit that exact named
-/// reference from the old management profile only; named profiles, inline
-/// permission sets, and additions on the new side remain unchanged.
 fn without_gate_derived<'a>(
     grants: Option<&'a Vec<PermissionSetReference>>,
     gated: &GatedContributions,
-    omit_legacy_automatic_observe: bool,
 ) -> Vec<&'a PermissionSetReference> {
     grants
         .map(|grants| {
             grants
                 .iter()
                 .filter(|grant| {
-                    if omit_legacy_automatic_observe
-                        && matches!(
-                            grant,
-                            PermissionSetReference::Name(name)
-                                if name == OBSERVE_PERMISSION_SET_ID
-                        )
-                    {
-                        return false;
-                    }
-
                     !gated.type_prefixes.iter().any(|prefix| {
                         grant
                             .id()
@@ -111,7 +92,6 @@ fn profiles_differ_outside_gates(
     old_profile: &PermissionProfile,
     new_profile: &PermissionProfile,
     gated: &GatedContributions,
-    allow_legacy_automatic_observe_removal: bool,
 ) -> bool {
     let scopes: HashSet<&str> = old_profile
         .0
@@ -125,9 +105,7 @@ fn profiles_differ_outside_gates(
         let new_grants = new_profile.0.get(scope);
 
         if scope == "*" {
-            if without_gate_derived(old_grants, gated, allow_legacy_automatic_observe_removal)
-                != without_gate_derived(new_grants, gated, false)
-            {
+            if without_gate_derived(old_grants, gated) != without_gate_derived(new_grants, gated) {
                 return true;
             }
             continue;
@@ -159,10 +137,7 @@ fn management_differs_outside_gates(
         | (
             ManagementPermissions::Override(old_profile),
             ManagementPermissions::Override(new_profile),
-        ) => profiles_differ_outside_gates(old_profile, new_profile, gated, true),
-        (ManagementPermissions::Extend(old_profile), ManagementPermissions::Auto) => {
-            profiles_differ_outside_gates(old_profile, &PermissionProfile::new(), gated, true)
-        }
+        ) => profiles_differ_outside_gates(old_profile, new_profile, gated),
         _ => true,
     }
 }
@@ -197,7 +172,7 @@ impl StackCompatibilityCheck for PermissionProfilesUnchangedCheck {
         for (profile_name, new_profile) in new_profiles {
             if let Some(old_profile) = old_profiles.get(profile_name) {
                 // Profile exists in both - check if it was modified
-                if profiles_differ_outside_gates(old_profile, new_profile, &gated, false) {
+                if profiles_differ_outside_gates(old_profile, new_profile, &gated) {
                     errors.push(format!(
                         "Permission profile '{}' was modified",
                         profile_name
@@ -486,48 +461,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_legacy_automatic_observe_grant_can_leave_management() {
-        let old_stack = Stack::new("s".to_string())
-            .management(ManagementPermissions::Extend(
-                PermissionProfile::new().global(["observe/observe", "worker/provision"]),
-            ))
-            .build();
-        let new_stack = Stack::new("s".to_string())
-            .management(ManagementPermissions::Extend(
-                PermissionProfile::new().global(["worker/provision"]),
-            ))
-            .build();
-
-        let result = PermissionProfilesUnchangedCheck
-            .check(&old_stack, &new_stack)
-            .await
-            .expect("check should run");
-
-        assert!(result.success, "{:?}", result.errors);
-        assert!(result.errors.is_empty());
-        assert!(result.warnings.is_empty());
-    }
-
-    #[tokio::test]
-    async fn a_legacy_observe_only_management_profile_can_return_to_auto() {
-        let old_stack = Stack::new("s".to_string())
-            .management(ManagementPermissions::Extend(
-                PermissionProfile::new().global(["observe/observe"]),
-            ))
-            .build();
-        let new_stack = Stack::new("s".to_string()).build();
-
-        let result = PermissionProfilesUnchangedCheck
-            .check(&old_stack, &new_stack)
-            .await
-            .expect("check should run");
-
-        assert!(result.success, "{:?}", result.errors);
-        assert!(result.errors.is_empty());
-        assert!(result.warnings.is_empty());
-    }
-
-    #[tokio::test]
     async fn an_observe_grant_cannot_enter_management() {
         let old_stack = Stack::new("s".to_string())
             .management(ManagementPermissions::Extend(
@@ -554,7 +487,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn observe_removal_from_a_named_profile_is_still_rejected() {
+    async fn observe_removal_from_a_named_profile_is_rejected() {
         let old_profile = PermissionProfile::new().global(["observe/observe", "worker/execute"]);
         let new_profile = PermissionProfile::new().global(["worker/execute"]);
 

--- a/crates/alien-preflights/src/mutations/management_permission_profile.rs
+++ b/crates/alien-preflights/src/mutations/management_permission_profile.rs
@@ -12,7 +12,7 @@ use alien_permissions::get_permission_set;
 use indexmap::IndexMap;
 use std::collections::BTreeSet;
 
-pub(crate) const OBSERVE_PERMISSION_SET_ID: &str = "observe/observe";
+const OBSERVE_PERMISSION_SET_ID: &str = "observe/observe";
 
 /// Automatically adds management permission profile with necessary permissions for all resources in the stack.
 ///


### PR DESCRIPTION
## Summary

- remove the temporary compatibility exception for automatically generated `observe/observe` management grants
- restore strict comparison for all management permission changes
- retain focused regression coverage rejecting observe additions and named-profile changes

## Production prerequisite

Verified every deployment in the supported Islo and AgentMail production workspaces now persists a management profile without the retired automatic grant.

## Permission review

This changes only compatibility comparison. It does not add or broaden permission sets, IAM actions, runtime roles, Terraform roles, or preflight-authored management grants.

## Validation

- `cargo test -p alien-preflights compatibility::permission_profiles_unchanged` — 13 passed
- targeted `rustfmt --check` on both modified Rust files
- `git diff --check`

Linear: ALIEN-388