### PR TITLE
feat(ai): serve the GPT-5 family over the Responses API

### DIFF
--- a/crates/alien-ai-gateway/src/availability.rs
+++ b/crates/alien-ai-gateway/src/availability.rs
@@ -161,10 +161,10 @@ fn openai_probe(route: &GatewayRoute, cm: &CatalogModel) -> Result<Probe> {
 /// 400, which classifies as unavailable and would hide a live model.
 fn responses_probe(route: &GatewayRoute, cm: &CatalogModel) -> Result<Probe> {
     if route.cloud != Platform::Aws {
-        return Err(missing_field(route, "aws cloud for the Responses API"));
+        return Err(missing_field(route, "AWS cloud"));
     }
     let target = ai_catalog::responses_target(cm.public_id)
-        .ok_or_else(|| missing_field(route, "a Responses endpoint for this model"))?;
+        .ok_or_else(|| missing_field(route, "Responses endpoint"))?;
     let region = route.region.as_deref().ok_or_else(|| missing_field(route, "region"))?;
     let base = route
         .upstream_base_override

--- a/crates/alien-ai-gateway/src/availability.rs
+++ b/crates/alien-ai-gateway/src/availability.rs
@@ -107,6 +107,7 @@ async fn probe_model(
     let built = match cm.protocol {
         Protocol::OpenAi => openai_probe(route, cm),
         Protocol::Anthropic => anthropic_probe(route, cm),
+        Protocol::OpenAiResponses => responses_probe(route, cm),
     };
     let (url, service, body, extra_headers) = match built {
         Ok(probe) => probe,
@@ -153,6 +154,30 @@ type Probe = (String, &'static str, Vec<u8>, Vec<(&'static str, String)>);
 fn openai_probe(route: &GatewayRoute, cm: &CatalogModel) -> Result<Probe> {
     let (url, service) = upstream_target(route, Protocol::OpenAi)?;
     Ok((url, service, openai_body(cm.upstream_id), Vec::new()))
+}
+
+/// The same mantle endpoint `proxy_responses` forwards to, with a minimal body.
+/// `max_output_tokens` is the API floor rather than 1: below it the request is a
+/// 400, which classifies as unavailable and would hide a live model.
+fn responses_probe(route: &GatewayRoute, cm: &CatalogModel) -> Result<Probe> {
+    if route.cloud != Platform::Aws {
+        return Err(missing_field(route, "aws cloud for the Responses API"));
+    }
+    let target = ai_catalog::responses_target(cm.public_id)
+        .ok_or_else(|| missing_field(route, "a Responses endpoint for this model"))?;
+    let region = route.region.as_deref().ok_or_else(|| missing_field(route, "region"))?;
+    let base = route
+        .upstream_base_override
+        .clone()
+        .unwrap_or_else(|| format!("https://bedrock-mantle.{region}.api.aws"));
+    let body = json!({
+        "model": target.upstream_id,
+        "input": "ping",
+        "max_output_tokens": 16,
+    })
+    .to_string()
+    .into_bytes();
+    Ok((format!("{}{}", base.trim_end_matches('/'), target.path), "bedrock-mantle", body, Vec::new()))
 }
 
 /// Build the same per-cloud Claude endpoint the proxy uses (Bedrock InvokeModel /

--- a/crates/alien-ai-gateway/src/router/bedrock.rs
+++ b/crates/alien-ai-gateway/src/router/bedrock.rs
@@ -108,6 +108,11 @@ pub(crate) async fn proxy_bedrock_anthropic(
         .is_some_and(|t| t != "enabled" && t != "disabled");
     if thinking_unsupported {
         obj.remove("thinking");
+    } else if let Some(thinking) = obj.get_mut("thinking").and_then(Value::as_object_mut) {
+        // `display` is newer than the pinned schema. The current models tolerate it,
+        // but Opus 4.1 answers `thinking.enabled.display: Extra inputs are not
+        // permitted`, so Claude Code cannot reach it at all without this.
+        thinking.remove("display");
     }
     // Anthropic *server*-executed tool types (web_search, code_execution, web fetch,
     // advisor) run on Anthropic's own API servers, which InvokeModel is not, so

--- a/crates/alien-ai-gateway/src/router/mod.rs
+++ b/crates/alien-ai-gateway/src/router/mod.rs
@@ -795,9 +795,9 @@ mod tests {
 
     #[tokio::test]
     async fn responses_only_models_are_refused_on_chat_completions() {
-        // These models list once AWS grants access, and a chat-completions client
-        // will then ask for one. It has to be told where to send it, not handed the
-        // catch-all's 500 claiming AWS does not serve the protocol.
+        // A chat-completions client will ask for one of these as soon as they list,
+        // so it has to be told where to send it rather than handed the catch-all's
+        // 500 claiming the cloud does not serve the protocol.
         let server = MockServer::start_async().await;
         let upstream = server
             .mock_async(|when, then| {
@@ -1140,6 +1140,48 @@ mod tests {
                 "output_config": {"effort": "xhigh"},
                 "context_management": {"edits": []},
                 "thinking": {"type": "adaptive"},
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(resp.status(), 200);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn bedrock_path_drops_thinking_display_but_keeps_the_thinking() {
+        // Opus 4.1 answers `thinking.enabled.display: Extra inputs are not permitted`,
+        // so Claude Code cannot reach it at all while the field is forwarded. Dropping
+        // the whole thinking block instead would silently turn extended thinking off.
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke-with-response-stream")
+                    .matches(|req: &HttpMockRequest| {
+                        let body = req
+                            .body
+                            .as_deref()
+                            .map(String::from_utf8_lossy)
+                            .unwrap_or_default();
+                        !body.contains("display") && body.contains("budget_tokens")
+                    });
+                then.status(200)
+                    .header("content-type", "application/vnd.amazon.eventstream")
+                    .body(eventstream_frame(r#"{"type":"message_stop"}"#));
+            })
+            .await;
+
+        let url = serve(build_router(vec![aws_route(&server.base_url())])).await;
+        let resp = reqwest::Client::new()
+            .post(format!("{url}/llm/v1/messages"))
+            .json(&json!({
+                "model": "claude-haiku-4.5",
+                "stream": true,
+                "max_tokens": 2048,
+                "thinking": {"type": "enabled", "budget_tokens": 1024, "display": "omitted"},
                 "messages": [{"role": "user", "content": "hi"}]
             }))
             .send()

--- a/crates/alien-ai-gateway/src/router/mod.rs
+++ b/crates/alien-ai-gateway/src/router/mod.rs
@@ -248,6 +248,18 @@ async fn proxy(
             .await;
     }
 
+    // Bedrock's model cards mark Chat Completions unsupported for these, so there is
+    // no chat endpoint to forward to. Without this, `upstream_target` falls to its
+    // catch-all and answers an opaque 500 saying the cloud does not serve the protocol.
+    if cm.protocol == Protocol::OpenAiResponses {
+        return Err(AlienError::new(ErrorData::InvalidRequest {
+            message: format!(
+                "model `{model}` is served over the Responses API; \
+                 send it to /{binding}/v1/responses instead of /v1/chat/completions"
+            ),
+        }));
+    }
+
     payload["model"] = Value::String(cm.upstream_id.to_string());
     let upstream_body = serde_json::to_vec(&payload)
         .into_alien_error()
@@ -284,7 +296,7 @@ async fn proxy_responses(
 
     // The Responses table implies AWS; the binding's cloud must still match so a
     // GCP/Azure binding doesn't forward to an AWS endpoint it has no credential for.
-    let upstream_id = ai_catalog::responses_upstream_id(&model)
+    let target = ai_catalog::responses_target(&model)
         .filter(|_| route.cloud == Platform::Aws)
         .ok_or_else(|| {
             AlienError::new(ErrorData::ModelNotAvailable {
@@ -293,7 +305,7 @@ async fn proxy_responses(
             })
         })?;
 
-    payload["model"] = Value::String(upstream_id.to_string());
+    payload["model"] = Value::String(target.upstream_id.to_string());
     let upstream_body = serde_json::to_vec(&payload)
         .into_alien_error()
         .context(ErrorData::Other {
@@ -305,7 +317,7 @@ async fn proxy_responses(
         .upstream_base_override
         .clone()
         .unwrap_or_else(|| format!("https://bedrock-mantle.{region}.api.aws"));
-    let url = format!("{}/v1/responses", base.trim_end_matches('/'));
+    let url = format!("{}{}", base.trim_end_matches('/'), target.path);
 
     let upstream =
         sign_and_execute(&state.client, &route.cred, &url, "bedrock-mantle", upstream_body, &[])
@@ -779,6 +791,35 @@ mod tests {
         // The mock only matches when the body carries the rewritten upstream id and an
         // Authorization header, so a hit proves the model rewrite and cred injection.
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn responses_only_models_are_refused_on_chat_completions() {
+        // These models list once AWS grants access, and a chat-completions client
+        // will then ask for one. It has to be told where to send it, not handed the
+        // catch-all's 500 claiming AWS does not serve the protocol.
+        let server = MockServer::start_async().await;
+        let upstream = server
+            .mock_async(|when, then| {
+                when.method(POST);
+                then.status(200).body("{}");
+            })
+            .await;
+
+        let url = serve(build_router(vec![aws_route(&server.base_url())])).await;
+        let resp = reqwest::Client::new()
+            .post(format!("{url}/llm/v1/chat/completions"))
+            .json(&json!({"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(resp.status(), 400);
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("GATEWAY_INVALID_REQUEST"), "wrong error variant: {body}");
+        assert!(body.contains("/v1/responses"), "must name the endpoint to use: {body}");
+        // Nothing may reach the cloud: a forwarded request would be signed and billed.
+        upstream.assert_hits_async(0).await;
     }
 
     #[tokio::test]
@@ -1470,6 +1511,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gpt5_responses_use_the_openai_prefixed_path() {
+        // The GPT-5 family serves on `/openai/v1/responses`, not the `/v1/responses`
+        // the open-weight models use. Sending it to the shared path 404s upstream.
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/openai/v1/responses")
+                    .body_contains("\"openai.gpt-5.6-sol\"");
+                then.status(200).header("content-type", "application/json").body("{}");
+            })
+            .await;
+
+        let url = serve(build_router(vec![aws_route(&server.base_url())])).await;
+        let resp = reqwest::Client::new()
+            .post(format!("{url}/llm/v1/responses"))
+            .json(&json!({"model":"gpt-5.6-sol","input":[{"role":"user","content":"hi"}]}))
+            .send()
+            .await
+            .expect("proxy request");
+
+        assert_eq!(resp.status(), 200);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn claude_over_responses_is_404() {
         // Claude on mantle is Messages-only; a Claude id over /v1/responses must be
         // rejected by the gateway, not forwarded.
@@ -1508,6 +1575,50 @@ mod tests {
             body.contains("GATEWAY_MODEL_NOT_AVAILABLE"),
             "the 404 must be the gateway's own rejection, not a forwarded upstream 404: {body}"
         );
+    }
+
+    #[tokio::test]
+    async fn responses_only_models_are_listed_when_their_endpoint_answers() {
+        // The GPT-5 family serves no chat endpoint, so the chat probe would reject it.
+        // It must be probed on its own mantle Responses path instead, or it would
+        // never appear in /v1/models despite being usable.
+        let server = MockServer::start_async().await;
+        let responses = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/openai/v1/responses");
+                then.status(200).header("content-type", "application/json").body("{}");
+            })
+            .await;
+        // Everything else on this account is denied, so a pass can only come from
+        // the Responses probe above.
+        server
+            .mock_async(|when, then| {
+                when.method(POST).matches(|req: &HttpMockRequest| {
+                    !req.path.contains("/openai/v1/responses")
+                });
+                then.status(403).body("access denied");
+            })
+            .await;
+
+        let url = serve(build_router(vec![aws_route(&server.base_url())])).await;
+        let body: Value = reqwest::get(format!("{url}/llm/v1/models"))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let ids: Vec<&str> =
+            body["data"].as_array().unwrap().iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        assert!(ids.contains(&"gpt-5.6-sol"), "gpt-5.6-sol must be listed: {ids:?}");
+        assert!(responses.hits_async().await > 0, "the Responses path must be probed");
+        let sol = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["id"] == "gpt-5.6-sol")
+            .expect("gpt-5.6-sol entry");
+        assert_eq!(sol["displayName"], "GPT-5.6 Sol");
     }
 
     #[tokio::test]

--- a/crates/alien-core/src/ai_catalog.rs
+++ b/crates/alien-core/src/ai_catalog.rs
@@ -22,6 +22,9 @@ pub enum Protocol {
     OpenAi,
     /// Anthropic Messages (`/v1/messages`).
     Anthropic,
+    /// OpenAI Responses on bedrock-mantle. The only API the GPT-5 family serves;
+    /// the exact path is per-model, see `RESPONSES_UPSTREAM`.
+    OpenAiResponses,
 }
 
 /// The one-time action, if any, a customer must take in the cloud provider before
@@ -87,6 +90,11 @@ impl CatalogModel {
     /// acronyms (GPT, OSS, GLM, VL) and versions read correctly.
     pub fn display_name(&self) -> &'static str {
         match self.public_id {
+            "gpt-5.6-sol" => "GPT-5.6 Sol",
+            "gpt-5.6-terra" => "GPT-5.6 Terra",
+            "gpt-5.6-luna" => "GPT-5.6 Luna",
+            "gpt-5.5" => "GPT-5.5",
+            "gpt-5.4" => "GPT-5.4",
             "gpt-oss-20b" => "GPT-OSS 20B",
             "gpt-oss-120b" => "GPT-OSS 120B",
             "gpt-oss-safeguard-20b" => "GPT-OSS Safeguard 20B",
@@ -118,6 +126,7 @@ impl CatalogModel {
             "glm-4.7-flash" => "GLM 4.7 Flash",
             "glm-5" => "GLM 5",
             "palmyra-vision-7b" => "Palmyra Vision 7B",
+            "claude-opus-5" => "Claude Opus 5",
             "claude-sonnet-5" => "Claude Sonnet 5",
             "claude-opus-4.8" => "Claude Opus 4.8",
             "claude-opus-4.7" => "Claude Opus 4.7",
@@ -129,6 +138,8 @@ impl CatalogModel {
             "claude-haiku-4.5" => "Claude Haiku 4.5",
             "claude-fable-5" => "Claude Fable 5",
             "claude-mythos-5" => "Claude Mythos 5",
+            "claude-sonnet-4" => "Claude Sonnet 4",
+            "claude-3-haiku" => "Claude 3 Haiku",
             "gemini-2.5-pro" => "Gemini 2.5 Pro",
             "gemini-2.5-flash" => "Gemini 2.5 Flash",
             "gemini-2.5-flash-lite" => "Gemini 2.5 Flash Lite",
@@ -166,6 +177,14 @@ static CATALOG: &[CatalogModel] = &[
     // AWS Bedrock over `/openai/v1` chat completions. The plain Bedrock model id,
     // not the `us.*` cross-region inference profile — that endpoint rejects it.
     // Invoke/Converse-only models (older Llama/Mistral-v0/Nova) can't be served here.
+    // The GPT-5 family is Responses-only: chat completions, converse and invoke are
+    // all unavailable, so `upstream_id` here is the mantle id and the chat probe
+    // would reject them.
+    CatalogModel { public_id: "gpt-5.6-sol", cloud: Platform::Aws, upstream_id: "openai.gpt-5.6-sol", protocol: Protocol::OpenAiResponses },
+    CatalogModel { public_id: "gpt-5.6-terra", cloud: Platform::Aws, upstream_id: "openai.gpt-5.6-terra", protocol: Protocol::OpenAiResponses },
+    CatalogModel { public_id: "gpt-5.6-luna", cloud: Platform::Aws, upstream_id: "openai.gpt-5.6-luna", protocol: Protocol::OpenAiResponses },
+    CatalogModel { public_id: "gpt-5.5", cloud: Platform::Aws, upstream_id: "openai.gpt-5.5", protocol: Protocol::OpenAiResponses },
+    CatalogModel { public_id: "gpt-5.4", cloud: Platform::Aws, upstream_id: "openai.gpt-5.4", protocol: Protocol::OpenAiResponses },
     CatalogModel { public_id: "gpt-oss-20b", cloud: Platform::Aws, upstream_id: "openai.gpt-oss-20b-1:0", protocol: Protocol::OpenAi },
     CatalogModel { public_id: "gpt-oss-120b", cloud: Platform::Aws, upstream_id: "openai.gpt-oss-120b-1:0", protocol: Protocol::OpenAi },
     CatalogModel { public_id: "gpt-oss-safeguard-20b", cloud: Platform::Aws, upstream_id: "openai.gpt-oss-safeguard-20b", protocol: Protocol::OpenAi },
@@ -203,6 +222,7 @@ static CATALOG: &[CatalogModel] = &[
     // geo prefix (`us.`/`eu.`/`apac.`) at request time, since Claude is invocable only
     // through a profile. Dated ids (`…-<date>-v1:0`) are required where AWS has no short
     // alias. These need Claude model access granted on the deployment's account.
+    CatalogModel { public_id: "claude-opus-5", cloud: Platform::Aws, upstream_id: "anthropic.claude-opus-5", protocol: Protocol::Anthropic },
     CatalogModel { public_id: "claude-sonnet-5", cloud: Platform::Aws, upstream_id: "anthropic.claude-sonnet-5", protocol: Protocol::Anthropic },
     CatalogModel { public_id: "claude-opus-4.8", cloud: Platform::Aws, upstream_id: "anthropic.claude-opus-4-8", protocol: Protocol::Anthropic },
     CatalogModel { public_id: "claude-opus-4.7", cloud: Platform::Aws, upstream_id: "anthropic.claude-opus-4-7", protocol: Protocol::Anthropic },
@@ -214,6 +234,8 @@ static CATALOG: &[CatalogModel] = &[
     CatalogModel { public_id: "claude-haiku-4.5", cloud: Platform::Aws, upstream_id: "anthropic.claude-haiku-4-5-20251001-v1:0", protocol: Protocol::Anthropic },
     CatalogModel { public_id: "claude-fable-5", cloud: Platform::Aws, upstream_id: "anthropic.claude-fable-5", protocol: Protocol::Anthropic },
     CatalogModel { public_id: "claude-mythos-5", cloud: Platform::Aws, upstream_id: "anthropic.claude-mythos-5", protocol: Protocol::Anthropic },
+    CatalogModel { public_id: "claude-sonnet-4", cloud: Platform::Aws, upstream_id: "anthropic.claude-sonnet-4-20250514-v1:0", protocol: Protocol::Anthropic },
+    CatalogModel { public_id: "claude-3-haiku", cloud: Platform::Aws, upstream_id: "anthropic.claude-3-haiku-20240307-v1:0", protocol: Protocol::Anthropic },
     // GCP Vertex, Gemini. The OpenAI-compatible Vertex endpoint expects the `google/` prefix.
     // The 2.5 family serves in-region; the 3.x models serve on the `global` location.
     CatalogModel { public_id: "gemini-2.5-pro", cloud: Platform::Gcp, upstream_id: "google/gemini-2.5-pro", protocol: Protocol::OpenAi },
@@ -268,23 +290,37 @@ static AZURE_DEPLOYMENTS: &[(&str, &str, &str)] = &[
     ("model-router", "model-router", "2025-11-18"),
 ];
 
-/// AWS models servable over the bedrock-mantle OpenAI Responses API, mapped to the
-/// id that endpoint expects (mantle drops the InvokeModel version suffix, and only
-/// a subset of the chat catalog supports Responses at all — Claude is Messages-only
-/// and e.g. Qwen rejects it). Kept explicit rather than derived: the two id schemes
-/// differ per model family, not by a rule.
-static RESPONSES_UPSTREAM: &[(&str, &str)] = &[
-    ("gpt-oss-20b", "openai.gpt-oss-20b"),
-    ("gpt-oss-120b", "openai.gpt-oss-120b"),
+/// Where a model sits on the bedrock-mantle Responses API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponsesTarget {
+    /// The id mantle expects, which drops the InvokeModel version suffix.
+    pub upstream_id: &'static str,
+    /// Path under the mantle host. The GPT-5 family serves on `/openai/v1/responses`,
+    /// the open-weight models on `/v1/responses`.
+    pub path: &'static str,
+}
+
+/// AWS models servable over the bedrock-mantle OpenAI Responses API. Only a subset
+/// of the chat catalog supports Responses at all — Claude is Messages-only and e.g.
+/// Qwen rejects it. Kept explicit rather than derived: both the id scheme and the
+/// path differ per model family, not by a rule.
+static RESPONSES_UPSTREAM: &[(&str, ResponsesTarget)] = &[
+    ("gpt-oss-20b", ResponsesTarget { upstream_id: "openai.gpt-oss-20b", path: "/v1/responses" }),
+    ("gpt-oss-120b", ResponsesTarget { upstream_id: "openai.gpt-oss-120b", path: "/v1/responses" }),
+    ("gpt-5.6-sol", ResponsesTarget { upstream_id: "openai.gpt-5.6-sol", path: "/openai/v1/responses" }),
+    ("gpt-5.6-terra", ResponsesTarget { upstream_id: "openai.gpt-5.6-terra", path: "/openai/v1/responses" }),
+    ("gpt-5.6-luna", ResponsesTarget { upstream_id: "openai.gpt-5.6-luna", path: "/openai/v1/responses" }),
+    ("gpt-5.5", ResponsesTarget { upstream_id: "openai.gpt-5.5", path: "/openai/v1/responses" }),
+    ("gpt-5.4", ResponsesTarget { upstream_id: "openai.gpt-5.4", path: "/openai/v1/responses" }),
 ];
 
-/// The bedrock-mantle Responses-API id for a public model id, or `None` when the
+/// The bedrock-mantle Responses target for a public model id, or `None` when the
 /// model is not servable over the Responses API.
-pub fn responses_upstream_id(public_id: &str) -> Option<&'static str> {
+pub fn responses_target(public_id: &str) -> Option<ResponsesTarget> {
     RESPONSES_UPSTREAM
         .iter()
         .find(|(public, _)| *public == public_id)
-        .map(|(_, upstream)| *upstream)
+        .map(|(_, target)| *target)
 }
 
 pub fn models_for(cloud: Platform) -> Vec<&'static CatalogModel> {
@@ -527,6 +563,22 @@ mod tests {
                     assert!(!summary.is_empty(), "'{}' step summary is empty", m.public_id);
                 }
             }
+        }
+    }
+
+    /// The gateway forwards, it does not translate, so a client picks its wire format
+    /// from the model id alone. Break this and an OpenAI body reaches the Anthropic
+    /// upstream, or the reverse, for a bare 400 no caller can act on.
+    #[test]
+    fn only_claude_ids_speak_the_anthropic_protocol() {
+        for m in CATALOG {
+            assert_eq!(
+                m.protocol == Protocol::Anthropic,
+                m.public_id.starts_with("claude"),
+                "'{}' is {:?} but its id says otherwise",
+                m.public_id,
+                m.protocol
+            );
         }
     }
 }

--- a/crates/alien-core/src/ai_catalog.rs
+++ b/crates/alien-core/src/ai_catalog.rs
@@ -540,6 +540,10 @@ mod tests {
     fn protocol_serializes_lowercase() {
         assert_eq!(serde_json::to_string(&Protocol::OpenAi).unwrap(), "\"openai\"");
         assert_eq!(serde_json::to_string(&Protocol::Anthropic).unwrap(), "\"anthropic\"");
+        assert_eq!(
+            serde_json::to_string(&Protocol::OpenAiResponses).unwrap(),
+            "\"openairesponses\""
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bedrock serves five GPT-5 models the catalog did not list, and they speak only the Responses API. This adds them along with three more Claude models, and stops one request field from making Opus 4.1 unreachable.

When a request arrives for one of these models:

1. `resolve_for` finds the catalog row and reads its protocol.
2. **The router forwards a Responses model to the mantle endpoint at the path that model's family uses** — `/openai/v1/responses` for GPT-5, `/v1/responses` for the open-weight ones. The two paths reject each other outright, so the table carries the path next to the id rather than deriving it.
3. A chat-completions request for one of them gets a 400 naming the endpoint to use, instead of falling through to `upstream_target`'s catch-all and answering an opaque 500.

This turns "the model is missing, or the gateway broke" into "the model is here, at this endpoint".

## What I did

The Claude additions are rows: Opus 5, Sonnet 4 and 3 Haiku all speak the Messages API the catalog already handles.

The GPT-5 family needed a third protocol. They were also invisible for a second reason: the availability probe asks every model a chat-completions question, and a model that serves no chat endpoint answers 400, which reads as "not enabled" and drops it from `/v1/models`. They now get a probe against the endpoint they answer on, asking for the smallest output the API permits rather than a single token — below that floor the request is a 400 and the fix would have hidden the models the same way the original bug did.

Ids come from the model cards, not from the naming pattern. The pattern does not hold: some carry a variant suffix and some do not, and the punctuation differs between families. A mistyped id and an un-enabled model are indistinguishable at runtime, since both fail the probe and vanish from the list.

Separately, Claude Code sends `thinking.display`, which is newer than the pinned `bedrock-2023-05-31` schema. Current models tolerate it; Opus 4.1 rejects the whole request with `thinking.enabled.display: Extra inputs are not permitted`. The bridge already strips fields outside that schema, so this strips one more — the field, not the whole thinking block, which would quietly turn extended thinking off instead.

## Files touched

- `alien-core/src/ai_catalog.rs` — the new protocol, eight catalog rows, and the per-model Responses path
- `alien-ai-gateway/src/availability.rs` — a Responses arm for the probe
- `alien-ai-gateway/src/router/mod.rs` — per-model path when forwarding; the wrong-endpoint guard
- `alien-ai-gateway/src/router/bedrock.rs` — drop `thinking.display`

## How I tested

`cargo test -p alien-ai-gateway -p alien-core` (543) and `cargo clippy --all-targets` are clean on top of current `main`.

Four new tests, each pinning a way this breaks rather than restating it: the wrong-endpoint case asserts the 400 **and** that zero requests reached the cloud; the listing test denies every path except `/openai/v1/responses`, so a pass can only come from the new probe; the thinking test asserts `display` is absent **and** `budget_tokens` still present.

The path split was checked against live Bedrock rather than inferred:

|  | `/v1/responses` | `/openai/v1/responses` |
|---|---|---|
| `openai.gpt-oss-120b` | 200 | 400 "does not support" |
| `openai.gpt-5.6-sol` | 400 "does not support" | 401 access_denied |

Each family rejects the other's path, so the per-model path is required, not cosmetic. The 401 on the correct path is what shows the routing is right and only entitlement is missing. `thinking.display` was isolated the same way: the identical request minus that one field returns 200 from Opus 4.1.

One limitation worth stating: no GPT-5 model can be invoked from our account yet, so the five ids are documented but unproven end to end. A mistyped id fails identically to an unentitled one.

- The guard rejects before signing or forwarding — the test asserts zero upstream hits, so a wrong-endpoint request is never signed or billed.
- The 400 is `internal = false` and carries only the model id and binding name, no credentials or endpoint internals.
- The body sanitiser only removes fields, never adds or rewrites them, and the test pins that the surrounding thinking block survives.
- Nothing turned up.
