### PR TITLE
fix(ci): make release patch bumps tolerate missing locks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,24 +102,10 @@ jobs:
             exit 1
           fi
 
-          COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s%n%b")
-
-          if echo "$COMMITS" | grep -qE "(BREAKING[- ]CHANGE|^[a-z]+(\([^)]+\))?!:)"; then
-            BUMP="major"
-          elif echo "$COMMITS" | grep -qE "^feat(\([^)]+\))?:"; then
-            BUMP="minor"
-          else
-            BUMP="patch"
-          fi
-
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-          case "$BUMP" in
-            major) VERSION="$((MAJOR + 1)).0.0" ;;
-            minor) VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
-            patch) VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
-          esac
+          VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
 
-          echo "Bump type: $BUMP"
+          echo "Bump type: patch"
           echo "New version: v${VERSION}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -242,22 +228,17 @@ jobs:
               fs.writeFileSync(path, content.replace(/\"version\": \"[^\"]*\"/, '\"version\": \"${VERSION}\"'));
             }
           "
-          # Speakeasy emits npm locks for both SDKs and the Manager examples.
-          # Stamp embedded package metadata alongside the publish manifests.
+          # Stamp package metadata in generated npm locks when present.
           node -e "
             const fs = require('fs');
             for (const sdk of ['platform', 'manager']) {
               const lockPath = 'client-sdks/' + sdk + '/typescript/package-lock.json';
+              if (!fs.existsSync(lockPath)) continue;
               const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
               lock.version = '${VERSION}';
               lock.packages[''].version = '${VERSION}';
               fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\\n');
             }
-
-            const examplesLockPath = 'client-sdks/manager/typescript/examples/package-lock.json';
-            const examplesLock = JSON.parse(fs.readFileSync(examplesLockPath, 'utf8'));
-            examplesLock.packages['..'].version = '${VERSION}';
-            fs.writeFileSync(examplesLockPath, JSON.stringify(examplesLock, null, 2) + '\\n');
           "
           # Both checked-in generation workflows use the version from gen.yaml.
           # Advance them with the release so later regeneration cannot reset manifests.
@@ -338,19 +319,7 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock packages/core/package.json packages/commands/package.json \
-            packages/sdk/package.json packages/testing/package.json \
-            client-sdks/platform/typescript/package.json client-sdks/platform/typescript/jsr.json \
-            client-sdks/platform/typescript/package-lock.json client-sdks/platform/typescript/.speakeasy/gen.yaml \
-            client-sdks/platform/typescript/.speakeasy/gen.lock \
-            client-sdks/manager/typescript/package.json client-sdks/manager/typescript/jsr.json \
-            client-sdks/manager/typescript/package-lock.json client-sdks/manager/typescript/examples/package-lock.json \
-            client-sdks/manager/typescript/.speakeasy/gen.yaml \
-            client-sdks/manager/typescript/.speakeasy/gen.lock \
-            packages/bindings/package.json crates/alien-bindings-node/package.json \
-            packages/bindings/npm/darwin-arm64/package.json packages/bindings/npm/darwin-x64/package.json \
-            packages/bindings/npm/linux-x64-gnu/package.json packages/bindings/npm/linux-arm64-gnu/package.json \
-            packages/ai-gateway/package.json
+          git add --update
           git commit -m "chore: release v${VERSION}"
           BRANCH="$RELEASE_BRANCH"
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then


### PR DESCRIPTION
Release preparation had two stale assumptions:

- Conventional Commit markers selected major/minor bumps. Alien releases now always increment the patch version.
- Generated Manager SDK npm lockfiles were assumed to exist both while stamping and staging. The current generator omits them.

The workflow now computes only `patch + 1`, skips absent generated npm locks while stamping, and stages the tracked version changes with `git add --update` instead of maintaining a stale file list. From v3.3.0, the Remote Bindings release will therefore be v3.3.1.

Validation:
- `git diff --check`
- shell version calculation asserts `3.3.0 -> 3.3.1`
- parsed the existing generated lock metadata with the same Node logic
- `actionlint` reports only the repository’s pre-existing custom Depot runner-label warnings

This also addresses Greptile’s finding that explicit `git add` paths still failed after absent locks were skipped.