### PR TITLE
feat(bindings)!: return storage object attributes

### DIFF
--- a/crates/alien-bindings-node/src/remote_storage.rs
+++ b/crates/alien-bindings-node/src/remote_storage.rs
@@ -2,7 +2,9 @@
 //! operations and cannot expose the wider local `StorageHandle` API.
 
 use crate::error::map_object_store_error;
-use crate::storage::{object_meta_to_js, ObjectMetaJs};
+use crate::storage::{
+    object_meta_to_js, object_store_put_options, ObjectMetaJs, StoragePutOptionsJs,
+};
 use alien_bindings::RemoteStorage;
 use futures::StreamExt;
 use napi::bindgen_prelude::Buffer;
@@ -40,11 +42,23 @@ impl RemoteStorageHandle {
     }
 
     #[napi]
-    pub async fn put(&self, path: String, data: Buffer) -> napi::Result<()> {
-        self.inner
-            .put(&Path::from(path), PutPayload::from(data.to_vec()))
-            .await
-            .map_err(|error| map_object_store_error(error, &self.binding, "put"))?;
+    pub async fn put(
+        &self,
+        path: String,
+        data: Buffer,
+        options: Option<StoragePutOptionsJs>,
+    ) -> napi::Result<()> {
+        let path = Path::from(path);
+        let payload = PutPayload::from(data.to_vec());
+        match options {
+            Some(options) => {
+                self.inner
+                    .put_opts(&path, payload, object_store_put_options(options))
+                    .await
+            }
+            None => self.inner.put(&path, payload).await,
+        }
+        .map_err(|error| map_object_store_error(error, &self.binding, "put"))?;
         Ok(())
     }
 

--- a/crates/alien-bindings-node/src/remote_storage.rs
+++ b/crates/alien-bindings-node/src/remote_storage.rs
@@ -3,14 +3,15 @@
 
 use crate::error::map_object_store_error;
 use crate::storage::{
-    object_meta_to_js, object_store_put_options, ObjectMetaJs, StoragePutOptionsJs,
+    object_attributes_to_js, object_meta_to_js, object_store_put_options, put_result_to_js,
+    ObjectMetaJs, StorageGetResultJs, StorageHeadResultJs, StoragePutOptionsJs, StoragePutResultJs,
 };
 use alien_bindings::RemoteStorage;
 use futures::StreamExt;
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use object_store::path::Path;
-use object_store::PutPayload;
+use object_store::{GetOptions, PutPayload};
 use std::sync::Arc;
 
 #[napi]
@@ -28,17 +29,23 @@ impl RemoteStorageHandle {
 #[napi]
 impl RemoteStorageHandle {
     #[napi]
-    pub async fn get(&self, path: String) -> napi::Result<Buffer> {
+    pub async fn get(&self, path: String) -> napi::Result<StorageGetResultJs> {
         let result = self
             .inner
             .get(&Path::from(path))
             .await
             .map_err(|error| map_object_store_error(error, &self.binding, "get"))?;
-        let bytes = result
+        let meta = object_meta_to_js(&result.meta);
+        let attributes = object_attributes_to_js(&result.attributes);
+        let data = result
             .bytes()
             .await
             .map_err(|error| map_object_store_error(error, &self.binding, "get"))?;
-        Ok(Buffer::from(bytes.to_vec()))
+        Ok(StorageGetResultJs {
+            data: Buffer::from(data.to_vec()),
+            meta,
+            attributes,
+        })
     }
 
     #[napi]
@@ -47,10 +54,10 @@ impl RemoteStorageHandle {
         path: String,
         data: Buffer,
         options: Option<StoragePutOptionsJs>,
-    ) -> napi::Result<()> {
+    ) -> napi::Result<StoragePutResultJs> {
         let path = Path::from(path);
         let payload = PutPayload::from(data.to_vec());
-        match options {
+        let result = match options {
             Some(options) => {
                 self.inner
                     .put_opts(&path, payload, object_store_put_options(options))
@@ -59,7 +66,7 @@ impl RemoteStorageHandle {
             None => self.inner.put(&path, payload).await,
         }
         .map_err(|error| map_object_store_error(error, &self.binding, "put"))?;
-        Ok(())
+        Ok(put_result_to_js(result))
     }
 
     #[napi]
@@ -84,11 +91,21 @@ impl RemoteStorageHandle {
     }
 
     #[napi]
-    pub async fn head(&self, path: String) -> napi::Result<ObjectMetaJs> {
-        self.inner
-            .head(&Path::from(path))
+    pub async fn head(&self, path: String) -> napi::Result<StorageHeadResultJs> {
+        let result = self
+            .inner
+            .get_opts(
+                &Path::from(path),
+                GetOptions {
+                    head: true,
+                    ..Default::default()
+                },
+            )
             .await
-            .map(|metadata| object_meta_to_js(&metadata))
-            .map_err(|error| map_object_store_error(error, &self.binding, "head"))
+            .map_err(|error| map_object_store_error(error, &self.binding, "head"))?;
+        Ok(StorageHeadResultJs {
+            meta: object_meta_to_js(&result.meta),
+            attributes: object_attributes_to_js(&result.attributes),
+        })
     }
 }

--- a/crates/alien-bindings-node/src/storage.rs
+++ b/crates/alien-bindings-node/src/storage.rs
@@ -10,7 +10,9 @@ use futures::StreamExt;
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use object_store::path::Path;
-use object_store::{Attribute, Attributes, ObjectMeta, PutOptions, PutPayload};
+use object_store::{
+    Attribute, Attributes, GetOptions, ObjectMeta, PutOptions, PutPayload, PutResult,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +26,10 @@ pub struct ObjectMetaJs {
     pub size: f64,
     /// Last-modified timestamp as an RFC 3339 string.
     pub last_modified: String,
+    /// Provider entity tag, when available.
+    pub e_tag: Option<String>,
+    /// Provider object version, when available.
+    pub version: Option<String>,
 }
 
 /// A presigned request: a URL plus the method and headers to replay it with.
@@ -37,9 +43,9 @@ pub struct PresignedRequestJs {
     pub headers: HashMap<String, String>,
 }
 
-/// Provider-neutral object attributes for a storage write.
+/// Provider-neutral object attributes accepted on a storage write.
 #[napi(object)]
-pub struct StoragePutOptionsJs {
+pub struct StoragePutAttributesJs {
     /// MIME type stored with the object.
     pub content_type: Option<String>,
     /// Browser content-disposition behavior stored with the object.
@@ -54,7 +60,51 @@ pub struct StoragePutOptionsJs {
     pub metadata: Option<HashMap<String, String>>,
 }
 
+/// Options for a storage write.
+#[napi(object)]
+pub struct StoragePutOptionsJs {
+    /// Object attributes to persist with the payload.
+    pub attributes: Option<StoragePutAttributesJs>,
+}
+
+/// Provider-neutral attributes returned with a stored object.
+#[napi(object)]
+pub struct StorageObjectAttributesJs {
+    pub content_type: Option<String>,
+    pub content_disposition: Option<String>,
+    pub content_encoding: Option<String>,
+    pub content_language: Option<String>,
+    pub cache_control: Option<String>,
+    pub storage_class: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+/// Result of reading a stored object.
+#[napi(object)]
+pub struct StorageGetResultJs {
+    pub data: Buffer,
+    pub meta: ObjectMetaJs,
+    pub attributes: StorageObjectAttributesJs,
+}
+
+/// Result of reading object metadata without its payload.
+#[napi(object)]
+pub struct StorageHeadResultJs {
+    pub meta: ObjectMetaJs,
+    pub attributes: StorageObjectAttributesJs,
+}
+
+/// Provider identifiers returned after a successful storage write.
+#[napi(object)]
+pub struct StoragePutResultJs {
+    pub e_tag: Option<String>,
+    pub version: Option<String>,
+}
+
 pub(crate) fn object_store_put_options(options: StoragePutOptionsJs) -> PutOptions {
+    let Some(options) = options.attributes else {
+        return PutOptions::default();
+    };
     let mut attributes = Attributes::new();
     for (attribute, value) in [
         (Attribute::ContentType, options.content_type),
@@ -76,12 +126,46 @@ pub(crate) fn object_store_put_options(options: StoragePutOptionsJs) -> PutOptio
     }
 }
 
+pub(crate) fn object_attributes_to_js(attributes: &Attributes) -> StorageObjectAttributesJs {
+    let value = |attribute| {
+        attributes
+            .get(&attribute)
+            .map(|value| value.as_ref().to_string())
+    };
+    let metadata = attributes
+        .iter()
+        .filter_map(|(attribute, value)| match attribute {
+            Attribute::Metadata(key) => Some((key.to_string(), value.as_ref().to_string())),
+            _ => None,
+        })
+        .collect();
+
+    StorageObjectAttributesJs {
+        content_type: value(Attribute::ContentType),
+        content_disposition: value(Attribute::ContentDisposition),
+        content_encoding: value(Attribute::ContentEncoding),
+        content_language: value(Attribute::ContentLanguage),
+        cache_control: value(Attribute::CacheControl),
+        storage_class: value(Attribute::StorageClass),
+        metadata,
+    }
+}
+
 /// Translate an `object_store::ObjectMeta` into its JS shape.
 pub(crate) fn object_meta_to_js(meta: &ObjectMeta) -> ObjectMetaJs {
     ObjectMetaJs {
         location: meta.location.to_string(),
         size: meta.size as f64,
         last_modified: meta.last_modified.to_rfc3339(),
+        e_tag: meta.e_tag.clone(),
+        version: meta.version.clone(),
+    }
+}
+
+pub(crate) fn put_result_to_js(result: PutResult) -> StoragePutResultJs {
+    StoragePutResultJs {
+        e_tag: result.e_tag,
+        version: result.version,
     }
 }
 
@@ -123,7 +207,7 @@ impl StorageHandle {
 impl StorageHandle {
     /// Fetch the object at `path`.
     #[napi]
-    pub async fn get(&self, path: String) -> napi::Result<Buffer> {
+    pub async fn get(&self, path: String) -> napi::Result<StorageGetResultJs> {
         let store = self.inner.clone();
         let binding = self.binding.clone();
         let location = parse_path(path, "path", "get")?;
@@ -131,11 +215,17 @@ impl StorageHandle {
             .get(&location)
             .await
             .map_err(|e| map_object_store_error(e, &binding, "get"))?;
-        let bytes = result
+        let meta = object_meta_to_js(&result.meta);
+        let attributes = object_attributes_to_js(&result.attributes);
+        let data = result
             .bytes()
             .await
             .map_err(|e| map_object_store_error(e, &binding, "get"))?;
-        Ok(Buffer::from(bytes.to_vec()))
+        Ok(StorageGetResultJs {
+            data: Buffer::from(data.to_vec()),
+            meta,
+            attributes,
+        })
     }
 
     /// Store `data` at `path`.
@@ -145,12 +235,12 @@ impl StorageHandle {
         path: String,
         data: Buffer,
         options: Option<StoragePutOptionsJs>,
-    ) -> napi::Result<()> {
+    ) -> napi::Result<StoragePutResultJs> {
         let store = self.inner.clone();
         let binding = self.binding.clone();
         let location = parse_path(path, "path", "put")?;
         let payload = PutPayload::from(data.to_vec());
-        match options {
+        let result = match options {
             Some(options) => {
                 store
                     .put_opts(&location, payload, object_store_put_options(options))
@@ -159,7 +249,7 @@ impl StorageHandle {
             None => store.put(&location, payload).await,
         }
         .map_err(|e| map_object_store_error(e, &binding, "put"))?;
-        Ok(())
+        Ok(put_result_to_js(result))
     }
 
     /// Delete the object at `path`.
@@ -194,15 +284,24 @@ impl StorageHandle {
 
     /// Fetch metadata for the object at `path`.
     #[napi]
-    pub async fn head(&self, path: String) -> napi::Result<ObjectMetaJs> {
+    pub async fn head(&self, path: String) -> napi::Result<StorageHeadResultJs> {
         let store = self.inner.clone();
         let binding = self.binding.clone();
         let location = parse_path(path, "path", "head")?;
-        let meta = store
-            .head(&location)
+        let result = store
+            .get_opts(
+                &location,
+                GetOptions {
+                    head: true,
+                    ..Default::default()
+                },
+            )
             .await
             .map_err(|e| map_object_store_error(e, &binding, "head"))?;
-        Ok(object_meta_to_js(&meta))
+        Ok(StorageHeadResultJs {
+            meta: object_meta_to_js(&result.meta),
+            attributes: object_attributes_to_js(&result.attributes),
+        })
     }
 
     /// Copy the object at `from` to `to`.
@@ -287,8 +386,8 @@ mod tests {
             location: Path::from("dir/file.txt"),
             last_modified: Utc.with_ymd_and_hms(2026, 7, 6, 12, 0, 0).unwrap(),
             size: 1234,
-            e_tag: None,
-            version: None,
+            e_tag: Some("etag-123".to_string()),
+            version: Some("version-456".to_string()),
         };
 
         let js = object_meta_to_js(&meta);
@@ -296,6 +395,8 @@ mod tests {
         assert_eq!(js.location, "dir/file.txt");
         assert_eq!(js.size, 1234.0);
         assert_eq!(js.last_modified, "2026-07-06T12:00:00+00:00");
+        assert_eq!(js.e_tag.as_deref(), Some("etag-123"));
+        assert_eq!(js.version.as_deref(), Some("version-456"));
     }
 
     #[test]
@@ -337,15 +438,17 @@ mod tests {
     #[test]
     fn storage_put_options_map_every_object_attribute() {
         let options = object_store_put_options(StoragePutOptionsJs {
-            content_type: Some("message/rfc822".to_string()),
-            content_disposition: Some("attachment; filename=message.eml".to_string()),
-            content_encoding: Some("gzip".to_string()),
-            content_language: Some("en-US".to_string()),
-            cache_control: Some("private, max-age=60".to_string()),
-            metadata: Some(HashMap::from([
-                ("message-id".to_string(), "msg_123".to_string()),
-                ("source".to_string(), "inbound".to_string()),
-            ])),
+            attributes: Some(StoragePutAttributesJs {
+                content_type: Some("message/rfc822".to_string()),
+                content_disposition: Some("attachment; filename=message.eml".to_string()),
+                content_encoding: Some("gzip".to_string()),
+                content_language: Some("en-US".to_string()),
+                cache_control: Some("private, max-age=60".to_string()),
+                metadata: Some(HashMap::from([
+                    ("message-id".to_string(), "msg_123".to_string()),
+                    ("source".to_string(), "inbound".to_string()),
+                ])),
+            }),
         });
 
         let expected = Attributes::from_iter([
@@ -374,5 +477,51 @@ mod tests {
         ]);
 
         assert_eq!(options.attributes, expected);
+    }
+
+    #[test]
+    fn object_attributes_to_js_maps_headers_storage_class_and_metadata() {
+        let attributes = Attributes::from_iter([
+            (Attribute::ContentType, AttributeValue::from("text/plain")),
+            (
+                Attribute::ContentDisposition,
+                AttributeValue::from("inline"),
+            ),
+            (Attribute::ContentEncoding, AttributeValue::from("gzip")),
+            (Attribute::ContentLanguage, AttributeValue::from("en-US")),
+            (
+                Attribute::CacheControl,
+                AttributeValue::from("private, max-age=60"),
+            ),
+            (Attribute::StorageClass, AttributeValue::from("STANDARD")),
+            (
+                Attribute::Metadata("source".into()),
+                AttributeValue::from("upload"),
+            ),
+        ]);
+
+        let js = object_attributes_to_js(&attributes);
+
+        assert_eq!(js.content_type.as_deref(), Some("text/plain"));
+        assert_eq!(js.content_disposition.as_deref(), Some("inline"));
+        assert_eq!(js.content_encoding.as_deref(), Some("gzip"));
+        assert_eq!(js.content_language.as_deref(), Some("en-US"));
+        assert_eq!(js.cache_control.as_deref(), Some("private, max-age=60"));
+        assert_eq!(js.storage_class.as_deref(), Some("STANDARD"));
+        assert_eq!(
+            js.metadata.get("source").map(String::as_str),
+            Some("upload")
+        );
+    }
+
+    #[test]
+    fn put_result_to_js_preserves_provider_identifiers() {
+        let js = put_result_to_js(PutResult {
+            e_tag: Some("etag-123".to_string()),
+            version: Some("version-456".to_string()),
+        });
+
+        assert_eq!(js.e_tag.as_deref(), Some("etag-123"));
+        assert_eq!(js.version.as_deref(), Some("version-456"));
     }
 }

--- a/crates/alien-bindings-node/src/storage.rs
+++ b/crates/alien-bindings-node/src/storage.rs
@@ -10,7 +10,7 @@ use futures::StreamExt;
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use object_store::path::Path;
-use object_store::{ObjectMeta, PutPayload};
+use object_store::{Attribute, Attributes, ObjectMeta, PutOptions, PutPayload};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -35,6 +35,45 @@ pub struct PresignedRequestJs {
     pub method: String,
     /// Headers to include with the request.
     pub headers: HashMap<String, String>,
+}
+
+/// Provider-neutral object attributes for a storage write.
+#[napi(object)]
+pub struct StoragePutOptionsJs {
+    /// MIME type stored with the object.
+    pub content_type: Option<String>,
+    /// Browser content-disposition behavior stored with the object.
+    pub content_disposition: Option<String>,
+    /// Content encoding stored with the object.
+    pub content_encoding: Option<String>,
+    /// Content language stored with the object.
+    pub content_language: Option<String>,
+    /// Cache-control policy stored with the object.
+    pub cache_control: Option<String>,
+    /// User-defined object metadata.
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+pub(crate) fn object_store_put_options(options: StoragePutOptionsJs) -> PutOptions {
+    let mut attributes = Attributes::new();
+    for (attribute, value) in [
+        (Attribute::ContentType, options.content_type),
+        (Attribute::ContentDisposition, options.content_disposition),
+        (Attribute::ContentEncoding, options.content_encoding),
+        (Attribute::ContentLanguage, options.content_language),
+        (Attribute::CacheControl, options.cache_control),
+    ] {
+        if let Some(value) = value {
+            attributes.insert(attribute, value.into());
+        }
+    }
+    for (key, value) in options.metadata.unwrap_or_default() {
+        attributes.insert(Attribute::Metadata(key.into()), value.into());
+    }
+    PutOptions {
+        attributes,
+        ..Default::default()
+    }
 }
 
 /// Translate an `object_store::ObjectMeta` into its JS shape.
@@ -101,14 +140,25 @@ impl StorageHandle {
 
     /// Store `data` at `path`.
     #[napi]
-    pub async fn put(&self, path: String, data: Buffer) -> napi::Result<()> {
+    pub async fn put(
+        &self,
+        path: String,
+        data: Buffer,
+        options: Option<StoragePutOptionsJs>,
+    ) -> napi::Result<()> {
         let store = self.inner.clone();
         let binding = self.binding.clone();
         let location = parse_path(path, "path", "put")?;
-        store
-            .put(&location, PutPayload::from(data.to_vec()))
-            .await
-            .map_err(|e| map_object_store_error(e, &binding, "put"))?;
+        let payload = PutPayload::from(data.to_vec());
+        match options {
+            Some(options) => {
+                store
+                    .put_opts(&location, payload, object_store_put_options(options))
+                    .await
+            }
+            None => store.put(&location, payload).await,
+        }
+        .map_err(|e| map_object_store_error(e, &binding, "put"))?;
         Ok(())
     }
 
@@ -205,6 +255,7 @@ mod tests {
     use super::*;
     use alien_bindings::presigned::PresignedOperation;
     use chrono::{TimeZone, Utc};
+    use object_store::AttributeValue;
 
     #[test]
     fn parse_path_preserves_rfc_message_id_characters() {
@@ -281,5 +332,47 @@ mod tests {
         assert_eq!(js.url, "local:///tmp/data/obj");
         assert_eq!(js.method, "GET");
         assert!(js.headers.is_empty());
+    }
+
+    #[test]
+    fn storage_put_options_map_every_object_attribute() {
+        let options = object_store_put_options(StoragePutOptionsJs {
+            content_type: Some("message/rfc822".to_string()),
+            content_disposition: Some("attachment; filename=message.eml".to_string()),
+            content_encoding: Some("gzip".to_string()),
+            content_language: Some("en-US".to_string()),
+            cache_control: Some("private, max-age=60".to_string()),
+            metadata: Some(HashMap::from([
+                ("message-id".to_string(), "msg_123".to_string()),
+                ("source".to_string(), "inbound".to_string()),
+            ])),
+        });
+
+        let expected = Attributes::from_iter([
+            (
+                Attribute::ContentType,
+                AttributeValue::from("message/rfc822"),
+            ),
+            (
+                Attribute::ContentDisposition,
+                AttributeValue::from("attachment; filename=message.eml"),
+            ),
+            (Attribute::ContentEncoding, AttributeValue::from("gzip")),
+            (Attribute::ContentLanguage, AttributeValue::from("en-US")),
+            (
+                Attribute::CacheControl,
+                AttributeValue::from("private, max-age=60"),
+            ),
+            (
+                Attribute::Metadata("message-id".into()),
+                AttributeValue::from("msg_123"),
+            ),
+            (
+                Attribute::Metadata("source".into()),
+                AttributeValue::from("inbound"),
+            ),
+        ]);
+
+        assert_eq!(options.attributes, expected);
     }
 }

--- a/crates/alien-bindings/src/providers/storage/gcp_gcs.rs
+++ b/crates/alien-bindings/src/providers/storage/gcp_gcs.rs
@@ -13,8 +13,8 @@ use futures::stream::BoxStream;
 use futures::TryStreamExt as _;
 use object_store::signer::Signer;
 use object_store::{
-    gcp::GoogleCloudStorage, path::Path, GetOptions, GetResult, ListResult, ObjectMeta,
-    ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    gcp::GoogleCloudStorage, path::Path, Attribute, Attributes, GetOptions, GetResult, ListResult,
+    ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
     Result as ObjectStoreResult,
 };
 use reqwest::Method;
@@ -82,6 +82,23 @@ impl GcsStorage {
 }
 
 impl Binding for GcsStorage {}
+
+fn validate_put_attributes(attributes: &Attributes) -> ObjectStoreResult<()> {
+    let gzip_encoding = attributes
+        .get(&Attribute::ContentEncoding)
+        .is_some_and(|value| value.as_ref().eq_ignore_ascii_case("gzip"));
+    if gzip_encoding {
+        return Err(object_store::Error::Generic {
+            store: "GcsStorage",
+            source: Box::new(AlienError::new(ErrorData::OperationNotSupported {
+                operation: "storage.put contentEncoding=gzip".to_string(),
+                reason: "GCS decompressive transcoding is incompatible with object reads"
+                    .to_string(),
+            })),
+        });
+    }
+    Ok(())
+}
 
 #[async_trait]
 impl Storage for GcsStorage {
@@ -218,6 +235,7 @@ impl ObjectStore for GcsStorage {
         opts: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
         let dst = prefixed_path(&self.base_dir, location);
+        validate_put_attributes(&opts.attributes)?;
         self.inner.put_opts(&dst, payload, opts).await
     }
 
@@ -235,6 +253,7 @@ impl ObjectStore for GcsStorage {
         opts: PutMultipartOptions,
     ) -> ObjectStoreResult<Box<dyn object_store::MultipartUpload>> {
         let dst = prefixed_path(&self.base_dir, location);
+        validate_put_attributes(&opts.attributes)?;
         self.inner.put_multipart_opts(&dst, opts).await
     }
 
@@ -329,5 +348,36 @@ impl ObjectStore for GcsStorage {
 impl std::fmt::Display for GcsStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "GcpStorage(url={})", self.url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::AttributeValue;
+
+    #[test]
+    fn rejects_gzip_content_encoding_before_upload() {
+        for encoding in ["gzip", "GZip"] {
+            let attributes = Attributes::from_iter([(
+                Attribute::ContentEncoding,
+                AttributeValue::from(encoding),
+            )]);
+
+            let error = validate_put_attributes(&attributes)
+                .expect_err("gzip would make the object unreadable through this backend");
+
+            assert!(matches!(error, object_store::Error::Generic { .. }));
+            assert!(error.to_string().contains("decompressive transcoding"));
+        }
+    }
+
+    #[test]
+    fn permits_non_transcoded_content_encoding() {
+        let attributes =
+            Attributes::from_iter([(Attribute::ContentEncoding, AttributeValue::from("br"))]);
+
+        validate_put_attributes(&attributes)
+            .expect("Brotli objects are served without transcoding");
     }
 }

--- a/crates/alien-bindings/src/providers/storage/local.rs
+++ b/crates/alien-bindings/src/providers/storage/local.rs
@@ -4,7 +4,7 @@ use crate::{
     presigned::{LocalOperation, PresignedOperation, PresignedRequest, PresignedRequestBackend},
     traits::{Binding, Storage},
 };
-use alien_error::{Context, IntoAlienError};
+use alien_error::{AlienError, Context, IntoAlienError};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;
@@ -252,7 +252,18 @@ impl ObjectStore for LocalStorage {
         opts: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
         let dst = prefixed_path(&self.base_dir, location);
-        // LocalFileSystem doesn't support attributes or tags, strip them to avoid UNIMPLEMENTED
+        if !opts.attributes.is_empty() {
+            return Err(object_store::Error::Generic {
+                store: "LocalStorage",
+                source: Box::new(AlienError::new(ErrorData::OperationNotSupported {
+                    operation: "storage.put object attributes".to_string(),
+                    reason: "the local filesystem backend cannot persist object attributes"
+                        .to_string(),
+                })),
+            });
+        }
+        // LocalFileSystem doesn't support tags. Preserve the existing behavior
+        // for Rust callers that use PutOptions only for conditional writes.
         let opts = PutOptions {
             mode: opts.mode,
             tags: Default::default(),

--- a/crates/alien-bindings/src/refreshing.rs
+++ b/crates/alien-bindings/src/refreshing.rs
@@ -315,6 +315,15 @@ impl RemoteStorage for RefreshingStorage {
         ObjectStore::put(self, path, payload).await
     }
 
+    async fn put_opts(
+        &self,
+        path: &Path,
+        payload: PutPayload,
+        options: ObjectStorePutOptions,
+    ) -> object_store::Result<PutResult> {
+        ObjectStore::put_opts(self, path, payload, options).await
+    }
+
     async fn head(&self, path: &Path) -> object_store::Result<ObjectMeta> {
         ObjectStore::head(self, path).await
     }

--- a/crates/alien-bindings/src/refreshing.rs
+++ b/crates/alien-bindings/src/refreshing.rs
@@ -311,6 +311,10 @@ impl RemoteStorage for RefreshingStorage {
         ObjectStore::get(self, path).await
     }
 
+    async fn get_opts(&self, path: &Path, options: GetOptions) -> object_store::Result<GetResult> {
+        ObjectStore::get_opts(self, path, options).await
+    }
+
     async fn put(&self, path: &Path, payload: PutPayload) -> object_store::Result<PutResult> {
         ObjectStore::put(self, path, payload).await
     }

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -188,6 +188,12 @@ pub trait RemoteStorage: Send + Sync + fmt::Debug {
         path: &object_store::path::Path,
         payload: object_store::PutPayload,
     ) -> object_store::Result<object_store::PutResult>;
+    async fn put_opts(
+        &self,
+        path: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        options: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult>;
     async fn head(
         &self,
         path: &object_store::path::Path,

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -183,6 +183,11 @@ pub trait RemoteStorage: Send + Sync + fmt::Debug {
         &self,
         path: &object_store::path::Path,
     ) -> object_store::Result<object_store::GetResult>;
+    async fn get_opts(
+        &self,
+        path: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult>;
     async fn put(
         &self,
         path: &object_store::path::Path,

--- a/crates/alien-bindings/tests/storage.rs
+++ b/crates/alien-bindings/tests/storage.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use alien_bindings::{
+    providers::storage::LocalStorage,
     traits::{BindingsProviderApi, Storage},
     BindingsProvider,
 };
@@ -13,8 +14,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::TryStreamExt;
 use object_store::{
-    path::Path, GetOptions, GetRange as OsGetRange, MultipartUpload, ObjectMeta, PutMode,
-    PutMultipartOpts, PutOptions,
+    path::Path, Attribute, AttributeValue, Attributes, GetOptions, GetRange as OsGetRange,
+    MultipartUpload, ObjectMeta, ObjectStore, PutMode, PutMultipartOpts, PutOptions,
 };
 use rstest::rstest;
 use std::path::PathBuf as StdPathBuf;
@@ -85,6 +86,40 @@ impl StorageTestContext for LocalProviderTestContext {
     fn provider_name(&self) -> &'static str {
         "local"
     }
+}
+
+#[tokio::test]
+async fn local_storage_rejects_object_attributes_without_writing_the_payload() {
+    let temp_dir = tempfile::tempdir().expect("create local storage directory");
+    let storage = LocalStorage::new_from_path(
+        temp_dir
+            .path()
+            .to_str()
+            .expect("temporary directory path is valid UTF-8"),
+    )
+    .expect("create local storage");
+    let path = Path::from("attributes.txt");
+    let options = PutOptions {
+        attributes: Attributes::from_iter([(
+            Attribute::ContentType,
+            AttributeValue::from("text/plain"),
+        )]),
+        ..Default::default()
+    };
+
+    let error = storage
+        .put_opts(&path, Bytes::from_static(b"data").into(), options)
+        .await
+        .expect_err("local storage must not silently discard object attributes");
+
+    assert!(matches!(&error, object_store::Error::Generic { .. }));
+    assert!(error
+        .to_string()
+        .contains("the local filesystem backend cannot persist object attributes"));
+    assert!(matches!(
+        storage.get(&path).await,
+        Err(object_store::Error::NotFound { .. })
+    ));
 }
 
 // --- gRPC Provider Context ---

--- a/crates/alien-bindings/tests/storage.rs
+++ b/crates/alien-bindings/tests/storage.rs
@@ -122,6 +122,95 @@ async fn local_storage_rejects_object_attributes_without_writing_the_payload() {
     ));
 }
 
+#[rstest]
+#[cfg_attr(feature = "aws", case::aws(AwsProviderTestContext::setup().await))]
+#[cfg_attr(feature = "gcp", case::gcp(GcpProviderTestContext::setup().await))]
+#[cfg_attr(feature = "azure", case::azure(AzureProviderTestContext::setup().await))]
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
+#[tokio::test]
+async fn cloud_storage_round_trips_object_attributes(#[case] ctx: impl StorageTestContext) {
+    let storage = ctx.get_storage().await;
+    let provider_name = ctx.provider_name();
+    let path = Path::from(format!(
+        "object-attributes/{provider_name}/{}.txt",
+        uuid::Uuid::new_v4()
+    ));
+    // Brotli-compressed "object attributes e2e". GCS preserves this encoding
+    // without applying the gzip-only decompressive transcoding behavior.
+    let data = Bytes::from_static(&[
+        27, 20, 0, 248, 165, 100, 202, 146, 16, 77, 128, 41, 76, 214, 193, 205, 84,
+    ]);
+    let expected_attributes = Attributes::from_iter([
+        (
+            Attribute::ContentType,
+            AttributeValue::from("text/plain; charset=utf-8"),
+        ),
+        (
+            Attribute::ContentDisposition,
+            AttributeValue::from("attachment; filename=payload.txt"),
+        ),
+        (Attribute::ContentEncoding, AttributeValue::from("br")),
+        (Attribute::ContentLanguage, AttributeValue::from("en-US")),
+        (
+            Attribute::CacheControl,
+            AttributeValue::from("private, max-age=60"),
+        ),
+        (
+            Attribute::Metadata("source".into()),
+            AttributeValue::from("object-attributes-e2e"),
+        ),
+    ]);
+
+    let operation = async {
+        let put_result = storage
+            .put_opts(
+                &path,
+                data.clone().into(),
+                PutOptions {
+                    attributes: expected_attributes.clone(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let get_result = storage.get(&path).await?;
+        let get_meta = get_result.meta.clone();
+        let get_attributes = get_result.attributes.clone();
+        let retrieved = get_result.bytes().await?;
+        let head_result = storage
+            .get_opts(
+                &path,
+                GetOptions {
+                    head: true,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        Ok::<_, object_store::Error>((put_result, get_meta, get_attributes, retrieved, head_result))
+    }
+    .await;
+    let cleanup = storage.delete(&path).await;
+    let (put_result, get_meta, get_attributes, retrieved, head_result) = operation
+        .unwrap_or_else(|error| panic!("[{provider_name}] attribute round trip failed: {error:?}"));
+    cleanup.unwrap_or_else(|error| panic!("[{provider_name}] attribute cleanup failed: {error:?}"));
+
+    assert_eq!(retrieved, data, "[{provider_name}] payload changed");
+    assert_eq!(get_meta.location, path);
+    assert_eq!(get_meta.e_tag, put_result.e_tag);
+    for (attribute, expected) in &expected_attributes {
+        assert_eq!(
+            get_attributes.get(attribute),
+            Some(expected),
+            "[{provider_name}] get omitted or changed {attribute:?}"
+        );
+        assert_eq!(
+            head_result.attributes.get(attribute),
+            Some(expected),
+            "[{provider_name}] head omitted or changed {attribute:?}"
+        );
+    }
+    assert_eq!(head_result.meta, get_meta);
+}
+
 // --- gRPC Provider Context ---
 // --- AWS Provider Context ---
 #[cfg(feature = "aws")]

--- a/examples/byob-storage-ts/README.md
+++ b/examples/byob-storage-ts/README.md
@@ -56,8 +56,9 @@ const bindings = await Bindings.forRemoteDeployment({
 
 const uploads = bindings.storage("uploads")
 await uploads.put("hello.txt", new TextEncoder().encode("hello"))
-await uploads.get("hello.txt")
-await uploads.head("hello.txt")
+const object = await uploads.get("hello.txt")
+const head = await uploads.head("hello.txt")
+console.log(new TextDecoder().decode(object.data), head.meta, head.attributes)
 await uploads.list()
 await uploads.delete("hello.txt")
 ```

--- a/examples/byob-storage-ts/src/vendor.ts
+++ b/examples/byob-storage-ts/src/vendor.ts
@@ -18,13 +18,13 @@ const objectPath = "hello.txt"
 
 await uploads.put(objectPath, new TextEncoder().encode("hello from the vendor backend"))
 
-const metadata = await uploads.head(objectPath)
-const contents = await uploads.get(objectPath)
+const head = await uploads.head(objectPath)
+const object = await uploads.get(objectPath)
 const objects = await uploads.list()
 
 console.log({
-  metadata,
-  contents: new TextDecoder().decode(contents),
+  head,
+  contents: new TextDecoder().decode(object.data),
   objects,
 })
 

--- a/examples/full-stack-microservices/services/api/src/index.ts
+++ b/examples/full-stack-microservices/services/api/src/index.ts
@@ -136,7 +136,7 @@ app.get("/files/:fileId", async c => {
     return c.json({ error: "file not found" }, 404)
   }
 
-  const object = new TextDecoder().decode(await files.get(result.rows[0].object_key))
+  const object = new TextDecoder().decode((await files.get(result.rows[0].object_key)).data)
   return c.json({ filename: result.rows[0].filename, content: object })
 })
 

--- a/examples/remote-worker-ts/src/index.ts
+++ b/examples/remote-worker-ts/src/index.ts
@@ -9,8 +9,8 @@ const tools: Record<string, { description: string; execute: (params: any) => Pro
     description: "Read a file from the customer's private workspace",
     execute: async ({ path }: { path: string }) => {
       const store = storage("files")
-      const data = await store.get(path)
-      return { content: new TextDecoder().decode(data) }
+      const object = await store.get(path)
+      return { content: new TextDecoder().decode(object.data) }
     },
   },
   "write-file": {

--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -22,14 +22,18 @@ const bindings = await Bindings.forRemoteDeployment({
 })
 
 const archive = bindings.storage("archive")
-await archive.put("reports/latest.json", Buffer.from(JSON.stringify({ ready: true })), {
-  contentType: "application/json",
-  cacheControl: "private, max-age=60",
-  metadata: { schema: "report-v1" },
+const write = await archive.put("reports/latest.json", Buffer.from(JSON.stringify({ ready: true })), {
+  attributes: {
+    contentType: "application/json",
+    cacheControl: "private, max-age=60",
+    metadata: { schema: "report-v1" },
+  },
 })
 
-const metadata = await archive.head("reports/latest.json")
-const report = await archive.get("reports/latest.json")
+const head = await archive.head("reports/latest.json")
+const object = await archive.get("reports/latest.json")
+const report = JSON.parse(object.data.toString())
+console.log(write.eTag, head.meta, head.attributes, report)
 const reports = await archive.list("reports/")
 
 await archive.delete("reports/latest.json")
@@ -37,6 +41,9 @@ await archive.delete("reports/latest.json")
 
 Cloud storage providers persist these object attributes. The local filesystem
 provider rejects attribute-bearing writes because it cannot represent them.
+GCS also rejects `contentEncoding: "gzip"`: its decompressive transcoding omits
+the response length required for byte-exact reads. Other GCS encodings, such as
+`br`, are preserved.
 
 Remote Storage exposes `get`, `put`, `head`, `list`, and `delete`. It does not
 expose copy or signed URLs. The same `Bindings` and Storage handles remain valid

--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -22,7 +22,11 @@ const bindings = await Bindings.forRemoteDeployment({
 })
 
 const archive = bindings.storage("archive")
-await archive.put("reports/latest.json", Buffer.from(JSON.stringify({ ready: true })))
+await archive.put("reports/latest.json", Buffer.from(JSON.stringify({ ready: true })), {
+  contentType: "application/json",
+  cacheControl: "private, max-age=60",
+  metadata: { schema: "report-v1" },
+})
 
 const metadata = await archive.head("reports/latest.json")
 const report = await archive.get("reports/latest.json")

--- a/packages/bindings/README.md
+++ b/packages/bindings/README.md
@@ -35,6 +35,9 @@ const reports = await archive.list("reports/")
 await archive.delete("reports/latest.json")
 ```
 
+Cloud storage providers persist these object attributes. The local filesystem
+provider rejects attribute-bearing writes because it cannot represent them.
+
 Remote Storage exposes `get`, `put`, `head`, `list`, and `delete`. It does not
 expose copy or signed URLs. The same `Bindings` and Storage handles remain valid
 while the native client refreshes short-lived cloud credentials and periodically

--- a/packages/bindings/scripts/remote-storage-smoke-lib.mjs
+++ b/packages/bindings/scripts/remote-storage-smoke-lib.mjs
@@ -8,6 +8,12 @@ const requiredEnvironmentVariables = [
 ]
 
 const payload = Buffer.from("alien remote storage smoke")
+const attributes = {
+  contentType: "application/octet-stream",
+  contentDisposition: 'attachment; filename="payload.txt"',
+  cacheControl: "private, max-age=60",
+  metadata: { source: "remote-storage-smoke" },
+}
 
 /**
  * @typedef {object} RemoteStorageSmokeConfig
@@ -49,15 +55,26 @@ export async function verifyRemoteStorage(storage, object) {
   let verificationError
 
   try {
-    await storage.put(object, payload)
+    const putResult = await storage.put(object, payload, { attributes })
+    assert.equal(typeof putResult, "object")
 
     const prefix = object.slice(0, object.lastIndexOf("/") + 1)
     const downloaded = await storage.get(object)
-    assert.deepEqual(downloaded, payload)
+    assert.deepEqual(downloaded.data, payload)
+    assert.equal(downloaded.meta.location, object)
+    assert.equal(downloaded.meta.size, payload.byteLength)
+    assert.equal(downloaded.attributes.contentType, attributes.contentType)
+    assert.equal(downloaded.attributes.contentDisposition, attributes.contentDisposition)
+    assert.equal(downloaded.attributes.cacheControl, attributes.cacheControl)
+    assert.deepEqual(downloaded.attributes.metadata, attributes.metadata)
 
-    const metadata = await storage.head(object)
-    assert.equal(metadata.location, object)
-    assert.equal(metadata.size, payload.byteLength)
+    const head = await storage.head(object)
+    assert.equal(head.meta.location, object)
+    assert.equal(head.meta.size, payload.byteLength)
+    assert.equal(head.attributes.contentType, attributes.contentType)
+    assert.equal(head.attributes.contentDisposition, attributes.contentDisposition)
+    assert.equal(head.attributes.cacheControl, attributes.cacheControl)
+    assert.deepEqual(head.attributes.metadata, attributes.metadata)
 
     const listed = await storage.list(prefix)
     assert.ok(

--- a/packages/bindings/scripts/remote-storage-smoke.test.mjs
+++ b/packages/bindings/scripts/remote-storage-smoke.test.mjs
@@ -5,25 +5,44 @@ const object = "alien-e2e/remote-storage-smoke/test/payload.txt"
 
 function fakeStorage() {
   const values = new Map()
-  const put = vi.fn(async (path, data) => {
-    values.set(path, Buffer.from(data))
+  const put = vi.fn(async (path, data, options) => {
+    values.set(path, {
+      data: Buffer.from(data),
+      attributes: options?.attributes ?? { metadata: {} },
+    })
+    return { eTag: "test-etag", version: "test-version" }
   })
   const get = vi.fn(async path => {
     const value = values.get(path)
     if (!value) throw new Error(`missing ${path}`)
-    return value
+    return {
+      data: value.data,
+      meta: {
+        location: path,
+        size: value.data.byteLength,
+        lastModified: "2026-01-01T00:00:00Z",
+      },
+      attributes: value.attributes,
+    }
   })
   const head = vi.fn(async path => {
     const value = values.get(path)
     if (!value) throw new Error(`missing ${path}`)
-    return { location: path, size: value.byteLength, lastModified: "2026-01-01T00:00:00Z" }
+    return {
+      meta: {
+        location: path,
+        size: value.data.byteLength,
+        lastModified: "2026-01-01T00:00:00Z",
+      },
+      attributes: value.attributes,
+    }
   })
   const list = vi.fn(async prefix =>
     [...values.entries()]
       .filter(([path]) => path.startsWith(prefix ?? ""))
       .map(([location, value]) => ({
         location,
-        size: value.byteLength,
+        size: value.data.byteLength,
         lastModified: "2026-01-01T00:00:00Z",
       })),
   )
@@ -62,6 +81,14 @@ describe("remote Storage smoke", () => {
     await verifyRemoteStorage(fixture.storage, object)
 
     expect(fixture.put).toHaveBeenCalledOnce()
+    expect(fixture.put).toHaveBeenCalledWith(object, expect.any(Buffer), {
+      attributes: {
+        contentType: "application/octet-stream",
+        contentDisposition: 'attachment; filename="payload.txt"',
+        cacheControl: "private, max-age=60",
+        metadata: { source: "remote-storage-smoke" },
+      },
+    })
     expect(fixture.get).toHaveBeenCalledWith(object)
     expect(fixture.head).toHaveBeenCalledOnce()
     expect(fixture.list).toHaveBeenCalledTimes(2)

--- a/packages/bindings/src/__tests__/factories.test.ts
+++ b/packages/bindings/src/__tests__/factories.test.ts
@@ -162,6 +162,20 @@ function addonForKv(kvHandle: RawKvHandle): NativeAddon {
   }
 }
 
+/** Build an addon whose `storage(name)` resolves to a caller-supplied handle. */
+function addonForStorage(storageHandle: RawStorageHandle): NativeAddon {
+  class FakeBindingsHandle {
+    async storage(): Promise<RawStorageHandle> {
+      return storageHandle
+    }
+  }
+  return {
+    BindingsHandle: FakeBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    RemoteBindingsHandle: unusedRemoteBindingsHandle(),
+    version: () => "test",
+  }
+}
+
 describe("createFactories laziness", () => {
   it("constructs factories without loading the addon; loads only on first op", async () => {
     const getAddon = vi.fn<() => NativeAddon>(() => {
@@ -283,6 +297,55 @@ describe("createFactories kv surface", () => {
 })
 
 describe("createFactories method mapping", () => {
+  it("forwards storage object attributes and converts Uint8Array data", async () => {
+    const put = vi.fn<RawStorageHandle["put"]>(async () => {})
+    const storageHandle: RawStorageHandle = {
+      get: async () => Buffer.from("x"),
+      put,
+      delete: async () => {},
+      list: async () => [],
+      head: async () => ({ location: "p", size: 0, lastModified: "" }),
+      copy: async () => {},
+      signedUrl: async () => ({ url: "u", method: "GET", headers: {} }),
+    }
+    const { storage } = createFactories(() => addonForStorage(storageHandle))
+    const options = {
+      contentType: "text/plain",
+      contentDisposition: 'attachment; filename="note.txt"',
+      contentEncoding: "gzip",
+      contentLanguage: "en-US",
+      cacheControl: "private, max-age=60",
+      metadata: { source: "upload", checksum: "abc123" },
+    }
+
+    await storage("files").put("notes/note.txt", new Uint8Array([1, 2, 3]), options)
+
+    expect(put).toHaveBeenCalledOnce()
+    const firstCall = put.mock.calls[0]
+    if (!firstCall) throw new Error("put was not called")
+    expect(firstCall[0]).toBe("notes/note.txt")
+    expect(firstCall[1]).toEqual(Buffer.from([1, 2, 3]))
+    expect(firstCall[2]).toEqual(options)
+  })
+
+  it("preserves two-argument storage puts", async () => {
+    const put = vi.fn<RawStorageHandle["put"]>(async () => {})
+    const storageHandle: RawStorageHandle = {
+      get: async () => Buffer.from("x"),
+      put,
+      delete: async () => {},
+      list: async () => [],
+      head: async () => ({ location: "p", size: 0, lastModified: "" }),
+      copy: async () => {},
+      signedUrl: async () => ({ url: "u", method: "GET", headers: {} }),
+    }
+    const { storage } = createFactories(() => addonForStorage(storageHandle))
+
+    await storage("files").put("note.txt", Buffer.from("hello"))
+
+    expect(put).toHaveBeenCalledWith("note.txt", Buffer.from("hello"), null)
+  })
+
   it("serializes queue.send payloads as JSON via the bound queue handle", async () => {
     const sendJson = vi.fn(async () => {})
     const queueHandle: RawQueueHandle = {

--- a/packages/bindings/src/__tests__/factories.test.ts
+++ b/packages/bindings/src/__tests__/factories.test.ts
@@ -68,11 +68,18 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
   const constructions: unknown[] = []
 
   const storageHandle: RawStorageHandle = {
-    get: async () => Buffer.from("x"),
-    put: async () => {},
+    get: async () => ({
+      data: Buffer.from("x"),
+      meta: { location: "p", size: 1, lastModified: "" },
+      attributes: { metadata: {} },
+    }),
+    put: async () => ({}),
     delete: async () => {},
     list: async () => [],
-    head: async () => ({ location: "p", size: 0, lastModified: "" }),
+    head: async () => ({
+      meta: { location: "p", size: 0, lastModified: "" },
+      attributes: { metadata: {} },
+    }),
     copy: async () => {},
     signedUrl: async () => ({ url: "u", method: "GET", headers: {} }),
   }
@@ -297,28 +304,74 @@ describe("createFactories kv surface", () => {
 })
 
 describe("createFactories method mapping", () => {
-  it("forwards storage object attributes and converts Uint8Array data", async () => {
-    const put = vi.fn<RawStorageHandle["put"]>(async () => {})
+  it("returns structured storage reads without discarding metadata or attributes", async () => {
+    const result = {
+      data: Buffer.from("hello"),
+      meta: {
+        location: "notes/note.txt",
+        size: 5,
+        lastModified: "2026-08-02T00:00:00Z",
+        eTag: "etag-123",
+        version: "version-456",
+      },
+      attributes: {
+        contentType: "text/plain",
+        storageClass: "STANDARD",
+        metadata: { source: "upload" },
+      },
+    }
     const storageHandle: RawStorageHandle = {
-      get: async () => Buffer.from("x"),
+      get: async () => result,
+      put: async () => ({}),
+      delete: async () => {},
+      list: async () => [],
+      head: async () => ({ meta: result.meta, attributes: result.attributes }),
+      copy: async () => {},
+      signedUrl: async () => ({ url: "u", method: "GET", headers: {} }),
+    }
+    const { storage } = createFactories(() => addonForStorage(storageHandle))
+
+    await expect(storage("files").get("notes/note.txt")).resolves.toEqual(result)
+    await expect(storage("files").head("notes/note.txt")).resolves.toEqual({
+      meta: result.meta,
+      attributes: result.attributes,
+    })
+  })
+
+  it("forwards storage object attributes and converts Uint8Array data", async () => {
+    const put = vi.fn<RawStorageHandle["put"]>(async () => ({
+      eTag: "etag-123",
+      version: "version-456",
+    }))
+    const storageHandle: RawStorageHandle = {
+      get: async () => ({
+        data: Buffer.from("x"),
+        meta: { location: "p", size: 1, lastModified: "" },
+        attributes: { metadata: {} },
+      }),
       put,
       delete: async () => {},
       list: async () => [],
-      head: async () => ({ location: "p", size: 0, lastModified: "" }),
+      head: async () => ({
+        meta: { location: "p", size: 0, lastModified: "" },
+        attributes: { metadata: {} },
+      }),
       copy: async () => {},
       signedUrl: async () => ({ url: "u", method: "GET", headers: {} }),
     }
     const { storage } = createFactories(() => addonForStorage(storageHandle))
     const options = {
-      contentType: "text/plain",
-      contentDisposition: 'attachment; filename="note.txt"',
-      contentEncoding: "gzip",
-      contentLanguage: "en-US",
-      cacheControl: "private, max-age=60",
-      metadata: { source: "upload", checksum: "abc123" },
+      attributes: {
+        contentType: "text/plain",
+        contentDisposition: 'attachment; filename="note.txt"',
+        contentEncoding: "gzip",
+        contentLanguage: "en-US",
+        cacheControl: "private, max-age=60",
+        metadata: { source: "upload", checksum: "abc123" },
+      },
     }
 
-    await storage("files").put("notes/note.txt", new Uint8Array([1, 2, 3]), options)
+    const result = await storage("files").put("notes/note.txt", new Uint8Array([1, 2, 3]), options)
 
     expect(put).toHaveBeenCalledOnce()
     const firstCall = put.mock.calls[0]
@@ -326,16 +379,24 @@ describe("createFactories method mapping", () => {
     expect(firstCall[0]).toBe("notes/note.txt")
     expect(firstCall[1]).toEqual(Buffer.from([1, 2, 3]))
     expect(firstCall[2]).toEqual(options)
+    expect(result).toEqual({ eTag: "etag-123", version: "version-456" })
   })
 
   it("preserves two-argument storage puts", async () => {
-    const put = vi.fn<RawStorageHandle["put"]>(async () => {})
+    const put = vi.fn<RawStorageHandle["put"]>(async () => ({}))
     const storageHandle: RawStorageHandle = {
-      get: async () => Buffer.from("x"),
+      get: async () => ({
+        data: Buffer.from("x"),
+        meta: { location: "p", size: 1, lastModified: "" },
+        attributes: { metadata: {} },
+      }),
       put,
       delete: async () => {},
       list: async () => [],
-      head: async () => ({ location: "p", size: 0, lastModified: "" }),
+      head: async () => ({
+        meta: { location: "p", size: 0, lastModified: "" },
+        attributes: { metadata: {} },
+      }),
       copy: async () => {},
       signedUrl: async () => ({ url: "u", method: "GET", headers: {} }),
     }

--- a/packages/bindings/src/__tests__/remote.test.ts
+++ b/packages/bindings/src/__tests__/remote.test.ts
@@ -26,9 +26,10 @@ function fakeRemoteAddon() {
   const head = vi.fn<RawRemoteStorageHandle["head"]>(async () => {
     throw new Error("unused")
   })
+  const put = vi.fn<RawRemoteStorageHandle["put"]>(async () => {})
   const storage: RawRemoteStorageHandle = {
     get: async path => Buffer.from(path),
-    put: async () => {},
+    put,
     delete: async () => {},
     list: async () => [],
     head,
@@ -92,6 +93,7 @@ function fakeRemoteAddon() {
     forRemoteDeployment,
     resolveStorage,
     head,
+    put,
   }
 }
 
@@ -148,6 +150,23 @@ describe("Bindings.forRemoteDeployment", () => {
 
     expect(fixture.forRemoteDeployment).toHaveBeenCalledOnce()
     expect(fixture.resolveStorage.mock.calls).toEqual([["archive"], ["logs"]])
+  })
+
+  it("forwards object attributes through remote Storage puts", async () => {
+    const fixture = fakeRemoteAddon()
+    loadAddon.mockReturnValue(fixture.addon)
+    const bindings = await Bindings.forRemoteDeployment({
+      deploymentId: "dep_123",
+      token: "token_123",
+    })
+    const options = {
+      contentType: "application/json",
+      metadata: { schema: "event-v1" },
+    }
+
+    await bindings.storage("archive").put("events/1.json", Buffer.from("{}"), options)
+
+    expect(fixture.put).toHaveBeenCalledWith("events/1.json", Buffer.from("{}"), options)
   })
 
   it("unwraps napi errors from discovery and Storage operations", async () => {

--- a/packages/bindings/src/__tests__/remote.test.ts
+++ b/packages/bindings/src/__tests__/remote.test.ts
@@ -26,9 +26,13 @@ function fakeRemoteAddon() {
   const head = vi.fn<RawRemoteStorageHandle["head"]>(async () => {
     throw new Error("unused")
   })
-  const put = vi.fn<RawRemoteStorageHandle["put"]>(async () => {})
+  const put = vi.fn<RawRemoteStorageHandle["put"]>(async () => ({}))
   const storage: RawRemoteStorageHandle = {
-    get: async path => Buffer.from(path),
+    get: async path => ({
+      data: Buffer.from(path),
+      meta: { location: path, size: path.length, lastModified: "" },
+      attributes: { metadata: {} },
+    }),
     put,
     delete: async () => {},
     list: async () => [],
@@ -129,9 +133,12 @@ describe("Bindings.forRemoteDeployment", () => {
   it("reuses one native bindings handle and resolves each Storage handle lazily once", async () => {
     const fixture = fakeRemoteAddon()
     fixture.head.mockResolvedValue({
-      location: "archive/a.txt",
-      size: 1,
-      lastModified: "2026-01-01T00:00:00Z",
+      meta: {
+        location: "archive/a.txt",
+        size: 1,
+        lastModified: "2026-01-01T00:00:00Z",
+      },
+      attributes: { metadata: {} },
     })
     loadAddon.mockReturnValue(fixture.addon)
 
@@ -160,8 +167,10 @@ describe("Bindings.forRemoteDeployment", () => {
       token: "token_123",
     })
     const options = {
-      contentType: "application/json",
-      metadata: { schema: "event-v1" },
+      attributes: {
+        contentType: "application/json",
+        metadata: { schema: "event-v1" },
+      },
     }
 
     await bindings.storage("archive").put("events/1.json", Buffer.from("{}"), options)

--- a/packages/bindings/src/factories.ts
+++ b/packages/bindings/src/factories.ts
@@ -46,6 +46,7 @@ import type {
   RemoteStorage,
   SignedUrlOptions,
   Storage,
+  StoragePutOptions,
   Vault,
 } from "./types.js"
 
@@ -97,7 +98,8 @@ async function guard<THandle, TResult>(
 function makeStorage(handle: () => Promise<RawStorageHandle>): Storage {
   return {
     get: path => guard(handle, raw => raw.get(path)),
-    put: (path, data) => guard(handle, raw => raw.put(path, toBuffer(data))),
+    put: (path, data, options?: StoragePutOptions) =>
+      guard(handle, raw => raw.put(path, toBuffer(data), options ?? null)),
     delete: path => guard(handle, raw => raw.delete(path)),
     list: prefix => guard(handle, raw => raw.list(prefix ?? null)),
     head: path => guard(handle, raw => raw.head(path)),
@@ -110,7 +112,8 @@ function makeStorage(handle: () => Promise<RawStorageHandle>): Storage {
 function makeRemoteStorage(handle: () => Promise<RawRemoteStorageHandle>): RemoteStorage {
   return {
     get: path => guard(handle, raw => raw.get(path)),
-    put: (path, data) => guard(handle, raw => raw.put(path, toBuffer(data))),
+    put: (path, data, options?: StoragePutOptions) =>
+      guard(handle, raw => raw.put(path, toBuffer(data), options ?? null)),
     delete: path => guard(handle, raw => raw.delete(path)),
     list: prefix => guard(handle, raw => raw.list(prefix ?? null)),
     head: path => guard(handle, raw => raw.head(path)),

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -57,5 +57,6 @@ export type {
   SignedUrlMethod,
   SignedUrlOptions,
   Storage,
+  StoragePutOptions,
   Vault,
 } from "./types.js"

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -57,6 +57,11 @@ export type {
   SignedUrlMethod,
   SignedUrlOptions,
   Storage,
+  StorageGetResult,
+  StorageHeadResult,
+  StorageObjectAttributes,
+  StoragePutAttributes,
   StoragePutOptions,
+  StoragePutResult,
   Vault,
 } from "./types.js"

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -34,6 +34,7 @@ import { existsSync } from "node:fs"
 import { createRequire } from "node:module"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import type { StoragePutOptions } from "./types.js"
 
 const require = createRequire(import.meta.url)
 
@@ -74,7 +75,7 @@ export interface RawQueueMessage {
 /** Raw napi storage handle. */
 export interface RawStorageHandle {
   get(path: string): Promise<Buffer>
-  put(path: string, data: Buffer): Promise<void>
+  put(path: string, data: Buffer, options?: StoragePutOptions | null): Promise<void>
   delete(path: string): Promise<void>
   list(prefix?: string | null): Promise<RawObjectMeta[]>
   head(path: string): Promise<RawObjectMeta>
@@ -85,7 +86,7 @@ export interface RawStorageHandle {
 /** Raw napi remote Storage v0 handle. */
 export interface RawRemoteStorageHandle {
   get(path: string): Promise<Buffer>
-  put(path: string, data: Buffer): Promise<void>
+  put(path: string, data: Buffer, options?: StoragePutOptions | null): Promise<void>
   delete(path: string): Promise<void>
   list(prefix?: string | null): Promise<RawObjectMeta[]>
   head(path: string): Promise<RawObjectMeta>

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -34,7 +34,12 @@ import { existsSync } from "node:fs"
 import { createRequire } from "node:module"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
-import type { StoragePutOptions } from "./types.js"
+import type {
+  StorageGetResult,
+  StorageHeadResult,
+  StoragePutOptions,
+  StoragePutResult,
+} from "./types.js"
 
 const require = createRequire(import.meta.url)
 
@@ -55,6 +60,8 @@ export interface RawObjectMeta {
   location: string
   size: number
   lastModified: string
+  eTag?: string
+  version?: string
 }
 
 /** Raw napi presigned request. */
@@ -74,22 +81,22 @@ export interface RawQueueMessage {
 
 /** Raw napi storage handle. */
 export interface RawStorageHandle {
-  get(path: string): Promise<Buffer>
-  put(path: string, data: Buffer, options?: StoragePutOptions | null): Promise<void>
+  get(path: string): Promise<StorageGetResult>
+  put(path: string, data: Buffer, options?: StoragePutOptions | null): Promise<StoragePutResult>
   delete(path: string): Promise<void>
   list(prefix?: string | null): Promise<RawObjectMeta[]>
-  head(path: string): Promise<RawObjectMeta>
+  head(path: string): Promise<StorageHeadResult>
   copy(from: string, to: string): Promise<void>
   signedUrl(method: string, path: string, expiresInSecs: number): Promise<RawPresignedRequest>
 }
 
 /** Raw napi remote Storage v0 handle. */
 export interface RawRemoteStorageHandle {
-  get(path: string): Promise<Buffer>
-  put(path: string, data: Buffer, options?: StoragePutOptions | null): Promise<void>
+  get(path: string): Promise<StorageGetResult>
+  put(path: string, data: Buffer, options?: StoragePutOptions | null): Promise<StoragePutResult>
   delete(path: string): Promise<void>
   list(prefix?: string | null): Promise<RawObjectMeta[]>
-  head(path: string): Promise<RawObjectMeta>
+  head(path: string): Promise<StorageHeadResult>
 }
 
 /** Raw napi key-value handle. */

--- a/packages/bindings/src/native.ts
+++ b/packages/bindings/src/native.ts
@@ -76,5 +76,6 @@ export type {
   SignedUrlMethod,
   SignedUrlOptions,
   Storage,
+  StoragePutOptions,
   Vault,
 } from "./types.js"

--- a/packages/bindings/src/native.ts
+++ b/packages/bindings/src/native.ts
@@ -76,6 +76,11 @@ export type {
   SignedUrlMethod,
   SignedUrlOptions,
   Storage,
+  StorageGetResult,
+  StorageHeadResult,
+  StorageObjectAttributes,
+  StoragePutAttributes,
   StoragePutOptions,
+  StoragePutResult,
   Vault,
 } from "./types.js"

--- a/packages/bindings/src/types.ts
+++ b/packages/bindings/src/types.ts
@@ -12,6 +12,10 @@ export interface ObjectMeta {
   size: number
   /** Last-modified timestamp as an RFC 3339 string. */
   lastModified: string
+  /** Provider entity tag, when available. */
+  eTag?: string
+  /** Provider object version, when available. */
+  version?: string
 }
 
 /** HTTP method a presigned request may be issued for. */
@@ -38,34 +42,80 @@ export interface PresignedRequest {
   headers: Record<string, string>
 }
 
-/** Provider-neutral object attributes for {@link Storage.put}. */
-export interface StoragePutOptions {
-  /** MIME type stored with the object. */
+/** Provider-neutral attributes returned with a stored object. */
+export interface StorageObjectAttributes {
+  /** Stored MIME type. */
   contentType?: string
-  /** Browser content-disposition behavior stored with the object. */
+  /** Stored browser content-disposition behavior. */
   contentDisposition?: string
-  /** Content encoding stored with the object. */
+  /** Stored content encoding. */
   contentEncoding?: string
-  /** Content language stored with the object. */
+  /** Stored content language. */
   contentLanguage?: string
-  /** Cache-control policy stored with the object. */
+  /** Stored cache-control policy. */
   cacheControl?: string
+  /** Provider storage class, when reported. */
+  storageClass?: string
   /** User-defined object metadata. */
+  metadata: Record<string, string>
+}
+
+/** Provider-neutral object attributes accepted by {@link Storage.put}. */
+export interface StoragePutAttributes {
+  /** MIME type to store with the object. */
+  contentType?: string
+  /** Browser content-disposition behavior to store with the object. */
+  contentDisposition?: string
+  /** Content encoding to store. GCS rejects `gzip` because it transcodes gzip responses. */
+  contentEncoding?: string
+  /** Content language to store with the object. */
+  contentLanguage?: string
+  /** Cache-control policy to store with the object. */
+  cacheControl?: string
+  /** User-defined object metadata to store. */
   metadata?: Record<string, string>
+}
+
+/** Options for {@link Storage.put}. */
+export interface StoragePutOptions {
+  attributes?: StoragePutAttributes
+}
+
+/** Result of reading a stored object. */
+export interface StorageGetResult {
+  data: Buffer
+  meta: ObjectMeta
+  attributes: StorageObjectAttributes
+}
+
+/** Result of reading object information without its payload. */
+export interface StorageHeadResult {
+  meta: ObjectMeta
+  attributes: StorageObjectAttributes
+}
+
+/** Provider identifiers returned after a successful storage write. */
+export interface StoragePutResult {
+  eTag?: string
+  version?: string
 }
 
 /** A resolved object-storage binding. */
 export interface Storage {
   /** Fetch the object at `path`. */
-  get(path: string): Promise<Buffer>
+  get(path: string): Promise<StorageGetResult>
   /** Store `data` at `path`, optionally with provider-neutral object attributes. */
-  put(path: string, data: Buffer | Uint8Array, options?: StoragePutOptions): Promise<void>
+  put(
+    path: string,
+    data: Buffer | Uint8Array,
+    options?: StoragePutOptions,
+  ): Promise<StoragePutResult>
   /** Delete the object at `path`. */
   delete(path: string): Promise<void>
   /** List objects, optionally filtered by `prefix`. */
   list(prefix?: string): Promise<ObjectMeta[]>
-  /** Fetch metadata for the object at `path`. */
-  head(path: string): Promise<ObjectMeta>
+  /** Fetch metadata and attributes for `path` without downloading its payload. */
+  head(path: string): Promise<StorageHeadResult>
   /** Copy the object at `from` to `to`. */
   copy(from: string, to: string): Promise<void>
   /** Create a presigned request for `path`. */

--- a/packages/bindings/src/types.ts
+++ b/packages/bindings/src/types.ts
@@ -38,12 +38,28 @@ export interface PresignedRequest {
   headers: Record<string, string>
 }
 
+/** Provider-neutral object attributes for {@link Storage.put}. */
+export interface StoragePutOptions {
+  /** MIME type stored with the object. */
+  contentType?: string
+  /** Browser content-disposition behavior stored with the object. */
+  contentDisposition?: string
+  /** Content encoding stored with the object. */
+  contentEncoding?: string
+  /** Content language stored with the object. */
+  contentLanguage?: string
+  /** Cache-control policy stored with the object. */
+  cacheControl?: string
+  /** User-defined object metadata. */
+  metadata?: Record<string, string>
+}
+
 /** A resolved object-storage binding. */
 export interface Storage {
   /** Fetch the object at `path`. */
   get(path: string): Promise<Buffer>
-  /** Store `data` at `path`. */
-  put(path: string, data: Buffer | Uint8Array): Promise<void>
+  /** Store `data` at `path`, optionally with provider-neutral object attributes. */
+  put(path: string, data: Buffer | Uint8Array, options?: StoragePutOptions): Promise<void>
   /** Delete the object at `path`. */
   delete(path: string): Promise<void>
   /** List objects, optionally filtered by `prefix`. */

--- a/packages/bindings/tests/storage.test.ts
+++ b/packages/bindings/tests/storage.test.ts
@@ -28,11 +28,16 @@ describe("storage (local file-tree provider)", () => {
     const s = freshStorage()
     const data = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0x00, 0x80, 0x7f, 0x00])
 
-    await s.put("bin/data.bin", data)
+    const putResult = await s.put("bin/data.bin", data)
     const fetched = await s.get("bin/data.bin")
 
-    expect(fetched.length).toBe(data.length)
-    expect(fetched.equals(data)).toBe(true)
+    expect(putResult.eTag).toEqual(expect.any(String))
+    expect(putResult.version).toBeUndefined()
+    expect(fetched.data.length).toBe(data.length)
+    expect(fetched.data.equals(data)).toBe(true)
+    expect(fetched.meta).toMatchObject({ location: "bin/data.bin", size: data.length })
+    expect(Number.isNaN(Date.parse(fetched.meta.lastModified))).toBe(false)
+    expect(fetched.attributes).toEqual({ metadata: {} })
   })
 
   it("rejects object attributes when the backend cannot persist them", async () => {
@@ -41,12 +46,14 @@ describe("storage (local file-tree provider)", () => {
 
     await expect(
       s.put("attributes.txt", data, {
-        contentType: "text/plain; charset=utf-8",
-        contentDisposition: 'attachment; filename="attributes.txt"',
-        contentEncoding: "identity",
-        contentLanguage: "en-US",
-        cacheControl: "private, max-age=60",
-        metadata: { source: "integration-test", checksum: "abc123" },
+        attributes: {
+          contentType: "text/plain; charset=utf-8",
+          contentDisposition: 'attachment; filename="attributes.txt"',
+          contentEncoding: "identity",
+          contentLanguage: "en-US",
+          cacheControl: "private, max-age=60",
+          metadata: { source: "integration-test", checksum: "abc123" },
+        },
       }),
     ).rejects.toMatchObject({
       code: "OPERATION_NOT_SUPPORTED",
@@ -63,15 +70,16 @@ describe("storage (local file-tree provider)", () => {
     const listed = await s.list()
     expect(listed.map(o => o.location).sort()).toEqual(["a.txt", "b.txt"])
 
-    const meta = await s.head("a.txt")
-    expect(meta.location).toBe("a.txt")
-    expect(meta.size).toBe(Buffer.from("a-content").length)
-    expect(Number.isNaN(Date.parse(meta.lastModified))).toBe(false)
+    const head = await s.head("a.txt")
+    expect(head.meta.location).toBe("a.txt")
+    expect(head.meta.size).toBe(Buffer.from("a-content").length)
+    expect(Number.isNaN(Date.parse(head.meta.lastModified))).toBe(false)
+    expect(head.attributes).toEqual({ metadata: {} })
 
     await s.copy("a.txt", "a-copy.txt")
-    expect((await s.get("a-copy.txt")).toString("utf8")).toBe("a-content")
+    expect((await s.get("a-copy.txt")).data.toString("utf8")).toBe("a-content")
     // copy must not remove the source
-    expect((await s.get("a.txt")).toString("utf8")).toBe("a-content")
+    expect((await s.get("a.txt")).data.toString("utf8")).toBe("a-content")
 
     await s.delete("a.txt")
     const afterDelete = await s.list()

--- a/packages/bindings/tests/storage.test.ts
+++ b/packages/bindings/tests/storage.test.ts
@@ -35,6 +35,25 @@ describe("storage (local file-tree provider)", () => {
     expect(fetched.equals(data)).toBe(true)
   })
 
+  it("accepts object attributes through the real napi boundary", async () => {
+    const s = freshStorage()
+    const data = Buffer.from("attribute-bearing object")
+
+    await s.put("attributes.txt", data, {
+      contentType: "text/plain; charset=utf-8",
+      contentDisposition: 'attachment; filename="attributes.txt"',
+      contentEncoding: "identity",
+      contentLanguage: "en-US",
+      cacheControl: "private, max-age=60",
+      metadata: { source: "integration-test", checksum: "abc123" },
+    })
+
+    // The local filesystem backend does not expose object attributes, but the
+    // successful round trip proves the public JS object crossed the real napi
+    // boundary and reached the storage write path.
+    expect(await s.get("attributes.txt")).toEqual(data)
+  })
+
   it("lists, heads, copies, and deletes objects", async () => {
     const s = freshStorage()
     await s.put("a.txt", Buffer.from("a-content"))

--- a/packages/bindings/tests/storage.test.ts
+++ b/packages/bindings/tests/storage.test.ts
@@ -35,23 +35,24 @@ describe("storage (local file-tree provider)", () => {
     expect(fetched.equals(data)).toBe(true)
   })
 
-  it("accepts object attributes through the real napi boundary", async () => {
+  it("rejects object attributes when the backend cannot persist them", async () => {
     const s = freshStorage()
     const data = Buffer.from("attribute-bearing object")
 
-    await s.put("attributes.txt", data, {
-      contentType: "text/plain; charset=utf-8",
-      contentDisposition: 'attachment; filename="attributes.txt"',
-      contentEncoding: "identity",
-      contentLanguage: "en-US",
-      cacheControl: "private, max-age=60",
-      metadata: { source: "integration-test", checksum: "abc123" },
+    await expect(
+      s.put("attributes.txt", data, {
+        contentType: "text/plain; charset=utf-8",
+        contentDisposition: 'attachment; filename="attributes.txt"',
+        contentEncoding: "identity",
+        contentLanguage: "en-US",
+        cacheControl: "private, max-age=60",
+        metadata: { source: "integration-test", checksum: "abc123" },
+      }),
+    ).rejects.toMatchObject({
+      code: "OPERATION_NOT_SUPPORTED",
+      retryable: false,
     })
-
-    // The local filesystem backend does not expose object attributes, but the
-    // successful round trip proves the public JS object crossed the real napi
-    // boundary and reached the storage write path.
-    expect(await s.get("attributes.txt")).toEqual(data)
+    expect(await s.list()).toEqual([])
   })
 
   it("lists, heads, copies, and deletes objects", async () => {

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
@@ -16,7 +16,7 @@ app.post("/storage-test/:bindingName", async c => {
 
     // 2. Get and verify
     const retrieved = await s.get(testKey)
-    const retrievedContent = new TextDecoder().decode(retrieved)
+    const retrievedContent = new TextDecoder().decode(retrieved.data)
     if (retrievedContent !== content) {
       return c.json({ success: false, error: "Data verification failed" }, 500)
     }

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/wait-until.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/wait-until.ts
@@ -30,7 +30,7 @@ app.get("/wait-until-verify/:testId/:storageBindingName", async c => {
     // Storage has no `exists`; a missing object surfaces as a thrown NotFound
     // from `get`, which the catch below maps to "not completed yet".
     const result = await s.get(`wait-until-${testId}.txt`)
-    const fileContent = new TextDecoder().decode(result)
+    const fileContent = new TextDecoder().decode(result.data)
     return c.json({
       success: true,
       testId,


### PR DESCRIPTION
## Summary

- replace the byte-only Storage read API with structured `get` and `head` results containing object metadata and provider attributes
- accept write attributes under `put(..., { attributes })` and return provider `eTag` / `version` identifiers
- preserve ETag and version on `ObjectMeta`; keep `list` as metadata-only because cloud list APIs do not return object attributes
- expose content type, content disposition, content encoding, content language, cache control, storage class, and custom metadata through Rust, NAPI, and TypeScript
- reject unsupported local attribute writes before writing any payload
- reject GCS `contentEncoding: "gzip"` before upload because decompressive transcoding omits the response length required for byte-exact reads; other encodings remain supported
- update package consumers, examples, E2E handlers, documentation, and the remote-storage smoke flow for the breaking API

## Breaking changes

- `Storage.get(path)` now returns `{ data, meta, attributes }`
- `Storage.head(path)` now returns `{ meta, attributes }`
- `Storage.put(path, data, options?)` now returns `{ eTag?, version? }`
- write attributes are nested under `options.attributes`

Backward compatibility is intentionally not preserved so reads and writes have one symmetric object model.

## Validation

- `cargo test -p alien-bindings-node --locked` — 21 passed
- `cargo test -p alien-bindings --features platform-sdk --lib remote:: --locked` — 21 passed
- `cargo test -p alien-bindings --lib --locked` — 118 passed
- `cargo test -p alien-bindings --test storage cloud_storage_round_trips_object_attributes --locked -- --nocapture` — real AWS S3, GCS, and Azure Blob cases passed and cleaned up
- rebuilt the release NAPI addon and ran the full bindings suite against it — 85 passed
- `pnpm --filter @alienplatform/bindings test:ts`
- `pnpm --filter @alienplatform/bindings build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec turbo test:ts --concurrency 4` — 19/19 tasks passed
- `pnpm format-and-lint`
- live TypeScript/NAPI/provider smoke: `put → get → head → list → delete` passed on S3, GCS, and Azure Blob with headers and custom metadata; GCS gzip rejection was structured and occurred before write

Linear: [ALIEN-431](https://linear.app/alienplatform/issue/ALIEN-431/expose-object-attributes-across-storage-bindings)