### PR TITLE
fix(ci): allow generated release metadata

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -62,6 +62,60 @@ jobs:
               echo "$unexpected"
               exit 1
             fi
+            BASE_SHA="$BASE_SHA" SOURCE_REF="$SOURCE_REF" node <<'NODE'
+            const { execFileSync } = require('child_process');
+
+            const changed = execFileSync(
+              'git',
+              ['diff', '--name-only', process.env.BASE_SHA, process.env.SOURCE_REF],
+              { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+            ).trim().split('\n').filter(Boolean);
+            const fromRef = (ref, path) => execFileSync(
+              'git',
+              ['show', ref + ':' + path],
+              { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+            );
+            const stable = (value) => {
+              if (Array.isArray(value)) return value.map(stable);
+              if (value && typeof value === 'object') {
+                return Object.fromEntries(
+                  Object.keys(value).sort().map((key) => [key, stable(value[key])]),
+                );
+              }
+              return value;
+            };
+            const normalizeJson = (path, content) => {
+              const value = JSON.parse(content);
+              value.version = '__RELEASE_VERSION__';
+              if (path.endsWith('/package-lock.json') && value.packages?.['']) {
+                value.packages[''].version = '__RELEASE_VERSION__';
+              }
+              return JSON.stringify(stable(value));
+            };
+            const normalizeSpeakeasy = (path, content) => path.endsWith('/gen.yaml')
+              ? content.replace(/(typescript:\n  version: )[^\n]+/, '$1__RELEASE_VERSION__')
+              : content.replace(/(  releaseVersion: )[^\n]+/, '$1__RELEASE_VERSION__');
+
+            for (const path of changed) {
+              let base;
+              let head;
+              if (path.endsWith('/package.json') || path.endsWith('/jsr.json') ||
+                  path.endsWith('/package-lock.json')) {
+                base = normalizeJson(path, fromRef(process.env.BASE_SHA, path));
+                head = normalizeJson(path, fromRef(process.env.SOURCE_REF, path));
+              } else if (path.endsWith('/.speakeasy/gen.yaml') ||
+                         path.endsWith('/.speakeasy/gen.lock')) {
+                base = normalizeSpeakeasy(path, fromRef(process.env.BASE_SHA, path));
+                head = normalizeSpeakeasy(path, fromRef(process.env.SOURCE_REF, path));
+              } else {
+                continue;
+              }
+              if (base !== head) {
+                console.error('::error::Release PR changes non-version metadata in ' + path);
+                process.exit(1);
+              }
+            }
+          NODE
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_release=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -55,7 +55,7 @@ jobs:
               echo "::error::Release qualification requires a Linear-derived branch"
               exit 1
             fi
-            allowed='^(Cargo.toml|Cargo.lock|packages/(core|commands|sdk|testing|bindings|ai-gateway)/package.json|crates/alien-bindings-node/package.json|client-sdks/(platform|manager)/typescript/package.json|packages/bindings/npm/(darwin-arm64|darwin-x64|linux-x64-gnu|linux-arm64-gnu)/package.json)$'
+            allowed='^(Cargo.toml|Cargo.lock|packages/(core|commands|sdk|testing|bindings|ai-gateway)/package.json|crates/alien-bindings-node/package.json|client-sdks/(platform|manager)/typescript/(package.json|jsr.json|package-lock.json|\.speakeasy/(gen.yaml|gen.lock))|packages/bindings/npm/(darwin-arm64|darwin-x64|linux-x64-gnu|linux-arm64-gnu)/package.json)$'
             unexpected=$(git diff --name-only "$BASE_SHA" "$SOURCE_REF" | grep -Ev "$allowed" || true)
             if [ -n "$unexpected" ]; then
               echo "::error::Release PR contains non-version files:"


### PR DESCRIPTION
The release preparer now advances JSR, Speakeasy, and existing npm-lock metadata alongside package manifests, but release qualification still rejected those generated version files as non-release changes.

Extend the version-only allowlist to the exact metadata paths produced by the preparer. Source files and other generated SDK content remain rejected.

Validation:
- every file in release PR #275 matches the updated allowlist
- an SDK source file does not match
- `git diff --check`
- `actionlint` reports only existing custom Depot runner-label warnings

This is workflow-only; path-aware CI should skip the Rust and TypeScript product suites.