### PR TITLE
fix(ci): requalify exact merged release commits

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -57,7 +57,16 @@ jobs:
               --jq '[.[] | select(.base.ref == "main")] | sort_by(.updated_at) | last')
             HEAD_REPOSITORY=$(jq -r '.head.repo.full_name // empty' <<< "$PR_JSON")
             HEAD_REF=$(jq -r '.head.ref // empty' <<< "$PR_JSON")
-            BASE_SHA=$(jq -r '.base.sha // empty' <<< "$PR_JSON")
+            MERGE_COMMIT_SHA=$(jq -r '.merge_commit_sha // empty' <<< "$PR_JSON")
+            if [ "$MERGE_COMMIT_SHA" != "$SOURCE_REF" ]; then
+              echo "::error::Workflow dispatch requalification requires the exact merged release commit"
+              exit 1
+            fi
+            # The PR's recorded base can be stale when another PR lands between
+            # qualification and merge. Compare the exact merged commit with its
+            # first parent so concurrent main changes are not misclassified as
+            # release-PR changes.
+            BASE_SHA=$(git rev-parse "${SOURCE_REF}^")
           fi
 
           CURRENT_VERSION=$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\(.*\)"/\1/p' Cargo.toml)

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -53,8 +53,9 @@ jobs:
           else
             PR_JSON=$(gh api \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${GITHUB_REPOSITORY}/commits/${SOURCE_REF}/pulls" \
-              --jq '[.[] | select(.base.ref == "main")] | sort_by(.updated_at) | last')
+              "/repos/${GITHUB_REPOSITORY}/commits/${SOURCE_REF}/pulls" |
+              jq --arg source "$SOURCE_REF" \
+                '[.[] | select(.base.ref == "main" and .merge_commit_sha == $source)] | last')
             HEAD_REPOSITORY=$(jq -r '.head.repo.full_name // empty' <<< "$PR_JSON")
             HEAD_REF=$(jq -r '.head.ref // empty' <<< "$PR_JSON")
             MERGE_COMMIT_SHA=$(jq -r '.merge_commit_sha // empty' <<< "$PR_JSON")


### PR DESCRIPTION
## Summary
- require workflow-dispatch requalification to target the exact merged release commit
- compare that commit with its first parent, not the PR’s potentially stale base SHA
- preserve the version-only release check while allowing concurrent `main` changes that landed before the squash merge

## Validation
- parsed workflow YAML
- verified PR #260 merge metadata resolves to `df0b29fe`
- verified `df0b29fe^..df0b29fe` contains only allowed release-version files

Linear: ALIEN-410