### PR TITLE
fix: serialize native addon source builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "dockdash",
  "dotenvy",
  "flate2",
+ "fs2",
  "futures",
  "glob",
  "object_store",

--- a/crates/alien-build/Cargo.toml
+++ b/crates/alien-build/Cargo.toml
@@ -32,6 +32,7 @@ tar = "0.4"
 flate2 = "1.0"
 dirs = "5.0"
 futures = "0.3"
+fs2 = "0.4"
 which = "6.0"
 
 

--- a/crates/alien-build/src/toolchain/native_addon.rs
+++ b/crates/alien-build/src/toolchain/native_addon.rs
@@ -151,7 +151,7 @@ async fn find_addon_source(
         addon_file_name,
         crate_dir.display()
     );
-    let _build_lock = lock_workspace_addon_build(&crate_dir, resource_name).await?;
+    let build_lock = lock_workspace_addon_build(&crate_dir, resource_name).await?;
 
     // Another process may have completed the build while this one waited.
     let dev_addon = crate_dir.join(addon_file_name);
@@ -159,20 +159,35 @@ async fn find_addon_source(
         return Ok(Some(dev_addon));
     }
 
-    let output = Command::new("npx")
-        .args(["napi", "build", "--platform", "--release"])
-        .current_dir(&crate_dir)
-        .output()
-        .await
-        .into_alien_error()
-        .context(ErrorData::ImageBuildFailed {
-            resource_name: resource_name.to_string(),
-            reason: format!(
-                "Failed to execute `npx napi build --platform --release` in {}",
-                crate_dir.display()
-            ),
-            build_output: None,
-        })?;
+    let build_dir = crate_dir.clone();
+    let output = tokio::task::spawn_blocking(move || {
+        // Keep the cross-process lock inside the blocking task. If the async caller is cancelled,
+        // Tokio detaches this task, which continues holding the lock until the child has exited.
+        let _build_lock = build_lock;
+        std::process::Command::new("npx")
+            .args(["napi", "build", "--platform", "--release"])
+            .current_dir(build_dir)
+            .output()
+    })
+    .await
+    .into_alien_error()
+    .context(ErrorData::ImageBuildFailed {
+        resource_name: resource_name.to_string(),
+        reason: format!(
+            "Failed to wait for `npx napi build --platform --release` in {}",
+            crate_dir.display()
+        ),
+        build_output: None,
+    })?
+    .into_alien_error()
+    .context(ErrorData::ImageBuildFailed {
+        resource_name: resource_name.to_string(),
+        reason: format!(
+            "Failed to execute `npx napi build --platform --release` in {}",
+            crate_dir.display()
+        ),
+        build_output: None,
+    })?;
     if !output.status.success() {
         let mut build_output = String::from_utf8_lossy(&output.stdout).into_owned();
         build_output.push_str(&String::from_utf8_lossy(&output.stderr));

--- a/crates/alien-build/src/toolchain/native_addon.rs
+++ b/crates/alien-build/src/toolchain/native_addon.rs
@@ -22,6 +22,8 @@
 use crate::error::{ErrorData, Result};
 use alien_core::BinaryTarget;
 use alien_error::{AlienError, Context, IntoAlienError};
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
@@ -149,6 +151,14 @@ async fn find_addon_source(
         addon_file_name,
         crate_dir.display()
     );
+    let _build_lock = lock_workspace_addon_build(&crate_dir, resource_name).await?;
+
+    // Another process may have completed the build while this one waited.
+    let dev_addon = crate_dir.join(addon_file_name);
+    if dev_addon.is_file() {
+        return Ok(Some(dev_addon));
+    }
+
     let output = Command::new("npx")
         .args(["napi", "build", "--platform", "--release"])
         .current_dir(&crate_dir)
@@ -182,6 +192,49 @@ async fn find_addon_source(
     } else {
         Ok(None)
     }
+}
+
+async fn lock_workspace_addon_build(crate_dir: &Path, resource_name: &str) -> Result<File> {
+    let workspace_dir = crate_dir
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or(crate_dir);
+    let lock_path = workspace_dir
+        .join("target")
+        .join("alien-bindings-node-build.lock");
+    let lock_path_for_error = lock_path.clone();
+
+    tokio::task::spawn_blocking(move || {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        FileExt::lock_exclusive(&file)?;
+        Ok::<_, std::io::Error>(file)
+    })
+    .await
+    .into_alien_error()
+    .context(ErrorData::ImageBuildFailed {
+        resource_name: resource_name.to_string(),
+        reason: format!(
+            "Failed to wait for the native bindings addon build lock at {}",
+            lock_path_for_error.display()
+        ),
+        build_output: None,
+    })?
+    .into_alien_error()
+    .context(ErrorData::ImageBuildFailed {
+        resource_name: resource_name.to_string(),
+        reason: format!(
+            "Failed to acquire the native bindings addon build lock at {}",
+            lock_path_for_error.display()
+        ),
+        build_output: None,
+    })
 }
 
 /// bun script that prints the resolved path of the bindings package's `./native`
@@ -530,6 +583,34 @@ mod tests {
         );
         assert_eq!(napi_triple(BinaryTarget::DarwinArm64), Some("darwin-arm64"));
         assert_eq!(napi_triple(BinaryTarget::WindowsX64), None);
+    }
+
+    #[tokio::test]
+    async fn workspace_addon_build_lock_waits_for_the_current_builder() {
+        let workspace = tempdir().unwrap();
+        let crate_dir = workspace.path().join("crates").join("alien-bindings-node");
+        fs::create_dir_all(&crate_dir).await.unwrap();
+        let first_lock = lock_workspace_addon_build(&crate_dir, "first")
+            .await
+            .expect("first builder should acquire the lock");
+
+        let waiting_crate_dir = crate_dir.clone();
+        let mut waiting_builder =
+            tokio::spawn(
+                async move { lock_workspace_addon_build(&waiting_crate_dir, "second").await },
+            );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut waiting_builder)
+                .await
+                .is_err(),
+            "a second builder must wait while the first holds the filesystem lock"
+        );
+
+        drop(first_lock);
+        waiting_builder
+            .await
+            .expect("waiting builder task should finish")
+            .expect("the next builder should acquire the released lock");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes ALIEN-401.

## What changed
- serialize workspace native-addon source builds with a filesystem lock shared across test processes
- recheck the built addon after waiting, so followers reuse the first build
- cover lock contention and release behavior

## Why
Nextest runs tests in separate processes. Multiple tests could concurrently run `napi build` in the same crate, racing in `target/napi-rs` and intermittently failing with ENOENT. The existing Tokio mutexes are process-local and cannot prevent that race.

## Validation
- `cargo test -p alien-build workspace_addon_build_lock_waits_for_the_current_builder --locked --offline`
- all 109 alien-build unit tests passed; integration tests that require `packages/sdk/dist` were not runnable until the JS package prerequisite is built