### PR TITLE
fix(aws): deliver inbound receipt events

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/email.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/email.rs
@@ -11,7 +11,10 @@
 //! `AWS::SNS::Topic`, which is subscribed to the linked SQS queue (plus the
 //! queue policy that allows the topic to send). When `inbound` is configured:
 //! an `AWS::SES::ReceiptRuleSet` and a catch-all `AWS::SES::ReceiptRule` whose
-//! `S3Action` writes raw incoming mail into the linked storage bucket (the
+//! `S3Action` writes raw incoming mail into the linked storage bucket and,
+//! when events are configured, publishes the SES receipt notification to the
+//! same topic. The notification carries the envelope recipients and verdicts
+//! that cannot be recovered safely from message headers (the
 //! bucket policy statement that allows `ses.amazonaws.com` writes is emitted
 //! by the storage emitter — S3 supports only one bucket policy resource per
 //! bucket). Because CloudFormation has no native resource for the account-wide
@@ -140,7 +143,17 @@ impl CfEmitter for AwsEmailEmitter {
                 &Storage::RESOURCE_TYPE,
                 "inbound.storage",
             )?;
-            resources.extend(inbound_resources(ctx, email, logical_id, bucket_id));
+            let event_topic_id = email
+                .events
+                .as_ref()
+                .map(|_| format!("{logical_id}EventsTopic"));
+            resources.extend(inbound_resources(
+                ctx,
+                email,
+                logical_id,
+                bucket_id,
+                event_topic_id.as_deref(),
+            ));
         }
 
         resources.extend(email_iam_policies(ctx, email, logical_id)?);
@@ -331,6 +344,46 @@ fn event_resources(
     );
     topic.properties.insert("Tags".to_string(), tags(ctx));
 
+    let topic_policy_id = format!("{logical_id}EventsTopicPolicy");
+    let mut topic_policy =
+        CfResource::new(topic_policy_id.clone(), "AWS::SNS::TopicPolicy".to_string());
+    topic_policy.properties.insert(
+        "Topics".to_string(),
+        CfExpression::list([CfExpression::ref_(&topic_id)]),
+    );
+    topic_policy.properties.insert(
+        "PolicyDocument".to_string(),
+        CfExpression::object([
+            ("Version", CfExpression::from("2012-10-17")),
+            (
+                "Statement",
+                CfExpression::list([CfExpression::object([
+                    ("Sid", CfExpression::from("AllowSesPublish")),
+                    ("Effect", CfExpression::from("Allow")),
+                    (
+                        "Principal",
+                        CfExpression::object([(
+                            "Service",
+                            CfExpression::from("ses.amazonaws.com"),
+                        )]),
+                    ),
+                    ("Action", CfExpression::from("sns:Publish")),
+                    ("Resource", CfExpression::ref_(&topic_id)),
+                    (
+                        "Condition",
+                        CfExpression::object([(
+                            "StringEquals",
+                            CfExpression::object([(
+                                "AWS:SourceAccount",
+                                CfExpression::ref_("AWS::AccountId"),
+                            )]),
+                        )]),
+                    ),
+                ])]),
+            ),
+        ]),
+    );
+
     let mut destination = CfResource::new(
         format!("{logical_id}EventDestination"),
         "AWS::SES::ConfigurationSetEventDestination".to_string(),
@@ -339,6 +392,8 @@ fn event_resources(
         "ConfigurationSetName".to_string(),
         CfExpression::ref_(config_set_id),
     );
+    // SES validates SNS publish access while creating the destination.
+    destination.depends_on.push(topic_policy_id);
     destination.properties.insert(
         "EventDestination".to_string(),
         CfExpression::object([
@@ -427,7 +482,7 @@ fn event_resources(
         ]),
     );
 
-    vec![topic, destination, subscription, queue_policy]
+    vec![topic, topic_policy, destination, subscription, queue_policy]
 }
 
 /// SES receipt rule set + receipt rule with an S3 action into the linked
@@ -439,6 +494,7 @@ fn inbound_resources(
     email: &Email,
     logical_id: &str,
     bucket_id: &str,
+    event_topic_id: Option<&str>,
 ) -> Vec<CfResource> {
     let rule_set_id = format!("{logical_id}RuleSet");
     let activator_role_id = format!("{logical_id}RuleSetActivatorRole");
@@ -456,6 +512,11 @@ fn inbound_resources(
     );
     rule.properties
         .insert("RuleSetName".to_string(), CfExpression::ref_(&rule_set_id));
+    let mut s3_action = vec![("BucketName", CfExpression::ref_(bucket_id))];
+    if let Some(topic_id) = event_topic_id {
+        s3_action.push(("TopicArn", CfExpression::ref_(topic_id)));
+    }
+
     rule.properties.insert(
         "Rule".to_string(),
         CfExpression::object([
@@ -471,7 +532,7 @@ fn inbound_resources(
                 "Actions",
                 CfExpression::list([CfExpression::object([(
                     "S3Action",
-                    CfExpression::object([("BucketName", CfExpression::ref_(bucket_id))]),
+                    CfExpression::object(s3_action),
                 )])]),
             ),
         ]),
@@ -479,6 +540,11 @@ fn inbound_resources(
     // The storage emitter emits `{bucket}BucketPolicy` with the statement that
     // allows ses.amazonaws.com to write; SES rejects the rule without it.
     rule.depends_on.push(format!("{bucket_id}BucketPolicy"));
+    // When TopicArn is present, SES validates publish access at rule creation.
+    if event_topic_id.is_some() {
+        rule.depends_on
+            .push(format!("{logical_id}EventsTopicPolicy"));
+    }
 
     let mut activator_role =
         CfResource::new(activator_role_id.clone(), "AWS::IAM::Role".to_string());

--- a/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
@@ -81,6 +81,21 @@ fn aws_email_renders_ses_infrastructure() {
         destination["SnsDestination"]["TopicARN"]["Ref"],
         "MailerEventsTopic"
     );
+    assert_eq!(
+        resources["MailerEventDestination"]["DependsOn"],
+        serde_json::json!(["MailerEventsTopicPolicy"]),
+        "SES validates topic publish access while creating the event destination"
+    );
+    let topic_policy_statement =
+        &resources["MailerEventsTopicPolicy"]["Properties"]["PolicyDocument"]["Statement"][0];
+    assert_eq!(
+        topic_policy_statement["Principal"]["Service"],
+        "ses.amazonaws.com"
+    );
+    assert_eq!(
+        topic_policy_statement["Condition"]["StringEquals"]["AWS:SourceAccount"]["Ref"],
+        "AWS::AccountId"
+    );
     let subscription = &resources["MailerEventsSubscription"]["Properties"];
     assert_eq!(subscription["Protocol"], "sqs");
     assert_eq!(
@@ -118,8 +133,12 @@ fn aws_email_renders_ses_infrastructure() {
         "Mailbox"
     );
     assert_eq!(
+        rule["Properties"]["Rule"]["Actions"][0]["S3Action"]["TopicArn"]["Ref"],
+        "MailerEventsTopic"
+    );
+    assert_eq!(
         rule["DependsOn"],
-        serde_json::json!(["MailboxBucketPolicy"])
+        serde_json::json!(["MailboxBucketPolicy", "MailerEventsTopicPolicy"])
     );
     let activation = &resources["MailerRuleSetActivation"];
     assert_eq!(activation["Type"], "AWS::CloudFormation::CustomResource");

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_email_tests__aws_email.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_email_tests__aws_email.snap
@@ -215,6 +215,25 @@ Resources:
         Value: mailer
       - Key: resource-type
         Value: email
+  MailerEventsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+      - Ref: MailerEventsTopic
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Sid: AllowSesPublish
+          Effect: Allow
+          Principal:
+            Service: ses.amazonaws.com
+          Action: sns:Publish
+          Resource:
+            Ref: MailerEventsTopic
+          Condition:
+            StringEquals:
+              AWS:SourceAccount:
+                Ref: AWS::AccountId
   MailerEventDestination:
     Type: AWS::SES::ConfigurationSetEventDestination
     Properties:
@@ -234,6 +253,8 @@ Resources:
         SnsDestination:
           TopicARN:
             Ref: MailerEventsTopic
+    DependsOn:
+    - MailerEventsTopicPolicy
   MailerEventsSubscription:
     Type: AWS::SNS::Subscription
     Properties:
@@ -285,8 +306,11 @@ Resources:
         - S3Action:
             BucketName:
               Ref: Mailbox
+            TopicArn:
+              Ref: MailerEventsTopic
     DependsOn:
     - MailboxBucketPolicy
+    - MailerEventsTopicPolicy
   MailerRuleSetActivatorRole:
     Type: AWS::IAM::Role
     Properties:

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -1193,6 +1193,25 @@ Resources:
         Value: mailer
       - Key: resource-type
         Value: email
+  MailerEventsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+      - Ref: MailerEventsTopic
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Sid: AllowSesPublish
+          Effect: Allow
+          Principal:
+            Service: ses.amazonaws.com
+          Action: sns:Publish
+          Resource:
+            Ref: MailerEventsTopic
+          Condition:
+            StringEquals:
+              AWS:SourceAccount:
+                Ref: AWS::AccountId
   MailerEventDestination:
     Type: AWS::SES::ConfigurationSetEventDestination
     Properties:
@@ -1212,6 +1231,8 @@ Resources:
         SnsDestination:
           TopicARN:
             Ref: MailerEventsTopic
+    DependsOn:
+    - MailerEventsTopicPolicy
   MailerEventsSubscription:
     Type: AWS::SNS::Subscription
     Properties:
@@ -1263,8 +1284,11 @@ Resources:
         - S3Action:
             BucketName:
               Ref: Mailbox
+            TopicArn:
+              Ref: MailerEventsTopic
     DependsOn:
     - MailboxBucketPolicy
+    - MailerEventsTopicPolicy
   MailerRuleSetActivatorRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1899,6 +1923,7 @@ Resources:
     - MailerConfigSet
     - MailerIdentity0
     - MailerEventsTopic
+    - MailerEventsTopicPolicy
     - MailerEventDestination
     - MailerEventsSubscription
     - MailerEventsQueuePolicy

--- a/crates/alien-core/src/resources/email.rs
+++ b/crates/alien-core/src/resources/email.rs
@@ -72,9 +72,11 @@ pub struct Email {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inbound: Option<EmailInbound>,
 
-    /// Optional sending-event configuration: send / delivery / bounce /
-    /// complaint / delivery-delay / reject events are delivered to the
-    /// linked Queue.
+    /// Optional event configuration: send / delivery / bounce / complaint /
+    /// delivery-delay / reject events are delivered to the linked Queue. On
+    /// AWS, when `inbound` is also configured, that Queue additionally
+    /// receives SES `Received` notifications containing the envelope
+    /// recipients, receipt verdicts, and inbound Storage object key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub events: Option<EmailEvents>,
 }
@@ -88,12 +90,13 @@ pub struct EmailInbound {
     pub storage: ResourceRef,
 }
 
-/// Sending-event configuration for an [`Email`] resource.
+/// Event configuration for an [`Email`] resource.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EmailEvents {
-    /// The Queue resource that receives sending events.
+    /// The Queue resource that receives sending events and, when inbound mail
+    /// is configured on AWS, SES `Received` notifications.
     pub queue: ResourceRef,
 }
 


### PR DESCRIPTION
## Summary

- publish SES inbound receipt notifications to the configured email event topic
- grant `ses.amazonaws.com` scoped publish access with `AWS:SourceAccount`
- order SES resources after the topic policy so CloudFormation validation is deterministic

## Validation

- `cargo test -p alien-cloudformation`
- generator templates validated by `cfn-lint` during the test suite
- `rustfmt --edition 2021 --check` on the changed Rust files
- `git diff --check`