### PR TITLE
fix(aws): consolidate CloudFormation inline policies

### DIFF
--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -1,5 +1,6 @@
 use crate::{
     emitters::enabled,
+    inline_policy::consolidate_role_inline_policies,
     registry::CfRegistry,
     template::{
         CfExpression, CfMapping, CfOutput, CfParameter, CfResource, CfRule, CfRuleAssertion,
@@ -388,6 +389,7 @@ pub fn generate_cloudformation_template(
         supports_custom_domain,
     );
     apply_resource_dependencies(stack, &emitted_resource_ids, &mut template);
+    consolidate_role_inline_policies(&mut template);
 
     if let Some(service_token) = options.registration.service_token(&mut template)? {
         add_custom_resource(

--- a/crates/alien-cloudformation/src/inline_policy.rs
+++ b/crates/alien-cloudformation/src/inline_policy.rs
@@ -1,0 +1,344 @@
+use crate::{
+    emitters::aws::helpers::uniquify_iam_statement_sids,
+    template::{CfExpression, CfResource, CfTemplate},
+};
+use indexmap::IndexMap;
+
+const IAM_POLICY_RESOURCE_TYPE: &str = "AWS::IAM::Policy";
+
+#[derive(PartialEq)]
+struct PolicyGroupKey {
+    roles: CfExpression,
+    condition: Option<String>,
+    document_properties: IndexMap<String, CfExpression>,
+}
+
+struct PolicyGroup {
+    key: PolicyGroupKey,
+    policy_ids: Vec<String>,
+}
+
+/// Combines compatible external inline policies attached to the same roles.
+///
+/// IAM applies one aggregate size quota to every inline policy on a role. The
+/// resource emitters intentionally produce independent permission grants, so a
+/// role with many grants otherwise repeats policy-document and statement
+/// overhead until it reaches that quota. Combining the documents also lets us
+/// safely combine equal actions across resources and equal resources across
+/// actions without broadening access.
+pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) {
+    let mut groups: Vec<PolicyGroup> = Vec::new();
+
+    for (logical_id, resource) in &template.resources {
+        let Some(key) = policy_group_key(resource) else {
+            continue;
+        };
+
+        if policy_is_referenced(template, logical_id) {
+            continue;
+        }
+
+        if let Some(group) = groups.iter_mut().find(|group| group.key == key) {
+            group.policy_ids.push(logical_id.clone());
+        } else {
+            groups.push(PolicyGroup {
+                key,
+                policy_ids: vec![logical_id.clone()],
+            });
+        }
+    }
+
+    let mut replacements = IndexMap::new();
+    let mut consolidated_resources = Vec::new();
+    let mut consolidated_ids = Vec::new();
+    for (group_index, group) in groups.into_iter().enumerate() {
+        if group.policy_ids.len() < 2 {
+            continue;
+        }
+
+        let logical_id =
+            consolidated_policy_logical_id(template, &consolidated_ids, &group.key, group_index);
+        consolidated_ids.push(logical_id.clone());
+        let mut statements = Vec::new();
+        let mut dependencies = Vec::new();
+        for policy_id in &group.policy_ids {
+            let policy = template
+                .resources
+                .get(policy_id)
+                .expect("grouped IAM policy should exist");
+            let CfExpression::Object(policy_document) = &policy.properties["PolicyDocument"] else {
+                unreachable!("grouped IAM policy document should be an object");
+            };
+            let Some(CfExpression::List(policy_statements)) = policy_document.get("Statement")
+            else {
+                unreachable!("grouped IAM policy statements should be a list");
+            };
+
+            statements.extend(policy_statements.iter().cloned());
+            dependencies.extend(policy.depends_on.iter().cloned());
+        }
+
+        let mut consolidated = template
+            .resources
+            .get(&group.policy_ids[0])
+            .expect("grouped IAM policy should exist")
+            .clone();
+        consolidated.logical_id = logical_id.clone();
+        consolidated.properties.insert(
+            "PolicyName".to_string(),
+            CfExpression::from(format!("resource-permissions-{}", group_index + 1)),
+        );
+        let CfExpression::Object(policy_document) = consolidated
+            .properties
+            .get_mut("PolicyDocument")
+            .expect("consolidated IAM policy document should exist")
+        else {
+            unreachable!("consolidated IAM policy document should be an object");
+        };
+        policy_document.insert(
+            "Statement".to_string(),
+            CfExpression::list(compact_statements(statements)),
+        );
+        consolidated.depends_on = deduplicate(dependencies);
+        consolidated_resources.push(consolidated);
+
+        for removed_id in &group.policy_ids {
+            replacements.insert(removed_id.clone(), logical_id.clone());
+        }
+    }
+
+    for removed_id in replacements.keys() {
+        template.resources.shift_remove(removed_id);
+    }
+    for resource in consolidated_resources {
+        template
+            .resources
+            .insert(resource.logical_id.clone(), resource);
+    }
+    for resource in template.resources.values_mut() {
+        for dependency in &mut resource.depends_on {
+            if let Some(retained_id) = replacements.get(dependency) {
+                *dependency = retained_id.clone();
+            }
+        }
+        resource.depends_on = deduplicate(std::mem::take(&mut resource.depends_on));
+    }
+}
+
+fn consolidated_policy_logical_id(
+    template: &CfTemplate,
+    consolidated_ids: &[String],
+    key: &PolicyGroupKey,
+    group_index: usize,
+) -> String {
+    let role_id = match &key.roles {
+        CfExpression::List(roles) if roles.len() == 1 => match &roles[0] {
+            CfExpression::Object(role_ref) => match role_ref.get("Ref") {
+                Some(CfExpression::String(role_id)) => Some(role_id.as_str()),
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    };
+    let base = role_id
+        .map(|role_id| format!("{role_id}InlinePermissions"))
+        .unwrap_or_else(|| format!("ConsolidatedRoleInlinePermissions{}", group_index + 1));
+
+    if !template.resources.contains_key(&base) && !consolidated_ids.contains(&base) {
+        return base;
+    }
+
+    (2..)
+        .map(|suffix| format!("{base}{suffix}"))
+        .find(|candidate| {
+            !template.resources.contains_key(candidate) && !consolidated_ids.contains(candidate)
+        })
+        .expect("a unique CloudFormation logical id should be available")
+}
+
+fn policy_group_key(resource: &CfResource) -> Option<PolicyGroupKey> {
+    if resource.resource_type != IAM_POLICY_RESOURCE_TYPE
+        || !resource.metadata.is_empty()
+        || resource.deletion_policy.is_some()
+        || resource.update_replace_policy.is_some()
+        || resource.properties.contains_key("Groups")
+        || resource.properties.contains_key("Users")
+    {
+        return None;
+    }
+
+    let roles = resource.properties.get("Roles")?.clone();
+    let CfExpression::Object(policy_document) = resource.properties.get("PolicyDocument")? else {
+        return None;
+    };
+    if !matches!(
+        policy_document.get("Statement"),
+        Some(CfExpression::List(_))
+    ) {
+        return None;
+    }
+
+    let mut document_properties = policy_document.clone();
+    document_properties.shift_remove("Statement");
+
+    Some(PolicyGroupKey {
+        roles,
+        condition: resource.condition.clone(),
+        document_properties,
+    })
+}
+
+fn policy_is_referenced(template: &CfTemplate, policy_id: &str) -> bool {
+    template
+        .resources
+        .values()
+        .flat_map(|resource| resource.properties.values())
+        .chain(template.conditions.values())
+        .chain(template.outputs.values().flat_map(|output| {
+            std::iter::once(&output.value)
+                .chain(output.export.iter().flat_map(|export| export.values()))
+        }))
+        .any(|expression| expression_references(expression, policy_id))
+}
+
+fn expression_references(expression: &CfExpression, logical_id: &str) -> bool {
+    match expression {
+        CfExpression::String(value) => {
+            value == logical_id
+                || value.starts_with(&format!("{logical_id}."))
+                || value.contains(&format!("${{{logical_id}}}"))
+                || value.contains(&format!("${{{logical_id}."))
+        }
+        CfExpression::List(values) => values
+            .iter()
+            .any(|value| expression_references(value, logical_id)),
+        CfExpression::Object(values) => values
+            .values()
+            .any(|value| expression_references(value, logical_id)),
+        CfExpression::Null
+        | CfExpression::Bool(_)
+        | CfExpression::Integer(_)
+        | CfExpression::Number(_) => false,
+    }
+}
+
+fn compact_statements(statements: Vec<CfExpression>) -> Vec<CfExpression> {
+    let statements = merge_statement_values(statements, "Resource");
+    uniquify_iam_statement_sids(merge_statement_values(statements, "Action"))
+}
+
+struct StatementGroup {
+    statement: IndexMap<String, CfExpression>,
+    sid: Option<CfExpression>,
+    values: Vec<CfExpression>,
+}
+
+fn merge_statement_values(statements: Vec<CfExpression>, property: &str) -> Vec<CfExpression> {
+    let mut groups: Vec<StatementGroup> = Vec::new();
+    let mut unchanged = Vec::new();
+
+    for statement in statements {
+        let CfExpression::Object(mut statement) = statement else {
+            unchanged.push(statement);
+            continue;
+        };
+        let Some(value) = statement.shift_remove(property) else {
+            unchanged.push(CfExpression::Object(statement));
+            continue;
+        };
+        let sid = statement.shift_remove("Sid");
+        let values = match value {
+            CfExpression::List(values) => values,
+            value => vec![value],
+        };
+
+        if let Some(group) = groups.iter_mut().find(|group| group.statement == statement) {
+            group.values.extend(values);
+        } else {
+            groups.push(StatementGroup {
+                statement,
+                sid,
+                values,
+            });
+        }
+    }
+
+    unchanged.extend(groups.into_iter().map(|mut group| {
+        if let Some(sid) = group.sid {
+            group.statement.insert("Sid".to_string(), sid);
+        }
+        let values = deduplicate(group.values);
+        let value = match values.as_slice() {
+            [value] => value.clone(),
+            _ => CfExpression::list(values),
+        };
+        group.statement.insert(property.to_string(), value);
+        CfExpression::Object(group.statement)
+    }));
+    unchanged
+}
+
+fn deduplicate<T: PartialEq>(values: Vec<T>) -> Vec<T> {
+    values.into_iter().fold(Vec::new(), |mut unique, value| {
+        if !unique.contains(&value) {
+            unique.push(value);
+        }
+        unique
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compact_statements;
+    use crate::template::CfExpression;
+
+    #[test]
+    fn compaction_does_not_create_action_resource_cross_products() {
+        let statements = vec![
+            statement("ReadOne", "s3:GetObject", "bucket-one"),
+            statement("ReadTwo", "s3:GetObject", "bucket-two"),
+            statement("WriteOne", "s3:PutObject", "bucket-one"),
+        ];
+
+        let compacted = compact_statements(statements);
+
+        assert_eq!(compacted.len(), 2);
+        assert!(compacted.contains(&statement_with_values(
+            "ReadOne",
+            vec!["s3:GetObject"],
+            vec!["bucket-one", "bucket-two"],
+        )));
+        assert!(compacted.contains(&statement_with_values(
+            "WriteOne",
+            vec!["s3:PutObject"],
+            vec!["bucket-one"],
+        )));
+    }
+
+    fn statement(sid: &str, action: &str, resource: &str) -> CfExpression {
+        CfExpression::object([
+            ("Sid", CfExpression::from(sid)),
+            ("Effect", CfExpression::from("Allow")),
+            ("Action", CfExpression::from(action)),
+            ("Resource", CfExpression::from(resource)),
+        ])
+    }
+
+    fn statement_with_values(sid: &str, actions: Vec<&str>, resources: Vec<&str>) -> CfExpression {
+        let action = match actions.as_slice() {
+            [action] => CfExpression::from(*action),
+            _ => CfExpression::list(actions.into_iter().map(CfExpression::from)),
+        };
+        let resource = match resources.as_slice() {
+            [resource] => CfExpression::from(*resource),
+            _ => CfExpression::list(resources.into_iter().map(CfExpression::from)),
+        };
+        CfExpression::object([
+            ("Effect", CfExpression::from("Allow")),
+            ("Sid", CfExpression::from(sid)),
+            ("Resource", resource),
+            ("Action", action),
+        ])
+    }
+}

--- a/crates/alien-cloudformation/src/lib.rs
+++ b/crates/alien-cloudformation/src/lib.rs
@@ -14,6 +14,7 @@ mod built_ins;
 mod emitter;
 pub mod emitters;
 mod generator;
+mod inline_policy;
 mod registry;
 mod template;
 #[doc(hidden)]

--- a/crates/alien-cloudformation/tests/generator/aws_data_layer_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_data_layer_tests.rs
@@ -317,30 +317,22 @@ fn aws_queue_resource_permissions_attach_to_service_account_role() {
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
 
-    let read_policy = &template["Resources"]["JobsExecutionSaRoleQueuePermission00"];
-    let write_policy = &template["Resources"]["JobsExecutionSaRoleQueuePermission01"];
-    assert_eq!(read_policy["Type"], "AWS::IAM::Policy");
-    assert_eq!(write_policy["Type"], "AWS::IAM::Policy");
-
-    let read_actions = read_policy["Properties"]["PolicyDocument"]["Statement"][0]["Action"]
-        .as_array()
-        .expect("read statement should list actions");
-    assert!(read_actions.contains(&serde_json::json!("sqs:ReceiveMessage")));
-    let write_actions = write_policy["Properties"]["PolicyDocument"]["Statement"][0]["Action"]
-        .as_array()
-        .expect("write statement should list actions");
-    assert!(write_actions.contains(&serde_json::json!("sqs:DeleteMessage")));
+    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    assert_eq!(policies.len(), 1);
+    let policy = policies[0];
+    let actions = policy_actions(policy);
+    assert!(actions.contains(&"sqs:ReceiveMessage"));
+    assert!(actions.contains(&"sqs:DeleteMessage"));
 
     // Statements must be pinned to the queue ARN: the physical queue name is
     // CloudFormation-generated, so a name-pattern binding would never match.
-    for policy in [read_policy, write_policy] {
+    for statement in policy["Properties"]["PolicyDocument"]["Statement"]
+        .as_array()
+        .expect("queue policy statements")
+    {
         assert_eq!(
-            policy["Properties"]["PolicyDocument"]["Statement"][0]["Resource"]["Fn::GetAtt"],
+            statement["Resource"]["Fn::GetAtt"],
             serde_json::json!(["Jobs", "Arn"])
-        );
-        assert_eq!(
-            policy["Properties"]["Roles"][0]["Ref"],
-            serde_json::json!("ExecutionSaRole")
         );
     }
 }
@@ -390,31 +382,23 @@ fn aws_kv_resource_permissions_attach_to_service_account_role() {
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
 
-    let read_policy = &template["Resources"]["StoreExecutionSaRoleKvPermission00"];
-    let write_policy = &template["Resources"]["StoreExecutionSaRoleKvPermission01"];
-    assert_eq!(read_policy["Type"], "AWS::IAM::Policy");
-    assert_eq!(write_policy["Type"], "AWS::IAM::Policy");
-
-    let read_actions = read_policy["Properties"]["PolicyDocument"]["Statement"][0]["Action"]
-        .as_array()
-        .expect("read statement should list actions");
-    assert!(read_actions.contains(&serde_json::json!("dynamodb:GetItem")));
-    assert!(read_actions.contains(&serde_json::json!("dynamodb:Query")));
-    let write_actions = write_policy["Properties"]["PolicyDocument"]["Statement"][0]["Action"]
-        .as_array()
-        .expect("write statement should list actions");
-    assert!(write_actions.contains(&serde_json::json!("dynamodb:PutItem")));
+    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    assert_eq!(policies.len(), 1);
+    let policy = policies[0];
+    let actions = policy_actions(policy);
+    assert!(actions.contains(&"dynamodb:GetItem"));
+    assert!(actions.contains(&"dynamodb:Query"));
+    assert!(actions.contains(&"dynamodb:PutItem"));
 
     // Statements must be pinned to the table ARN: the physical table name is
     // CloudFormation-generated, so a name-pattern binding would never match.
-    for policy in [read_policy, write_policy] {
+    for statement in policy["Properties"]["PolicyDocument"]["Statement"]
+        .as_array()
+        .expect("kv policy statements")
+    {
         assert_eq!(
-            policy["Properties"]["PolicyDocument"]["Statement"][0]["Resource"]["Fn::GetAtt"],
+            statement["Resource"]["Fn::GetAtt"],
             serde_json::json!(["Store", "Arn"])
-        );
-        assert_eq!(
-            policy["Properties"]["Roles"][0]["Ref"],
-            serde_json::json!("ExecutionSaRole")
         );
     }
 }
@@ -469,7 +453,7 @@ fn aws_vault_resource_permissions_attach_to_service_account_role() {
 }
 
 #[test]
-fn aws_vault_permissions_include_vault_logical_id() {
+fn aws_vault_permissions_include_every_vault_scope() {
     let stack = Stack::new("vault-permissions".to_string())
         .permission(
             "execution",
@@ -498,6 +482,116 @@ fn aws_vault_permissions_include_vault_logical_id() {
         "aws multiple vault service account permissions",
     );
 
-    assert!(yaml.contains("SecretsExecutionSaRoleVaultPermission00"));
-    assert!(yaml.contains("ProviderKeysExecutionSaRoleVaultPermission00"));
+    let template: serde_json::Value =
+        serde_yaml::from_str(&yaml).expect("template YAML should parse");
+    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    assert_eq!(policies.len(), 1);
+    let policy = serde_json::to_string(policies[0]).expect("policy should serialize");
+    assert!(policy.contains("parameter/${AWS::StackName}-secrets-*"));
+    assert!(policy.contains("parameter/${AWS::StackName}-provider-keys-*"));
+}
+
+#[test]
+fn many_resource_grants_stay_within_the_role_inline_policy_quota() {
+    let mut stack = Stack::new("many-resource-grants".to_string())
+        .permission(
+            "execution",
+            PermissionProfile::new().global([
+                "storage/data-read",
+                "storage/data-write",
+                "kv/data-read",
+                "kv/data-write",
+            ]),
+        )
+        .add(
+            ServiceAccount::new("execution-sa".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        );
+
+    for index in 0..12 {
+        stack = stack.add(
+            Storage::new(format!("data-{index}")).build(),
+            ResourceLifecycle::Frozen,
+        );
+    }
+
+    let yaml = render_built_ins(
+        &stack.build(),
+        StackSettings::default(),
+        RegistrationMode::OutputsFallback,
+        "many AWS resource grants",
+    );
+    let template: serde_json::Value =
+        serde_yaml::from_str(&yaml).expect("template YAML should parse");
+    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    assert_eq!(policies.len(), 1, "resource grants should share one policy");
+
+    let aggregate_size = role_inline_policy_documents(&template, "ExecutionSaRole")
+        .into_iter()
+        .map(|document| {
+            serde_json::to_string(document)
+                .expect("policy should serialize")
+                .len()
+        })
+        .sum::<usize>();
+    assert!(
+        aggregate_size < 10_240,
+        "rendered inline policy documents use {aggregate_size} non-whitespace characters"
+    );
+
+    let policy = serde_json::to_string(policies[0]).expect("policy should serialize");
+    for index in 0..12 {
+        assert!(
+            policy.contains(&format!("Data{index}")),
+            "storage {index} should remain granted"
+        );
+    }
+}
+
+fn inline_policies_for_role<'a>(
+    template: &'a serde_json::Value,
+    role_id: &str,
+) -> Vec<&'a serde_json::Value> {
+    template["Resources"]
+        .as_object()
+        .expect("resources should be an object")
+        .values()
+        .filter(|resource| {
+            resource["Type"] == "AWS::IAM::Policy"
+                && resource["Properties"]["Roles"]
+                    .as_array()
+                    .is_some_and(|roles| roles.contains(&serde_json::json!({ "Ref": role_id })))
+        })
+        .collect()
+}
+
+fn policy_actions(policy: &serde_json::Value) -> Vec<&str> {
+    policy["Properties"]["PolicyDocument"]["Statement"]
+        .as_array()
+        .expect("policy statements")
+        .iter()
+        .flat_map(|statement| match &statement["Action"] {
+            serde_json::Value::Array(actions) => actions.iter().collect::<Vec<_>>(),
+            action => vec![action],
+        })
+        .filter_map(serde_json::Value::as_str)
+        .collect()
+}
+
+fn role_inline_policy_documents<'a>(
+    template: &'a serde_json::Value,
+    role_id: &str,
+) -> Vec<&'a serde_json::Value> {
+    let mut documents = template["Resources"][role_id]["Properties"]["Policies"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|policy| &policy["PolicyDocument"])
+        .collect::<Vec<_>>();
+    documents.extend(
+        inline_policies_for_role(template, role_id)
+            .into_iter()
+            .map(|policy| &policy["Properties"]["PolicyDocument"]),
+    );
+    documents
 }

--- a/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
@@ -494,38 +494,33 @@ fn aws_email_resource_permissions_attach_to_service_account_role() {
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
 
-    let send_policy = &template["Resources"]["MailerSenderSaRoleEmailPermission00"];
-    let identities_policy = &template["Resources"]["MailerSenderSaRoleEmailPermission01"];
-    assert_eq!(send_policy["Type"], "AWS::IAM::Policy");
-    assert_eq!(identities_policy["Type"], "AWS::IAM::Policy");
-
-    let send_actions = send_policy["Properties"]["PolicyDocument"]["Statement"][0]["Action"]
+    let policies = template["Resources"]
+        .as_object()
+        .expect("resources should be an object")
+        .values()
+        .filter(|resource| {
+            resource["Type"] == "AWS::IAM::Policy"
+                && resource["Properties"]["Roles"][0]["Ref"] == "SenderSaRole"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(policies.len(), 1);
+    let policy = policies[0];
+    let identity_statements = policy["Properties"]["PolicyDocument"]["Statement"]
         .as_array()
-        .expect("send statement should list actions");
-    assert!(send_actions.contains(&serde_json::json!("ses:SendEmail")));
-    assert!(send_actions.contains(&serde_json::json!("ses:SendRawEmail")));
-
-    let identity_statements = identities_policy["Properties"]["PolicyDocument"]["Statement"]
-        .as_array()
-        .expect("manage-identities statements");
-    let identity_actions: Vec<String> = identity_statements
+        .expect("email permission statements");
+    let actions: Vec<String> = identity_statements
         .iter()
-        .flat_map(|statement| statement["Action"].as_array().cloned().unwrap_or_default())
+        .flat_map(|statement| match statement["Action"].as_array() {
+            Some(actions) => actions.clone(),
+            None => vec![statement["Action"].clone()],
+        })
         .filter_map(|action| action.as_str().map(str::to_string))
         .collect();
-    assert!(identity_actions.contains(&"ses:CreateEmailIdentity".to_string()));
-    let identity_resources = identity_statements[0]["Resource"]
-        .as_array()
-        .expect("manage-identities statement should list resources");
-    assert!(identity_resources.contains(&serde_json::json!({
-        "Fn::Sub":
-            "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:configuration-set/${AWS::StackName}-mailer"
-    })));
-
-    for policy in [send_policy, identities_policy] {
-        assert_eq!(
-            policy["Properties"]["Roles"][0]["Ref"],
-            serde_json::json!("SenderSaRole")
-        );
-    }
+    assert!(actions.contains(&"ses:SendEmail".to_string()));
+    assert!(actions.contains(&"ses:SendRawEmail".to_string()));
+    assert!(actions.contains(&"ses:CreateEmailIdentity".to_string()));
+    let rendered_policy = serde_json::to_string(policy).expect("policy should serialize");
+    assert!(rendered_policy.contains(
+        "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:configuration-set/${AWS::StackName}-mailer"
+    ));
 }

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -1017,33 +1017,6 @@ Resources:
           Condition:
             Bool:
               aws:SecureTransport: 'false'
-  AssetsManagementRoleStoragePermission00:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName:
-        Fn::Sub: ${AWS::StackName}-assets-storage-0-0
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-        - Action:
-          - s3:GetBucketAcl
-          - s3:GetBucketLocation
-          - s3:GetBucketPolicy
-          - s3:GetBucketPublicAccessBlock
-          - s3:GetBucketVersioning
-          - s3:GetEncryptionConfiguration
-          - s3:GetLifecycleConfiguration
-          Effect: Allow
-          Resource:
-          - Fn::GetAtt:
-            - Assets
-            - Arn
-          Sid: CheckS3BucketHealth
-      Roles:
-      - Ref: ManagementRole
-    DependsOn:
-    - Assets
-    - ManagementRole
   Jobs:
     Type: AWS::SQS::Queue
     Properties:
@@ -1093,23 +1066,6 @@ Resources:
         Value: kv
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
-  SecretsManagementVaultPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName:
-        Fn::Sub: management-secrets-vault-policy
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-        - Action:
-          - ssm:DeleteParameter
-          - ssm:PutParameter
-          Effect: Allow
-          Resource:
-          - Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}-secrets-*
-          Sid: WriteSsmParameters
-      Roles:
-      - Ref: ManagementRole
   Mailbox:
     Type: AWS::S3::Bucket
     Properties:
@@ -1182,33 +1138,6 @@ Resources:
             StringEquals:
               aws:SourceAccount:
                 Ref: AWS::AccountId
-  MailboxManagementRoleStoragePermission00:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName:
-        Fn::Sub: ${AWS::StackName}-mailbox-storage-0-0
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-        - Action:
-          - s3:GetBucketAcl
-          - s3:GetBucketLocation
-          - s3:GetBucketPolicy
-          - s3:GetBucketPublicAccessBlock
-          - s3:GetBucketVersioning
-          - s3:GetEncryptionConfiguration
-          - s3:GetLifecycleConfiguration
-          Effect: Allow
-          Resource:
-          - Fn::GetAtt:
-            - Mailbox
-            - Arn
-          Sid: CheckS3BucketHealth
-      Roles:
-      - Ref: ManagementRole
-    DependsOn:
-    - Mailbox
-    - ManagementRole
   MailEvents:
     Type: AWS::SQS::Queue
     Properties:
@@ -1619,6 +1548,43 @@ Resources:
         Value: build
     DependsOn:
     - BuilderLogGroup
+  ManagementRoleInlinePermissions:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: resource-permissions-1
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Resource:
+          - Fn::GetAtt:
+            - Assets
+            - Arn
+          - Fn::GetAtt:
+            - Mailbox
+            - Arn
+          Sid: CheckS3BucketHealth
+          Action:
+          - s3:GetBucketAcl
+          - s3:GetBucketLocation
+          - s3:GetBucketPolicy
+          - s3:GetBucketPublicAccessBlock
+          - s3:GetBucketVersioning
+          - s3:GetEncryptionConfiguration
+          - s3:GetLifecycleConfiguration
+        - Effect: Allow
+          Resource:
+            Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}-secrets-*
+          Sid: WriteSsmParameters
+          Action:
+          - ssm:DeleteParameter
+          - ssm:PutParameter
+      Roles:
+      - Ref: ManagementRole
+    DependsOn:
+    - Assets
+    - ManagementRole
+    - Mailbox
   DeploymentRegistration:
     Type: AWS::CloudFormation::CustomResource
     Properties:
@@ -1925,13 +1891,10 @@ Resources:
     - ManagementRoleManagementPolicy2
     - Assets
     - AssetsBucketPolicy
-    - AssetsManagementRoleStoragePermission00
     - Jobs
     - Metadata
-    - SecretsManagementVaultPolicy
     - Mailbox
     - MailboxBucketPolicy
-    - MailboxManagementRoleStoragePermission00
     - MailEvents
     - MailerConfigSet
     - MailerIdentity0
@@ -1949,6 +1912,7 @@ Resources:
     - RegistryPushRole
     - BuilderLogGroup
     - Builder
+    - ManagementRoleInlinePermissions
 Outputs:
   DeploymentSourceKind:
     Value: cloudformation


### PR DESCRIPTION
## Summary

- combine compatible external inline policies attached to the same IAM role
- merge identical action/resource axes while preserving the exact permission matrix
- retain conditions, document properties, role attachments, and resource dependencies
- leave directly referenced policy resources unchanged

## Why

AWS caps the aggregate size of all inline policies on a role at 10,240 non-whitespace characters. Emitting one policy document per resource grant repeats document and statement overhead until permission-heavy stacks fail during creation.

AWS quota reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-limits-entity-length

## Validation

- cargo test -p alien-cloudformation: 91 tests passed
- every rendered generator scenario passed cfn-lint
- crate clippy passed with the repository existing lint exceptions allowed
- rustfmt and git diff checks passed
- AWS CloudFormation validate-template passed for a 12-resource quota fixture
- a disposable stack reached CREATE_COMPLETE in the AWS test target
- the resolved role had one 1,713-character policy containing all 11 expected actions and all 24 bucket/object ARNs
- the test stack, IAM resources, and 12 retained buckets were deleted; exact-prefix cleanup returned empty

Linear: https://linear.app/alienplatform/issue/ALIEN-430/keep-generated-cloudformation-iam-policies-within-inline-quota