### PR TITLE
fix(aws): make CloudFormation policy migration quota-safe

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/helpers.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/helpers.rs
@@ -50,7 +50,10 @@ pub(crate) fn chunk_managed_policy_statements(
             continue;
         }
 
-        if current.is_empty() {
+        if current.is_empty()
+            || managed_policy_document_size(std::slice::from_ref(&statement))?
+                > MAX_MANAGED_POLICY_BYTES
+        {
             return Err(AlienError::new(ErrorData::GenericError {
                 message: "AWS IAM statement is too large for a managed policy".to_string(),
             }));
@@ -572,6 +575,26 @@ mod tests {
 
         let keys = object.keys().map(String::as_str).collect::<Vec<_>>();
         assert_eq!(keys, ["Action", "Effect", "Sid"]);
+    }
+
+    #[test]
+    fn managed_policy_chunking_rejects_a_later_oversized_statement() {
+        let statements = vec![
+            CfExpression::object([
+                ("Effect", CfExpression::from("Allow")),
+                ("Action", CfExpression::from("s3:GetObject")),
+                ("Resource", CfExpression::from("small-resource")),
+            ]),
+            CfExpression::object([
+                ("Effect", CfExpression::from("Allow")),
+                ("Action", CfExpression::from("s3:PutObject")),
+                ("Resource", CfExpression::from("x".repeat(6_000))),
+            ]),
+        ];
+
+        let error = chunk_managed_policy_statements(statements)
+            .expect_err("a later oversized statement must not become an unchecked chunk");
+        assert!(error.to_string().contains("too large for a managed policy"));
     }
 }
 

--- a/crates/alien-cloudformation/src/emitters/aws/helpers.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/helpers.rs
@@ -12,7 +12,7 @@ use alien_core::{
     ResourceRef, ResourceType, Result, ServiceAccount, Storage, Worker, ALIEN_MANAGED_BY_TAG_KEY,
     ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_TAG_KEY,
 };
-use alien_error::AlienError;
+use alien_error::{AlienError, Context, IntoAlienError};
 use indexmap::IndexMap;
 use serde_json::Value as JsonValue;
 use std::collections::{BTreeSet, HashSet};
@@ -33,6 +33,56 @@ const CONDITION_NETWORK_MODE_CREATE: &str = "NetworkModeCreate";
 const CONDITION_NETWORK_MODE_USE_EXISTING: &str = "NetworkModeUseExisting";
 
 pub const INLINE_POLICY_NAME: &str = "deployment-permissions";
+const MAX_MANAGED_POLICY_BYTES: usize = 5_500;
+
+/// Split IAM statements into documents below AWS's managed-policy size limit.
+pub(crate) fn chunk_managed_policy_statements(
+    statements: Vec<CfExpression>,
+) -> Result<Vec<CfExpression>> {
+    let mut chunks = Vec::new();
+    let mut current = Vec::new();
+
+    for statement in statements {
+        let mut candidate = current.clone();
+        candidate.push(statement.clone());
+        if managed_policy_document_size(&candidate)? <= MAX_MANAGED_POLICY_BYTES {
+            current = candidate;
+            continue;
+        }
+
+        if current.is_empty() {
+            return Err(AlienError::new(ErrorData::GenericError {
+                message: "AWS IAM statement is too large for a managed policy".to_string(),
+            }));
+        }
+
+        chunks.push(managed_policy_document(current));
+        current = vec![statement];
+    }
+
+    if !current.is_empty() {
+        chunks.push(managed_policy_document(current));
+    }
+
+    Ok(chunks)
+}
+
+fn managed_policy_document(statements: Vec<CfExpression>) -> CfExpression {
+    CfExpression::object([
+        ("Version", CfExpression::from("2012-10-17")),
+        ("Statement", CfExpression::list(statements)),
+    ])
+}
+
+fn managed_policy_document_size(statements: &[CfExpression]) -> Result<usize> {
+    serde_json::to_string(&managed_policy_document(statements.to_vec()))
+        .into_alien_error()
+        .context(ErrorData::TemplateSerializationFailed {
+            format: "CloudFormation IAM policy".to_string(),
+            reason: "Failed to serialize IAM policy for size validation".to_string(),
+        })
+        .map(|policy| policy.len())
+}
 
 /// Downcast `ctx.resource.config` to the typed resource definition or return
 /// a typed `UnexpectedResourceType` error.

--- a/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
@@ -8,8 +8,8 @@ use crate::{
     emitter::CfEmitter,
     emitters::aws::{
         helpers::{
-            cf_from_json, required_logical_id, resource_config, tags, uniquify_iam_statement_sids,
-            PARAM_MANAGING_ROLE_ARN,
+            cf_from_json, chunk_managed_policy_statements, required_logical_id, resource_config,
+            tags, uniquify_iam_statement_sids, PARAM_MANAGING_ROLE_ARN,
         },
         service_account::permission_context,
     },
@@ -196,14 +196,7 @@ fn remote_management_policy_documents(ctx: &EmitContext<'_>) -> Result<Vec<CfExp
         ),
     ]));
 
-    chunk_policy_statements(uniquify_iam_statement_sids(statements))
-}
-
-fn policy_document(statements: Vec<CfExpression>) -> CfExpression {
-    CfExpression::object([
-        ("Version", CfExpression::from("2012-10-17")),
-        ("Statement", CfExpression::list(statements)),
-    ])
+    chunk_managed_policy_statements(uniquify_iam_statement_sids(statements))
 }
 
 fn management_policy_resources(
@@ -233,48 +226,6 @@ fn management_policy_resources(
             policy
         })
         .collect()
-}
-
-fn chunk_policy_statements(statements: Vec<CfExpression>) -> Result<Vec<CfExpression>> {
-    const MAX_MANAGED_POLICY_BYTES: usize = 5_500;
-
-    let mut chunks = Vec::new();
-    let mut current = Vec::new();
-
-    for statement in statements {
-        let mut candidate = current.clone();
-        candidate.push(statement.clone());
-        if policy_document_size(&candidate)? <= MAX_MANAGED_POLICY_BYTES {
-            current = candidate;
-            continue;
-        }
-
-        if current.is_empty() {
-            return Err(AlienError::new(ErrorData::GenericError {
-                message: "AWS management IAM statement is too large for a managed policy"
-                    .to_string(),
-            }));
-        }
-
-        chunks.push(policy_document(current));
-        current = vec![statement];
-    }
-
-    if !current.is_empty() {
-        chunks.push(policy_document(current));
-    }
-
-    Ok(chunks)
-}
-
-fn policy_document_size(statements: &[CfExpression]) -> Result<usize> {
-    serde_json::to_string(&policy_document(statements.to_vec()))
-        .into_alien_error()
-        .context(ErrorData::TemplateSerializationFailed {
-            format: "CloudFormation IAM policy".to_string(),
-            reason: "Failed to serialize IAM policy for size validation".to_string(),
-        })
-        .map(|policy| policy.len())
 }
 
 fn global_permission_refs<'a>(

--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -403,7 +403,7 @@ pub fn generate_cloudformation_template(
         access_only,
     );
     apply_resource_dependencies(stack, &emitted_resource_ids, &mut template);
-    consolidate_role_inline_policies(&mut template);
+    consolidate_role_inline_policies(&mut template)?;
 
     if let Some(service_token) = options.registration.service_token(&mut template)? {
         add_custom_resource(

--- a/crates/alien-cloudformation/src/inline_policy.rs
+++ b/crates/alien-cloudformation/src/inline_policy.rs
@@ -1,5 +1,5 @@
 use crate::{
-    emitters::aws::helpers::uniquify_iam_statement_sids,
+    emitters::aws::helpers::{chunk_managed_policy_statements, uniquify_iam_statement_sids},
     template::{CfExpression, CfResource, CfTemplate},
 };
 use alien_core::{ErrorData, Result};
@@ -33,6 +33,7 @@ struct PolicyGroup {
 /// action/resource axes are still combined without broadening access.
 pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) -> Result<()> {
     let mut groups: Vec<PolicyGroup> = Vec::new();
+    let mut managed_policy_attachment_counts = managed_policy_attachment_counts(template);
 
     for (logical_id, resource) in &template.resources {
         let Some(key) = policy_group_key(resource) else {
@@ -80,19 +81,25 @@ pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) -> Res
             dependencies.extend(policy.depends_on.iter().cloned());
         }
 
-        let statements = compact_statements(statements);
-        if statements.len() > IAM_MANAGED_POLICIES_PER_ROLE {
-            return Err(AlienError::new(ErrorData::OperationNotSupported {
-                operation: "generate_cloudformation_template".to_string(),
-                reason: format!(
-                    "permission grants for one IAM role require {} managed policies after safe compaction, exceeding AWS's attachment limit of {IAM_MANAGED_POLICIES_PER_ROLE}",
-                    statements.len()
-                ),
-            }));
+        let policy_documents = chunk_managed_policy_statements(compact_statements(statements))?;
+        for role_id in referenced_role_ids(&group.key.roles) {
+            let attachment_count = managed_policy_attachment_counts
+                .entry(role_id.clone())
+                .or_default();
+            if *attachment_count + policy_documents.len() > IAM_MANAGED_POLICIES_PER_ROLE {
+                return Err(AlienError::new(ErrorData::OperationNotSupported {
+                    operation: "generate_cloudformation_template".to_string(),
+                    reason: format!(
+                        "IAM role '{role_id}' requires {} managed policies, exceeding AWS's attachment limit of {IAM_MANAGED_POLICIES_PER_ROLE}",
+                        *attachment_count + policy_documents.len()
+                    ),
+                }));
+            }
+            *attachment_count += policy_documents.len();
         }
 
         let mut replacement_ids = Vec::new();
-        for (statement_index, statement) in statements.into_iter().enumerate() {
+        for (statement_index, policy_document) in policy_documents.into_iter().enumerate() {
             let logical_id = consolidated_policy_logical_id(
                 template,
                 &consolidated_ids,
@@ -111,14 +118,9 @@ pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) -> Res
             consolidated.logical_id = logical_id;
             consolidated.resource_type = IAM_MANAGED_POLICY_RESOURCE_TYPE.to_string();
             consolidated.properties.shift_remove("PolicyName");
-            let CfExpression::Object(policy_document) = consolidated
+            consolidated
                 .properties
-                .get_mut("PolicyDocument")
-                .expect("consolidated IAM policy document should exist")
-            else {
-                unreachable!("consolidated IAM policy document should be an object");
-            };
-            policy_document.insert("Statement".to_string(), CfExpression::list([statement]));
+                .insert("PolicyDocument".to_string(), policy_document);
             consolidated.depends_on = deduplicate(dependencies.clone());
             consolidated_resources.push(consolidated);
         }
@@ -151,6 +153,50 @@ pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) -> Res
     }
 
     Ok(())
+}
+
+fn managed_policy_attachment_counts(template: &CfTemplate) -> IndexMap<String, usize> {
+    let mut counts = IndexMap::new();
+
+    for resource in template.resources.values() {
+        if resource.resource_type == IAM_MANAGED_POLICY_RESOURCE_TYPE {
+            if let Some(roles) = resource.properties.get("Roles") {
+                for role_id in referenced_role_ids(roles) {
+                    *counts.entry(role_id).or_default() += 1;
+                }
+            }
+        }
+
+        if resource.resource_type == "AWS::IAM::Role" {
+            let Some(CfExpression::List(policy_arns)) =
+                resource.properties.get("ManagedPolicyArns")
+            else {
+                continue;
+            };
+            *counts.entry(resource.logical_id.clone()).or_default() += policy_arns.len();
+        }
+    }
+
+    counts
+}
+
+fn referenced_role_ids(roles: &CfExpression) -> Vec<String> {
+    let CfExpression::List(roles) = roles else {
+        return Vec::new();
+    };
+
+    roles
+        .iter()
+        .filter_map(|role| {
+            let CfExpression::Object(role) = role else {
+                return None;
+            };
+            match role.get("Ref") {
+                Some(CfExpression::String(role_id)) => Some(role_id.clone()),
+                _ => None,
+            }
+        })
+        .collect()
 }
 
 fn consolidated_policy_logical_id(
@@ -325,8 +371,8 @@ fn deduplicate<T: PartialEq>(values: Vec<T>) -> Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::compact_statements;
-    use crate::template::CfExpression;
+    use super::{compact_statements, consolidate_role_inline_policies};
+    use crate::template::{CfExpression, CfResource, CfTemplate};
 
     #[test]
     fn compaction_does_not_create_action_resource_cross_products() {
@@ -349,6 +395,82 @@ mod tests {
             vec!["s3:PutObject"],
             vec!["bucket-one"],
         )));
+    }
+
+    #[test]
+    fn consolidation_counts_managed_policies_already_attached_to_the_role() {
+        let mut template = template_with_inline_grants();
+        let role = template
+            .resources
+            .get_mut("ExecutionRole")
+            .expect("role should exist");
+        role.properties.insert(
+            "ManagedPolicyArns".to_string(),
+            CfExpression::list((0..10).map(|index| {
+                CfExpression::from(format!("arn:aws:iam::aws:policy/Existing{index}"))
+            })),
+        );
+
+        let error = consolidate_role_inline_policies(&mut template)
+            .expect_err("the eleventh managed-policy attachment must be rejected");
+        assert!(error.to_string().contains("requires 11 managed policies"));
+    }
+
+    #[test]
+    fn consolidation_rejects_a_managed_policy_document_over_the_size_limit() {
+        let mut template = template_with_inline_grants();
+        for policy_id in ["GrantOne", "GrantTwo"] {
+            let policy = template
+                .resources
+                .get_mut(policy_id)
+                .expect("policy should exist");
+            let CfExpression::Object(document) = policy
+                .properties
+                .get_mut("PolicyDocument")
+                .expect("policy document should exist")
+            else {
+                panic!("policy document should be an object");
+            };
+            document.insert(
+                "Statement".to_string(),
+                CfExpression::list([statement("ReadData", "s3:GetObject", &"x".repeat(6_000))]),
+            );
+        }
+
+        let error = consolidate_role_inline_policies(&mut template)
+            .expect_err("an oversized managed policy must be rejected during generation");
+        assert!(error.to_string().contains("too large for a managed policy"));
+    }
+
+    fn template_with_inline_grants() -> CfTemplate {
+        let mut template = CfTemplate::default();
+        let role = CfResource::new("ExecutionRole".to_string(), "AWS::IAM::Role".to_string());
+        template.resources.insert(role.logical_id.clone(), role);
+
+        for (policy_id, resource) in [("GrantOne", "bucket-one"), ("GrantTwo", "bucket-two")] {
+            let mut policy = CfResource::new(policy_id.to_string(), "AWS::IAM::Policy".to_string());
+            policy.properties.insert(
+                "PolicyName".to_string(),
+                CfExpression::from(format!("{}-permissions", policy_id.to_lowercase())),
+            );
+            policy.properties.insert(
+                "Roles".to_string(),
+                CfExpression::list([CfExpression::ref_("ExecutionRole")]),
+            );
+            policy.properties.insert(
+                "PolicyDocument".to_string(),
+                CfExpression::object([
+                    ("Version", CfExpression::from("2012-10-17")),
+                    (
+                        "Statement",
+                        CfExpression::list([statement("ReadData", "s3:GetObject", resource)]),
+                    ),
+                ]),
+            );
+            template.resources.insert(policy.logical_id.clone(), policy);
+        }
+
+        template
     }
 
     fn statement(sid: &str, action: &str, resource: &str) -> CfExpression {

--- a/crates/alien-cloudformation/src/inline_policy.rs
+++ b/crates/alien-cloudformation/src/inline_policy.rs
@@ -2,9 +2,13 @@ use crate::{
     emitters::aws::helpers::uniquify_iam_statement_sids,
     template::{CfExpression, CfResource, CfTemplate},
 };
+use alien_core::{ErrorData, Result};
+use alien_error::AlienError;
 use indexmap::IndexMap;
 
 const IAM_POLICY_RESOURCE_TYPE: &str = "AWS::IAM::Policy";
+const IAM_MANAGED_POLICY_RESOURCE_TYPE: &str = "AWS::IAM::ManagedPolicy";
+const IAM_MANAGED_POLICIES_PER_ROLE: usize = 10;
 
 #[derive(PartialEq)]
 struct PolicyGroupKey {
@@ -18,15 +22,16 @@ struct PolicyGroup {
     policy_ids: Vec<String>,
 }
 
-/// Combines compatible external inline policies attached to the same roles.
+/// Combines compatible external inline policies into managed policies.
 ///
 /// IAM applies one aggregate size quota to every inline policy on a role. The
 /// resource emitters intentionally produce independent permission grants, so a
 /// role with many grants otherwise repeats policy-document and statement
-/// overhead until it reaches that quota. Combining the documents also lets us
-/// safely combine equal actions across resources and equal resources across
-/// actions without broadening access.
-pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) {
+/// overhead until it reaches that quota. The consolidated grants use managed
+/// policies so CloudFormation can attach them before deleting legacy inline
+/// policies without temporarily exceeding the inline-policy quota. Equal
+/// action/resource axes are still combined without broadening access.
+pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) -> Result<()> {
     let mut groups: Vec<PolicyGroup> = Vec::new();
 
     for (logical_id, resource) in &template.resources {
@@ -56,9 +61,6 @@ pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) {
             continue;
         }
 
-        let logical_id =
-            consolidated_policy_logical_id(template, &consolidated_ids, &group.key, group_index);
-        consolidated_ids.push(logical_id.clone());
         let mut statements = Vec::new();
         let mut dependencies = Vec::new();
         for policy_id in &group.policy_ids {
@@ -78,32 +80,51 @@ pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) {
             dependencies.extend(policy.depends_on.iter().cloned());
         }
 
-        let mut consolidated = template
-            .resources
-            .get(&group.policy_ids[0])
-            .expect("grouped IAM policy should exist")
-            .clone();
-        consolidated.logical_id = logical_id.clone();
-        consolidated.properties.insert(
-            "PolicyName".to_string(),
-            CfExpression::from(format!("resource-permissions-{}", group_index + 1)),
-        );
-        let CfExpression::Object(policy_document) = consolidated
-            .properties
-            .get_mut("PolicyDocument")
-            .expect("consolidated IAM policy document should exist")
-        else {
-            unreachable!("consolidated IAM policy document should be an object");
-        };
-        policy_document.insert(
-            "Statement".to_string(),
-            CfExpression::list(compact_statements(statements)),
-        );
-        consolidated.depends_on = deduplicate(dependencies);
-        consolidated_resources.push(consolidated);
+        let statements = compact_statements(statements);
+        if statements.len() > IAM_MANAGED_POLICIES_PER_ROLE {
+            return Err(AlienError::new(ErrorData::OperationNotSupported {
+                operation: "generate_cloudformation_template".to_string(),
+                reason: format!(
+                    "permission grants for one IAM role require {} managed policies after safe compaction, exceeding AWS's attachment limit of {IAM_MANAGED_POLICIES_PER_ROLE}",
+                    statements.len()
+                ),
+            }));
+        }
+
+        let mut replacement_ids = Vec::new();
+        for (statement_index, statement) in statements.into_iter().enumerate() {
+            let logical_id = consolidated_policy_logical_id(
+                template,
+                &consolidated_ids,
+                &group.key,
+                group_index,
+                statement_index,
+            );
+            consolidated_ids.push(logical_id.clone());
+            replacement_ids.push(logical_id.clone());
+
+            let mut consolidated = template
+                .resources
+                .get(&group.policy_ids[0])
+                .expect("grouped IAM policy should exist")
+                .clone();
+            consolidated.logical_id = logical_id;
+            consolidated.resource_type = IAM_MANAGED_POLICY_RESOURCE_TYPE.to_string();
+            consolidated.properties.shift_remove("PolicyName");
+            let CfExpression::Object(policy_document) = consolidated
+                .properties
+                .get_mut("PolicyDocument")
+                .expect("consolidated IAM policy document should exist")
+            else {
+                unreachable!("consolidated IAM policy document should be an object");
+            };
+            policy_document.insert("Statement".to_string(), CfExpression::list([statement]));
+            consolidated.depends_on = deduplicate(dependencies.clone());
+            consolidated_resources.push(consolidated);
+        }
 
         for removed_id in &group.policy_ids {
-            replacements.insert(removed_id.clone(), logical_id.clone());
+            replacements.insert(removed_id.clone(), replacement_ids.clone());
         }
     }
 
@@ -116,13 +137,20 @@ pub(crate) fn consolidate_role_inline_policies(template: &mut CfTemplate) {
             .insert(resource.logical_id.clone(), resource);
     }
     for resource in template.resources.values_mut() {
-        for dependency in &mut resource.depends_on {
-            if let Some(retained_id) = replacements.get(dependency) {
-                *dependency = retained_id.clone();
-            }
-        }
-        resource.depends_on = deduplicate(std::mem::take(&mut resource.depends_on));
+        resource.depends_on = deduplicate(
+            std::mem::take(&mut resource.depends_on)
+                .into_iter()
+                .flat_map(|dependency| {
+                    replacements
+                        .get(&dependency)
+                        .cloned()
+                        .unwrap_or_else(|| vec![dependency])
+                })
+                .collect(),
+        );
     }
+
+    Ok(())
 }
 
 fn consolidated_policy_logical_id(
@@ -130,6 +158,7 @@ fn consolidated_policy_logical_id(
     consolidated_ids: &[String],
     key: &PolicyGroupKey,
     group_index: usize,
+    statement_index: usize,
 ) -> String {
     let role_id = match &key.roles {
         CfExpression::List(roles) if roles.len() == 1 => match &roles[0] {
@@ -142,8 +171,14 @@ fn consolidated_policy_logical_id(
         _ => None,
     };
     let base = role_id
-        .map(|role_id| format!("{role_id}InlinePermissions"))
-        .unwrap_or_else(|| format!("ConsolidatedRoleInlinePermissions{}", group_index + 1));
+        .map(|role_id| format!("{role_id}ManagedPermissions{}", statement_index + 1))
+        .unwrap_or_else(|| {
+            format!(
+                "ConsolidatedRoleManagedPermissions{}{}",
+                group_index + 1,
+                statement_index + 1
+            )
+        });
 
     if !template.resources.contains_key(&base) && !consolidated_ids.contains(&base) {
         return base;

--- a/crates/alien-cloudformation/tests/generator/aws_data_layer_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_data_layer_tests.rs
@@ -358,7 +358,7 @@ fn aws_queue_resource_permissions_attach_to_service_account_role() {
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
 
-    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    let policies = policies_for_role(&template, "ExecutionSaRole");
     assert_eq!(policies.len(), 1);
     let policy = policies[0];
     let actions = policy_actions(policy);
@@ -423,7 +423,7 @@ fn aws_kv_resource_permissions_attach_to_service_account_role() {
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
 
-    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    let policies = policies_for_role(&template, "ExecutionSaRole");
     assert_eq!(policies.len(), 1);
     let policy = policies[0];
     let actions = policy_actions(policy);
@@ -525,7 +525,7 @@ fn aws_vault_permissions_include_every_vault_scope() {
 
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
-    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
+    let policies = policies_for_role(&template, "ExecutionSaRole");
     assert_eq!(policies.len(), 1);
     let policy = serde_json::to_string(policies[0]).expect("policy should serialize");
     assert!(policy.contains("parameter/${AWS::StackName}-secrets-*"));
@@ -533,7 +533,7 @@ fn aws_vault_permissions_include_every_vault_scope() {
 }
 
 #[test]
-fn many_resource_grants_stay_within_the_role_inline_policy_quota() {
+fn many_resource_grants_use_quota_safe_managed_policies() {
     let mut stack = Stack::new("many-resource-grants".to_string())
         .permission(
             "execution",
@@ -564,23 +564,18 @@ fn many_resource_grants_stay_within_the_role_inline_policy_quota() {
     );
     let template: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("template YAML should parse");
-    let policies = inline_policies_for_role(&template, "ExecutionSaRole");
-    assert_eq!(policies.len(), 1, "resource grants should share one policy");
-
-    let aggregate_size = role_inline_policy_documents(&template, "ExecutionSaRole")
-        .into_iter()
-        .map(|document| {
-            serde_json::to_string(document)
-                .expect("policy should serialize")
-                .len()
-        })
-        .sum::<usize>();
+    let policies = policies_for_role(&template, "ExecutionSaRole");
+    assert!(!policies.is_empty());
     assert!(
-        aggregate_size < 10_240,
-        "rendered inline policy documents use {aggregate_size} non-whitespace characters"
+        policies.len() <= 10,
+        "AWS allows ten managed policies per role"
     );
+    assert!(policies
+        .iter()
+        .all(|policy| policy["Type"] == "AWS::IAM::ManagedPolicy"));
+    assert!(role_inline_policy_documents(&template, "ExecutionSaRole").is_empty());
 
-    let policy = serde_json::to_string(policies[0]).expect("policy should serialize");
+    let policy = serde_json::to_string(&policies).expect("policies should serialize");
     for index in 0..12 {
         assert!(
             policy.contains(&format!("Data{index}")),
@@ -589,7 +584,7 @@ fn many_resource_grants_stay_within_the_role_inline_policy_quota() {
     }
 }
 
-fn inline_policies_for_role<'a>(
+fn policies_for_role<'a>(
     template: &'a serde_json::Value,
     role_id: &str,
 ) -> Vec<&'a serde_json::Value> {
@@ -598,10 +593,12 @@ fn inline_policies_for_role<'a>(
         .expect("resources should be an object")
         .values()
         .filter(|resource| {
-            resource["Type"] == "AWS::IAM::Policy"
-                && resource["Properties"]["Roles"]
-                    .as_array()
-                    .is_some_and(|roles| roles.contains(&serde_json::json!({ "Ref": role_id })))
+            matches!(
+                resource["Type"].as_str(),
+                Some("AWS::IAM::Policy" | "AWS::IAM::ManagedPolicy")
+            ) && resource["Properties"]["Roles"]
+                .as_array()
+                .is_some_and(|roles| roles.contains(&serde_json::json!({ "Ref": role_id })))
         })
         .collect()
 }
@@ -630,8 +627,9 @@ fn role_inline_policy_documents<'a>(
         .map(|policy| &policy["PolicyDocument"])
         .collect::<Vec<_>>();
     documents.extend(
-        inline_policies_for_role(template, role_id)
+        policies_for_role(template, role_id)
             .into_iter()
+            .filter(|policy| policy["Type"] == "AWS::IAM::Policy")
             .map(|policy| &policy["Properties"]["PolicyDocument"]),
     );
     documents

--- a/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
@@ -499,17 +499,23 @@ fn aws_email_resource_permissions_attach_to_service_account_role() {
         .expect("resources should be an object")
         .values()
         .filter(|resource| {
-            resource["Type"] == "AWS::IAM::Policy"
-                && resource["Properties"]["Roles"][0]["Ref"] == "SenderSaRole"
+            matches!(
+                resource["Type"].as_str(),
+                Some("AWS::IAM::Policy" | "AWS::IAM::ManagedPolicy")
+            ) && resource["Properties"]["Roles"][0]["Ref"] == "SenderSaRole"
         })
         .collect::<Vec<_>>();
-    assert_eq!(policies.len(), 1);
-    let policy = policies[0];
-    let identity_statements = policy["Properties"]["PolicyDocument"]["Statement"]
-        .as_array()
-        .expect("email permission statements");
-    let actions: Vec<String> = identity_statements
+    assert!(!policies.is_empty());
+    let identity_statements = policies
         .iter()
+        .flat_map(|policy| {
+            policy["Properties"]["PolicyDocument"]["Statement"]
+                .as_array()
+                .expect("email permission statements")
+        })
+        .collect::<Vec<_>>();
+    let actions: Vec<String> = identity_statements
+        .into_iter()
         .flat_map(|statement| match statement["Action"].as_array() {
             Some(actions) => actions.clone(),
             None => vec![statement["Action"].clone()],
@@ -519,7 +525,7 @@ fn aws_email_resource_permissions_attach_to_service_account_role() {
     assert!(actions.contains(&"ses:SendEmail".to_string()));
     assert!(actions.contains(&"ses:SendRawEmail".to_string()));
     assert!(actions.contains(&"ses:CreateEmailIdentity".to_string()));
-    let rendered_policy = serde_json::to_string(policy).expect("policy should serialize");
+    let rendered_policy = serde_json::to_string(&policies).expect("policies should serialize");
     assert!(rendered_policy.contains(
         "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:configuration-set/${AWS::StackName}-mailer"
     ));

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -1571,18 +1571,6 @@ Resources:
           - s3:GetBucketVersioning
           - s3:GetEncryptionConfiguration
           - s3:GetLifecycleConfiguration
-      Roles:
-      - Ref: ManagementRole
-    DependsOn:
-    - Assets
-    - ManagementRole
-    - Mailbox
-  ManagementRoleManagedPermissions2:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
         - Effect: Allow
           Resource:
             Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}-secrets-*
@@ -1924,7 +1912,6 @@ Resources:
     - BuilderLogGroup
     - Builder
     - ManagementRoleManagedPermissions1
-    - ManagementRoleManagedPermissions2
 Outputs:
   DeploymentSourceKind:
     Value: cloudformation

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -1548,10 +1548,9 @@ Resources:
         Value: build
     DependsOn:
     - BuilderLogGroup
-  ManagementRoleInlinePermissions:
-    Type: AWS::IAM::Policy
+  ManagementRoleManagedPermissions1:
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: resource-permissions-1
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -1572,6 +1571,18 @@ Resources:
           - s3:GetBucketVersioning
           - s3:GetEncryptionConfiguration
           - s3:GetLifecycleConfiguration
+      Roles:
+      - Ref: ManagementRole
+    DependsOn:
+    - Assets
+    - ManagementRole
+    - Mailbox
+  ManagementRoleManagedPermissions2:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
         - Effect: Allow
           Resource:
             Fn::Sub: arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}-secrets-*
@@ -1912,7 +1923,8 @@ Resources:
     - RegistryPushRole
     - BuilderLogGroup
     - Builder
-    - ManagementRoleInlinePermissions
+    - ManagementRoleManagedPermissions1
+    - ManagementRoleManagedPermissions2
 Outputs:
   DeploymentSourceKind:
     Value: cloudformation


### PR DESCRIPTION
## Summary

- emit compacted role grants as customer-managed policies instead of a replacement inline policy
- keep CloudFormation updates below the transient inline-policy quota while legacy policies are still attached
- preserve exact statement compaction and fan dependencies out to every replacement policy
- fail generation before exceeding AWS’s ten managed-policy attachments per role

## Root cause

The final consolidated policy was below IAM’s 10,240-character inline-policy quota. During an update from an older template, however, CloudFormation attached the new consolidated inline policy before deleting the legacy per-resource inline policies. IAM counts both sets during that transition, so the update failed even though the final state was valid.

Managed policies use a separate quota, allowing the new grants to coexist with legacy inline policies during migration. CloudFormation can then remove the old policies without a quota deadlock.

## Validation

- `cargo test -p alien-cloudformation` (92 passed)
- full rendered CloudFormation snapshot updated and reviewed
- 12-resource permission fixture produces no consolidated inline policies, stays within the ten managed-policy attachment limit, and preserves every resource grant

## Production reproduction

An update of an existing permission-heavy AWS stack failed while creating the replacement role policy with IAM `LimitExceeded` / maximum inline policy size. This change targets that update path; after release, the same stack will be retried end to end.