### PR TITLE
fix: make deployment references discoverable

### DIFF
--- a/crates/alien-cli/src/commands/commands.rs
+++ b/crates/alien-cli/src/commands/commands.rs
@@ -43,7 +43,7 @@ pub struct CommandsArgs {
 pub enum CommandsAction {
     /// Invoke a command on a deployment and wait for the result
     Invoke {
-        /// Deployment name or ID
+        /// Deployment ID, or <deployment-group-name>/<deployment-name>
         #[arg(long)]
         deployment: String,
 

--- a/crates/alien-cli/src/commands/debug.rs
+++ b/crates/alien-cli/src/commands/debug.rs
@@ -40,7 +40,7 @@ const DEBUG_SESSIONS_PATH: &str = "/v1/debug/sessions";
     long_about = "Request a debug session from the manager for a deployment, then run a \
 local command (or an interactive shell) with the env the manager returns.
 
-DEPLOYMENT can be a deployment ID (`dep_...`), a deployment name, or `<group>/<name>`.",
+DEPLOYMENT can be a deployment ID (`dep_...`) or `<group>/<name>`.",
     after_help = "EXAMPLES:
     alien debug dep_abc123 -- aws sts get-caller-identity
     alien debug acme/prod -- gcloud projects list
@@ -63,7 +63,7 @@ pub struct DebugArgs {
     #[command(subcommand)]
     pub command: Option<DebugSubcommand>,
 
-    /// Deployment ID (`dep_...`), deployment name, or `<group>/<name>`.
+    /// Deployment ID (`dep_...`) or `<group>/<name>`.
     pub deployment: Option<String>,
 
     /// Command and arguments to execute. Everything after `--` is forwarded verbatim.
@@ -92,7 +92,7 @@ pub enum DebugSubcommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct DebugShellArgs {
-    /// Deployment ID (`dep_...`), deployment name, or `<group>/<name>`.
+    /// Deployment ID (`dep_...`) or `<group>/<name>`.
     pub deployment: String,
 
     /// Container or daemon resource ID to attach to.
@@ -110,7 +110,7 @@ pub struct DebugShellArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct DebugExecArgs {
-    /// Deployment ID (`dep_...`), deployment name, or `<group>/<name>`.
+    /// Deployment ID (`dep_...`) or `<group>/<name>`.
     pub deployment: String,
 
     /// Container or daemon resource ID to attach to.

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -125,7 +125,7 @@ pub enum DeploymentsCmd {
     },
     /// Get deployment details
     Get {
-        /// Deployment name or ID
+        /// Deployment ID, or <deployment-group-name>/<deployment-name>
         id: String,
 
         /// Print machine-readable JSON
@@ -134,7 +134,7 @@ pub enum DeploymentsCmd {
     },
     /// Delete a deployment
     Delete {
-        /// Deployment name or ID
+        /// Deployment ID, or <deployment-group-name>/<deployment-name>
         id: String,
 
         /// Skip confirmation prompt
@@ -143,7 +143,7 @@ pub enum DeploymentsCmd {
     },
     /// Retry a deployment
     Retry {
-        /// Deployment name or ID
+        /// Deployment ID, or <deployment-group-name>/<deployment-name>
         id: String,
         /// Print the updated deployment as machine-readable JSON
         #[arg(long)]
@@ -151,7 +151,7 @@ pub enum DeploymentsCmd {
     },
     /// Redeploy a deployment with the same release
     Redeploy {
-        /// Deployment name or ID
+        /// Deployment ID, or <deployment-group-name>/<deployment-name>
         id: String,
         /// Print the updated deployment as machine-readable JSON
         #[arg(long)]
@@ -415,6 +415,7 @@ async fn resolve_deployment_reference(
 async fn list_deployments_task(client: &alien_manager_api::Client, json: bool) -> Result<()> {
     let response = client
         .list_deployments()
+        .include(vec!["deploymentGroup".to_string()])
         .send()
         .await
         .into_sdk_error()
@@ -434,7 +435,7 @@ async fn list_deployments_task(client: &alien_manager_api::Client, json: bool) -
     }
 
     let mut table = make_table(&[
-        "Name",
+        "Reference",
         "ID",
         "Status",
         "Platform",
@@ -444,7 +445,7 @@ async fn list_deployments_task(client: &alien_manager_api::Client, json: bool) -
     ]);
     for deployment in &response.items {
         table.add_row(vec![
-            deployment.name.clone().into(),
+            deployment_reference(deployment).into(),
             deployment.id.clone().into(),
             status_cell(&deployment.status),
             deployment.platform.to_string().into(),
@@ -464,6 +465,14 @@ async fn list_deployments_task(client: &alien_manager_api::Client, json: bool) -
     print_table(table);
 
     Ok(())
+}
+
+fn deployment_reference(deployment: &DeploymentResponse) -> String {
+    deployment
+        .deployment_group
+        .as_ref()
+        .map(|group| format!("{}/{}", group.name, deployment.name))
+        .unwrap_or_else(|| deployment.name.clone())
 }
 
 fn desired_release_cell(deployment: &DeploymentResponse) -> String {
@@ -1469,7 +1478,7 @@ fn parse_targeted_env_var(input: &str) -> Option<(String, String, Vec<String>)> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alien_manager_api::types::Platform;
+    use alien_manager_api::types::{DeploymentGroupMinimal, Platform};
 
     fn deployment_with_releases(
         current: Option<&str>,
@@ -1510,6 +1519,20 @@ mod tests {
             desired_release_cell(&deployment_with_releases(None, Some("rel_first"))),
             "rel_first"
         );
+    }
+
+    #[test]
+    fn deployment_reference_includes_the_group_name() {
+        let mut deployment = deployment_with_releases(Some("rel_a"), None);
+        deployment.deployment_group = Some(
+            DeploymentGroupMinimal::builder()
+                .id("dg_1")
+                .name("production")
+                .try_into()
+                .expect("valid deployment group"),
+        );
+
+        assert_eq!(deployment_reference(&deployment), "production/example");
     }
 
     #[test]

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -472,7 +472,7 @@ fn deployment_reference(deployment: &DeploymentResponse) -> String {
         .deployment_group
         .as_ref()
         .map(|group| format!("{}/{}", group.name, deployment.name))
-        .unwrap_or_else(|| deployment.name.clone())
+        .unwrap_or_else(|| deployment.id.clone())
 }
 
 fn desired_release_cell(deployment: &DeploymentResponse) -> String {
@@ -1533,6 +1533,13 @@ mod tests {
         );
 
         assert_eq!(deployment_reference(&deployment), "production/example");
+    }
+
+    #[test]
+    fn deployment_reference_falls_back_to_the_id_without_group_data() {
+        let deployment = deployment_with_releases(Some("rel_a"), None);
+
+        assert_eq!(deployment_reference(&deployment), "dep_1");
     }
 
     #[test]

--- a/crates/alien-cli/tests/help_security_tests.rs
+++ b/crates/alien-cli/tests/help_security_tests.rs
@@ -32,3 +32,21 @@ fn api_key_environment_value_is_absent_from_subcommand_help() {
     assert!(!stdout.contains(SENTINEL), "help stdout leaked the API key");
     assert!(!stderr.contains(SENTINEL), "help stderr leaked the API key");
 }
+
+#[test]
+fn deployments_get_help_documents_unambiguous_references() {
+    let output = Command::new(get_alien_cli_binary())
+        .args(["deployments", "get", "--help"])
+        .output()
+        .expect("alien help subprocess should run");
+
+    assert!(
+        output.status.success(),
+        "help should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("help stdout should be UTF-8");
+
+    assert!(stdout.contains("Deployment ID, or <deployment-group-name>/<deployment-name>"));
+}


### PR DESCRIPTION
## Summary
- make `alien deployments ls` print the unambiguous `group/deployment` reference accepted by `get`
- request deployment-group data explicitly for list output
- correct help text for get, delete, retry, redeploy, invoke, and debug commands
- keep the safety rule that rejects ambiguous bare deployment names

## Validation
- `cargo test -p alien-cli deployment_reference_includes_the_group_name --locked`
- `cargo test -p alien-cli --test help_security_tests deployments_get_help_documents_unambiguous_references --locked`
- compiled CLI against production: list exposed `big-bank/prod-aws`, then get with that reference succeeded
- changed files pass rustfmt and `git diff --check`

The repository-wide `cargo fmt --check` also reports unrelated pre-existing formatting drift on main.

[ALIEN-400](https://linear.app/alienplatform/issue/ALIEN-400/fix-nullable-api-response-codegen-and-release-rollout-empty-state)