### PR TITLE
fix(ci): disable package cache for client SDK release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -725,6 +725,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Validate npm auth
         if: ${{ inputs.stable_action == 'publish' }}


### PR DESCRIPTION
The client SDK release job intentionally uses npm in each generated SDK directory. actions/setup-node@v5 otherwise auto-detects the root pnpm package manager and invokes pnpm caching, which either fails before the build when pnpm is absent or fails post-job when no pnpm store exists. Disable package-manager caching explicitly for this npm-only job.