### PR TITLE
refactor(ci): publish releases in one workflow run

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,0 +1,71 @@
+name: Publish stable release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-stable-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  resolve:
+    runs-on: depot-ubuntu-24.04-arm
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve unreleased version commit
+        id: release
+        run: |
+          VERSION=$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\(.*\)"/\1/p' Cargo.toml)
+          if git rev-parse --verify --quiet "refs/tags/v${VERSION}" >/dev/null; then
+            echo "::error::v${VERSION} is already published"
+            exit 1
+          fi
+
+          LATEST_TAG=$(git tag --list "v[0-9]*" --sort=-v:refname | head -n1)
+          RELEASE_COMMIT=""
+          while read -r COMMIT; do
+            COMMIT_VERSION=$(git show "${COMMIT}:Cargo.toml" |
+              sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\(.*\)"/\1/p')
+            if [ "$COMMIT_VERSION" = "$VERSION" ]; then
+              RELEASE_COMMIT="$COMMIT"
+              break
+            fi
+          done < <(git rev-list --reverse "${LATEST_TAG}..HEAD")
+
+          if [ -z "$RELEASE_COMMIT" ]; then
+            echo "::error::Could not find the commit that introduced v${VERSION}"
+            exit 1
+          fi
+
+          echo "Publishing v${VERSION} from ${RELEASE_COMMIT}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "commit=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
+
+  qualify:
+    needs: resolve
+    uses: ./.github/workflows/release.yml
+    with:
+      mode: stable
+      stable_action: qualification
+      source_ref: ${{ needs.resolve.outputs.commit }}
+    secrets: inherit
+
+  publish:
+    needs: [resolve, qualify]
+    uses: ./.github/workflows/release.yml
+    with:
+      mode: stable
+      stable_action: publish
+      source_ref: ${{ needs.resolve.outputs.commit }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ on:
         default: stable
         options: [stable, dev]
       stable_action:
-        description: Prepare a version PR or publish the qualified merged version
+        description: Prepare a version PR
         type: choice
         default: prepare
-        options: [prepare, publish]
+        options: [prepare]
       release_branch:
         description: Linear-derived branch name for the version PR (prepare only)
         type: string
@@ -401,43 +401,7 @@ jobs:
           RELEASE_COMMIT: ${{ steps.merged_version.outputs.commit }}
           VERSION: ${{ steps.merged_version.outputs.version }}
         run: |
-          PR_JSON=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${GITHUB_REPOSITORY}/commits/${RELEASE_COMMIT}/pulls" \
-            --jq '[.[] | select(.base.ref == "main" and .merged_at != null)] | sort_by(.merged_at) | last')
-          HEAD_SHA=$(jq -r '.head.sha // empty' <<< "$PR_JSON")
-          if [ -z "$HEAD_SHA" ]; then
-            echo "::error::The release commit is not associated with a merged pull request"
-            exit 1
-          fi
-
-          mkdir -p qualification-candidates
-          RUN_ID=""
-          while read -r CANDIDATE_RUN_ID; do
-            CANDIDATE_DIR="qualification-candidates/${CANDIDATE_RUN_ID}"
-            mkdir -p "$CANDIDATE_DIR"
-            if ! gh run download "$CANDIDATE_RUN_ID" \
-              --repo "$GITHUB_REPOSITORY" \
-              --name release-qualification-manifest \
-              --dir "$CANDIDATE_DIR" 2>/dev/null; then
-              continue
-            fi
-            CANDIDATE_HEAD=$(jq -r '.headSha // empty' "$CANDIDATE_DIR/manifest.json")
-            if [ "$CANDIDATE_HEAD" = "$RELEASE_COMMIT" ]; then
-              RUN_ID="$CANDIDATE_RUN_ID"
-              break
-            fi
-          done < <(gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow release-qualification.yml \
-            --status success \
-            --limit 100 \
-            --json databaseId \
-            --jq '.[].databaseId')
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::No successful release qualification exists for exact release commit ${RELEASE_COMMIT}"
-            exit 1
-          fi
+          RUN_ID="$GITHUB_RUN_ID"
 
           mkdir -p qualification
           gh run download "$RUN_ID" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -411,16 +411,31 @@ jobs:
             exit 1
           fi
 
-          RUN_ID=$(gh run list \
+          mkdir -p qualification-candidates
+          RUN_ID=""
+          while read -r CANDIDATE_RUN_ID; do
+            CANDIDATE_DIR="qualification-candidates/${CANDIDATE_RUN_ID}"
+            mkdir -p "$CANDIDATE_DIR"
+            if ! gh run download "$CANDIDATE_RUN_ID" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name release-qualification-manifest \
+              --dir "$CANDIDATE_DIR" 2>/dev/null; then
+              continue
+            fi
+            CANDIDATE_HEAD=$(jq -r '.headSha // empty' "$CANDIDATE_DIR/manifest.json")
+            if [ "$CANDIDATE_HEAD" = "$RELEASE_COMMIT" ]; then
+              RUN_ID="$CANDIDATE_RUN_ID"
+              break
+            fi
+          done < <(gh run list \
             --repo "$GITHUB_REPOSITORY" \
             --workflow release-qualification.yml \
-            --commit "$HEAD_SHA" \
             --status success \
-            --limit 1 \
+            --limit 100 \
             --json databaseId \
-            --jq '.[0].databaseId // empty')
+            --jq '.[].databaseId')
           if [ -z "$RUN_ID" ]; then
-            echo "::error::No successful release qualification exists for ${HEAD_SHA}"
+            echo "::error::No successful release qualification exists for exact release commit ${RELEASE_COMMIT}"
             exit 1
           fi
 
@@ -438,7 +453,7 @@ jobs:
           QUALIFIED_TREE=$(jq -r '.sourceTree' qualification/manifest.json)
           RELEASE_TREE=$(git rev-parse "${RELEASE_COMMIT}^{tree}")
           if [ "$QUALIFIED_VERSION" != "$VERSION" ] || \
-             [ "$QUALIFIED_HEAD" != "$HEAD_SHA" ] || \
+             [ "$QUALIFIED_HEAD" != "$RELEASE_COMMIT" ] || \
              [ "$QUALIFIED_TREE" != "$RELEASE_TREE" ]; then
             echo "::error::Qualified artifact set does not match the merged release tree"
             exit 1
@@ -463,7 +478,7 @@ jobs:
           jq -r '.images | to_entries[] | [.key, .value] | @tsv' \
             qualification/manifest.json |
             while IFS=$'\t' read -r image expected_digest; do
-              ref="ghcr.io/alienplatform/${image}:qualification-${HEAD_SHA}"
+              ref="ghcr.io/alienplatform/${image}:qualification-${RELEASE_COMMIT}"
               actual_digest=$(docker buildx imagetools inspect "$ref" |
                 sed -n 's/^Digest:[[:space:]]*//p' | head -n1)
               if [ "$actual_digest" != "$expected_digest" ]; then
@@ -473,7 +488,7 @@ jobs:
             done
 
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Select release source
         id: release_source


### PR DESCRIPTION
Simplify stable releases to one deterministic action after the version PR merges:\n\n1. Resolve the exact commit that introduced the unreleased version.\n2. Build and verify every artifact from that commit.\n3. Publish those artifacts from the same workflow run.\n\nThis removes historical workflow-run discovery, manual exact-merge requalification, and PR-head/merge-tree matching. The existing checksum, source-tree, native-addon smoke, image-digest, and idempotent publication checks remain.\n\nValidation:\n- The resolver selects v3.3.0 commit `df0b29feb0f07b72f4b1517378f0a2bcee038f15`.\n- Same-run artifact handoff follows the existing reusable-workflow pattern already used by Release qualification.\n- `git diff --check` passes.\n- `actionlint` reports only the repository’s known custom Depot runner labels.