### PR TITLE
fix: grant AWS compute runtime health reads

### DIFF
--- a/crates/alien-permissions/permission-sets/compute-cluster/execute.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/execute.jsonc
@@ -76,10 +76,27 @@
           }
         }
       },
-      // AWS requires Resource: "*" for DescribeVolumes.
+      // AWS requires Resource: "*" for EC2 Describe actions.
       {
+        "label": "observe-ec2-runtime-state",
         "grant": {
-          "actions": ["ec2:DescribeVolumes"]
+          "actions": ["ec2:DescribeTags", "ec2:DescribeVolumes"]
+        },
+        "binding": {
+          "stack": {
+            "resources": ["*"]
+          },
+          "resource": {
+            "resources": ["*"]
+          }
+        }
+      },
+      // Horizon observes the target state after deregistration before stopping the workload.
+      // DescribeTargetHealth does not support resource-level IAM permissions.
+      {
+        "label": "observe-load-balancer-target-health",
+        "grant": {
+          "actions": ["elasticloadbalancing:DescribeTargetHealth"]
         },
         "binding": {
           "stack": {

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -59,6 +59,13 @@ fn compute_cluster_execute_does_not_read_workload_secrets() {
     let result = generator
         .generate_policy(permission_set, BindingTarget::Stack, &context)
         .expect("compute cluster execute policy should generate");
+
+    let unique_sids = result
+        .statement
+        .iter()
+        .map(|statement| statement.sid.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(unique_sids.len(), result.statement.len());
     let actions = result
         .statement
         .iter()
@@ -74,6 +81,35 @@ fn compute_cluster_execute_does_not_read_workload_secrets() {
         assert!(
             !actions.contains(&action),
             "machine role must not grant {action}"
+        );
+    }
+}
+
+#[test]
+fn compute_cluster_execute_can_observe_runtime_cleanup() {
+    let generator = AwsRuntimePermissionsGenerator::new();
+    let permission_set =
+        get_permission_set("compute-cluster/execute").expect("permission set exists");
+    let context = create_test_context();
+
+    let result = generator
+        .generate_policy(permission_set, BindingTarget::Stack, &context)
+        .expect("compute cluster execute policy should generate");
+
+    for action in [
+        "ec2:DescribeTags",
+        "elasticloadbalancing:DescribeTargetHealth",
+    ] {
+        let statement = result
+            .statement
+            .iter()
+            .find(|statement| statement.action.iter().any(|candidate| candidate == action))
+            .unwrap_or_else(|| panic!("compute runtime should grant {action}"));
+
+        assert_eq!(statement.resource, ["*".to_string()]);
+        assert!(
+            statement.condition.is_none(),
+            "{action} does not support resource-scoped conditions"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add EC2 tag and load-balancer target-health observation to the canonical compute runtime permission set
- keep AWS wildcard reads explicit and uniquely labeled
- cover the effective generated runtime policy

## Validation
- cargo test -p alien-permissions

Linear: ALIEN-423