### PR TITLE
chore: release v3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-ai-gateway"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-bindings",
  "alien-error",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "aegis",
  "alien-azure-clients",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error",
  "chrono",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -63,39 +63,39 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.2.0", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.3.0", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.2.0", default-features = false }
-alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.2.0" }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.2.0" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.2.0", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.2.0" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.3.0", default-features = false }
+alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.0" }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.0" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.3.0", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.0" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.2.0" }
-alien-infra = { path = "crates/alien-infra", version = "3.2.0" }
-alien-build = { path = "crates/alien-build", version = "3.2.0" }
-alien-macros = { path = "crates/alien-macros", version = "3.2.0" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.2.0" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.2.0" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.2.0" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.2.0" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.2.0" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.2.0" }
-alien-error = { path = "crates/alien-error", version = "3.2.0", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.2.0" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.2.0" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.2.0" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.2.0" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.2.0" }
-alien-local = { path = "crates/alien-local", version = "3.2.0" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.2.0" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.2.0" }
-alien-helm = { path = "crates/alien-helm", version = "3.2.0" }
-alien-manager = { path = "crates/alien-manager", version = "3.2.0" }
-alien-observer = { path = "crates/alien-observer", version = "3.2.0" }
+alien-core = { path = "crates/alien-core", version = "3.3.0" }
+alien-infra = { path = "crates/alien-infra", version = "3.3.0" }
+alien-build = { path = "crates/alien-build", version = "3.3.0" }
+alien-macros = { path = "crates/alien-macros", version = "3.3.0" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.3.0" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.3.0" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.0" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.0" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.0" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.0" }
+alien-error = { path = "crates/alien-error", version = "3.3.0", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.0" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.3.0" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.3.0" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.3.0" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.0" }
+alien-local = { path = "crates/alien-local", version = "3.3.0" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.0" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.3.0" }
+alien-helm = { path = "crates/alien-helm", version = "3.3.0" }
+alien-manager = { path = "crates/alien-manager", version = "3.3.0" }
+alien-observer = { path = "crates/alien-observer", version = "3.3.0" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.2.0", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.2.0", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.0", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.0", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/ai-gateway",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "cpu": ["arm64"],
   "main": "alien-bindings-node.darwin-arm64.node",
   "files": ["alien-bindings-node.darwin-arm64.node"],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "cpu": ["x64"],
   "main": "alien-bindings-node.darwin-x64.node",
   "files": ["alien-bindings-node.darwin-x64.node"],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "cpu": ["arm64"],
   "main": "alien-bindings-node.linux-arm64-gnu.node",
   "files": ["alien-bindings-node.linux-arm64-gnu.node"],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "cpu": ["x64"],
   "main": "alien-bindings-node.linux-x64-gnu.node",
   "files": ["alien-bindings-node.linux-x64-gnu.node"],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "files": ["dist"],
   "exports": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "module",
   "files": ["dist"],
   "exports": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Version-only release PR generated by the stable release workflow. The **Release qualification** check builds and records the exact artifact set. After every required check passes and this merges, run the stable **publish** action from `main` to promote those qualified artifacts.