### PR TITLE
fix(ci): pack the bindings wrapper with pnpm so workspace ranges resolve

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1150,8 +1150,11 @@ jobs:
       - name: Inject optionalDependencies into the wrapper
         run: node packages/bindings/scripts/inject-optional-deps.mjs
 
+      # pnpm, not npm: only pnpm rewrites the `workspace:` range on
+      # `@alienplatform/core` into the released version, and npm rejects a
+      # published package that still carries the protocol.
       - name: Pack bindings wrapper
-        run: npm pack ./packages/bindings --pack-destination "$PWD/qualified/bindings"
+        run: pnpm --filter @alienplatform/bindings pack --pack-destination "$PWD/qualified/bindings"
 
       - name: Upload qualified bindings packages
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

The release pipeline packs the `@alienplatform/bindings` wrapper with `npm pack`, which copies `package.json` verbatim — so the published tarball ships `"@alienplatform/core": "workspace:^"`, a protocol npm rejects at install time. Since the sdk depends on the bindings package, `npm install @alienplatform/sdk` currently fails for everyone.

Step-by-step flow when a release qualification runs:

1. `qualify-bindings` builds the wrapper and injects the exact-version `optionalDependencies`.
2. **It then packs the wrapper with `pnpm --filter @alienplatform/bindings pack`, which rewrites every `workspace:` range into the released version — `npm pack` kept them verbatim.** ← the fix
3. `publish-bindings` later ships that qualified tarball to npm unchanged, so what qualification packs is exactly what users install.

This PR changes the bindings wrapper pack from `npm pack` to `pnpm pack`.

## What was broken

Installing the sdk from npm fails today:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

The published bindings 3.2.0 carries the raw `workspace:^` dependency on core, and the sdk pulls the bindings package in. Only pnpm rewrites `workspace:` ranges while packing; the ai-gateway wrapper a few steps below already packs with pnpm for exactly this reason, comment and all.

## What I did

- Switched the "Pack bindings wrapper" step to `pnpm --filter @alienplatform/bindings pack`, and copied the ai-gateway job's comment explaining why.
- The per-platform prebuild packages stay on `npm pack` — they have no `workspace:` dependencies.

## Files touched

- `.github/workflows/release.yml` — one step in `qualify-bindings`.

## How I tested

- **Reproduced the failure:** in a clean directory, `npm install @alienplatform/sdk@3.2.0` fails with `EUNSUPPORTEDPROTOCOL`; `npm view @alienplatform/bindings@3.2.0 dependencies` shows the raw `workspace:^`. The qualified 3.3.0 bindings tarball from the current qualification run carries the same (inspected its `package.json` with `tar -xzO`).
- **Verified the fix:** ran `pnpm --filter @alienplatform/bindings pack` from the workspace and inspected the tarball — `dependencies` comes out as a real caret range and zero `workspace:` references remain anywhere in the manifest, with `devDependencies` rewritten too. Injected `optionalDependencies` are plain versions, so packing order is unaffected.
- **Couldn't test:** the workflow end-to-end — the next release qualification run exercises it.
