### PR TITLE
refactor(ci): remove cross-run release manifests

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -3,12 +3,6 @@ name: Release qualification
 on:
   pull_request:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      source_ref:
-        description: Exact 40-character commit to requalify
-        type: string
-        required: true
 
 permissions:
   # The reusable release workflow also serves the prepare/publish entrypoint
@@ -28,15 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.source_ref || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Detect version-only release pull request
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
-          SOURCE_REF_INPUT: ${{ inputs.source_ref || github.event.pull_request.head.sha }}
-          EVENT_NAME: ${{ github.event_name }}
+          SOURCE_REF_INPUT: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -46,29 +39,9 @@ jobs:
             echo "::error::Release qualification requires an exact 40-character commit"
             exit 1
           fi
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            HEAD_REPOSITORY="$PR_HEAD_REPOSITORY"
-            HEAD_REF="$PR_HEAD_REF"
-            BASE_SHA="$PR_BASE_SHA"
-          else
-            PR_JSON=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "/repos/${GITHUB_REPOSITORY}/commits/${SOURCE_REF}/pulls" |
-              jq --arg source "$SOURCE_REF" \
-                '[.[] | select(.base.ref == "main" and .merge_commit_sha == $source)] | last')
-            HEAD_REPOSITORY=$(jq -r '.head.repo.full_name // empty' <<< "$PR_JSON")
-            HEAD_REF=$(jq -r '.head.ref // empty' <<< "$PR_JSON")
-            MERGE_COMMIT_SHA=$(jq -r '.merge_commit_sha // empty' <<< "$PR_JSON")
-            if [ "$MERGE_COMMIT_SHA" != "$SOURCE_REF" ]; then
-              echo "::error::Workflow dispatch requalification requires the exact merged release commit"
-              exit 1
-            fi
-            # The PR's recorded base can be stale when another PR lands between
-            # qualification and merge. Compare the exact merged commit with its
-            # first parent so concurrent main changes are not misclassified as
-            # release-PR changes.
-            BASE_SHA=$(git rev-parse "${SOURCE_REF}^")
-          fi
+          HEAD_REPOSITORY="$PR_HEAD_REPOSITORY"
+          HEAD_REF="$PR_HEAD_REF"
+          BASE_SHA="$PR_BASE_SHA"
 
           CURRENT_VERSION=$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\(.*\)"/\1/p' Cargo.toml)
           BASE_VERSION=$(git show "${BASE_SHA}:Cargo.toml" |
@@ -105,82 +78,9 @@ jobs:
       source_ref: ${{ needs.detect.outputs.source_ref }}
     secrets: inherit
 
-  manifest:
-    needs: [detect, qualify]
-    if: needs.detect.outputs.is_release == 'true'
-    runs-on: depot-ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.detect.outputs.source_ref }}
-
-      - name: Download qualified artifacts
-        uses: actions/download-artifact@v7
-        with:
-          pattern: "*"
-          path: qualified-artifacts
-          merge-multiple: false
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Record qualified source
-        env:
-          VERSION: ${{ needs.qualify.outputs.version }}
-          SOURCE_REF: ${{ needs.detect.outputs.source_ref }}
-        run: |
-          SOURCE_TREE=$(git rev-parse 'HEAD^{tree}')
-          find qualified-artifacts -type f -print0 |
-            sort -z |
-            xargs -0 sha256sum > artifact-checksums.txt
-          ARTIFACTS=$(jq -Rn \
-            '[inputs | capture("^(?<sha>[0-9a-f]+)  (?<path>.*)$")] |
-             map({key: .path, value: .sha}) | from_entries' \
-            < artifact-checksums.txt)
-
-          IMAGES='{}'
-          for name in alien-base alien-worker-typescript alien-builder alien-operator alien-manager; do
-            ref="ghcr.io/alienplatform/${name}:qualification-${SOURCE_REF}"
-            digest=$(docker buildx imagetools inspect "$ref" |
-              sed -n 's/^Digest:[[:space:]]*//p' | head -n1)
-            if [ -z "$digest" ]; then
-              echo "::error::Qualified image ${ref} has no manifest digest"
-              exit 1
-            fi
-            IMAGES=$(jq --arg name "$name" --arg digest "$digest" \
-              '. + {($name): $digest}' <<< "$IMAGES")
-          done
-
-          jq -n \
-            --arg version "$VERSION" \
-            --arg headSha "$SOURCE_REF" \
-            --arg sourceTree "$SOURCE_TREE" \
-            --argjson artifacts "$ARTIFACTS" \
-            --argjson images "$IMAGES" \
-            '{
-              schemaVersion: 1,
-              version: $version,
-              headSha: $headSha,
-              sourceTree: $sourceTree,
-              artifacts: $artifacts,
-              images: $images
-            }' \
-            > manifest.json
-
-      - uses: actions/upload-artifact@v6
-        with:
-          name: release-qualification-manifest
-          retention-days: 30
-          if-no-files-found: error
-          path: manifest.json
-
   release-qualification:
     name: Release qualification
-    needs: [detect, qualify, manifest]
+    needs: [detect, qualify]
     if: always()
     runs-on: depot-ubuntu-24.04-arm
     steps:
@@ -189,14 +89,12 @@ jobs:
           DETECT_RESULT: ${{ needs.detect.result }}
           IS_RELEASE: ${{ needs.detect.outputs.is_release }}
           QUALIFY_RESULT: ${{ needs.qualify.result }}
-          MANIFEST_RESULT: ${{ needs.manifest.result }}
         run: |
           if [ "$DETECT_RESULT" != "success" ]; then
             echo "::error::Release qualification detection failed"
             exit 1
           fi
-          if [ "$IS_RELEASE" = "true" ] && \
-             { [ "$QUALIFY_RESULT" != "success" ] || [ "$MANIFEST_RESULT" != "success" ]; }; then
+          if [ "$IS_RELEASE" = "true" ] && [ "$QUALIFY_RESULT" != "success" ]; then
             echo "::error::Release qualification did not complete successfully"
             exit 1
           fi

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -68,4 +68,5 @@ jobs:
       mode: stable
       stable_action: publish
       source_ref: ${{ needs.resolve.outputs.commit }}
+      qualification_run_id: ${{ github.run_id }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
         type: string
         required: false
         default: main
+      qualification_run_id:
+        type: string
+        required: false
+        default: ""
       dry_run:
         type: boolean
         required: false
@@ -390,8 +394,13 @@ jobs:
         if: ${{ inputs.stable_action == 'publish' && !inputs.dry_run }}
         env:
           RELEASE_COMMIT: ${{ steps.merged_version.outputs.commit }}
+          QUALIFICATION_RUN_ID: ${{ inputs.qualification_run_id }}
         run: |
-          echo "run_id=$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
+          if ! grep -qE '^[0-9]+$' <<< "$QUALIFICATION_RUN_ID"; then
+            echo "::error::Stable publication requires its orchestrator run ID"
+            exit 1
+          fi
+          echo "run_id=$QUALIFICATION_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "head_sha=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Select release source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
       version: ${{ steps.bump.outputs.version || steps.qualification_version.outputs.version || steps.merged_version.outputs.version }}
       ready: ${{ steps.release_state.outputs.ready }}
       source_ref: ${{ steps.release_source.outputs.ref }}
-      qualification_run_id: ${{ steps.verify_qualification.outputs.run_id }}
-      qualification_head_sha: ${{ steps.verify_qualification.outputs.head_sha }}
+      qualification_run_id: ${{ steps.qualification.outputs.run_id }}
+      qualification_head_sha: ${{ steps.qualification.outputs.head_sha }}
       release_commit: ${{ steps.merged_version.outputs.commit }}
     steps:
       - uses: actions/checkout@v5
@@ -385,73 +385,13 @@ jobs:
             fi
           done
 
-      - name: Login to GHCR for qualification verification
-        if: ${{ inputs.stable_action == 'publish' && !inputs.dry_run }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify release qualification
-        id: verify_qualification
+      - name: Select same-run qualification artifacts
+        id: qualification
         if: ${{ inputs.stable_action == 'publish' && !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
           RELEASE_COMMIT: ${{ steps.merged_version.outputs.commit }}
-          VERSION: ${{ steps.merged_version.outputs.version }}
         run: |
-          RUN_ID="$GITHUB_RUN_ID"
-
-          mkdir -p qualification
-          gh run download "$RUN_ID" \
-            --repo "$GITHUB_REPOSITORY" \
-            --name release-qualification-manifest \
-            --dir qualification
-          gh run download "$RUN_ID" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir qualification/artifacts
-
-          QUALIFIED_VERSION=$(jq -r '.version' qualification/manifest.json)
-          QUALIFIED_HEAD=$(jq -r '.headSha' qualification/manifest.json)
-          QUALIFIED_TREE=$(jq -r '.sourceTree' qualification/manifest.json)
-          RELEASE_TREE=$(git rev-parse "${RELEASE_COMMIT}^{tree}")
-          if [ "$QUALIFIED_VERSION" != "$VERSION" ] || \
-             [ "$QUALIFIED_HEAD" != "$RELEASE_COMMIT" ] || \
-             [ "$QUALIFIED_TREE" != "$RELEASE_TREE" ]; then
-            echo "::error::Qualified artifact set does not match the merged release tree"
-            exit 1
-          fi
-
-          jq -r '.artifacts | to_entries[] | [.key, .value] | @tsv' \
-            qualification/manifest.json |
-            while IFS=$'\t' read -r qualified_path expected_checksum; do
-              relative_path=${qualified_path#qualified-artifacts/}
-              artifact_path="qualification/artifacts/${relative_path}"
-              if [ ! -f "$artifact_path" ]; then
-                echo "::error::Qualified artifact is missing: ${relative_path}"
-                exit 1
-              fi
-              actual_checksum=$(sha256sum "$artifact_path" | awk '{print $1}')
-              if [ "$actual_checksum" != "$expected_checksum" ]; then
-                echo "::error::Qualified artifact checksum changed: ${relative_path}"
-                exit 1
-              fi
-            done
-
-          jq -r '.images | to_entries[] | [.key, .value] | @tsv' \
-            qualification/manifest.json |
-            while IFS=$'\t' read -r image expected_digest; do
-              ref="ghcr.io/alienplatform/${image}:qualification-${RELEASE_COMMIT}"
-              actual_digest=$(docker buildx imagetools inspect "$ref" |
-                sed -n 's/^Digest:[[:space:]]*//p' | head -n1)
-              if [ "$actual_digest" != "$expected_digest" ]; then
-                echo "::error::Qualified image digest changed: ${image}"
-                exit 1
-              fi
-            done
-
-          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_id=$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "head_sha=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Select release source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1960,6 +1960,36 @@ jobs:
           provenance: true
           sbom: true
 
+      - name: Record qualified image digests
+        env:
+          RELEASE_COMMIT: ${{ inputs.source_ref }}
+        run: |
+          DIGESTS='{}'
+          for name in alien-base alien-worker-typescript alien-builder alien-operator alien-manager; do
+            qualified="ghcr.io/alienplatform/${name}:qualification-${RELEASE_COMMIT}"
+            digest=$(docker buildx imagetools inspect "$qualified" |
+              sed -n 's/^Digest:[[:space:]]*//p' | head -n1)
+            if [ -z "$digest" ]; then
+              echo "::error::Qualified image ${qualified} has no manifest digest"
+              exit 1
+            fi
+            DIGESTS=$(jq --arg name "$name" --arg digest "$digest" \
+              '. + {($name): $digest}' <<< "$DIGESTS")
+          done
+          jq -n \
+            --arg releaseCommit "$RELEASE_COMMIT" \
+            --argjson images "$DIGESTS" \
+            '{releaseCommit: $releaseCommit, images: $images}' \
+            > qualified-image-digests.json
+
+      - name: Upload qualified image digests
+        uses: actions/upload-artifact@v6
+        with:
+          name: qualified-image-digests
+          retention-days: 30
+          if-no-files-found: error
+          path: qualified-image-digests.json
+
   publish-images:
     needs: prepare
     if: ${{ inputs.mode == 'stable' && needs.prepare.outputs.ready == 'true' && inputs.stable_action == 'publish' }}
@@ -1973,34 +2003,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download qualified image digests
+        uses: actions/download-artifact@v7
+        with:
+          run-id: ${{ needs.prepare.outputs.qualification_run_id }}
+          github-token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          name: qualified-image-digests
+          path: qualification
+
       - name: Promote qualified image manifests
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           RELEASE_COMMIT: ${{ needs.prepare.outputs.qualification_head_sha }}
         run: |
-          for name in alien-base alien-worker-typescript alien-builder alien-operator alien-manager; do
-            image="ghcr.io/alienplatform/${name}"
-            qualified="${image}:qualification-${RELEASE_COMMIT}"
-            source_digest=$(docker buildx imagetools inspect "$qualified" |
-              sed -n 's/^Digest:[[:space:]]*//p' | head -n1)
-            if [ -z "$source_digest" ]; then
-              echo "::error::Qualified image ${qualified} is unavailable"
-              exit 1
-            fi
+          recorded_commit=$(jq -r '.releaseCommit' qualification/qualified-image-digests.json)
+          if [ "$recorded_commit" != "$RELEASE_COMMIT" ]; then
+            echo "::error::Qualified images belong to ${recorded_commit}, expected ${RELEASE_COMMIT}"
+            exit 1
+          fi
 
-            versioned="${image}:v${VERSION}"
-            published_digest=$(docker buildx imagetools inspect "$versioned" 2>/dev/null |
-              sed -n 's/^Digest:[[:space:]]*//p' | head -n1 || true)
-            if [ -n "$published_digest" ] && [ "$published_digest" != "$source_digest" ]; then
-              echo "::error::${versioned} exists with a different manifest"
-              exit 1
-            fi
+          jq -r '.images | to_entries[] | [.key, .value] | @tsv' \
+            qualification/qualified-image-digests.json |
+            while IFS=$'\t' read -r name source_digest; do
+              image="ghcr.io/alienplatform/${name}"
+              if ! docker buildx imagetools inspect "${image}@${source_digest}" >/dev/null; then
+                echo "::error::Qualified image ${image}@${source_digest} is unavailable"
+                exit 1
+              fi
 
-            docker buildx imagetools create \
-              --tag "$versioned" \
-              --tag "${image}:latest" \
-              "${image}@${source_digest}"
-          done
+              versioned="${image}:v${VERSION}"
+              published_digest=$(docker buildx imagetools inspect "$versioned" 2>/dev/null |
+                sed -n 's/^Digest:[[:space:]]*//p' | head -n1 || true)
+              if [ -n "$published_digest" ] && [ "$published_digest" != "$source_digest" ]; then
+                echo "::error::${versioned} exists with a different manifest"
+                exit 1
+              fi
+
+              docker buildx imagetools create \
+                --tag "$versioned" \
+                --tag "${image}:latest" \
+                "${image}@${source_digest}"
+            done
 
   # Publish the GitHub release only after the registries and binary store have
   # accepted their qualified artifacts. Homebrew follows because its formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1964,40 +1964,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download qualification manifest
-        uses: actions/download-artifact@v7
-        with:
-          run-id: ${{ needs.prepare.outputs.qualification_run_id }}
-          github-token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          name: release-qualification-manifest
-          path: qualification
-
       - name: Promote qualified image manifests
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_COMMIT: ${{ needs.prepare.outputs.qualification_head_sha }}
         run: |
-          jq -r '.images | to_entries[] | [.key, .value] | @tsv' \
-            qualification/manifest.json |
-            while IFS=$'\t' read -r name source_digest; do
-              image="ghcr.io/alienplatform/${name}"
-              if ! docker buildx imagetools inspect "${image}@${source_digest}" >/dev/null; then
-                echo "::error::Qualified image ${image}@${source_digest} is unavailable"
-                exit 1
-              fi
+          for name in alien-base alien-worker-typescript alien-builder alien-operator alien-manager; do
+            image="ghcr.io/alienplatform/${name}"
+            qualified="${image}:qualification-${RELEASE_COMMIT}"
+            source_digest=$(docker buildx imagetools inspect "$qualified" |
+              sed -n 's/^Digest:[[:space:]]*//p' | head -n1)
+            if [ -z "$source_digest" ]; then
+              echo "::error::Qualified image ${qualified} is unavailable"
+              exit 1
+            fi
 
-              versioned="${image}:v${VERSION}"
-              published_digest=$(docker buildx imagetools inspect "$versioned" 2>/dev/null |
-                sed -n 's/^Digest:[[:space:]]*//p' | head -n1 || true)
-              if [ -n "$published_digest" ] && [ "$published_digest" != "$source_digest" ]; then
-                echo "::error::${versioned} exists with a different manifest"
-                exit 1
-              fi
+            versioned="${image}:v${VERSION}"
+            published_digest=$(docker buildx imagetools inspect "$versioned" 2>/dev/null |
+              sed -n 's/^Digest:[[:space:]]*//p' | head -n1 || true)
+            if [ -n "$published_digest" ] && [ "$published_digest" != "$source_digest" ]; then
+              echo "::error::${versioned} exists with a different manifest"
+              exit 1
+            fi
 
-              docker buildx imagetools create \
-                --tag "$versioned" \
-                --tag "${image}:latest" \
-                "${image}@${source_digest}"
-            done
+            docker buildx imagetools create \
+              --tag "$versioned" \
+              --tag "${image}:latest" \
+              "${image}@${source_digest}"
+          done
 
   # Publish the GitHub release only after the registries and binary store have
   # accepted their qualified artifacts. Homebrew follows because its formula


### PR DESCRIPTION
Complete the stable-release simplification after the first same-run execution exposed that the manifest was only produced by the old wrapper workflow.\n\n- Publish jobs now consume qualification artifacts from the current stable-release run.\n- The stable orchestrator already blocks publication on the complete qualification workflow.\n- Remove exact-merge requalification dispatch, historical manifests, aggregate checksums, and image-manifest discovery.\n- Preserve artifact-specific verification and idempotency in each registry/image/binary publisher.\n\nNo registry publication occurred in the failed validation run.\n\nValidation: `git diff --check`; `actionlint` reports only known custom Depot runner labels.