### PR TITLE
fix: clear recovered deployment errors

### DIFF
--- a/crates/alien-deployment/src/helpers.rs
+++ b/crates/alien-deployment/src/helpers.rs
@@ -903,12 +903,54 @@ pub fn create_aggregated_error_from_stack_state(stack_state: &StackState) -> Opt
 pub fn deployment_headline_error_from_state(
     state: &alien_core::DeploymentState,
 ) -> Option<AlienError> {
-    state.error.clone().or_else(|| {
-        state
-            .stack_state
-            .as_ref()
-            .and_then(create_aggregated_error_from_stack_state)
-    })
+    let deployment_error = deployment_state_error_from_headline(state.error.clone());
+    if deployment_error.is_some() {
+        return deployment_error;
+    }
+
+    if !state.status.is_failed() {
+        return None;
+    }
+
+    state
+        .stack_state
+        .as_ref()
+        .and_then(create_aggregated_error_from_stack_state)
+}
+
+/// Removes a derived resource-error summary before rebuilding deployment state.
+///
+/// DEPLOYMENT_FAILED with resource counts is a display projection of
+/// StackState resource errors, not a deployment-level error.
+pub fn deployment_state_error_from_headline(error: Option<AlienError>) -> Option<AlienError> {
+    error.filter(|error| !is_resource_error_headline(error))
+}
+
+fn is_resource_error_headline(error: &AlienError) -> bool {
+    if error.code != "DEPLOYMENT_FAILED" {
+        return false;
+    }
+
+    let Some(context) = error
+        .context
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+    else {
+        return false;
+    };
+
+    context
+        .get("resource_errors")
+        .is_some_and(serde_json::Value::is_array)
+        && context
+            .get("total_resources")
+            .is_some_and(serde_json::Value::is_number)
+        && context
+            .get("failed_resources")
+            .is_some_and(serde_json::Value::is_number)
+        && context
+            .get("interrupted_resources")
+            .is_some_and(serde_json::Value::is_number)
 }
 
 #[cfg(test)]
@@ -967,9 +1009,9 @@ mod tests {
     // ── inject_environment_variables tests ──────────────────────────
 
     use alien_core::{
-        ExternalBindings, Platform, Resource, ResourceEntry, ResourceLifecycle, ResourceStatus,
-        RuntimeMetadata, StackResourceState, StackSettings, Vault, VaultBinding, Worker,
-        WorkerCode,
+        DeploymentState, DeploymentStatus, ExternalBindings, Platform, Resource, ResourceEntry,
+        ResourceLifecycle, ResourceStatus, RuntimeMetadata, StackResourceState, StackSettings,
+        Vault, VaultBinding, Worker, WorkerCode,
     };
     use alien_error::GenericError;
     use indexmap::IndexMap;
@@ -1076,6 +1118,73 @@ mod tests {
         AlienError::new(GenericError {
             message: code_message.to_string(),
         })
+    }
+
+    fn make_deployment_state(
+        status: DeploymentStatus,
+        stack_state: Option<StackState>,
+        error: Option<AlienError>,
+    ) -> DeploymentState {
+        DeploymentState {
+            status,
+            platform: Platform::Test,
+            current_release: None,
+            target_release: None,
+            stack_state,
+            error,
+            environment_info: None,
+            runtime_metadata: None,
+            retry_requested: false,
+            protocol_version: alien_core::DEPLOYMENT_PROTOCOL_VERSION,
+        }
+    }
+
+    fn stack_state_with_resource_error() -> StackState {
+        let mut stack_state = StackState::new(Platform::Test);
+        stack_state.resources.insert(
+            "worker".to_string(),
+            make_worker_resource_state("worker", Some(generic_error("worker failed"))),
+        );
+        stack_state
+    }
+
+    #[test]
+    fn running_deployment_does_not_publish_resource_error_headline() {
+        let state = make_deployment_state(
+            DeploymentStatus::Running,
+            Some(stack_state_with_resource_error()),
+            None,
+        );
+
+        assert!(deployment_headline_error_from_state(&state).is_none());
+    }
+
+    #[test]
+    fn failed_deployment_publishes_resource_error_headline() {
+        let state = make_deployment_state(
+            DeploymentStatus::ProvisioningFailed,
+            Some(stack_state_with_resource_error()),
+            None,
+        );
+
+        let error = deployment_headline_error_from_state(&state).unwrap();
+        assert_eq!(error.code, "DEPLOYMENT_FAILED");
+    }
+
+    #[test]
+    fn derived_resource_headline_is_not_replayed_as_deployment_error() {
+        let headline = create_aggregated_error_from_stack_state(&stack_state_with_resource_error());
+
+        assert!(deployment_state_error_from_headline(headline).is_none());
+    }
+
+    #[test]
+    fn genuine_deployment_error_is_preserved() {
+        let error = generic_error("deployment failed");
+
+        let preserved = deployment_state_error_from_headline(Some(error.clone())).unwrap();
+        assert_eq!(preserved.code, error.code);
+        assert_eq!(preserved.message, error.message);
     }
 
     #[test]

--- a/crates/alien-deployment/src/lib.rs
+++ b/crates/alien-deployment/src/lib.rs
@@ -35,6 +35,7 @@ pub use alien_core::{
 pub use helpers::collect_environment_info;
 pub use helpers::create_aggregated_error_from_stack_state;
 pub use helpers::deployment_headline_error_from_state;
+pub use helpers::deployment_state_error_from_headline;
 pub use observe::run_observe_pass;
 
 use tracing::{debug, info, warn};

--- a/crates/alien-deployment/src/running.rs
+++ b/crates/alien-deployment/src/running.rs
@@ -111,6 +111,7 @@ pub async fn handle_running(
         info!("Health check passed for all resources");
 
         next.stack_state = Some(step_result.next_state);
+        next.error = None;
 
         Ok(DeploymentStepResult {
             state: next,

--- a/crates/alien-manager/src/loops/deployment.rs
+++ b/crates/alien-manager/src/loops/deployment.rs
@@ -1818,9 +1818,10 @@ fn needs_provision_capability(status: DeploymentStatus) -> bool {
 }
 
 fn deployment_record_error(error: &Option<serde_json::Value>) -> Option<AlienError> {
-    error
+    let error = error
         .clone()
-        .and_then(|value| serde_json::from_value::<AlienError>(value).ok())
+        .and_then(|value| serde_json::from_value::<AlienError>(value).ok());
+    alien_deployment::deployment_state_error_from_headline(error)
 }
 
 /// Parse a status string (kebab-case, as stored in the DB) to `DeploymentStatus`.

--- a/crates/alien-manager/src/routes/sync.rs
+++ b/crates/alien-manager/src/routes/sync.rs
@@ -1714,9 +1714,10 @@ fn deployment_status_from_record(status: &str) -> Option<DeploymentStatus> {
 }
 
 fn deployment_record_error(error: &Option<serde_json::Value>) -> Option<AlienError> {
-    error
+    let error = error
         .clone()
-        .and_then(|value| serde_json::from_value::<AlienError>(value).ok())
+        .and_then(|value| serde_json::from_value::<AlienError>(value).ok());
+    alien_deployment::deployment_state_error_from_headline(error)
 }
 
 fn release_info_from_record(

--- a/crates/alien-manager/src/stores/sqlite/migrations.rs
+++ b/crates/alien-manager/src/stores/sqlite/migrations.rs
@@ -371,6 +371,35 @@ pub async fn run_migrations(db: &SqliteDatabase) -> Result<(), AlienError> {
         }
     }
 
+    // DEPLOYMENT_FAILED with resource counts is a derived headline. Older
+    // versions could retain it after the deployment returned to a healthy
+    // status, even though the resource errors had already cleared.
+    conn.execute(
+        "UPDATE deployments
+         SET error = NULL
+         WHERE error IS NOT NULL
+           AND json_valid(error)
+           AND status NOT IN (
+             'preflights-failed',
+             'initial-setup-failed',
+             'provisioning-failed',
+             'refresh-failed',
+             'update-failed',
+             'delete-failed',
+             'teardown-failed',
+             'error'
+           )
+           AND json_extract(error, '$.code') = 'DEPLOYMENT_FAILED'
+           AND json_type(error, '$.context.resource_errors') = 'array'
+           AND json_type(error, '$.context.total_resources') IN ('integer', 'real')
+           AND json_type(error, '$.context.failed_resources') IN ('integer', 'real')
+           AND json_type(error, '$.context.interrupted_resources') IN ('integer', 'real')",
+        (),
+    )
+    .await
+    .into_alien_error()
+    .map_err(|e| db_error(&format!("Recovered error cleanup failed: {}", e.message)))?;
+
     let post_index_statements: &[&str] = &[
         "CREATE INDEX IF NOT EXISTS idx_releases_project ON releases(workspace_id, project_id)",
         "CREATE INDEX IF NOT EXISTS idx_deployments_project ON deployments(workspace_id, project_id)",

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -176,6 +176,52 @@ async fn create_and_get_deployment() {
     assert_eq!(fetched.status, "pending");
 }
 
+#[tokio::test]
+async fn migrations_clear_only_recovered_resource_error_headlines() {
+    let db = fresh_db().await;
+    let store = SqliteDeploymentStore::new(db.clone());
+    let group_id = create_test_group(&store).await;
+    let running = create_test_deployment(&store, &group_id, "running", Platform::Aws).await;
+    let failed = create_test_deployment(&store, &group_id, "failed", Platform::Aws).await;
+    let headline = serde_json::json!({
+        "code": "DEPLOYMENT_FAILED",
+        "message": "Deployment failed",
+        "context": {
+            "resource_errors": [],
+            "total_resources": 1,
+            "failed_resources": 1,
+            "interrupted_resources": 0
+        }
+    });
+
+    for (deployment, status) in [(&running, "running"), (&failed, "provisioning-failed")] {
+        db.conn()
+            .lock()
+            .await
+            .execute(
+                "UPDATE deployments SET status = ?1, error = ?2 WHERE id = ?3",
+                (status, headline.to_string(), deployment.id.as_str()),
+            )
+            .await
+            .unwrap();
+    }
+
+    migrations::run_migrations(&db).await.unwrap();
+
+    let running = store
+        .get_deployment(&test_subject(), &running.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let failed = store
+        .get_deployment(&test_subject(), &failed.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(running.error.is_none());
+    assert_eq!(failed.error, Some(headline));
+}
+
 /// Gated live resources resolve against the deployer's stored answers on
 /// every reconcile, so losing them here would silently flip resources back
 /// to their declared defaults.


### PR DESCRIPTION
## Summary
- publish resource-error summaries only while a deployment is failed
- stop replaying derived summaries as durable deployment-level errors
- clear recovered summaries from existing SQLite records

## Validation
- `cargo test -p alien-deployment headline`
- `cargo test -p alien-deployment genuine_deployment_error_is_preserved`
- `cargo test -p alien-manager --features sqlite --test sqlite_store_tests migrations_clear_only_recovered_resource_error_headlines`