### PR TITLE
chore: enable Renovate automerge (ALIEN-370)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,4 +1,6 @@
 {
   "triggerOnUpdates": true,
+  "includeAuthors": ["*"],
+  "excludeAuthors": [],
   "ignorePatterns": "packages/core/openapi.json\npackages/core/src/generated/**\npackages/sdk/src/generated/**\npackages/sdk/src/worker-runtime/generated/**\npackages/sdk/dist/generated/**"
 }

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,6 +1,4 @@
 {
   "triggerOnUpdates": true,
-  "includeAuthors": ["*"],
-  "excludeAuthors": [],
   "ignorePatterns": "packages/core/openapi.json\npackages/core/src/generated/**\npackages/sdk/src/generated/**\npackages/sdk/src/worker-runtime/generated/**\npackages/sdk/dist/generated/**"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,7 @@
       "groupSlug": "stable-minor-patch",
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "platformAutomerge": false
+      "automergeStrategy": "squash"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "group:allNonMajor"],
-  "additionalBranchPrefix": "alien-370-"
+  "additionalBranchPrefix": "alien-370-",
+  "packageRules": [
+    {
+      "description": "Automerge stable non-major updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "groupName": "stable non-major dependencies",
+      "groupSlug": "stable-minor-patch",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "platformAutomerge": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- automatically merge stable minor and patch Renovate updates in a dedicated group
- keep major updates, pre-1.0 dependencies, `pin`-type conversions, and digest updates under manual review
- use GitHub platform-native squash automerge after required checks pass

## Safety

- automerge remains gated by repository rules and required checks
- existing exact-version dependencies remain eligible for stable minor and patch automerge; `pin` refers to the separate Renovate range-to-exact update type
- the Renovate Greptile exemption must be handled separately at the GitHub organization ruleset level; this PR does not change Greptile configuration
- stable updates are separated from the existing all-non-major group so a pre-1.0 dependency cannot silently change the merge policy
- current grouped Renovate PRs may be replaced once as Renovate applies the new grouping

## Validation

- current official `renovate-config-validator --strict`
- JSON parsing
- repository Biome check where configured
- `git diff --check`

## Tracking

- [ALIEN-370](https://linear.app/alienplatform/issue/ALIEN-370/automated-dependency-updates)
