### PR TITLE
chore: release v3.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alien-ai-gateway"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-bindings",
  "alien-error",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "base64 0.22.1",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "aegis",
  "alien-aws-clients",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error",
  "chrono",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.3.2"
+version = "3.3.3"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -63,39 +63,39 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.3.2", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.3.3", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.3.2", default-features = false }
-alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.2" }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.2" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.3.2", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.2" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.3.3", default-features = false }
+alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.3" }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.3" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.3.3", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.3" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.3.2" }
-alien-infra = { path = "crates/alien-infra", version = "3.3.2" }
-alien-build = { path = "crates/alien-build", version = "3.3.2" }
-alien-macros = { path = "crates/alien-macros", version = "3.3.2" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.3.2" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.3.2" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.2" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.2" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.2" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.2" }
-alien-error = { path = "crates/alien-error", version = "3.3.2", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.2" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.3.2" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.3.2" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.3.2" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.2" }
-alien-local = { path = "crates/alien-local", version = "3.3.2" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.2" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.3.2" }
-alien-helm = { path = "crates/alien-helm", version = "3.3.2" }
-alien-manager = { path = "crates/alien-manager", version = "3.3.2" }
-alien-observer = { path = "crates/alien-observer", version = "3.3.2" }
+alien-core = { path = "crates/alien-core", version = "3.3.3" }
+alien-infra = { path = "crates/alien-infra", version = "3.3.3" }
+alien-build = { path = "crates/alien-build", version = "3.3.3" }
+alien-macros = { path = "crates/alien-macros", version = "3.3.3" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.3.3" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.3.3" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.3" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.3" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.3" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.3" }
+alien-error = { path = "crates/alien-error", version = "3.3.3", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.3" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.3.3" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.3.3" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.3.3" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.3" }
+alien-local = { path = "crates/alien-local", version = "3.3.3" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.3" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.3.3" }
+alien-helm = { path = "crates/alien-helm", version = "3.3.3" }
+alien-manager = { path = "crates/alien-manager", version = "3.3.3" }
+alien-observer = { path = "crates/alien-observer", version = "3.3.3" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.2", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.2", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.3", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.3", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/.speakeasy/gen.lock
+++ b/client-sdks/manager/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.2
+  releaseVersion: 3.3.3
   configChecksum: 44d827c044b50072551da66b6620ad00
   repoURL: https://github.com/alienplatform/alien.git
   repoSubDirectory: client-sdks/manager/typescript

--- a/client-sdks/manager/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/manager/typescript/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: automatic
 typescript:
-  version: 3.3.2
+  version: 3.3.3
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/manager/typescript/jsr.json
+++ b/client-sdks/manager/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/.speakeasy/gen.lock
+++ b/client-sdks/platform/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.2
+  releaseVersion: 3.3.3
   configChecksum: 63869a3d2a5d56230cef83f771a82d02
 persistentEdits:
   generation_id: db6ac3e5-6bcc-4de5-a81f-eb659048385d

--- a/client-sdks/platform/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/platform/typescript/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.2
+  version: 3.3.3
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/platform/typescript/jsr.json
+++ b/client-sdks/platform/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/platform/typescript/package-lock.json
+++ b/client-sdks/platform/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alienplatform/platform-api",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "FSL-1.1-Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/ai-gateway",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "cpu": ["arm64"],
   "main": "alien-bindings-node.darwin-arm64.node",
   "files": ["alien-bindings-node.darwin-arm64.node"],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "cpu": ["x64"],
   "main": "alien-bindings-node.darwin-x64.node",
   "files": ["alien-bindings-node.darwin-x64.node"],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "cpu": ["arm64"],
   "main": "alien-bindings-node.linux-arm64-gnu.node",
   "files": ["alien-bindings-node.linux-arm64-gnu.node"],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "cpu": ["x64"],
   "main": "alien-bindings-node.linux-x64-gnu.node",
   "files": ["alien-bindings-node.linux-x64-gnu.node"],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "files": ["dist"],
   "exports": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "files": ["dist"],
   "exports": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Version-only release PR generated by the stable release workflow. The **Release qualification** check builds and records the exact artifact set. After every required check passes and this merges, run the stable **publish** action from `main` to promote those qualified artifacts.