### PR TITLE
fix(gcp): expose Cloud SQL server CA certificate

### DIFF
--- a/crates/alien-gcp-clients/src/gcp/cloud_sql.rs
+++ b/crates/alien-gcp-clients/src/gcp/cloud_sql.rs
@@ -60,6 +60,15 @@ pub struct DatabaseInstance {
     /// fallback attachment surface if a future API revision drops `pscServiceAttachmentLink`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ip_addresses: Vec<IpMapping>,
+    /// Current server CA certificate reported by Cloud SQL (response only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_ca_cert: Option<ServerCaCert>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerCaCert {
+    pub cert: String,
 }
 
 /// One entry of a Cloud SQL instance's reported IP addresses. `type` distinguishes
@@ -376,7 +385,23 @@ mod tests {
             state: None,
             psc_service_attachment_link: None,
             ip_addresses: vec![],
+            server_ca_cert: None,
         }
+    }
+
+    #[test]
+    fn database_instance_deserializes_server_ca_certificate() {
+        let mut value = serde_json::to_value(private_instance()).unwrap();
+        value["serverCaCert"] = serde_json::json!({
+            "cert": "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----\n"
+        });
+
+        let instance: DatabaseInstance = serde_json::from_value(value).unwrap();
+
+        assert_eq!(
+            instance.server_ca_cert.unwrap().cert,
+            "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----\n"
+        );
     }
 
     #[test]

--- a/crates/alien-gcp-clients/src/gcp/cloud_sql.rs
+++ b/crates/alien-gcp-clients/src/gcp/cloud_sql.rs
@@ -61,7 +61,7 @@ pub struct DatabaseInstance {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ip_addresses: Vec<IpMapping>,
     /// Current server CA certificate reported by Cloud SQL (response only).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing)]
     pub server_ca_cert: Option<ServerCaCert>,
 }
 
@@ -402,6 +402,18 @@ mod tests {
             instance.server_ca_cert.unwrap().cert,
             "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----\n"
         );
+    }
+
+    #[test]
+    fn database_instance_never_serializes_response_only_server_ca_certificate() {
+        let mut instance = private_instance();
+        instance.server_ca_cert = Some(ServerCaCert {
+            cert: "response-only".to_string(),
+        });
+
+        let value = serde_json::to_value(instance).unwrap();
+
+        assert!(value.get("serverCaCert").is_none());
     }
 
     #[test]

--- a/crates/alien-gcp-clients/tests/gcp_cloud_sql_client_tests.rs
+++ b/crates/alien-gcp-clients/tests/gcp_cloud_sql_client_tests.rs
@@ -131,6 +131,7 @@ async fn cloud_sql_tier_resize_is_in_place_not_recreate() {
         state: None,
         psc_service_attachment_link: None,
         ip_addresses: vec![],
+        server_ca_cert: None,
     };
 
     // Create a small instance and wait until it is serving.


### PR DESCRIPTION
Closes ALIEN-402.

Paired with the platform controller change.

## What changed
- deserialize the `serverCaCert.cert` field returned by Cloud SQL
- keep the response-only field absent from create requests
- cover the real camelCase API response shape

## Why
Alien now fails closed unless Cloud SQL bindings contain their per-instance CA roots, but the GCP client dropped that response field. Platform therefore could neither compile against nor satisfy the new binding contract.

## Validation
- `cargo test -p alien-gcp-clients database_instance_deserializes_server_ca_certificate --locked`