### PR TITLE
fix(ci): remove unused client SDK pnpm setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -721,10 +721,6 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.source_ref }}
 
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.0
-
       - uses: actions/setup-node@v5
         with:
           node-version: 22


### PR DESCRIPTION
The client SDK release job builds both generated SDKs with npm only. Initializing pnpm is unused, and pnpm/action-setup fails during post-job cache validation because this job never creates a pnpm store. Remove the unused setup so successfully built SDK artifacts do not fail qualification.