### PR TITLE
feat(bindings)!: add versioned KV writes

### DIFF
--- a/crates/alien-bindings-node/src/kv.rs
+++ b/crates/alien-bindings-node/src/kv.rs
@@ -2,7 +2,9 @@
 //! trait.
 
 use crate::error::map_alien_error;
-use alien_bindings::traits::{Kv, PutOptions, ScanResult};
+#[cfg(test)]
+use alien_bindings::traits::KvEntry;
+use alien_bindings::traits::{Kv, PutCondition, PutOptions, ScanResult};
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use std::sync::Arc;
@@ -15,6 +17,8 @@ pub struct KvItemJs {
     pub key: String,
     /// The value bytes.
     pub value: Buffer,
+    /// Opaque version for a later conditional set or delete.
+    pub version: String,
 }
 
 /// A page of scan results.
@@ -32,26 +36,41 @@ fn scan_to_js(result: ScanResult) -> ScanResultJs {
         items: result
             .items
             .into_iter()
-            .map(|(key, value)| KvItemJs {
-                key,
-                value: Buffer::from(value),
+            .map(|entry| KvItemJs {
+                key: entry.key,
+                value: Buffer::from(entry.value),
+                version: entry.version,
             })
             .collect(),
         next_cursor: result.next_cursor,
     }
 }
 
-/// Build `PutOptions` from the optional JS arguments, or `None` when neither is
-/// set (so the provider takes its default unconditional-put path).
-fn put_options(ttl_secs: Option<u32>, if_not_exists: Option<bool>) -> Option<PutOptions> {
-    let if_not_exists = if_not_exists.unwrap_or(false);
-    if ttl_secs.is_none() && !if_not_exists {
-        return None;
+fn put_options(
+    ttl_secs: Option<u32>,
+    condition: Option<String>,
+    version: Option<String>,
+) -> napi::Result<Option<PutOptions>> {
+    let condition =
+        match condition.as_deref() {
+            None => PutCondition::None,
+            Some("absent") => PutCondition::Absent,
+            Some("version") => PutCondition::Version(version.ok_or_else(|| {
+                napi::Error::from_reason("a version condition requires a version")
+            })?),
+            Some(other) => {
+                return Err(napi::Error::from_reason(format!(
+                    "unsupported KV put condition '{other}'"
+                )))
+            }
+        };
+    if ttl_secs.is_none() && matches!(condition, PutCondition::None) {
+        return Ok(None);
     }
-    Some(PutOptions {
+    Ok(Some(PutOptions {
         ttl: ttl_secs.map(|secs| Duration::from_secs(u64::from(secs))),
-        if_not_exists,
-    })
+        condition,
+    }))
 }
 
 /// Handle to a resolved key-value binding.
@@ -68,38 +87,44 @@ impl KvHandle {
 
 #[napi]
 impl KvHandle {
-    /// Get the value for `key`, or `None` if absent/expired.
+    /// Get the entry for `key`, or `None` if absent/expired.
     #[napi]
-    pub async fn get(&self, key: String) -> napi::Result<Option<Buffer>> {
+    pub async fn get(&self, key: String) -> napi::Result<Option<KvItemJs>> {
         let kv = self.inner.clone();
-        let value = kv.get(&key).await.map_err(map_alien_error)?;
-        Ok(value.map(Buffer::from))
+        let entry = kv.get(&key).await.map_err(map_alien_error)?;
+        Ok(entry.map(|entry| KvItemJs {
+            key: entry.key,
+            value: Buffer::from(entry.value),
+            version: entry.version,
+        }))
     }
 
     /// Put `value` at `key`.
     ///
-    /// With `if_not_exists`, returns `true` when created and `false` when the
-    /// key already existed; otherwise always returns `true`.
+    /// Returns `false` when a supplied precondition does not match.
     #[napi]
     pub async fn put(
         &self,
         key: String,
         value: Buffer,
         ttl_secs: Option<u32>,
-        if_not_exists: Option<bool>,
+        condition: Option<String>,
+        version: Option<String>,
     ) -> napi::Result<bool> {
         let kv = self.inner.clone();
-        let options = put_options(ttl_secs, if_not_exists);
+        let options = put_options(ttl_secs, condition, version)?;
         kv.put(&key, value.to_vec(), options)
             .await
             .map_err(map_alien_error)
     }
 
-    /// Delete `key` (no error if absent).
+    /// Delete `key`, optionally only at the supplied version.
     #[napi]
-    pub async fn delete(&self, key: String) -> napi::Result<()> {
+    pub async fn delete(&self, key: String, if_version: Option<String>) -> napi::Result<bool> {
         let kv = self.inner.clone();
-        kv.delete(&key).await.map_err(map_alien_error)
+        kv.delete(&key, if_version.as_deref())
+            .await
+            .map_err(map_alien_error)
     }
 
     /// Check whether `key` exists.
@@ -131,32 +156,51 @@ mod tests {
     use super::*;
 
     #[test]
-    fn put_options_none_when_no_ttl_and_no_if_not_exists() {
-        assert!(put_options(None, None).is_none());
-        assert!(put_options(None, Some(false)).is_none());
+    fn put_options_none_when_unconditional_and_without_ttl() {
+        assert!(put_options(None, None, None).unwrap().is_none());
     }
 
     #[test]
-    fn put_options_sets_ttl_and_flag() {
-        let opts = put_options(Some(30), Some(true)).expect("options should be present");
+    fn put_options_sets_ttl_and_condition() {
+        let opts = put_options(Some(30), Some("absent".to_string()), None)
+            .unwrap()
+            .expect("options should be present");
         assert_eq!(opts.ttl, Some(Duration::from_secs(30)));
-        assert!(opts.if_not_exists);
+        assert_eq!(opts.condition, PutCondition::Absent);
 
-        let ttl_only = put_options(Some(5), None).expect("options should be present");
+        let ttl_only = put_options(Some(5), None, None)
+            .unwrap()
+            .expect("options should be present");
         assert_eq!(ttl_only.ttl, Some(Duration::from_secs(5)));
-        assert!(!ttl_only.if_not_exists);
+        assert_eq!(ttl_only.condition, PutCondition::None);
 
-        let flag_only = put_options(None, Some(true)).expect("options should be present");
-        assert_eq!(flag_only.ttl, None);
-        assert!(flag_only.if_not_exists);
+        let version = put_options(
+            None,
+            Some("version".to_string()),
+            Some("opaque".to_string()),
+        )
+        .unwrap()
+        .expect("options should be present");
+        assert_eq!(
+            version.condition,
+            PutCondition::Version("opaque".to_string())
+        );
     }
 
     #[test]
     fn scan_to_js_maps_items_and_cursor() {
         let result = ScanResult {
             items: vec![
-                ("a".to_string(), b"one".to_vec()),
-                ("b".to_string(), b"two".to_vec()),
+                KvEntry {
+                    key: "a".to_string(),
+                    value: b"one".to_vec(),
+                    version: "v1".to_string(),
+                },
+                KvEntry {
+                    key: "b".to_string(),
+                    value: b"two".to_vec(),
+                    version: "v2".to_string(),
+                },
             ],
             next_cursor: Some("next".to_string()),
         };
@@ -166,6 +210,7 @@ mod tests {
         assert_eq!(js.items.len(), 2);
         assert_eq!(js.items[0].key, "a");
         assert_eq!(js.items[0].value.as_ref(), b"one");
+        assert_eq!(js.items[0].version, "v1");
         assert_eq!(js.items[1].key, "b");
         assert_eq!(js.items[1].value.as_ref(), b"two");
         assert_eq!(js.next_cursor, Some("next".to_string()));

--- a/crates/alien-bindings/FORMAT.md
+++ b/crates/alien-bindings/FORMAT.md
@@ -25,7 +25,7 @@ modules are the gate that the mode actually delivers the semantics pinned
 below. Alongside the database file turso maintains WAL sidecar files (e.g.
 `-wal`); treat every `<file>.sqlite*` sibling as part of the store.
 
-## `localkv.v1` — `LocalKv`
+## `localkv.v2` — `LocalKv`
 
 Backed by a single database file at `<dataDir>/localkv.sqlite`, where
 `<dataDir>` is the directory passed to `LocalKv::new`. The directory is created
@@ -60,12 +60,13 @@ CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-INSERT OR IGNORE INTO meta (key, value) VALUES ('format', 'localkv.v1');
+INSERT OR IGNORE INTO meta (key, value) VALUES ('format', 'localkv.v2');
 
 CREATE TABLE IF NOT EXISTS kv (
     key        TEXT PRIMARY KEY,
     value      BLOB NOT NULL,
-    expires_at INTEGER          -- unix epoch MILLISECONDS, NULL = no expiry
+    expires_at INTEGER,         -- unix epoch MILLISECONDS, NULL = no expiry
+    version    TEXT NOT NULL    -- changes on every applied put
 );
 ```
 
@@ -75,12 +76,12 @@ a 5s `busy_timeout` (on every connection, via the turso API).
 ### Versioning rule
 
 The `meta` table carries the format identifier in the row
-`('format', 'localkv.v1')`. Any future incompatible change to the `kv` schema
-MUST bump this string (e.g. `localkv.v2`) and add explicit migration/rejection
+`('format', 'localkv.v2')`. Any future incompatible change to the `kv` schema
+MUST bump this string and add explicit migration/rejection
 logic. Readers MUST reject a format they do not understand — and this
 implementation does: `LocalKv::new` checks the marker before creating any
 provider tables and fails fast (`BINDING_SETUP_FAILED`, naming both the found
-and the supported format) unless it equals `localkv.v1`, so a rejected foreign
+and the supported format) unless it equals `localkv.v2`, so a rejected foreign
 store is left untouched. The `meta` row is written with `INSERT OR
 IGNORE`, so re-opening an existing store never overwrites it.
 
@@ -96,22 +97,28 @@ IGNORE`, so re-opening an existing store never overwrites it.
   expired rows out of its results but does not delete them. Physical deletion is
   therefore eventual, matching the `Kv` trait's soft-hint TTL contract.
 
+- **Versions.** Every applied put writes a fresh random version. Reads wrap that
+  backend version in an opaque, key-bound token. Callers may pass the token to
+  a conditional put or delete; tokens must never be parsed or modified.
+
 - **Unconditional put.** Upsert in one statement:
 
   ```sql
-  INSERT INTO kv (key, value, expires_at) VALUES (?1, ?2, ?3)
-  ON CONFLICT(key) DO UPDATE SET value = ?2, expires_at = ?3;
+  INSERT INTO kv (key, value, expires_at, version) VALUES (?1, ?2, ?3, ?4)
+  ON CONFLICT(key) DO UPDATE
+  SET value = ?2, expires_at = ?3, version = ?4;
   ```
 
   Always returns `true`.
 
-- **Conditional put (`if_not_exists`).** One atomic statement; the winner is
+- **Conditional put (absent).** One atomic statement; the winner is
   detected via the changed-row count returned by `execute`:
 
   ```sql
-  INSERT INTO kv (key, value, expires_at) VALUES (?1, ?2, ?3)
-  ON CONFLICT(key) DO UPDATE SET value = ?2, expires_at = ?3
-  WHERE kv.expires_at IS NOT NULL AND kv.expires_at <= ?4;   -- ?4 = now
+  INSERT INTO kv (key, value, expires_at, version) VALUES (?1, ?2, ?3, ?4)
+  ON CONFLICT(key) DO UPDATE
+  SET value = ?2, expires_at = ?3, version = ?4
+  WHERE kv.expires_at IS NOT NULL AND kv.expires_at <= ?5;   -- ?5 = now
   ```
 
   - Key absent → `INSERT` runs → changed count `== 1` → **win** (returns
@@ -125,19 +132,29 @@ IGNORE`, so re-opening an existing store never overwrites it.
   handles/processes) race this statement on the same key, exactly one observes
   a changed count of 1.
 
+- **Conditional put (version).** A single `UPDATE` matches the key, stored
+  version, and live TTL. It writes the new value, TTL, and a fresh version.
+  The changed-row count is `1` only for the winner.
+
+- **Conditional delete.** A single `DELETE` matches the key, stored version,
+  and live TTL. A mismatch, missing row, or logically expired row returns
+  `false`; a matching delete returns `true`.
+
 - **Scan.** `scan_prefix` selects `WHERE key >= ?prefix ORDER BY key`, stops at
   the first key that no longer starts with the prefix, filters expired rows, and
-  paginates with a simple 0-based integer offset cursor. Results are ordered by
-  key. An unparseable cursor returns `INVALID_INPUT`.
+  returns each entry's opaque version. Pagination resumes strictly after the
+  last returned key using a prefix-bound opaque cursor. Results are ordered by
+  key. An invalid or cross-prefix cursor returns `INVALID_INPUT`.
 
 ### Single implementation
 
 `LocalKv` (`src/providers/kv/local.rs`) is the **only** reader/writer of
-`localkv.v1`. There is no separate migration binary or alternate accessor; the
-schema, settings, and the statements above are defined once in that file (the
-shared open/init handshake lives in `src/providers/local_store.rs`). Any
-change to the on-disk contract must update both this document and that file
-together (and bump the `meta` format string if incompatible).
+`localkv.v2`. There is no separate migration binary or alternate accessor;
+the schema, settings, and the statements above are defined once in that file
+(the shared open/init handshake lives in `src/providers/local_store.rs`).
+Existing stores with another format marker, including `localkv.v1`, are
+rejected. Any change to the on-disk contract must update both this document
+and that file together (and bump the `meta` format string if incompatible).
 
 ## `localqueue.v1` — `LocalQueue`
 
@@ -148,7 +165,7 @@ created if missing; the database file (plus its WAL siblings) lives inside it.
 
 ### Connection strategy
 
-Identical to `localkv.v1`: `LocalQueue` holds one `turso::Database` handle;
+Identical to `localkv.v2`: `LocalQueue` holds one `turso::Database` handle;
 every operation opens its own short-lived connection from it, which is dropped
 when the operation completes, and every statement is driven to completion. No
 connection crosses operations and there is no `Mutex<Connection>` anywhere.

--- a/crates/alien-bindings/src/bindings.rs
+++ b/crates/alien-bindings/src/bindings.rs
@@ -354,7 +354,7 @@ mod tests {
             .await
             .expect("get should succeed")
             .expect("value should exist");
-        assert_eq!(value, b"hi");
+        assert_eq!(value.value, b"hi");
     }
 
     #[tokio::test]
@@ -394,7 +394,7 @@ mod tests {
             .await
             .expect("the same long-lived handle should read")
             .expect("value should exist");
-        assert_eq!(value, b"hi");
+        assert_eq!(value.value, b"hi");
         assert_eq!(
             calls.load(Ordering::SeqCst),
             2,

--- a/crates/alien-bindings/src/lib.rs
+++ b/crates/alien-bindings/src/lib.rs
@@ -10,9 +10,9 @@ pub use remote::{RemoteBindings, RemoteStorage};
 pub use traits::{
     ArtifactRegistry, ArtifactRegistryCredentials, ArtifactRegistryPermissions,
     AwsServiceAccountInfo, AzureServiceAccountInfo, Binding, BindingsProviderApi, Build, Container,
-    GcpServiceAccountInfo, ImpersonationRequest, InvalidPostgresCaCertificates, Kv, Postgres,
-    PostgresConnectionParams, PostgresTlsPolicy, Queue, RegistryAuthMethod, RepositoryResponse,
-    ServiceAccount, ServiceAccountInfo, SslMode, Storage, Vault, Worker,
+    GcpServiceAccountInfo, ImpersonationRequest, InvalidPostgresCaCertificates, Kv, KvEntry,
+    Postgres, PostgresConnectionParams, PostgresTlsPolicy, PutCondition, Queue, RegistryAuthMethod,
+    RepositoryResponse, ServiceAccount, ServiceAccountInfo, SslMode, Storage, Vault, Worker,
 };
 
 pub mod bindings;

--- a/crates/alien-bindings/src/providers/kv/aws_dynamodb.rs
+++ b/crates/alien-bindings/src/providers/kv/aws_dynamodb.rs
@@ -1,5 +1,5 @@
 use crate::error::{map_cloud_client_error, ErrorData, Result};
-use crate::traits::{Binding, Kv, PutOptions, ScanResult};
+use crate::traits::{Binding, Kv, KvEntry, PutCondition, PutOptions, ScanResult};
 use alien_aws_clients::dynamodb::*;
 use alien_error::{AlienError, Context, IntoAlienError};
 use async_trait::async_trait;
@@ -8,8 +8,9 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+use uuid::Uuid;
 
-use super::{validate_key, validate_value};
+use super::{decode_version, encode_version, validate_key, validate_value};
 
 const HASH_BUCKET_COUNT: u8 = 16;
 
@@ -63,6 +64,50 @@ impl AwsDynamodbKv {
         } else {
             false
         }
+    }
+
+    fn primary_key(&self, key: &str) -> HashMap<String, AttributeValue> {
+        HashMap::from([
+            ("pk".to_string(), AttributeValue::s(self.hash_bucket(key))),
+            ("sk".to_string(), AttributeValue::s(key.to_string())),
+        ])
+    }
+
+    async fn load_item(&self, key: &str) -> Result<Option<HashMap<String, AttributeValue>>> {
+        let request = GetItemRequest::builder()
+            .table_name(self.table_name.clone())
+            .key(self.primary_key(key))
+            .consistent_read(true)
+            .build();
+        self.client
+            .get_item(request)
+            .await
+            .map(|response| response.item)
+            .map_err(|error| {
+                map_cloud_client_error(
+                    error,
+                    format!("Failed to get item with key '{}'", key),
+                    Some(key.to_string()),
+                )
+            })
+    }
+
+    fn item_ttl(item: &HashMap<String, AttributeValue>) -> Option<i64> {
+        item.get("ttl")
+            .and_then(|attribute| attribute.n.as_deref())
+            .and_then(|value| value.parse::<i64>().ok())
+    }
+
+    fn item_value(key: &str, item: &HashMap<String, AttributeValue>) -> Result<Vec<u8>> {
+        item.get("value")
+            .and_then(|attribute| attribute.b.as_ref())
+            .and_then(|value| base64::prelude::BASE64_STANDARD.decode(value).ok())
+            .ok_or_else(|| {
+                AlienError::new(ErrorData::CloudPlatformError {
+                    message: format!("Missing or invalid value attribute for key '{}'", key),
+                    resource_id: Some(key.to_string()),
+                })
+            })
     }
 
     fn encode_cursor(state: &CursorState) -> Result<String> {
@@ -119,57 +164,34 @@ impl Binding for AwsDynamodbKv {}
 
 #[async_trait]
 impl Kv for AwsDynamodbKv {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<KvEntry>> {
         validate_key(key)?;
 
-        let bucket = self.hash_bucket(key);
-        let mut primary_key = HashMap::new();
-        primary_key.insert("pk".to_string(), AttributeValue::s(bucket));
-        primary_key.insert("sk".to_string(), AttributeValue::s(key.to_string()));
-
-        let request = GetItemRequest::builder()
-            .table_name(self.table_name.clone())
-            .key(primary_key)
-            // `Kv::put` followed by `Kv::get` must observe the write. DynamoDB
-            // GetItem is eventually consistent by default, which can make a
-            // freshly stored command payload appear missing during immediate
-            // push dispatch.
-            .consistent_read(true)
-            .build();
-
-        let response = self.client.get_item(request).await.map_err(|e| {
-            map_cloud_client_error(
-                e,
-                format!("Failed to get item with key '{}'", key),
-                Some(key.to_string()),
-            )
-        })?;
-
-        if let Some(item) = response.item {
-            // Check TTL expiry (logical expiry contract)
-            if let Some(ttl_attr) = item.get("ttl") {
-                if let Some(ttl_epoch) = ttl_attr.n.as_ref().and_then(|s| s.parse::<i64>().ok()) {
-                    if self.is_expired(Some(ttl_epoch)) {
-                        return Ok(None); // Logically expired
-                    }
-                }
-            }
-
-            let value = item
-                .get("value")
-                .and_then(|attr| attr.b.as_ref())
-                .and_then(|base64_value| base64::prelude::BASE64_STANDARD.decode(base64_value).ok())
-                .ok_or_else(|| {
-                    AlienError::new(ErrorData::CloudPlatformError {
-                        message: format!("Missing or invalid value attribute for key '{}'", key),
-                        resource_id: Some(key.to_string()),
-                    })
-                })?;
-
-            Ok(Some(value))
-        } else {
-            Ok(None)
+        let Some(item) = self.load_item(key).await? else {
+            return Ok(None);
+        };
+        let ttl = Self::item_ttl(&item);
+        if self.is_expired(ttl) {
+            return Ok(None);
         }
+        let backend_version = item
+            .get("version")
+            .and_then(|value| value.s.clone())
+            .ok_or_else(|| {
+                AlienError::new(ErrorData::CloudPlatformError {
+                    message: format!("Missing or invalid version attribute for key '{}'", key),
+                    resource_id: Some(key.to_string()),
+                })
+            })?;
+        Ok(Some(KvEntry {
+            key: key.to_string(),
+            value: Self::item_value(key, &item)?,
+            version: encode_version(
+                key,
+                backend_version,
+                ttl.map(|expires_at| expires_at.saturating_mul(1000)),
+            )?,
+        }))
     }
 
     async fn put(&self, key: &str, value: Vec<u8>, options: Option<PutOptions>) -> Result<bool> {
@@ -186,13 +208,17 @@ impl Kv for AwsDynamodbKv {
             "value".to_string(),
             AttributeValue::b(base64::prelude::BASE64_STANDARD.encode(&value)),
         );
+        item.insert(
+            "version".to_string(),
+            AttributeValue::s(Uuid::new_v4().simple().to_string()),
+        );
 
         if let Some(ttl) = options.ttl {
             let expires_at = (Utc::now() + ttl).timestamp();
             item.insert("ttl".to_string(), AttributeValue::n(expires_at.to_string()));
         }
 
-        let request = if options.if_not_exists {
+        let request = if matches!(options.condition, PutCondition::Absent) {
             // Expired rows count as ABSENT, exactly like the local provider's
             // atomic takeover: DynamoDB's background TTL sweeper can lag the
             // logical expiry by hours, and without the `#ttl <= :now` arm a
@@ -216,6 +242,33 @@ impl Kv for AwsDynamodbKv {
                 .expression_attribute_names(expression_attribute_names)
                 .expression_attribute_values(expression_attribute_values)
                 .build()
+        } else if let PutCondition::Version(ref version) = options.condition {
+            let expected = decode_version(key, version)?;
+            if expected.expired {
+                return Ok(false);
+            }
+            PutItemRequest::builder()
+                .table_name(self.table_name.clone())
+                .item(item)
+                .condition_expression(
+                    "#version = :version AND (attribute_not_exists(#ttl) OR #ttl > :now)"
+                        .to_string(),
+                )
+                .expression_attribute_names(HashMap::from([
+                    ("#version".to_string(), "version".to_string()),
+                    ("#ttl".to_string(), "ttl".to_string()),
+                ]))
+                .expression_attribute_values(HashMap::from([
+                    (
+                        ":version".to_string(),
+                        AttributeValue::s(expected.backend_version),
+                    ),
+                    (
+                        ":now".to_string(),
+                        AttributeValue::n(Utc::now().timestamp().to_string()),
+                    ),
+                ]))
+                .build()
         } else {
             PutItemRequest::builder()
                 .table_name(self.table_name.clone())
@@ -226,8 +279,7 @@ impl Kv for AwsDynamodbKv {
         match self.client.put_item(request).await {
             Ok(_) => Ok(true),
             Err(e) => {
-                // Check if this is a conditional check failure for if_not_exists
-                if options.if_not_exists {
+                if !matches!(options.condition, PutCondition::None) {
                     if let Some(alien_client_core::ErrorData::RemoteResourceConflict { .. }) =
                         &e.error
                     {
@@ -243,28 +295,60 @@ impl Kv for AwsDynamodbKv {
         }
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> Result<bool> {
         validate_key(key)?;
 
-        let bucket = self.hash_bucket(key);
-        let mut primary_key = HashMap::new();
-        primary_key.insert("pk".to_string(), AttributeValue::s(bucket));
-        primary_key.insert("sk".to_string(), AttributeValue::s(key.to_string()));
+        let request = if let Some(version) = if_version {
+            let expected = decode_version(key, version)?;
+            if expected.expired {
+                return Ok(false);
+            }
+            DeleteItemRequest::builder()
+                .table_name(self.table_name.clone())
+                .key(self.primary_key(key))
+                .condition_expression(
+                    "#version = :version AND (attribute_not_exists(#ttl) OR #ttl > :now)"
+                        .to_string(),
+                )
+                .expression_attribute_names(HashMap::from([
+                    ("#version".to_string(), "version".to_string()),
+                    ("#ttl".to_string(), "ttl".to_string()),
+                ]))
+                .expression_attribute_values(HashMap::from([
+                    (
+                        ":version".to_string(),
+                        AttributeValue::s(expected.backend_version),
+                    ),
+                    (
+                        ":now".to_string(),
+                        AttributeValue::n(Utc::now().timestamp().to_string()),
+                    ),
+                ]))
+                .build()
+        } else {
+            DeleteItemRequest::builder()
+                .table_name(self.table_name.clone())
+                .key(self.primary_key(key))
+                .build()
+        };
 
-        let request = DeleteItemRequest::builder()
-            .table_name(self.table_name.clone())
-            .key(primary_key)
-            .build();
-
-        self.client.delete_item(request).await.map_err(|e| {
-            map_cloud_client_error(
-                e,
+        match self.client.delete_item(request).await {
+            Ok(_) => Ok(true),
+            Err(error)
+                if if_version.is_some()
+                    && matches!(
+                        error.error.as_ref(),
+                        Some(alien_client_core::ErrorData::RemoteResourceConflict { .. })
+                    ) =>
+            {
+                Ok(false)
+            }
+            Err(error) => Err(map_cloud_client_error(
+                error,
                 format!("Failed to delete item with key '{}'", key),
                 Some(key.to_string()),
-            )
-        })?;
-
-        Ok(())
+            )),
+        }
     }
 
     async fn exists(&self, key: &str) -> Result<bool> {
@@ -384,7 +468,28 @@ impl Kv for AwsDynamodbKv {
                         (key_attr.s.as_ref(), value_attr.b.as_ref())
                     {
                         if let Ok(value) = base64::prelude::BASE64_STANDARD.decode(base64_value) {
-                            items.push((key.clone(), value));
+                            let ttl = Self::item_ttl(&item);
+                            if let Some(backend_version) =
+                                item.get("version").and_then(|value| value.s.clone())
+                            {
+                                items.push(KvEntry {
+                                    key: key.clone(),
+                                    value,
+                                    version: encode_version(
+                                        key,
+                                        backend_version,
+                                        ttl.map(|expires_at| expires_at.saturating_mul(1000)),
+                                    )?,
+                                });
+                            } else {
+                                return Err(AlienError::new(ErrorData::CloudPlatformError {
+                                    message: format!(
+                                        "Missing or invalid version attribute for key '{}'",
+                                        key
+                                    ),
+                                    resource_id: Some(key.clone()),
+                                }));
+                            }
                         }
                     }
                 }

--- a/crates/alien-bindings/src/providers/kv/azure_table_storage.rs
+++ b/crates/alien-bindings/src/providers/kv/azure_table_storage.rs
@@ -1,5 +1,5 @@
 use crate::error::{ErrorData, Result};
-use crate::traits::{Binding, Kv, PutOptions, ScanResult};
+use crate::traits::{Binding, Kv, KvEntry, PutCondition, PutOptions, ScanResult};
 use alien_azure_clients::tables::{
     AzureTableStorageClient, EntityQueryContinuation, EntityQueryOptions, TableEntity,
     TableStorageApi,
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
-use super::{validate_key, validate_value};
+use super::{decode_version, encode_version, validate_key, validate_value};
 
 /// Convert a KV operation to a Table Storage entity
 /// This only base64 encodes the raw bytes when creating the properties map, not in memory
@@ -83,6 +83,23 @@ fn is_entity_expired(entity: &TableEntity) -> bool {
         }
     }
     false
+}
+
+fn entity_expiration_millis(entity: &TableEntity) -> Option<i64> {
+    entity
+        .properties
+        .get("ExpiresAt")
+        .and_then(Value::as_str)
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.timestamp_millis())
+}
+
+fn entity_etag(entity: &TableEntity) -> Option<String> {
+    entity
+        .properties
+        .get("odata.etag")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
 }
 
 /// Cursor state for pagination across partitions
@@ -298,7 +315,7 @@ impl Binding for AzureTableStorageKv {}
 
 #[async_trait]
 impl Kv for AzureTableStorageKv {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<KvEntry>> {
         validate_key(key)?;
 
         let (partition_key, row_key) = self.split_key(key);
@@ -322,7 +339,19 @@ impl Kv for AzureTableStorageKv {
                 }
 
                 let value = extract_value_from_entity(&entity)?;
-                Ok(Some(value))
+                let etag = entity_etag(&entity).ok_or_else(|| {
+                    AlienError::new(ErrorData::UnexpectedResponseFormat {
+                        provider: "azure".to_string(),
+                        binding_name: "table-storage".to_string(),
+                        field: "odata.etag".to_string(),
+                        response_json: serde_json::to_string(&entity).unwrap_or_default(),
+                    })
+                })?;
+                Ok(Some(KvEntry {
+                    key: key.to_string(),
+                    value,
+                    version: encode_version(key, etag, entity_expiration_millis(&entity))?,
+                }))
             }
             Err(e) => {
                 use alien_client_core::ErrorData as CloudErrorData;
@@ -349,7 +378,7 @@ impl Kv for AzureTableStorageKv {
         let entity =
             create_table_entity(partition_key.clone(), row_key.clone(), &value, expires_at);
 
-        if options.if_not_exists {
+        if matches!(options.condition, PutCondition::Absent) {
             match self
                 .client
                 .insert_entity(
@@ -383,6 +412,42 @@ impl Kv for AzureTableStorageKv {
                     }
                 }
             }
+        } else if let PutCondition::Version(ref version) = options.condition {
+            let expected = decode_version(key, version)?;
+            if expected.expired {
+                return Ok(false);
+            }
+            match self
+                .client
+                .update_entity(
+                    &self.resource_group_name,
+                    &self.account_name,
+                    &self.table_name,
+                    &partition_key,
+                    &row_key,
+                    &entity,
+                    Some(alien_azure_clients::azure::tables::ETag::from(
+                        expected.backend_version,
+                    )),
+                )
+                .await
+            {
+                Ok(_) => Ok(true),
+                Err(error)
+                    if matches!(
+                        error.error.as_ref(),
+                        Some(alien_client_core::ErrorData::RemoteResourceConflict { .. })
+                            | Some(alien_client_core::ErrorData::RemoteResourceNotFound { .. })
+                    ) =>
+                {
+                    Ok(false)
+                }
+                Err(error) => Err(crate::error::map_cloud_client_error(
+                    error,
+                    format!("Failed to conditionally update entity for key '{}'", key),
+                    Some(key.to_string()),
+                )),
+            }
         } else {
             // Insert Or Replace (upsert) - matches Azure REST API terminology
             self.client
@@ -406,12 +471,23 @@ impl Kv for AzureTableStorageKv {
         }
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> Result<bool> {
         validate_key(key)?;
 
         let (partition_key, row_key) = self.split_key(key);
 
-        // Delete entity, ignore if not found
+        let etag = if let Some(version) = if_version {
+            let expected = decode_version(key, version)?;
+            if expected.expired {
+                return Ok(false);
+            }
+            Some(alien_azure_clients::azure::tables::ETag::from(
+                expected.backend_version,
+            ))
+        } else {
+            None
+        };
+
         match self
             .client
             .delete_entity(
@@ -420,15 +496,18 @@ impl Kv for AzureTableStorageKv {
                 &self.table_name,
                 &partition_key,
                 &row_key,
-                None, // No specific ETag constraint
+                etag,
             )
             .await
         {
-            Ok(_) => Ok(()),
+            Ok(_) => Ok(true),
             Err(e) => {
                 use alien_client_core::ErrorData as CloudErrorData;
                 match e.error.as_ref() {
-                    Some(CloudErrorData::RemoteResourceNotFound { .. }) => Ok(()), // No error if key doesn't exist
+                    Some(CloudErrorData::RemoteResourceNotFound { .. }) => Ok(if_version.is_none()),
+                    Some(CloudErrorData::RemoteResourceConflict { .. }) if if_version.is_some() => {
+                        Ok(false)
+                    }
                     _ => Err(crate::error::map_cloud_client_error(
                         e,
                         format!("Failed to delete entity for key '{}'", key),
@@ -549,7 +628,15 @@ impl Kv for AzureTableStorageKv {
                 let key = self.combine_key(&entity.partition_key, &entity.row_key);
                 let value = extract_value_from_entity(&entity)?;
 
-                items.push((key, value));
+                if let Some(etag) = entity_etag(&entity) {
+                    items.push(KvEntry {
+                        version: encode_version(&key, etag, entity_expiration_millis(&entity))?,
+                        key,
+                        value,
+                    });
+                } else if let Some(entry) = self.get(&key).await? {
+                    items.push(entry);
+                }
             }
 
             if items.len() == limit {

--- a/crates/alien-bindings/src/providers/kv/gcp_firestore.rs
+++ b/crates/alien-bindings/src/providers/kv/gcp_firestore.rs
@@ -1,5 +1,5 @@
 use crate::error::{ErrorData, Result};
-use crate::traits::{Binding, Kv, PutOptions, ScanResult};
+use crate::traits::{Binding, Kv, KvEntry, PutCondition, PutOptions, ScanResult};
 use alien_error::{AlienError, Context, IntoAlienError};
 use alien_gcp_clients::firestore::{
     CollectionSelector, CompositeFilter, CompositeFilterOperator, Cursor, Direction, Document,
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
-use super::{validate_key, validate_value};
+use super::{decode_version, encode_version, validate_key, validate_value};
 
 /// Firestore document for KV storage
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -325,7 +325,7 @@ impl Binding for GcpFirestoreKv {}
 
 #[async_trait]
 impl Kv for GcpFirestoreKv {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<KvEntry>> {
         validate_key(key)?;
 
         let document_id = key;
@@ -353,7 +353,25 @@ impl Kv for GcpFirestoreKv {
                         reason: "Failed to decode base64 value".to_string(),
                     })?;
 
-                Ok(Some(value))
+                let update_time = doc.update_time.clone().ok_or_else(|| {
+                    AlienError::new(ErrorData::UnexpectedResponseFormat {
+                        provider: "gcp".to_string(),
+                        binding_name: "firestore".to_string(),
+                        field: "updateTime".to_string(),
+                        response_json: serde_json::to_string(&doc).unwrap_or_default(),
+                    })
+                })?;
+                Ok(Some(KvEntry {
+                    key: key.to_string(),
+                    value,
+                    version: encode_version(
+                        key,
+                        update_time,
+                        kv_doc
+                            .expires_at
+                            .map(|expires_at| expires_at.timestamp_millis()),
+                    )?,
+                }))
             }
             Err(e) => {
                 // Check if this is a "not found" error
@@ -386,7 +404,7 @@ impl Kv for GcpFirestoreKv {
 
         let document = self.kv_document_to_firestore(key, &kv_doc);
 
-        if options.if_not_exists {
+        if matches!(options.condition, PutCondition::Absent) {
             let document_id = key.to_string();
             match self
                 .client
@@ -424,47 +442,96 @@ impl Kv for GcpFirestoreKv {
             let document_id = key;
             let document_path = format!("{}/{}", self.collection_name, document_id);
             let document_with_name = self.kv_document_to_firestore_with_name(key, &kv_doc);
+            let current_document = match &options.condition {
+                PutCondition::Version(version) => {
+                    let expected = decode_version(key, version)?;
+                    if expected.expired {
+                        return Ok(false);
+                    }
+                    Some(alien_gcp_clients::gcp::firestore::Precondition {
+                        condition: alien_gcp_clients::gcp::firestore::PreconditionType::UpdateTime(
+                            expected.backend_version,
+                        ),
+                    })
+                }
+                PutCondition::None => None,
+                PutCondition::Absent => unreachable!("handled above"),
+            };
 
-            self.client
+            match self
+                .client
                 .patch_document(
                     self.database_id.clone(),
                     document_path,
                     document_with_name,
                     None,
                     None,
-                    None,
+                    current_document,
                 )
                 .await
-                .map_err(|e| {
-                    crate::error::map_cloud_client_error(
-                        e,
-                        "Failed to patch Firestore document".to_string(),
-                        Some(key.to_string()),
-                    )
-                })?;
-
-            Ok(true)
+            {
+                Ok(_) => Ok(true),
+                Err(error)
+                    if matches!(options.condition, PutCondition::Version(_))
+                        && matches!(
+                            error.error.as_ref(),
+                            Some(alien_client_core::ErrorData::RemoteResourceConflict { .. })
+                                | Some(alien_client_core::ErrorData::RemoteResourceNotFound { .. })
+                        ) =>
+                {
+                    Ok(false)
+                }
+                Err(error) => Err(crate::error::map_cloud_client_error(
+                    error,
+                    "Failed to patch Firestore document".to_string(),
+                    Some(key.to_string()),
+                )),
+            }
         }
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> Result<bool> {
         validate_key(key)?;
 
         let document_id = key;
         let document_path = format!("{}/{}", self.collection_name, document_id);
 
-        self.client
-            .delete_document(self.database_id.clone(), document_path, None)
-            .await
-            .map_err(|e| {
-                crate::error::map_cloud_client_error(
-                    e,
-                    "Failed to delete Firestore document".to_string(),
-                    Some(key.to_string()),
-                )
-            })?;
+        let current_document = if let Some(version) = if_version {
+            let expected = decode_version(key, version)?;
+            if expected.expired {
+                return Ok(false);
+            }
+            Some(alien_gcp_clients::gcp::firestore::Precondition {
+                condition: alien_gcp_clients::gcp::firestore::PreconditionType::UpdateTime(
+                    expected.backend_version,
+                ),
+            })
+        } else {
+            None
+        };
 
-        Ok(())
+        match self
+            .client
+            .delete_document(self.database_id.clone(), document_path, current_document)
+            .await
+        {
+            Ok(()) => Ok(true),
+            Err(error)
+                if if_version.is_some()
+                    && matches!(
+                        error.error.as_ref(),
+                        Some(alien_client_core::ErrorData::RemoteResourceConflict { .. })
+                            | Some(alien_client_core::ErrorData::RemoteResourceNotFound { .. })
+                    ) =>
+            {
+                Ok(false)
+            }
+            Err(error) => Err(crate::error::map_cloud_client_error(
+                error,
+                "Failed to delete Firestore document".to_string(),
+                Some(key.to_string()),
+            )),
+        }
     }
 
     async fn exists(&self, key: &str) -> Result<bool> {
@@ -613,7 +680,25 @@ impl Kv for GcpFirestoreKv {
                     field: "value".to_string(),
                     response_json: serde_json::to_string(document).unwrap_or_default(),
                 })?;
-            items.push((key.to_string(), value));
+            let update_time = document.update_time.clone().ok_or_else(|| {
+                AlienError::new(ErrorData::UnexpectedResponseFormat {
+                    provider: "gcp".to_string(),
+                    binding_name: "firestore".to_string(),
+                    field: "updateTime".to_string(),
+                    response_json: serde_json::to_string(document).unwrap_or_default(),
+                })
+            })?;
+            items.push(KvEntry {
+                key: key.to_string(),
+                value,
+                version: encode_version(
+                    key,
+                    update_time,
+                    kv_doc
+                        .expires_at
+                        .map(|expires_at| expires_at.timestamp_millis()),
+                )?,
+            });
         }
 
         let next_cursor = if documents.len() == limit {

--- a/crates/alien-bindings/src/providers/kv/local.rs
+++ b/crates/alien-bindings/src/providers/kv/local.rs
@@ -1,4 +1,4 @@
-//! Local disk-persisted KV backed by turso (`localkv.v1`), multi-process safe.
+//! Local disk-persisted KV backed by turso (`localkv.v2`), multi-process safe.
 //!
 //! # Connection strategy
 //!
@@ -19,12 +19,12 @@
 //! are a single atomic `INSERT ... ON CONFLICT DO UPDATE ... WHERE` so the
 //! race is resolved by the database, not by application-level locking.
 //!
-//! See `crates/alien-bindings/FORMAT.md` for the on-disk `localkv.v1` contract.
+//! See `crates/alien-bindings/FORMAT.md` for the on-disk `localkv.v2` contract.
 use crate::error::{ErrorData, Result};
 use crate::providers::local_store::{
     as_blob, as_i64, as_opt_i64, as_text, opt_i64_value, query_all, LocalStore, StoreSpec,
 };
-use crate::traits::{Binding, Kv, PutOptions, ScanResult};
+use crate::traits::{Binding, Kv, KvEntry, PutCondition, PutOptions, ScanResult};
 use alien_error::{AlienError, Context as _, IntoAlienError as _};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -32,12 +32,15 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use turso::Connection;
+use uuid::Uuid;
+
+use super::{decode_version, encode_version};
 
 static KV_SPEC: StoreSpec = StoreSpec {
     db_filename: "localkv.sqlite",
-    format_version: "localkv.v1",
+    format_version: "localkv.v2",
     binding_type: "local KV",
-    schema_ddl: "CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value BLOB NOT NULL, expires_at INTEGER);",
+    schema_ddl: "CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value BLOB NOT NULL, expires_at INTEGER, version TEXT NOT NULL);",
 };
 
 #[derive(Debug)]
@@ -202,7 +205,7 @@ impl Binding for LocalKv {}
 
 #[async_trait]
 impl Kv for LocalKv {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<KvEntry>> {
         Self::validate_key(key)?;
 
         self.store
@@ -210,12 +213,12 @@ impl Kv for LocalKv {
                 let now = Utc::now().timestamp_millis();
                 let rows = query_all(
                     &conn,
-                    "SELECT value, expires_at FROM kv WHERE key = ?1",
+                    "SELECT value, expires_at, version FROM kv WHERE key = ?1",
                     (key,),
                 )
                 .await
                 .into_alien_error()
-                .context(kv_error("get", key, "failed to read value"))?;
+                .context(kv_error("get", key, "failed to read entry"))?;
 
                 let Some(row) = rows.first() else {
                     return Ok(None);
@@ -226,14 +229,20 @@ impl Kv for LocalKv {
                 let expires_at = row.get(1).and_then(as_opt_i64).ok_or_else(|| {
                     AlienError::new(kv_error("get", key, "stored expires_at is not an integer"))
                 })?;
+                let backend_version = row.get(2).and_then(as_text).ok_or_else(|| {
+                    AlienError::new(kv_error("get", key, "stored version is not text"))
+                })?;
 
                 if matches!(expires_at, Some(exp) if exp <= now) {
-                    // Lazily remove the expired row.
                     delete_expired(&conn, "get", key, now).await?;
-                    Ok(None)
-                } else {
-                    Ok(Some(value))
+                    return Ok(None);
                 }
+
+                Ok(Some(KvEntry {
+                    key: key.to_string(),
+                    value,
+                    version: encode_version(key, backend_version, expires_at)?,
+                }))
             })
             .await
     }
@@ -249,28 +258,52 @@ impl Kv for LocalKv {
                 let expires_at: Option<i64> = options
                     .ttl
                     .map(|d| now.saturating_add(i64::try_from(d.as_millis()).unwrap_or(i64::MAX)));
+                let new_version = Uuid::new_v4().simple().to_string();
 
-                if options.if_not_exists {
+                if matches!(options.condition, PutCondition::Absent) {
                     // One atomic statement: insert if absent, otherwise overwrite
                     // ONLY when the existing row is already expired. The changed
                     // row count (returned by `execute`) is 1 for the winner, 0
                     // for a loser.
                     let changed = conn
                         .execute(
-                            "INSERT INTO kv (key, value, expires_at) VALUES (?1, ?2, ?3) \
-                             ON CONFLICT(key) DO UPDATE SET value = ?2, expires_at = ?3 \
-                             WHERE kv.expires_at IS NOT NULL AND kv.expires_at <= ?4",
-                            (key, value, opt_i64_value(expires_at), now),
+                            "INSERT INTO kv (key, value, expires_at, version) VALUES (?1, ?2, ?3, ?4) \
+                             ON CONFLICT(key) DO UPDATE SET value = ?2, expires_at = ?3, version = ?4 \
+                             WHERE kv.expires_at IS NOT NULL AND kv.expires_at <= ?5",
+                            (key, value, opt_i64_value(expires_at), new_version, now),
                         )
                         .await
                         .into_alien_error()
                         .context(kv_error("put", key, "failed conditional put"))?;
                     Ok(changed == 1)
+                } else if let PutCondition::Version(if_version) = options.condition {
+                    let expected = decode_version(key, &if_version)?;
+                    if expected.expired {
+                        return Ok(false);
+                    }
+                    let changed = conn
+                        .execute(
+                            "UPDATE kv SET value = ?2, expires_at = ?3, version = ?4 \
+                             WHERE key = ?1 AND version = ?5 \
+                               AND (expires_at IS NULL OR expires_at > ?6)",
+                            (
+                                key,
+                                value,
+                                opt_i64_value(expires_at),
+                                new_version,
+                                expected.backend_version,
+                                now,
+                            ),
+                        )
+                        .await
+                        .into_alien_error()
+                        .context(kv_error("put", key, "failed versioned put"))?;
+                    Ok(changed == 1)
                 } else {
                     conn.execute(
-                        "INSERT INTO kv (key, value, expires_at) VALUES (?1, ?2, ?3) \
-                         ON CONFLICT(key) DO UPDATE SET value = ?2, expires_at = ?3",
-                        (key, value, opt_i64_value(expires_at)),
+                        "INSERT INTO kv (key, value, expires_at, version) VALUES (?1, ?2, ?3, ?4) \
+                         ON CONFLICT(key) DO UPDATE SET value = ?2, expires_at = ?3, version = ?4",
+                        (key, value, opt_i64_value(expires_at), new_version),
                     )
                     .await
                     .into_alien_error()
@@ -281,16 +314,33 @@ impl Kv for LocalKv {
             .await
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> Result<bool> {
         Self::validate_key(key)?;
 
         self.store
             .with_conn(|conn| async move {
-                conn.execute("DELETE FROM kv WHERE key = ?1", (key,))
-                    .await
-                    .into_alien_error()
-                    .context(kv_error("delete", key, "failed to delete key"))?;
-                Ok(())
+                if let Some(version) = if_version {
+                    let expected = decode_version(key, version)?;
+                    if expected.expired {
+                        return Ok(false);
+                    }
+                    let changed = conn
+                        .execute(
+                            "DELETE FROM kv WHERE key = ?1 AND version = ?2 \
+                             AND (expires_at IS NULL OR expires_at > ?3)",
+                            (key, expected.backend_version, Utc::now().timestamp_millis()),
+                        )
+                        .await
+                        .into_alien_error()
+                        .context(kv_error("delete", key, "failed conditional delete"))?;
+                    Ok(changed == 1)
+                } else {
+                    conn.execute("DELETE FROM kv WHERE key = ?1", (key,))
+                        .await
+                        .into_alien_error()
+                        .context(kv_error("delete", key, "failed to delete key"))?;
+                    Ok(true)
+                }
             })
             .await
     }
@@ -349,7 +399,7 @@ impl Kv for LocalKv {
             });
         }
         // Collect matching, non-expired items after the last key in sorted order.
-        let matching: Vec<(String, Vec<u8>)> =
+        let matching: Vec<KvEntry> =
             self.store
                 .with_conn(|conn| async move {
                     let now = Utc::now().timestamp_millis();
@@ -357,14 +407,14 @@ impl Kv for LocalKv {
                         Some(last_key) => {
                             query_all(
                                 &conn,
-                                "SELECT key, value, expires_at FROM kv WHERE key > ?1 ORDER BY key",
+                                "SELECT key, value, expires_at, version FROM kv WHERE key > ?1 ORDER BY key",
                                 (last_key,),
                             )
                             .await
                         }
                         None => query_all(
                             &conn,
-                            "SELECT key, value, expires_at FROM kv WHERE key >= ?1 ORDER BY key",
+                            "SELECT key, value, expires_at, version FROM kv WHERE key >= ?1 ORDER BY key",
                             (prefix,),
                         )
                         .await,
@@ -407,7 +457,18 @@ impl Kv for LocalKv {
                         if matches!(exp, Some(e) if e <= now) {
                             continue; // expired: treat as absent
                         }
-                        matching.push((k, v));
+                        let backend_version = row.get(3).and_then(as_text).ok_or_else(|| {
+                            AlienError::new(kv_error(
+                                "scan_prefix",
+                                prefix,
+                                "stored version is not text",
+                            ))
+                        })?;
+                        matching.push(KvEntry {
+                            version: encode_version(&k, backend_version, exp)?,
+                            key: k,
+                            value: v,
+                        });
                     }
                     Ok(matching)
                 })
@@ -418,11 +479,11 @@ impl Kv for LocalKv {
         let next_cursor = if has_more {
             items
                 .last()
-                .map(|(last_key, _)| {
+                .map(|entry| {
                     Self::encode_cursor(&CursorState {
                         version: 1,
                         prefix: prefix.to_string(),
-                        last_key: last_key.clone(),
+                        last_key: entry.key.clone(),
                     })
                 })
                 .transpose()?
@@ -459,13 +520,13 @@ mod tests {
             .put("test_key", b"test_value".to_vec(), None)
             .await
             .unwrap());
-        let value = kv.get("test_key").await.unwrap();
+        let value = kv.get("test_key").await.unwrap().map(|entry| entry.value);
         assert_eq!(value, Some(b"test_value".to_vec()));
 
         assert!(kv.exists("test_key").await.unwrap());
         assert!(!kv.exists("nonexistent").await.unwrap());
 
-        kv.delete("test_key").await.unwrap();
+        kv.delete("test_key", None).await.unwrap();
         assert!(!kv.exists("test_key").await.unwrap());
         assert_eq!(kv.get("test_key").await.unwrap(), None);
     }
@@ -476,7 +537,7 @@ mod tests {
 
         let options = Some(PutOptions {
             ttl: None,
-            if_not_exists: true,
+            condition: PutCondition::Absent,
         });
         assert!(kv
             .put("key", b"value1".to_vec(), options.clone())
@@ -485,10 +546,16 @@ mod tests {
 
         assert!(!kv.put("key", b"value2".to_vec(), options).await.unwrap());
 
-        assert_eq!(kv.get("key").await.unwrap(), Some(b"value1".to_vec()));
+        assert_eq!(
+            kv.get("key").await.unwrap().map(|entry| entry.value),
+            Some(b"value1".to_vec())
+        );
 
         assert!(kv.put("key", b"value3".to_vec(), None).await.unwrap());
-        assert_eq!(kv.get("key").await.unwrap(), Some(b"value3".to_vec()));
+        assert_eq!(
+            kv.get("key").await.unwrap().map(|entry| entry.value),
+            Some(b"value3".to_vec())
+        );
     }
 
     #[tokio::test]
@@ -497,7 +564,7 @@ mod tests {
 
         let options = Some(PutOptions {
             ttl: Some(Duration::from_millis(500)),
-            if_not_exists: false,
+            condition: PutCondition::None,
         });
 
         kv.put("expiring_key", b"value".to_vec(), options)
@@ -506,7 +573,10 @@ mod tests {
 
         assert!(kv.exists("expiring_key").await.unwrap());
         assert_eq!(
-            kv.get("expiring_key").await.unwrap(),
+            kv.get("expiring_key")
+                .await
+                .unwrap()
+                .map(|entry| entry.value),
             Some(b"value".to_vec())
         );
 
@@ -535,9 +605,9 @@ mod tests {
         assert_eq!(result.items.len(), 3);
         assert!(result.next_cursor.is_none());
 
-        assert_eq!(result.items[0].0, "prefix:key1");
-        assert_eq!(result.items[1].0, "prefix:key2");
-        assert_eq!(result.items[2].0, "prefix:key3");
+        assert_eq!(result.items[0].key, "prefix:key1");
+        assert_eq!(result.items[1].key, "prefix:key2");
+        assert_eq!(result.items[2].key, "prefix:key3");
 
         let result = kv.scan_prefix("prefix:", Some(2), None).await.unwrap();
         assert_eq!(result.items.len(), 2);
@@ -549,7 +619,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.items.len(), 1);
-        assert_eq!(result.items[0].0, "prefix:key3");
+        assert_eq!(result.items[0].key, "prefix:key3");
         assert!(result.next_cursor.is_none());
     }
 
@@ -565,17 +635,17 @@ mod tests {
             first
                 .items
                 .iter()
-                .map(|(key, _)| key.as_str())
+                .map(|entry| entry.key.as_str())
                 .collect::<Vec<_>>(),
             ["prefix:key1", "prefix:key2"]
         );
 
-        kv.delete("prefix:key1").await.unwrap();
+        kv.delete("prefix:key1", None).await.unwrap();
         let second = kv
             .scan_prefix("prefix:", Some(2), first.next_cursor)
             .await
             .unwrap();
-        assert_eq!(second.items[0].0, "prefix:key3");
+        assert_eq!(second.items[0].key, "prefix:key3");
         assert!(second.next_cursor.is_none());
     }
 
@@ -624,7 +694,11 @@ mod tests {
             let kv = LocalKv::new(db_path)
                 .await
                 .expect("Failed to reopen LocalKv");
-            let value = kv.get("persistent_key").await.unwrap();
+            let value = kv
+                .get("persistent_key")
+                .await
+                .unwrap()
+                .map(|entry| entry.value);
             assert_eq!(value, Some(b"persistent_value".to_vec()));
         }
     }
@@ -712,7 +786,7 @@ mod tests {
                 .expect("raw open");
             let conn = db.connect().expect("raw connect");
             conn.execute(
-                "UPDATE meta SET value = 'localkv.v2' WHERE key = 'format'",
+                "UPDATE meta SET value = 'localkv.v99' WHERE key = 'format'",
                 (),
             )
             .await
@@ -725,11 +799,11 @@ mod tests {
             .expect_err("unknown format must be rejected");
         let msg = err.to_string();
         assert!(
-            msg.contains("localkv.v2"),
+            msg.contains("localkv.v99"),
             "error must name the found format, got: {msg}"
         );
         assert!(
-            msg.contains("localkv.v1"),
+            msg.contains("localkv.v2"),
             "error must name the expected format, got: {msg}"
         );
     }
@@ -756,7 +830,7 @@ mod tests {
                 let val = format!("val-{i}").into_bytes();
                 let opts = Some(PutOptions {
                     ttl: None,
-                    if_not_exists: true,
+                    condition: PutCondition::Absent,
                 });
                 let won = kv.put("race", val.clone(), opts).await.expect("put ok");
                 (won, val)
@@ -777,9 +851,16 @@ mod tests {
             "exactly one conditional put must win across both handles"
         );
         let stored = kv_a.get("race").await.unwrap().expect("key present");
-        assert_eq!(stored, winners[0], "stored value must equal the winner");
         assert_eq!(
-            kv_b.get("race").await.unwrap().expect("key present via b"),
+            stored.value, winners[0],
+            "stored value must equal the winner"
+        );
+        assert_eq!(
+            kv_b.get("race")
+                .await
+                .unwrap()
+                .expect("key present via b")
+                .value,
             winners[0]
         );
     }
@@ -798,7 +879,7 @@ mod tests {
                 b"initial".to_vec(),
                 Some(PutOptions {
                     ttl: Some(Duration::from_millis(300)),
-                    if_not_exists: true,
+                    condition: PutCondition::Absent,
                 }),
             )
             .await
@@ -811,7 +892,7 @@ mod tests {
                 b"early".to_vec(),
                 Some(PutOptions {
                     ttl: None,
-                    if_not_exists: true,
+                    condition: PutCondition::Absent,
                 }),
             )
             .await
@@ -837,7 +918,7 @@ mod tests {
                         val.clone(),
                         Some(PutOptions {
                             ttl: None,
-                            if_not_exists: true,
+                            condition: PutCondition::Absent,
                         }),
                     )
                     .await
@@ -861,7 +942,7 @@ mod tests {
         );
         let stored = kv_b.get("k").await.unwrap().expect("key present");
         assert_eq!(
-            stored, winners[0],
+            stored.value, winners[0],
             "stored value must equal the takeover winner"
         );
     }
@@ -886,7 +967,7 @@ mod tests {
                 // No busy errors expected under multi-process WAL + busy_timeout.
                 kv.put(&key, val.clone(), None).await.expect("put ok");
                 let got = kv.get(&key).await.expect("get ok");
-                assert_eq!(got, Some(val));
+                assert_eq!(got.map(|entry| entry.value), Some(val));
             }));
         }
         for h in handles {

--- a/crates/alien-bindings/src/providers/kv/mod.rs
+++ b/crates/alien-bindings/src/providers/kv/mod.rs
@@ -1,10 +1,95 @@
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+use crate::error::{ErrorData, Result};
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+use alien_error::{AlienError, Context, IntoAlienError};
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+use chrono::Utc;
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+use serde::{Deserialize, Serialize};
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+const VERSION_TOKEN_FORMAT: u8 = 1;
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VersionToken {
+    format: u8,
+    key: String,
+    backend_version: String,
+    expires_at_millis: Option<i64>,
+}
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+pub(crate) struct DecodedVersion {
+    pub backend_version: String,
+    pub expired: bool,
+}
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+pub(crate) fn encode_version(
+    key: &str,
+    backend_version: String,
+    expires_at_millis: Option<i64>,
+) -> Result<String> {
+    let bytes = serde_json::to_vec(&VersionToken {
+        format: VERSION_TOKEN_FORMAT,
+        key: key.to_string(),
+        backend_version,
+        expires_at_millis,
+    })
+    .into_alien_error()
+    .context(ErrorData::InvalidInput {
+        operation_context: "KV version encoding".to_string(),
+        details: "Failed to serialize the version token".to_string(),
+        field_name: Some("version".to_string()),
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp", feature = "local"))]
+pub(crate) fn decode_version(key: &str, encoded: &str) -> Result<DecodedVersion> {
+    let bytes =
+        URL_SAFE_NO_PAD
+            .decode(encoded)
+            .into_alien_error()
+            .context(ErrorData::InvalidInput {
+                operation_context: "KV version decoding".to_string(),
+                details: "Invalid version token encoding".to_string(),
+                field_name: Some("ifVersion".to_string()),
+            })?;
+    let token: VersionToken =
+        serde_json::from_slice(&bytes)
+            .into_alien_error()
+            .context(ErrorData::InvalidInput {
+                operation_context: "KV version decoding".to_string(),
+                details: "Invalid version token data".to_string(),
+                field_name: Some("ifVersion".to_string()),
+            })?;
+    if token.format != VERSION_TOKEN_FORMAT || token.key != key {
+        return Err(AlienError::new(ErrorData::InvalidInput {
+            operation_context: "KV version validation".to_string(),
+            details: "Version token does not belong to this key".to_string(),
+            field_name: Some("ifVersion".to_string()),
+        }));
+    }
+
+    Ok(DecodedVersion {
+        backend_version: token.backend_version,
+        expired: token
+            .expires_at_millis
+            .is_some_and(|expires_at| expires_at <= Utc::now().timestamp_millis()),
+    })
+}
+
 /// Maximum value size in bytes for KV storage (24 KiB = 24,576 bytes)
 ///
 /// This limit ensures compatibility across all KV backends, accounting for encoding overhead:
 /// - **AWS DynamoDB**: 400KB item limit (much higher, not constraining)
 /// - **GCP Firestore**: 1MiB document limit (much higher, not constraining)  
 /// - **Azure Table Storage**: 64KB UTF-16 string limit, accounting for base64 + UTF-16 encoding
-/// - **Redis**: No practical limits (memory-bound)
 ///
 /// The 24KB limit accounts for Azure Table Storage's most restrictive constraint:
 /// - 24KB raw data → ~32KB base64 → ~64KB UTF-16, fitting within Azure's 64KB limit
@@ -24,7 +109,6 @@ pub const MAX_VALUE_BYTES: usize = 24_576; // 24 KiB
 /// - **AWS DynamoDB**: Sort Key ≤ 1024 bytes  
 /// - **GCP Firestore**: Document ID ≤ 1500 bytes
 /// - **Azure Table Storage**: RowKey ≤ 1024 bytes
-/// - **Redis**: No practical limits
 ///
 /// The 512-byte limit ensures:
 /// - Universal compatibility across all backends
@@ -52,7 +136,6 @@ pub const MAX_KEY_BYTES: usize = 512;
 /// - **AWS DynamoDB**: More permissive, but we follow the global restriction
 /// - **GCP Firestore**: More permissive, but we follow the global restriction  
 /// - **Azure Table Storage**: Most restrictive, sets the global standard
-/// - **Redis**: No restrictions, but we follow the global standard
 pub fn validate_key(key: &str) -> crate::error::Result<()> {
     use crate::error::ErrorData;
     use alien_error::AlienError;

--- a/crates/alien-bindings/src/refreshing.rs
+++ b/crates/alien-bindings/src/refreshing.rs
@@ -33,7 +33,7 @@ use crate::presigned::PresignedRequest;
 #[cfg(feature = "platform-sdk")]
 use crate::remote::RemoteStorage;
 use crate::traits::{
-    Binding, BindingsProviderApi, Kv, MessagePayload, PutOptions as KvPutOptions, Queue,
+    Binding, BindingsProviderApi, Kv, KvEntry, MessagePayload, PutOptions as KvPutOptions, Queue,
     QueueMessage, ScanResult, Storage, Vault,
 };
 
@@ -359,7 +359,7 @@ impl Binding for RefreshingKv {}
 
 #[async_trait]
 impl Kv for RefreshingKv {
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> Result<Option<KvEntry>> {
         self.resolver.kv().await?.get(key).await
     }
 
@@ -367,8 +367,8 @@ impl Kv for RefreshingKv {
         self.resolver.kv().await?.put(key, value, options).await
     }
 
-    async fn delete(&self, key: &str) -> Result<()> {
-        self.resolver.kv().await?.delete(key).await
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> Result<bool> {
+        self.resolver.kv().await?.delete(key, if_version).await
     }
 
     async fn exists(&self, key: &str) -> Result<bool> {

--- a/crates/alien-bindings/src/traits.rs
+++ b/crates/alien-bindings/src/traits.rs
@@ -637,30 +637,54 @@ pub trait Postgres: Binding {
     }
 }
 
-/// Represents options for put operations in KV stores.
+/// A precondition for a KV put operation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PutCondition {
+    /// Replace any current value, or create the key when it is absent.
+    #[default]
+    None,
+    /// Create the key only when it is absent or logically expired.
+    Absent,
+    /// Replace the value only when the key still has this opaque version.
+    Version(String),
+}
+
+/// Options for KV put operations.
 #[derive(Debug, Clone, Default)]
 pub struct PutOptions {
     /// Optional TTL for automatic expiration (soft hint - items MAY be deleted after expiry)
     pub ttl: Option<Duration>,
-    /// Only put if the key does not exist
-    pub if_not_exists: bool,
+    /// Optional atomic write precondition.
+    pub condition: PutCondition,
+}
+
+/// A KV entry together with its opaque version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvEntry {
+    /// Stored key.
+    pub key: String,
+    /// Stored value bytes.
+    pub value: Vec<u8>,
+    /// Provider-neutral version for conditional writes. Callers must treat it as opaque.
+    pub version: String,
 }
 
 /// Represents the result of a scan operation.
 #[derive(Debug)]
 pub struct ScanResult {
-    /// Key-value pairs found (may be ≤ limit, no guarantee to fill)
-    pub items: Vec<(String, Vec<u8>)>,
+    /// Entries found (may be ≤ limit, no guarantee to fill).
+    pub items: Vec<KvEntry>,
     /// Opaque, prefix-bound cursor for pagination. None if the traversal is complete.
     /// A non-empty cursor may lead to an empty page when records expire between pages.
     pub next_cursor: Option<String>,
 }
 
 /// A trait for key-value store bindings that provide minimal, platform-agnostic KV operations.
-/// This API is designed to work consistently across DynamoDB, Firestore, Redis, and Azure Table Storage.
+/// This API is designed to work consistently across DynamoDB, Firestore, Azure Table Storage,
+/// and the local provider.
 #[async_trait]
 pub trait Kv: Binding {
-    /// Get a value by key. Returns None if key doesn't exist or has expired.
+    /// Get an entry by key. Returns `None` if the key doesn't exist or has expired.
     ///
     /// **TTL Behavior**: TTL is a soft hint for automatic cleanup. If `now >= expires_at`,
     /// implementations SHOULD behave as if the key is absent, even if the item still exists
@@ -668,10 +692,10 @@ pub trait Kv: Binding {
     ///
     /// **Validation**: Keys are validated against MAX_KEY_BYTES and portable charset.
     /// Invalid keys return `KvError::InvalidKey` immediately.
-    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>>;
+    async fn get(&self, key: &str) -> Result<Option<KvEntry>>;
 
-    /// Put a value with optional options. When options.if_not_exists is true, returns true if created,
-    /// false if already exists. When options.if_not_exists is false or options is None, always returns true.
+    /// Put a value with optional options. Conditional writes return `false` when their precondition
+    /// does not match. Unconditional writes return `true`.
     ///
     /// **Size Limits**:
     /// - Keys: ≤ MAX_KEY_BYTES (512 bytes) with portable ASCII charset
@@ -684,18 +708,20 @@ pub trait Kv: Binding {
     /// item expires at `put_time + ttl`. Expired items SHOULD appear absent on subsequent
     /// reads, but physical deletion is eventual and not guaranteed.
     ///
-    /// **Conditional Logic**: The if_not_exists operation maps to backend primitives:
-    /// - Redis: SETNX
-    /// - DynamoDB: PutItem with condition_expression="attribute_not_exists(pk)"
-    /// - Firestore: create() with Precondition::DoesNotExist
-    /// - Azure Table Storage: InsertEntity (409 on conflict)
+    /// **Conditional Logic**: [`PutCondition::Absent`] uses each backend's atomic create
+    /// primitive, with a version-guarded takeover when an expired row still exists physically.
+    /// [`PutCondition::Version`] uses DynamoDB conditions, Firestore update-time preconditions,
+    /// Azure entity tags, or the local database's conditional update.
     async fn put(&self, key: &str, value: Vec<u8>, options: Option<PutOptions>) -> Result<bool>;
 
     /// Delete a key. No error if key doesn't exist.
     ///
     /// **Validation**: Keys are validated against MAX_KEY_BYTES and portable charset.
     /// Invalid keys return `KvError::InvalidKey` immediately.
-    async fn delete(&self, key: &str) -> Result<()>;
+    /// When `if_version` is supplied, delete only if the key still has that opaque version.
+    /// Returns `false` when a conditional delete finds the key absent, expired, or changed.
+    /// Unconditional deletes return `true`, including when the key is already absent.
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> Result<bool>;
 
     /// Check if a key exists without retrieving the value.
     ///
@@ -710,7 +736,7 @@ pub trait Kv: Binding {
     ///
     /// **Scan Contract**:
     /// - Returns an **arbitrary, unordered subset** in backend-natural order
-    /// - **No ordering guarantees** across backends (Redis SCAN, Azure fan-out, etc.)
+    /// - **No ordering guarantees** across backends (for example, Azure partition fan-out)
     /// - **May return ≤ limit items** (not guaranteed to fill even if more data exists)
     /// - **Clients MUST de-duplicate** keys across pages (backends may return duplicates)
     /// - **No completeness guarantee** under concurrent writes (may miss or duplicate)

--- a/crates/alien-bindings/tests/kv.rs
+++ b/crates/alien-bindings/tests/kv.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use alien_bindings::{
-    traits::{BindingsProviderApi, Kv, PutOptions},
+    traits::{BindingsProviderApi, Kv, PutCondition, PutOptions},
     BindingsProvider,
 };
 
@@ -130,7 +130,7 @@ impl KvTestContext for LocalProviderTestContext {
 
 impl LocalProviderTestContext {
     async fn cleanup_key(&self, key: &str) {
-        match self.kv.delete(key).await {
+        match self.kv.delete(key, None).await {
             Ok(_) => {
                 // Successfully deleted
             }
@@ -384,7 +384,7 @@ impl AwsProviderTestContext {
     }
 
     async fn cleanup_key(&self, key: &str) {
-        match self.kv.delete(key).await {
+        match self.kv.delete(key, None).await {
             Ok(_) => {
                 // Successfully deleted
             }
@@ -689,7 +689,7 @@ impl GcpProviderTestContext {
     }
 
     async fn cleanup_key(&self, key: &str) {
-        match self.kv.delete(key).await {
+        match self.kv.delete(key, None).await {
             Ok(_) => {
                 // Successfully deleted
             }
@@ -875,7 +875,7 @@ impl AzureProviderTestContext {
     }
 
     async fn cleanup_key(&self, key: &str) {
-        match self.kv.delete(key).await {
+        match self.kv.delete(key, None).await {
             Ok(_) => {
                 // Successfully deleted
             }
@@ -964,7 +964,7 @@ impl KvTestContext for KubernetesProviderTestContext {
 #[cfg(feature = "kubernetes")]
 impl KubernetesProviderTestContext {
     async fn cleanup_key(&self, key: &str) {
-        match self.kv.delete(key).await {
+        match self.kv.delete(key, None).await {
             Ok(_) => {
                 // Successfully deleted
             }
@@ -1012,9 +1012,128 @@ async fn test_put_and_get(#[case] ctx: impl KvTestContext) {
         .unwrap_or_else(|| panic!("[{}] Value should exist after put", provider_name));
 
     assert_eq!(
-        value, retrieved_value,
+        value, retrieved_value.value,
         "[{}] Retrieved value should match original",
         provider_name
+    );
+}
+
+#[rstest]
+#[cfg_attr(feature = "local", case::local(LocalProviderTestContext::setup().await))]
+#[cfg_attr(feature = "aws", case::aws(AwsProviderTestContext::setup().await))]
+#[cfg_attr(feature = "azure", case::azure(AzureProviderTestContext::setup().await))]
+#[cfg_attr(feature = "gcp", case::gcp(GcpProviderTestContext::setup().await))]
+#[tokio::test]
+async fn test_versioned_compare_and_set(#[case] ctx: impl KvTestContext) {
+    let kv = ctx.get_kv().await;
+    let provider_name = ctx.provider_name();
+    let key = format!("test-cas-{}", Uuid::new_v4().simple());
+    let other_key = format!("test-cas-other-{}", Uuid::new_v4().simple());
+    ctx.track_key(&key);
+    ctx.track_key(&other_key);
+
+    let create = Some(PutOptions {
+        ttl: None,
+        condition: PutCondition::Absent,
+    });
+    assert!(kv
+        .put(&key, b"initial".to_vec(), create.clone())
+        .await
+        .unwrap());
+    assert!(!kv.put(&key, b"duplicate".to_vec(), create).await.unwrap());
+
+    let initial = kv.get(&key).await.unwrap().expect("entry must exist");
+    assert_eq!(initial.key, key);
+    assert_eq!(initial.value, b"initial");
+
+    let update = Some(PutOptions {
+        ttl: None,
+        condition: PutCondition::Version(initial.version.clone()),
+    });
+    assert!(kv
+        .put(&key, b"updated".to_vec(), update.clone())
+        .await
+        .unwrap());
+    assert!(
+        !kv.put(&key, b"stale".to_vec(), update).await.unwrap(),
+        "[{provider_name}] a stale version must not overwrite a newer value"
+    );
+
+    let current = kv.get(&key).await.unwrap().expect("entry must exist");
+    assert_eq!(current.value, b"updated");
+    assert_ne!(current.version, initial.version);
+    assert!(!kv.delete(&key, Some(&initial.version)).await.unwrap());
+
+    let wrong_key = kv
+        .put(
+            &other_key,
+            b"wrong-key".to_vec(),
+            Some(PutOptions {
+                ttl: None,
+                condition: PutCondition::Version(current.version.clone()),
+            }),
+        )
+        .await;
+    assert!(
+        wrong_key.is_err(),
+        "[{provider_name}] versions must be key-bound"
+    );
+
+    assert!(kv.delete(&key, Some(&current.version)).await.unwrap());
+    assert!(kv.get(&key).await.unwrap().is_none());
+}
+
+#[rstest]
+#[cfg_attr(feature = "local", case::local(LocalProviderTestContext::setup().await))]
+#[cfg_attr(feature = "aws", case::aws(AwsProviderTestContext::setup().await))]
+#[cfg_attr(feature = "azure", case::azure(AzureProviderTestContext::setup().await))]
+#[cfg_attr(feature = "gcp", case::gcp(GcpProviderTestContext::setup().await))]
+#[tokio::test]
+async fn test_concurrent_compare_and_set_has_one_winner(#[case] ctx: impl KvTestContext) {
+    let kv = ctx.get_kv().await;
+    let provider_name = ctx.provider_name();
+    let key = format!("test-cas-race-{}", Uuid::new_v4().simple());
+    ctx.track_key(&key);
+    kv.put(&key, b"initial".to_vec(), None).await.unwrap();
+    let version = kv.get(&key).await.unwrap().unwrap().version;
+
+    let left = {
+        let kv = kv.clone();
+        let key = key.clone();
+        let version = version.clone();
+        tokio::spawn(async move {
+            kv.put(
+                &key,
+                b"left".to_vec(),
+                Some(PutOptions {
+                    ttl: None,
+                    condition: PutCondition::Version(version),
+                }),
+            )
+            .await
+        })
+    };
+    let right = {
+        let kv = kv.clone();
+        let key = key.clone();
+        tokio::spawn(async move {
+            kv.put(
+                &key,
+                b"right".to_vec(),
+                Some(PutOptions {
+                    ttl: None,
+                    condition: PutCondition::Version(version),
+                }),
+            )
+            .await
+        })
+    };
+
+    let results = [left.await.unwrap().unwrap(), right.await.unwrap().unwrap()];
+    assert_eq!(
+        results.into_iter().filter(|applied| *applied).count(),
+        1,
+        "[{provider_name}] exactly one writer must win a version race"
     );
 }
 
@@ -1055,7 +1174,7 @@ async fn test_delete_operation(#[case] ctx: impl KvTestContext) {
     );
 
     // Delete the key
-    kv.delete(&key)
+    kv.delete(&key, None)
         .await
         .unwrap_or_else(|e| panic!("[{}] Failed to delete key: {:?}", provider_name, e));
 
@@ -1143,7 +1262,7 @@ async fn test_exists_operation(#[case] ctx: impl KvTestContext) {
 #[cfg_attr(feature = "gcp", case::gcp(GcpProviderTestContext::setup().await))]
 // #[cfg_attr(feature = "kubernetes", case::kubernetes(KubernetesProviderTestContext::setup().await))]
 #[tokio::test]
-async fn test_put_if_not_exists(#[case] ctx: impl KvTestContext) {
+async fn test_put_when_absent(#[case] ctx: impl KvTestContext) {
     let kv = ctx.get_kv().await;
     let provider_name = ctx.provider_name();
     let key = format!("test-if-not-exists-{}", Uuid::new_v4().simple());
@@ -1154,7 +1273,7 @@ async fn test_put_if_not_exists(#[case] ctx: impl KvTestContext) {
 
     let options = Some(PutOptions {
         ttl: None,
-        if_not_exists: true,
+        condition: PutCondition::Absent,
     });
 
     // First put should succeed
@@ -1163,13 +1282,13 @@ async fn test_put_if_not_exists(#[case] ctx: impl KvTestContext) {
         .await
         .unwrap_or_else(|e| {
             panic!(
-                "[{}] Failed first put with if_not_exists: {:?}",
+                "[{}] Failed first put with an absent precondition: {:?}",
                 provider_name, e
             )
         });
     assert!(
         put_result1,
-        "[{}] First put with if_not_exists should succeed",
+        "[{}] First put with an absent precondition should succeed",
         provider_name
     );
 
@@ -1185,7 +1304,7 @@ async fn test_put_if_not_exists(#[case] ctx: impl KvTestContext) {
         })
         .unwrap_or_else(|| panic!("[{}] Value should exist after first put", provider_name));
     assert_eq!(
-        value1, retrieved_value,
+        value1, retrieved_value.value,
         "[{}] Retrieved value should match first value",
         provider_name
     );
@@ -1196,13 +1315,13 @@ async fn test_put_if_not_exists(#[case] ctx: impl KvTestContext) {
         .await
         .unwrap_or_else(|e| {
             panic!(
-                "[{}] Failed second put with if_not_exists: {:?}",
+                "[{}] Failed second put with an absent precondition: {:?}",
                 provider_name, e
             )
         });
     assert!(
         !put_result2,
-        "[{}] Second put with if_not_exists should fail",
+        "[{}] Second put with an absent precondition should fail",
         provider_name
     );
 
@@ -1223,8 +1342,8 @@ async fn test_put_if_not_exists(#[case] ctx: impl KvTestContext) {
             )
         });
     assert_eq!(
-        value1, retrieved_value2,
-        "[{}] Value should not change after failed if_not_exists",
+        value1, retrieved_value2.value,
+        "[{}] Value should not change after a failed absent precondition",
         provider_name
     );
 }
@@ -1249,7 +1368,7 @@ async fn test_ttl_expiry(#[case] ctx: impl KvTestContext) {
     // mid-test on high-latency links even though it passes on CI runners.
     let options = Some(PutOptions {
         ttl: Some(Duration::from_secs(8)),
-        if_not_exists: false,
+        condition: PutCondition::None,
     });
 
     // Put the value with TTL
@@ -1360,7 +1479,7 @@ async fn test_scan_prefix(#[case] ctx: impl KvTestContext) {
             b"expired".to_vec(),
             Some(PutOptions {
                 ttl: Some(Duration::from_secs(1)),
-                if_not_exists: false,
+                condition: PutCondition::None,
             }),
         )
         .await
@@ -1384,6 +1503,7 @@ async fn test_scan_prefix(#[case] ctx: impl KvTestContext) {
     let mut first_cursor = None;
     let mut visited_cursors = HashSet::new();
     let mut found = HashMap::new();
+    let mut found_versions = HashMap::new();
     for page_number in 0..256 {
         let scan_result = kv
             .scan_prefix(&prefix, Some(3), cursor)
@@ -1400,15 +1520,22 @@ async fn test_scan_prefix(#[case] ctx: impl KvTestContext) {
             provider_name,
             page_number
         );
-        for (key, value) in scan_result.items {
+        for entry in scan_result.items {
             assert!(
-                key.starts_with(&prefix),
+                entry.key.starts_with(&prefix),
                 "[{}] Scan returned key '{}' outside prefix '{}'",
                 provider_name,
-                key,
+                entry.key,
                 prefix
             );
-            found.insert(key, value);
+            assert!(
+                !entry.version.is_empty(),
+                "[{}] Scan returned an empty version for '{}'",
+                provider_name,
+                entry.key
+            );
+            found_versions.insert(entry.key.clone(), entry.version);
+            found.insert(entry.key, entry.value);
         }
 
         let Some(next_cursor) = scan_result.next_cursor else {
@@ -1439,6 +1566,25 @@ async fn test_scan_prefix(#[case] ctx: impl KvTestContext) {
         found, expected,
         "[{}] Following scan cursors must visit exactly the live prefix keys",
         provider_name
+    );
+
+    let scanned_key = &test_keys[0];
+    let scanned_version = found_versions
+        .get(scanned_key)
+        .expect("every scanned entry must have a version")
+        .clone();
+    assert!(
+        kv.put(
+            scanned_key,
+            b"updated-from-scan".to_vec(),
+            Some(PutOptions {
+                ttl: None,
+                condition: PutCondition::Version(scanned_version),
+            }),
+        )
+        .await
+        .unwrap(),
+        "[{provider_name}] a scan version must be valid for compare-and-set"
     );
 
     let first_cursor = first_cursor.expect("a three-item page must produce a cursor");
@@ -1580,7 +1726,7 @@ async fn test_value_validation(#[case] ctx: impl KvTestContext) {
         .unwrap_or_else(|e| panic!("[{}] Failed to get large value: {:?}", provider_name, e))
         .unwrap_or_else(|| panic!("[{}] Large value should exist", provider_name));
     assert_eq!(
-        max_value, retrieved_value,
+        max_value, retrieved_value.value,
         "[{}] Retrieved large value should match original",
         provider_name
     );
@@ -1655,7 +1801,7 @@ async fn test_overwrite_value(#[case] ctx: impl KvTestContext) {
         .unwrap_or_else(|e| panic!("[{}] Failed to get initial value: {:?}", provider_name, e))
         .unwrap_or_else(|| panic!("[{}] Initial value should exist", provider_name));
     assert_eq!(
-        value1, retrieved_value1,
+        value1, retrieved_value1.value,
         "[{}] Retrieved initial value should match",
         provider_name
     );
@@ -1677,7 +1823,7 @@ async fn test_overwrite_value(#[case] ctx: impl KvTestContext) {
         })
         .unwrap_or_else(|| panic!("[{}] Overwritten value should exist", provider_name));
     assert_eq!(
-        value2, retrieved_value2,
+        value2, retrieved_value2.value,
         "[{}] Retrieved overwritten value should match new value",
         provider_name
     );
@@ -1713,7 +1859,7 @@ async fn test_binary_data(#[case] ctx: impl KvTestContext) {
         .unwrap_or_else(|| panic!("[{}] Binary data should exist", provider_name));
 
     assert_eq!(
-        binary_data, retrieved_data,
+        binary_data, retrieved_data.value,
         "[{}] Retrieved binary data should match original",
         provider_name
     );
@@ -1748,7 +1894,7 @@ async fn test_expired_row_takeover_conditional_put(#[case] ctx: impl KvTestConte
             b"first-holder".to_vec(),
             Some(PutOptions {
                 ttl: Some(Duration::from_secs(120)),
-                if_not_exists: true,
+                condition: PutCondition::Absent,
             }),
         )
         .await
@@ -1761,7 +1907,7 @@ async fn test_expired_row_takeover_conditional_put(#[case] ctx: impl KvTestConte
             b"contender".to_vec(),
             Some(PutOptions {
                 ttl: Some(Duration::from_secs(120)),
-                if_not_exists: true,
+                condition: PutCondition::Absent,
             }),
         )
         .await
@@ -1780,20 +1926,45 @@ async fn test_expired_row_takeover_conditional_put(#[case] ctx: impl KvTestConte
         b"dead-holder".to_vec(),
         Some(PutOptions {
             ttl: Some(Duration::from_secs(2)),
-            if_not_exists: true,
+            condition: PutCondition::Absent,
         }),
     )
     .await
     .unwrap_or_else(|e| panic!("[{}] short claim failed: {:?}", provider_name, e));
+    let expired_version = kv
+        .get(&expired_key)
+        .await
+        .unwrap_or_else(|e| panic!("[{}] short claim read failed: {:?}", provider_name, e))
+        .expect("short-lived claim must initially exist")
+        .version;
 
     tokio::time::sleep(Duration::from_secs(4)).await;
+    assert!(
+        !kv.put(
+            &expired_key,
+            b"stale-holder".to_vec(),
+            Some(PutOptions {
+                ttl: Some(Duration::from_secs(120)),
+                condition: PutCondition::Version(expired_version.clone()),
+            }),
+        )
+        .await
+        .unwrap(),
+        "[{provider_name}] an expired version must not authorize an update"
+    );
+    assert!(
+        !kv.delete(&expired_key, Some(&expired_version))
+            .await
+            .unwrap(),
+        "[{provider_name}] an expired version must not authorize a delete"
+    );
     let taken = kv
         .put(
             &expired_key,
             b"second-holder".to_vec(),
             Some(PutOptions {
                 ttl: Some(Duration::from_secs(120)),
-                if_not_exists: true,
+                condition: PutCondition::Absent,
             }),
         )
         .await
@@ -1810,7 +1981,7 @@ async fn test_expired_row_takeover_conditional_put(#[case] ctx: impl KvTestConte
         .unwrap_or_else(|e| panic!("[{}] read-back failed: {:?}", provider_name, e))
         .expect("taken-over key must be readable");
     assert_eq!(
-        value, b"second-holder",
+        value.value, b"second-holder",
         "[{}] the takeover's value must be served",
         provider_name
     );

--- a/crates/alien-build/tests/image_shape_tests.rs
+++ b/crates/alien-build/tests/image_shape_tests.rs
@@ -330,7 +330,7 @@ const seeded = store.set("smoke-key", "{value}")
 export default {{
   async fetch(): Promise<Response> {{
     await seeded
-    const got = await store.getText("smoke-key")
+    const got = (await store.getText("smoke-key"))?.value
     if (got !== "{value}") {{
       return new Response(`MISMATCH: got ${{JSON.stringify(got)}}`, {{ status: 500 }})
     }}

--- a/crates/alien-commands/src/server/mod.rs
+++ b/crates/alien-commands/src/server/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alien_bindings::presigned::PresignedRequest;
-use alien_bindings::traits::{Kv, PutOptions, Storage};
+use alien_bindings::traits::{Kv, PutCondition, PutOptions, Storage};
 use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 use chrono::{DateTime, Utc};
 use hex;
@@ -733,7 +733,8 @@ impl CommandServer {
                 message: "Failed to scan for pending commands".to_string(),
             })?;
 
-        for (index_key, _) in scan_result.items {
+        for entry in scan_result.items {
+            let index_key = entry.key;
             if leases.len() >= lease_request.max_leases {
                 break;
             }
@@ -763,7 +764,7 @@ impl CommandServer {
 
             let options = Some(PutOptions {
                 ttl: Some(lease_duration),
-                if_not_exists: true,
+                condition: PutCondition::Absent,
             });
 
             let success = self
@@ -792,7 +793,7 @@ impl CommandServer {
                     command_id.as_bytes().to_vec(),
                     Some(PutOptions {
                         ttl: Some(lease_duration),
-                        if_not_exists: false,
+                        condition: PutCondition::None,
                     }),
                 )
                 .await
@@ -812,7 +813,7 @@ impl CommandServer {
                 None => {
                     // Command doesn't exist in registry, clean up
                     self.delete_lease(&command_id).await?;
-                    let _ = self.kv.delete(&index_key).await;
+                    let _ = self.kv.delete(&index_key, None).await;
                     continue;
                 }
             };
@@ -851,7 +852,7 @@ impl CommandServer {
             if metadata.state.is_terminal() {
                 // Clean up stale data
                 self.delete_lease(&command_id).await?;
-                let _ = self.kv.delete(&index_key).await;
+                let _ = self.kv.delete(&index_key, None).await;
                 continue;
             }
 
@@ -870,7 +871,7 @@ impl CommandServer {
                         )
                         .await?;
                     self.delete_lease(&command_id).await?;
-                    let _ = self.kv.delete(&index_key).await;
+                    let _ = self.kv.delete(&index_key, None).await;
                     continue;
                 }
             }
@@ -899,7 +900,7 @@ impl CommandServer {
                     "Command turned terminal while leasing; releasing the lease"
                 );
                 self.delete_lease(&command_id).await?;
-                let _ = self.kv.delete(&index_key).await;
+                let _ = self.kv.delete(&index_key, None).await;
                 continue;
             }
 
@@ -986,7 +987,7 @@ impl CommandServer {
 
         // 1. Verify lease ownership
         if let Ok(Some(lease_data)) = self.kv.get(&lease_key).await {
-            let lease: LeaseData = serde_json::from_slice(&lease_data)
+            let lease: LeaseData = serde_json::from_slice(&lease_data.value)
                 .into_alien_error()
                 .context(ErrorData::SerializationFailed {
                     message: "Failed to deserialize lease data".to_string(),
@@ -1001,7 +1002,7 @@ impl CommandServer {
 
             // 2. Delete lease from KV (and its reverse index)
             self.delete_lease(command_id).await?;
-            let _ = self.kv.delete(&format!("lease:{}", lease_id)).await;
+            let _ = self.kv.delete(&format!("lease:{}", lease_id), None).await;
 
             // 3. Return the command to Pending only while it is still
             // non-terminal. A racing response/deadline completion wins.
@@ -1065,7 +1066,7 @@ impl CommandServer {
         else {
             return Ok(None);
         };
-        let command_id = String::from_utf8(command_id_bytes).map_err(|_| {
+        let command_id = String::from_utf8(command_id_bytes.value).map_err(|_| {
             AlienError::new(ErrorData::Other {
                 message: format!("Lease reverse index '{}' is not valid UTF-8", reverse_key),
             })
@@ -1084,7 +1085,7 @@ impl CommandServer {
         else {
             return Ok(None);
         };
-        let lease: LeaseData = serde_json::from_slice(&lease_data)
+        let lease: LeaseData = serde_json::from_slice(&lease_data.value)
             .into_alien_error()
             .context(ErrorData::SerializationFailed {
                 message: "Failed to deserialize lease data".to_string(),
@@ -1188,7 +1189,7 @@ impl CommandServer {
                 message: "Failed to check idempotency".to_string(),
             })?
         {
-            let command_id = String::from_utf8(data).into_alien_error().context(
+            let command_id = String::from_utf8(data.value).into_alien_error().context(
                 ErrorData::SerializationFailed {
                     message: "Invalid idempotency data".to_string(),
                     data_type: Some("String".to_string()),
@@ -1216,7 +1217,7 @@ impl CommandServer {
                 command_id.as_bytes().to_vec(),
                 Some(PutOptions {
                     ttl: Some(ttl),
-                    if_not_exists: true,
+                    condition: PutCondition::Absent,
                 }),
             )
             .await
@@ -1347,12 +1348,12 @@ impl CommandServer {
                 message: "Failed to get params".to_string(),
             })?
         {
-            let data: CommandParamsData = serde_json::from_slice(&value)
+            let data: CommandParamsData = serde_json::from_slice(&value.value)
                 .into_alien_error()
                 .context(ErrorData::SerializationFailed {
-                    message: "Failed to deserialize params".to_string(),
-                    data_type: Some("CommandParamsData".to_string()),
-                })?;
+                message: "Failed to deserialize params".to_string(),
+                data_type: Some("CommandParamsData".to_string()),
+            })?;
             return Ok(Some(data.params));
         }
         Ok(None)
@@ -1472,7 +1473,7 @@ impl CommandServer {
                 message: "Failed to get response".to_string(),
             })?
         {
-            let data: CommandResponseData = serde_json::from_slice(&value)
+            let data: CommandResponseData = serde_json::from_slice(&value.value)
                 .into_alien_error()
                 .context(ErrorData::SerializationFailed {
                     message: "Failed to deserialize response".to_string(),
@@ -1535,9 +1536,9 @@ impl CommandServer {
                 message: "Failed to scan pending index".to_string(),
             })?;
 
-        for (key, _) in scan_result.items {
-            if key.ends_with(&format!(":{}", command_id)) {
-                let _ = self.kv.delete(&key).await;
+        for entry in scan_result.items {
+            if entry.key.ends_with(&format!(":{}", command_id)) {
+                let _ = self.kv.delete(&entry.key, None).await;
                 break;
             }
         }
@@ -1548,7 +1549,7 @@ impl CommandServer {
 
     async fn delete_lease(&self, command_id: &str) -> Result<()> {
         let key = format!("cmd:{}:lease", command_id);
-        let _ = self.kv.delete(&key).await;
+        let _ = self.kv.delete(&key, None).await;
         Ok(())
     }
 
@@ -1583,10 +1584,10 @@ impl CommandServer {
                     message: "Failed to scan the deadline index".to_string(),
                 })?;
             let next_cursor = scan.next_cursor.clone();
-            for (key, value) in scan.items {
-                let Ok(data) = serde_json::from_slice::<DeadlineIndexData>(&value) else {
-                    warn!(key = %key, "Unparseable deadline index entry; deleting");
-                    let _ = self.kv.delete(&key).await;
+            for entry in scan.items {
+                let Ok(data) = serde_json::from_slice::<DeadlineIndexData>(&entry.value) else {
+                    warn!(key = %entry.key, "Unparseable deadline index entry; deleting");
+                    let _ = self.kv.delete(&entry.key, None).await;
                     continue;
                 };
                 if data.deadline > now {
@@ -1601,10 +1602,10 @@ impl CommandServer {
                     .await?;
                 match status {
                     None => {
-                        let _ = self.kv.delete(&key).await;
+                        let _ = self.kv.delete(&entry.key, None).await;
                     }
                     Some(status) if status.state.is_terminal() => {
-                        let _ = self.kv.delete(&key).await;
+                        let _ = self.kv.delete(&entry.key, None).await;
                     }
                     Some(status) => {
                         let won = self
@@ -1632,7 +1633,7 @@ impl CommandServer {
                                 )
                                 .await;
                         }
-                        let _ = self.kv.delete(&key).await;
+                        let _ = self.kv.delete(&entry.key, None).await;
                     }
                 }
             }
@@ -1677,7 +1678,7 @@ impl CommandServer {
             .unwrap_or(DEADLINE_INDEX_GRACE);
         let options = (ttl.num_seconds() > 0).then(|| PutOptions {
             ttl: Some(Duration::from_secs(ttl.num_seconds() as u64)),
-            if_not_exists: false,
+            condition: PutCondition::None,
         });
 
         self.kv

--- a/crates/alien-commands/src/test_utils/server.rs
+++ b/crates/alien-commands/src/test_utils/server.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 
 use alien_bindings::{
     providers::{kv::LocalKv, storage::LocalStorage},
-    traits::{Binding, Kv, PutOptions, ScanResult, Storage},
+    traits::{Binding, Kv, KvEntry, PutOptions, ScanResult, Storage},
     ErrorData,
 };
 
@@ -57,7 +57,7 @@ impl Binding for FaultInjectingKv {}
 
 #[async_trait]
 impl Kv for FaultInjectingKv {
-    async fn get(&self, key: &str) -> alien_bindings::Result<Option<Vec<u8>>> {
+    async fn get(&self, key: &str) -> alien_bindings::Result<Option<KvEntry>> {
         self.inner.get(key).await
     }
 
@@ -70,8 +70,8 @@ impl Kv for FaultInjectingKv {
         self.inner.put(key, value, options).await
     }
 
-    async fn delete(&self, key: &str) -> alien_bindings::Result<()> {
-        self.inner.delete(key).await
+    async fn delete(&self, key: &str, if_version: Option<&str>) -> alien_bindings::Result<bool> {
+        self.inner.delete(key, if_version).await
     }
 
     async fn exists(&self, key: &str) -> alien_bindings::Result<bool> {

--- a/crates/alien-local/Cargo.toml
+++ b/crates/alien-local/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 # Database
-# Format probe for the localkv.v1 store in KV health checks. Needs
+# Format probe for the localkv.v2 store in KV health checks. Needs
 # `experimental_multiprocess_wal` (0.7-pre only) to probe a store other
 # processes hold open; the exact pin and rationale live in the workspace
 # Cargo.toml.

--- a/crates/alien-local/src/kv_manager.rs
+++ b/crates/alien-local/src/kv_manager.rs
@@ -6,7 +6,7 @@ use tracing::{debug, info};
 /// Manager for local KV resources.
 ///
 /// Creates the on-disk directory for each KV resource. The `LocalKv` binding
-/// opens its own SQLite-compatible database (`localkv.v1`) inside that
+/// opens its own SQLite-compatible database (`localkv.v2`) inside that
 /// directory and performs all operations directly.
 ///
 /// # State Scoping
@@ -124,12 +124,12 @@ impl LocalKvManager {
     }
 
     /// Verifies that a KV resource exists and is healthy by inspecting its
-    /// store against the `localkv.v1` on-disk contract.
+    /// store against the `localkv.v2` on-disk contract.
     ///
     /// Mirrors the format check `LocalKv` performs on open: it opens
     /// `<kv_path>/localkv.sqlite` with turso (SQLite-compatible file format),
     /// reads the `('format', ...)` row from the `meta` table, and reports
-    /// healthy only when it equals `localkv.v1`. turso exposes no read-only
+    /// healthy only when it equals `localkv.v2`. turso exposes no read-only
     /// open, so the probe is a plain open that only ever runs `SELECT`;
     /// turso's multi-process WAL mode (experimental upstream, enabled
     /// explicitly here exactly as in the binding) plus a busy_timeout let it
@@ -183,7 +183,7 @@ impl LocalKvManager {
             return Ok(());
         }
 
-        crate::store_probe::check_store_format(&db_path, "localkv.v1").await
+        crate::store_probe::check_store_format(&db_path, "localkv.v2").await
     }
 
     /// Gets the binding configuration for a KV resource.

--- a/crates/alien-local/src/store_probe.rs
+++ b/crates/alien-local/src/store_probe.rs
@@ -1,4 +1,4 @@
-//! Shared health probe for versioned local stores (`localkv.v1`, `localqueue.v1`).
+//! Shared health probe for versioned local stores (`localkv.v2`, `localqueue.v1`).
 //!
 //! Opens the store database read-only-in-spirit (same multi-process WAL opt-in
 //! as the bindings) and verifies the `meta.format` marker, so a resource whose
@@ -145,7 +145,7 @@ mod tests {
     #[tokio::test]
     async fn missing_format_marker_is_unhealthy() {
         let (db_path, _dir) = create_store(None).await;
-        check_store_format(&db_path, "localkv.v1")
+        check_store_format(&db_path, "localkv.v2")
             .await
             .expect_err("missing format marker must fail the probe");
     }

--- a/crates/alien-local/tests/kv_integration.rs
+++ b/crates/alien-local/tests/kv_integration.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify that:
 //! 1. Manager creates KV databases usable by LocalKv binding
-//! 2. Health checks read the localkv.v1 format marker
+//! 2. Health checks read the localkv.v2 format marker
 //! 3. Data persists across sessions
 
 use alien_bindings::providers::kv::local::LocalKv;
@@ -29,10 +29,10 @@ async fn test_manager_creates_usable_kv() {
         .await
         .unwrap();
     let value = kv.get("key1").await.unwrap();
-    assert_eq!(value, Some(b"value1".to_vec()));
+    assert_eq!(value.map(|entry| entry.value), Some(b"value1".to_vec()));
 }
 
-/// Health check reads the localkv.v1 format marker
+/// Health check reads the localkv.v2 format marker
 #[tokio::test]
 async fn test_health_check_opens_database() {
     let temp_dir = TempDir::new().unwrap();
@@ -46,7 +46,7 @@ async fn test_health_check_opens_database() {
     let kv_path = manager.create_kv("healthy-kv").await.unwrap();
     manager.check_health("healthy-kv").await.unwrap();
 
-    // Open the store so localkv.sqlite exists with the localkv.v1 marker.
+    // Open the store so localkv.sqlite exists with the localkv.v2 marker.
     {
         let _kv = LocalKv::new(kv_path).await.unwrap();
     }
@@ -87,7 +87,10 @@ async fn test_kv_data_persists_across_sessions() {
         let kv_path = manager.get_kv_path("persist-kv").unwrap();
         let kv = LocalKv::new(kv_path).await.unwrap();
         let value = kv.get("persistent-key").await.unwrap();
-        assert_eq!(value, Some(b"persistent-value".to_vec()));
+        assert_eq!(
+            value.map(|entry| entry.value),
+            Some(b"persistent-value".to_vec())
+        );
     }
 }
 
@@ -149,8 +152,14 @@ async fn test_multiple_kvs_coexist() {
         .unwrap();
 
     // Verify data is isolated
-    assert_eq!(kv_a.get("key").await.unwrap(), Some(b"value-a".to_vec()));
-    assert_eq!(kv_b.get("key").await.unwrap(), Some(b"value-b".to_vec()));
+    assert_eq!(
+        kv_a.get("key").await.unwrap().map(|entry| entry.value),
+        Some(b"value-a".to_vec())
+    );
+    assert_eq!(
+        kv_b.get("key").await.unwrap().map(|entry| entry.value),
+        Some(b"value-b".to_vec())
+    );
 }
 
 /// KV TTL functionality works
@@ -208,7 +217,10 @@ async fn test_kv_scan_prefix() {
     // Scan user prefix
     let result = kv.scan_prefix("user:", None, None).await.unwrap();
     assert_eq!(result.items.len(), 2);
-    assert!(result.items.iter().all(|(k, _)| k.starts_with("user:")));
+    assert!(result
+        .items
+        .iter()
+        .all(|entry| entry.key.starts_with("user:")));
 
     // Scan config prefix
     let result = kv.scan_prefix("config:", None, None).await.unwrap();

--- a/crates/alien-local/tests/local_services.rs
+++ b/crates/alien-local/tests/local_services.rs
@@ -66,7 +66,10 @@ async fn test_full_local_workflow() {
             .unwrap(),
         Bytes::from("data")
     );
-    assert_eq!(kv.get("key").await.unwrap(), Some(b"value".to_vec()));
+    assert_eq!(
+        kv.get("key").await.unwrap().map(|entry| entry.value),
+        Some(b"value".to_vec())
+    );
     assert_eq!(vault.get_secret("secret").await.unwrap(), "value");
 }
 
@@ -287,7 +290,7 @@ async fn test_multiple_resources_workflow() {
 
         let kv = provider.load_kv(&format!("kv-{}", i)).await.unwrap();
         let value = kv.get("key").await.unwrap().unwrap();
-        assert_eq!(value, format!("value-{}", i).as_bytes());
+        assert_eq!(value.value, format!("value-{}", i).as_bytes());
 
         let vault = provider.load_vault(&format!("vault-{}", i)).await.unwrap();
         let secret = vault.get_secret("secret").await.unwrap();

--- a/crates/alien-manager/tests/credentials_mint_bootstrap.rs
+++ b/crates/alien-manager/tests/credentials_mint_bootstrap.rs
@@ -438,7 +438,7 @@ async fn authorized_bootstrap_mints_via_real_manager_and_loads_a_working_binding
     drop(guard);
 
     assert_eq!(
-        value,
+        value.map(|entry| entry.value),
         Some(b"world".to_vec()),
         "a binding loaded through minted credentials must actually read/write, not just construct"
     );

--- a/crates/alien-sdk/src/lib.rs
+++ b/crates/alien-sdk/src/lib.rs
@@ -25,7 +25,7 @@
 //!     let bindings = Bindings::from_env()?;
 //!     let cache = bindings.kv("cache").await?;
 //!     cache.put("greeting", b"hello".to_vec(), None).await?;
-//!     assert_eq!(cache.get("greeting").await?, Some(b"hello".to_vec()));
+//!     assert_eq!(cache.get("greeting").await?.unwrap().value, b"hello");
 //!     Ok(())
 //! }
 //! ```
@@ -82,7 +82,8 @@ pub mod presigned {
 /// through storage/KV/queue/vault/container calls).
 pub mod traits {
     pub use alien_bindings::traits::{
-        Kv, MessagePayload, PutOptions, QueueMessage, ScanResult, Storage, Vault,
+        Kv, KvEntry, MessagePayload, PutCondition, PutOptions, QueueMessage, ScanResult, Storage,
+        Vault,
     };
     pub use alien_bindings::{BoundQueue as Queue, Container};
 }

--- a/crates/alien-test-app/src/bin/main.rs
+++ b/crates/alien-test-app/src/bin/main.rs
@@ -386,8 +386,8 @@ async fn get_storage_event(
     let kv_key = format!("storage_event:{}", sanitized_key);
 
     match kv.get(&kv_key).await {
-        Ok(Some(data)) => {
-            let event: serde_json::Value = serde_json::from_slice(&data)
+        Ok(Some(entry)) => {
+            let event: serde_json::Value = serde_json::from_slice(&entry.value)
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
             Ok(Json(event))
         }
@@ -415,8 +415,8 @@ async fn get_cron_event(
     let kv_key = format!("cron_event:{}", sanitized_name);
 
     match kv.get(&kv_key).await {
-        Ok(Some(data)) => {
-            let event: serde_json::Value = serde_json::from_slice(&data)
+        Ok(Some(entry)) => {
+            let event: serde_json::Value = serde_json::from_slice(&entry.value)
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
             Ok(Json(event))
         }
@@ -444,8 +444,8 @@ async fn get_queue_message(
     let kv_key = format!("queue_message:{}", sanitized_id);
 
     match kv.get(&kv_key).await {
-        Ok(Some(data)) => {
-            let message: serde_json::Value = serde_json::from_slice(&data)
+        Ok(Some(entry)) => {
+            let message: serde_json::Value = serde_json::from_slice(&entry.value)
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
             Ok(Json(message))
         }

--- a/examples/data-connector-ts/src/index.ts
+++ b/examples/data-connector-ts/src/index.ts
@@ -57,7 +57,7 @@ command(
     if (useCache) {
       const cached = await c.get(cacheKey)
       if (cached) {
-        return { ...JSON.parse(new TextDecoder().decode(cached)), cached: true }
+        return { ...JSON.parse(new TextDecoder().decode(cached.value)), cached: true }
       }
     }
 

--- a/packages/bindings/scripts/smoke-prebuild.mjs
+++ b/packages/bindings/scripts/smoke-prebuild.mjs
@@ -32,11 +32,13 @@ async function main() {
   await cache.set("greeting", "hi")
   const got = await cache.getText("greeting")
 
-  if (got !== "hi") {
+  if (got?.value !== "hi") {
     throw new Error(`expected 'hi', got ${JSON.stringify(got)}`)
   }
 
-  console.log(`[smoke:${runtime}] OK: kv put/get through the prebuilt addon returned '${got}'`)
+  console.log(
+    `[smoke:${runtime}] OK: kv put/get through the prebuilt addon returned '${got.value}'`,
+  )
 }
 
 main().catch(err => {

--- a/packages/bindings/src/__tests__/factories.test.ts
+++ b/packages/bindings/src/__tests__/factories.test.ts
@@ -86,7 +86,7 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
   const kvHandle: RawKvHandle = {
     get: async () => null,
     put: async () => true,
-    delete: async () => {},
+    delete: async () => true,
     exists: async () => false,
     scan: async () => ({ items: [] }),
   }
@@ -224,12 +224,16 @@ describe("createFactories laziness", () => {
 })
 
 describe("createFactories kv surface", () => {
-  it("kv.get returns the raw value bytes over the napi get", async () => {
-    const get = vi.fn(async () => Buffer.from("raw-bytes"))
+  it("kv.get returns the value and opaque version over the napi get", async () => {
+    const get = vi.fn(async () => ({
+      key: "k",
+      value: Buffer.from("raw-bytes"),
+      version: "opaque",
+    }))
     const kvHandle: RawKvHandle = {
       get,
       put: async () => true,
-      delete: async () => {},
+      delete: async () => true,
       exists: async () => false,
       scan: async () => ({ items: [] }),
     }
@@ -240,14 +244,15 @@ describe("createFactories kv surface", () => {
 
     expect(get).toHaveBeenCalledWith("k")
     expect(value).not.toBeNull()
-    expect((value as Buffer).toString("utf8")).toBe("raw-bytes")
+    expect(value?.value.toString("utf8")).toBe("raw-bytes")
+    expect(value?.version).toBe("opaque")
   })
 
   it("kv.get returns null when the key is absent", async () => {
     const kvHandle: RawKvHandle = {
       get: async () => null,
       put: async () => true,
-      delete: async () => {},
+      delete: async () => true,
       exists: async () => false,
       scan: async () => ({ items: [] }),
     }
@@ -261,7 +266,7 @@ describe("createFactories kv surface", () => {
     const kvHandle: RawKvHandle = {
       get: async () => null,
       put,
-      delete: async () => {},
+      delete: async () => true,
       exists: async () => false,
       scan: async () => ({ items: [] }),
     }
@@ -272,23 +277,24 @@ describe("createFactories kv surface", () => {
     expect(created).toBe(true)
     const firstCall = put.mock.calls[0]
     if (!firstCall) throw new Error("put was not called")
-    const [key, buffer, ttl, ifNotExists] = firstCall
+    const [key, buffer, ttl, condition, version] = firstCall
     expect(key).toBe("k")
     expect(buffer.toString("utf8")).toBe(JSON.stringify({ hello: "world" }))
     expect(ttl).toBe(30)
-    expect(ifNotExists).toBeNull()
+    expect(condition).toBeNull()
+    expect(version).toBeNull()
   })
 
   it("kv.scan surfaces items with both keys and values (no data discarded)", async () => {
     const kvHandle: RawKvHandle = {
       get: async () => null,
       put: async () => true,
-      delete: async () => {},
+      delete: async () => true,
       exists: async () => false,
       scan: async () => ({
         items: [
-          { key: "a", value: Buffer.from("one") },
-          { key: "b", value: Buffer.from("two") },
+          { key: "a", value: Buffer.from("one"), version: "v1" },
+          { key: "b", value: Buffer.from("two"), version: "v2" },
         ],
         nextCursor: "next",
       }),

--- a/packages/bindings/src/factories.ts
+++ b/packages/bindings/src/factories.ts
@@ -35,6 +35,7 @@ import type {
 import type {
   Container,
   Kv,
+  KvEntry,
   KvScanResult,
   KvSetOptions,
   Postgres,
@@ -125,13 +126,15 @@ function makeKv(handle: () => Promise<RawKvHandle>): Kv {
     get: key => guard(handle, raw => raw.get(key)),
     getText: key =>
       guard(handle, async raw => {
-        const value = await raw.get(key)
-        return value === null ? null : value.toString("utf8")
+        const entry = await raw.get(key)
+        return entry === null ? null : { ...entry, value: entry.value.toString("utf8") }
       }),
-    getJson: <T = unknown>(key: string): Promise<T | null> =>
+    getJson: <T = unknown>(key: string): Promise<KvEntry<T> | null> =>
       guard(handle, async raw => {
-        const value = await raw.get(key)
-        return value === null ? null : (JSON.parse(value.toString("utf8")) as T)
+        const entry = await raw.get(key)
+        return entry === null
+          ? null
+          : { ...entry, value: JSON.parse(entry.value.toString("utf8")) as T }
       }),
     set: (key, value, options?: KvSetOptions) =>
       guard(handle, raw =>
@@ -139,7 +142,12 @@ function makeKv(handle: () => Promise<RawKvHandle>): Kv {
           key,
           Buffer.from(value, "utf8"),
           options?.ttl ?? null,
-          options?.ifNotExists ?? null,
+          options && "ifVersion" in options
+            ? options.ifVersion === null
+              ? "absent"
+              : "version"
+            : null,
+          typeof options?.ifVersion === "string" ? options.ifVersion : null,
         ),
       ),
     setJson: (key, value, options?: KvSetOptions) =>
@@ -148,10 +156,15 @@ function makeKv(handle: () => Promise<RawKvHandle>): Kv {
           key,
           Buffer.from(JSON.stringify(value), "utf8"),
           options?.ttl ?? null,
-          options?.ifNotExists ?? null,
+          options && "ifVersion" in options
+            ? options.ifVersion === null
+              ? "absent"
+              : "version"
+            : null,
+          typeof options?.ifVersion === "string" ? options.ifVersion : null,
         ),
       ),
-    delete: key => guard(handle, raw => raw.delete(key)),
+    delete: (key, options) => guard(handle, raw => raw.delete(key, options?.ifVersion ?? null)),
     exists: key => guard(handle, raw => raw.exists(key)),
     // The napi scan already returns each key with its value bytes; pass them
     // straight through rather than dropping the values.

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -42,6 +42,8 @@ export {
 export type {
   Container,
   Kv,
+  KvDeleteOptions,
+  KvEntry,
   KvScanItem,
   KvScanResult,
   KvSetOptions,

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -47,6 +47,7 @@ const require = createRequire(import.meta.url)
 export interface RawKvItem {
   key: string
   value: Buffer
+  version: string
 }
 
 /** Raw napi scan result. */
@@ -101,14 +102,15 @@ export interface RawRemoteStorageHandle {
 
 /** Raw napi key-value handle. */
 export interface RawKvHandle {
-  get(key: string): Promise<Buffer | null>
+  get(key: string): Promise<RawKvItem | null>
   put(
     key: string,
     value: Buffer,
     ttlSecs?: number | null,
-    ifNotExists?: boolean | null,
+    condition?: "absent" | "version" | null,
+    version?: string | null,
   ): Promise<boolean>
-  delete(key: string): Promise<void>
+  delete(key: string, ifVersion?: string | null): Promise<boolean>
   exists(key: string): Promise<boolean>
   scan(prefix: string, limit?: number | null, cursor?: string | null): Promise<RawScanResult>
 }

--- a/packages/bindings/src/native.ts
+++ b/packages/bindings/src/native.ts
@@ -62,6 +62,8 @@ export {
 export type {
   Container,
   Kv,
+  KvDeleteOptions,
+  KvEntry,
   KvScanItem,
   KvScanResult,
   KvSetOptions,

--- a/packages/bindings/src/types.ts
+++ b/packages/bindings/src/types.ts
@@ -129,17 +129,32 @@ export type RemoteStorage = Pick<Storage, "get" | "put" | "delete" | "list" | "h
 export interface KvSetOptions {
   /** Time-to-live, in seconds. */
   ttl?: number
-  /** Only create the key if it does not already exist. */
-  ifNotExists?: boolean
+  /**
+   * Atomic write precondition. `null` means the key must be absent; an opaque
+   * version means the key must still match an earlier read. Omit for an
+   * unconditional write.
+   */
+  ifVersion?: string | null
 }
 
-/** A single key-value pair returned by a scan. */
-export interface KvScanItem {
+/** Options for {@link Kv.delete}. */
+export interface KvDeleteOptions {
+  /** Delete only when the key still matches this opaque version. */
+  ifVersion?: string
+}
+
+/** A value and its opaque version. */
+export interface KvEntry<T> {
   /** The key. */
   key: string
-  /** The raw value bytes. */
-  value: Buffer
+  /** The decoded value. */
+  value: T
+  /** Opaque version for a later conditional set or delete. */
+  version: string
 }
+
+/** A raw entry returned by a scan. */
+export type KvScanItem = KvEntry<Buffer>
 
 /** A page of scan results. */
 export interface KvScanResult {
@@ -154,25 +169,25 @@ export interface KvScanResult {
 
 /** A resolved key-value binding. */
 export interface Kv {
-  /** Get the raw value bytes for `key`, or `null` if absent/expired. */
-  get(key: string): Promise<Buffer | null>
-  /** Get the value for `key` as UTF-8 text, or `null` if absent/expired. */
-  getText(key: string): Promise<string | null>
-  /** Get the value for `key` parsed as JSON, or `null` if absent/expired. */
-  getJson<T = unknown>(key: string): Promise<T | null>
+  /** Get the raw entry for `key`, or `null` if absent/expired. */
+  get(key: string): Promise<KvEntry<Buffer> | null>
+  /** Get the entry for `key` with its value decoded as UTF-8 text. */
+  getText(key: string): Promise<KvEntry<string> | null>
+  /** Get the entry for `key` with its value parsed as JSON. */
+  getJson<T = unknown>(key: string): Promise<KvEntry<T> | null>
   /**
-   * Set `key` to the UTF-8 `value`. With `ifNotExists`, resolves `true` when
-   * created and `false` when the key already existed; otherwise `true`.
+   * Set `key` to the UTF-8 `value`. Conditional writes resolve `false` when
+   * their version precondition is not met; all applied writes resolve `true`.
    */
   set(key: string, value: string, options?: KvSetOptions): Promise<boolean>
   /**
-   * Set `key` to `value` serialized as JSON (via `JSON.stringify`). With
-   * `ifNotExists`, resolves `true` when created and `false` when the key already
-   * existed; otherwise `true`.
+   * Set `key` to `value` serialized as JSON (via `JSON.stringify`). Conditional
+   * writes resolve `false` when their version precondition is not
+   * met; all applied writes resolve `true`.
    */
   setJson(key: string, value: unknown, options?: KvSetOptions): Promise<boolean>
-  /** Delete `key` (no error if absent). */
-  delete(key: string): Promise<void>
+  /** Delete `key`, optionally only when its version still matches. */
+  delete(key: string, options?: KvDeleteOptions): Promise<boolean>
   /** Check whether `key` exists. */
   exists(key: string): Promise<boolean>
   /** Scan keys under `prefix`, with optional pagination. */

--- a/packages/bindings/tests/helpers/credential-mint-client.ts
+++ b/packages/bindings/tests/helpers/credential-mint-client.ts
@@ -16,7 +16,7 @@ export async function exerciseLongLivedKvHandle(): Promise<CredentialMintClientR
   await cache.set("key", "second")
   const second = await cache.getText("key")
 
-  return { first, second }
+  return { first: first?.value ?? null, second: second?.value ?? null }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/packages/bindings/tests/kv.test.ts
+++ b/packages/bindings/tests/kv.test.ts
@@ -32,7 +32,8 @@ describe("kv (local turso-backed provider)", () => {
     const value = await k.get("greeting")
 
     expect(value).not.toBeNull()
-    expect((value as Buffer).toString("utf8")).toBe("hello")
+    expect(value?.value.toString("utf8")).toBe("hello")
+    expect(value?.version).toEqual(expect.any(String))
   })
 
   it("get returns null for an absent key", async () => {
@@ -44,23 +45,27 @@ describe("kv (local turso-backed provider)", () => {
     const k = freshKv()
     await k.set("text-key", "plain text value")
 
-    expect(await k.getText("text-key")).toBe("plain text value")
+    expect((await k.getText("text-key"))?.value).toBe("plain text value")
   })
 
   it("setJson/getJson round-trip a JSON value", async () => {
     const k = freshKv()
     await k.setJson("json-key", { hello: "world", n: 1, nested: { a: [1, 2, 3] } })
 
-    expect(await k.getJson("json-key")).toEqual({ hello: "world", n: 1, nested: { a: [1, 2, 3] } })
+    expect((await k.getJson("json-key"))?.value).toEqual({
+      hello: "world",
+      n: 1,
+      nested: { a: [1, 2, 3] },
+    })
   })
 
-  it("ifNotExists: the second set returns false and the value is unchanged", async () => {
+  it("an absent precondition creates exactly once", async () => {
     const k = freshKv()
 
-    expect(await k.set("once", "first", { ifNotExists: true })).toBe(true)
-    expect(await k.set("once", "second", { ifNotExists: true })).toBe(false)
+    expect(await k.set("once", "first", { ifVersion: null })).toBe(true)
+    expect(await k.set("once", "second", { ifVersion: null })).toBe(false)
 
-    expect(await k.getText("once")).toBe("first")
+    expect((await k.getText("once"))?.value).toBe("first")
   })
 
   it("a plain (non-conditional) set always overwrites", async () => {
@@ -68,14 +73,14 @@ describe("kv (local turso-backed provider)", () => {
     await k.set("plain", "first")
     await k.set("plain", "second")
 
-    expect(await k.getText("plain")).toBe("second")
+    expect((await k.getText("plain"))?.value).toBe("second")
   })
 
   it("ttl: a short-lived key expires and reads back absent", async () => {
     const k = freshKv()
     await k.set("short-lived", "value", { ttl: 1 })
 
-    expect(await k.getText("short-lived")).toBe("value")
+    expect((await k.getText("short-lived"))?.value).toBe("value")
     expect(await k.exists("short-lived")).toBe(true)
 
     // Deliberately generous margin over the 1s ttl to avoid CI flakiness; the
@@ -101,6 +106,23 @@ describe("kv (local turso-backed provider)", () => {
 
     expect(await k.exists("to-delete")).toBe(false)
     expect(await k.get("to-delete")).toBeNull()
+  })
+
+  it("conditionally updates and deletes with opaque versions", async () => {
+    const k = freshKv()
+    await k.set("cas", "initial")
+    const initial = await k.getText("cas")
+    if (!initial) throw new Error("initial entry was not stored")
+
+    expect(await k.set("cas", "updated", { ifVersion: initial.version })).toBe(true)
+    expect(await k.set("cas", "stale", { ifVersion: initial.version })).toBe(false)
+
+    const current = await k.getText("cas")
+    if (!current) throw new Error("updated entry is missing")
+    expect(current.value).toBe("updated")
+    expect(current.version).not.toBe(initial.version)
+    expect(await k.delete("cas", { ifVersion: initial.version })).toBe(false)
+    expect(await k.delete("cas", { ifVersion: current.version })).toBe(true)
   })
 
   it("scan paginates by prefix, limit, and cursor with exact page boundaries", async () => {

--- a/packages/bindings/tests/process-env.test.ts
+++ b/packages/bindings/tests/process-env.test.ts
@@ -16,6 +16,6 @@ describe("process environment", () => {
     if (!isBun) localKvBindingEnv(name)
     const k = kv(name)
     await k.set("k", "v")
-    expect(await k.getText("k")).toBe("v")
+    expect((await k.getText("k"))?.value).toBe("v")
   })
 })

--- a/packages/core/src/kv.ts
+++ b/packages/core/src/kv.ts
@@ -15,15 +15,15 @@ export { KvSchema as KvConfigSchema } from "./generated/index.js"
  * All operations support TTL for automatic expiration and conditional operations.
  *
  * Key Features:
- * - Universal size limits: 512B keys, 64KB values
+ * - Universal size limits: 512-byte keys, 24 KiB values
  * - TTL support with logical expiry across all platforms
- * - Conditional puts with if_not_exists support
+ * - Atomic absent and version preconditions for puts and deletes
  * - Prefix-based scanning with pagination
  * - Platform-specific optimizations while maintaining consistent API
  *
  * Size Constraints:
- * - Keys: ≤ 512 bytes with portable ASCII charset (a-z, A-Z, 0-9, -, _, :, /, .)
- * - Values: ≤ 65,536 bytes (64 KiB)
+ * - Keys: ≤ 512 bytes with portable ASCII charset (a-z, A-Z, 0-9, -, _, :, .)
+ * - Values: ≤ 24,576 bytes (24 KiB)
  *
  * TTL Behavior:
  * - Expired items appear absent on reads even if physically present

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/events.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/events.rs
@@ -50,8 +50,8 @@ pub async fn get_storage_event(
     let sanitized_key = crate::sanitize_kv_key_part(&key);
     let kv_key = format!("storage_event:{}", sanitized_key);
     match kv.get(&kv_key).await {
-        Ok(Some(data)) => {
-            let event: serde_json::Value = serde_json::from_slice(&data).unwrap_or_default();
+        Ok(Some(entry)) => {
+            let event: serde_json::Value = serde_json::from_slice(&entry.value).unwrap_or_default();
             Ok(Json(EventResponse {
                 found: true,
                 event: Some(event),
@@ -84,8 +84,8 @@ pub async fn get_cron_event(
     let sanitized_schedule = crate::sanitize_kv_key_part(&schedule);
     let kv_key = format!("cron_event:{}", sanitized_schedule);
     match kv.get(&kv_key).await {
-        Ok(Some(data)) => {
-            let event: serde_json::Value = serde_json::from_slice(&data).unwrap_or_default();
+        Ok(Some(entry)) => {
+            let event: serde_json::Value = serde_json::from_slice(&entry.value).unwrap_or_default();
             Ok(Json(EventResponse {
                 found: true,
                 event: Some(event),
@@ -118,8 +118,8 @@ pub async fn get_queue_message(
     let sanitized_id = crate::sanitize_kv_key_part(&message_id);
     let kv_key = format!("queue_message:{}", sanitized_id);
     match kv.get(&kv_key).await {
-        Ok(Some(data)) => {
-            let event: serde_json::Value = serde_json::from_slice(&data).unwrap_or_default();
+        Ok(Some(entry)) => {
+            let event: serde_json::Value = serde_json::from_slice(&entry.value).unwrap_or_default();
             Ok(Json(EventResponse {
                 found: true,
                 event: Some(event),
@@ -151,8 +151,8 @@ pub async fn list_events(State(app_state): State<AppState>) -> Result<Json<Event
 
     // Scan for storage events
     if let Ok(result) = kv.scan_prefix("storage_event:", Some(100), None).await {
-        for (_, value) in result.items {
-            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&value) {
+        for entry in result.items {
+            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&entry.value) {
                 storage_events.push(event);
             }
         }
@@ -160,8 +160,8 @@ pub async fn list_events(State(app_state): State<AppState>) -> Result<Json<Event
 
     // Scan for cron events
     if let Ok(result) = kv.scan_prefix("cron_event:", Some(100), None).await {
-        for (_, value) in result.items {
-            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&value) {
+        for entry in result.items {
+            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&entry.value) {
                 cron_events.push(event);
             }
         }
@@ -169,8 +169,8 @@ pub async fn list_events(State(app_state): State<AppState>) -> Result<Json<Event
 
     // Scan for queue messages
     if let Ok(result) = kv.scan_prefix("queue_message:", Some(100), None).await {
-        for (_, value) in result.items {
-            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&value) {
+        for entry in result.items {
+            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&entry.value) {
                 queue_messages.push(event);
             }
         }

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/kv.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/kv.rs
@@ -10,7 +10,7 @@ use crate::{
     ErrorData, Result,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
-use alien_sdk::traits::PutOptions;
+use alien_sdk::traits::{PutCondition, PutOptions};
 
 /// Test KV operations with a full E2E flow
 #[utoipa::path(
@@ -75,35 +75,35 @@ pub async fn test_kv(
         }));
     }
 
-    // 2. Put the second key-value pair with if_not_exists option
-    info!(%test_key2, "Putting second key-value pair with if_not_exists");
+    // 2. Put the second key-value pair only when absent
+    info!(%test_key2, "Putting second key-value pair with an absent precondition");
     let put_options = PutOptions {
         ttl: None,
-        if_not_exists: true,
+        condition: PutCondition::Absent,
     };
     let put2_result = kv_instance
         .put(&test_key2, test_value2.clone(), Some(put_options))
         .await
         .into_alien_error()
         .context(ErrorData::KvOperationFailed {
-            operation: "put_if_not_exists".to_string(),
+            operation: "put_when_absent".to_string(),
             key: test_key2.clone(),
-            reason: "Failed to put second key-value pair with if_not_exists".to_string(),
+            reason: "Failed to put second key-value pair with an absent precondition".to_string(),
         })?;
 
     if !put2_result {
         return Err(AlienError::new(ErrorData::KvOperationFailed {
-            operation: "put_if_not_exists".to_string(),
+            operation: "put_when_absent".to_string(),
             key: test_key2.clone(),
-            reason: "Put with if_not_exists returned false unexpectedly".to_string(),
+            reason: "Put with an absent precondition returned false unexpectedly".to_string(),
         }));
     }
 
-    // 3. Try to put the second key again with if_not_exists (should return false)
-    info!(%test_key2, "Attempting to put existing key with if_not_exists (should fail)");
+    // 3. Try to put the second key again with an absent precondition
+    info!(%test_key2, "Attempting to put existing key with an absent precondition");
     let put_options_duplicate = PutOptions {
         ttl: None,
-        if_not_exists: true,
+        condition: PutCondition::Absent,
     };
     let put_duplicate_result = kv_instance
         .put(
@@ -114,17 +114,18 @@ pub async fn test_kv(
         .await
         .into_alien_error()
         .context(ErrorData::KvOperationFailed {
-            operation: "put_if_not_exists_duplicate".to_string(),
+            operation: "put_when_absent_duplicate".to_string(),
             key: test_key2.clone(),
-            reason: "Failed to test duplicate put with if_not_exists".to_string(),
+            reason: "Failed to test duplicate put with an absent precondition".to_string(),
         })?;
 
     if put_duplicate_result {
         return Err(AlienError::new(ErrorData::KvOperationFailed {
-            operation: "put_if_not_exists_duplicate".to_string(),
+            operation: "put_when_absent_duplicate".to_string(),
             key: test_key2.clone(),
-            reason: "Put with if_not_exists should have returned false for existing key"
-                .to_string(),
+            reason:
+                "Put with an absent precondition should have returned false for an existing key"
+                    .to_string(),
         }));
     }
 
@@ -141,16 +142,16 @@ pub async fn test_kv(
         })?;
 
     match retrieved_value1 {
-        Some(value) if value == test_value1 => {
+        Some(entry) if entry.value == test_value1 => {
             info!(%test_key1, "First value retrieved and verified successfully");
         }
-        Some(value) => {
+        Some(entry) => {
             return Err(AlienError::new(ErrorData::KvOperationFailed {
                 operation: "get_verification".to_string(),
                 key: test_key1.clone(),
                 reason: format!(
                     "Retrieved value doesn't match expected. Got: {:?}, Expected: {:?}",
-                    value, test_value1
+                    entry.value, test_value1
                 ),
             }));
         }
@@ -207,7 +208,11 @@ pub async fn test_kv(
     }
 
     // Verify the scanned items contain our keys
-    let scanned_keys: Vec<String> = scan_result.items.iter().map(|(k, _)| k.clone()).collect();
+    let scanned_keys: Vec<String> = scan_result
+        .items
+        .iter()
+        .map(|entry| entry.key.clone())
+        .collect();
     if !scanned_keys.contains(&test_key1) || !scanned_keys.contains(&test_key2) {
         return Err(AlienError::new(ErrorData::KvOperationFailed {
             operation: "scan_prefix_verification".to_string(),
@@ -224,7 +229,7 @@ pub async fn test_kv(
     tokio::spawn(async move {
         for cleanup_key in cleanup_keys {
             info!(test_key = %cleanup_key, "Deleting KV test key");
-            if let Err(error) = cleanup_kv.delete(&cleanup_key).await {
+            if let Err(error) = cleanup_kv.delete(&cleanup_key, None).await {
                 warn!(
                     test_key = %cleanup_key,
                     error = ?error,

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/queue_message.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/queue_message.rs
@@ -56,14 +56,14 @@ pub async fn get_received_queue_messages(
                 "Found keys with scan_prefix"
             );
 
-            for (key, value) in scan_result.items {
-                match serde_json::from_slice::<serde_json::Value>(&value) {
+            for entry in scan_result.items {
+                match serde_json::from_slice::<serde_json::Value>(&entry.value) {
                     Ok(parsed_message) => {
                         retrieved_messages.push(parsed_message);
-                        info!(key = %key, "Found stored queue message");
+                        info!(key = %entry.key, "Found stored queue message");
                     }
                     Err(e) => {
-                        info!(key = %key, error = %e, "Failed to parse stored message");
+                        info!(key = %entry.key, error = %e, "Failed to parse stored message");
                     }
                 }
             }

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/events.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/events.ts
@@ -34,7 +34,7 @@ app.get("/events/storage/:key", async c => {
     const sanitizedKey = sanitizeKvKeyPart(key)
     const data = await k.get(`storage_event:${sanitizedKey}`)
     if (!data) return c.json({ found: false })
-    return c.json({ found: true, event: JSON.parse(new TextDecoder().decode(data)) })
+    return c.json({ found: true, event: JSON.parse(new TextDecoder().decode(data.value)) })
   } catch {
     return c.json({ found: false })
   }
@@ -47,7 +47,7 @@ app.get("/events/cron/:schedule", async c => {
     const sanitizedSchedule = sanitizeKvKeyPart(schedule)
     const data = await k.get(`cron_event:${sanitizedSchedule}`)
     if (!data) return c.json({ found: false })
-    return c.json({ found: true, event: JSON.parse(new TextDecoder().decode(data)) })
+    return c.json({ found: true, event: JSON.parse(new TextDecoder().decode(data.value)) })
   } catch {
     return c.json({ found: false })
   }
@@ -60,7 +60,7 @@ app.get("/events/queue/:messageId", async c => {
     const sanitizedId = sanitizeKvKeyPart(messageId)
     const data = await k.get(`queue_message:${sanitizedId}`)
     if (!data) return c.json({ found: false })
-    return c.json({ found: true, event: JSON.parse(new TextDecoder().decode(data)) })
+    return c.json({ found: true, event: JSON.parse(new TextDecoder().decode(data.value)) })
   } catch {
     return c.json({ found: false })
   }

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/kv.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/kv.ts
@@ -16,12 +16,12 @@ app.post("/kv-test/:bindingName", async c => {
     // 1. Put
     await k.setJson(key1, testValue)
 
-    // 2. Put with ifNotExists — second set should return false
-    const firstSet = await k.setJson(key2, testValue, { ifNotExists: true })
-    const secondSet = await k.setJson(key2, { message: "duplicate" }, { ifNotExists: true })
+    // 2. Put only when absent — second set should return false
+    const firstSet = await k.setJson(key2, testValue, { ifVersion: null })
+    const secondSet = await k.setJson(key2, { message: "duplicate" }, { ifVersion: null })
     if (secondSet !== false) {
       return c.json(
-        { success: false, error: "ifNotExists: duplicate set should return false" },
+        { success: false, error: "absent precondition: duplicate set should return false" },
         500,
       )
     }
@@ -31,7 +31,7 @@ app.post("/kv-test/:bindingName", async c => {
     if (!retrieved) {
       return c.json({ success: false, error: "Get returned undefined for existing key" }, 500)
     }
-    const value = JSON.parse(new TextDecoder().decode(retrieved))
+    const value = JSON.parse(new TextDecoder().decode(retrieved.value))
     if (value.message !== testValue.message) {
       return c.json({ success: false, error: "Value mismatch" }, 500)
     }


### PR DESCRIPTION
## Summary

- return values together with opaque, key-bound versions from KV reads and scans
- add atomic create-if-absent, compare-and-set, and compare-and-delete across DynamoDB, Firestore, Azure Table Storage, and Local KV
- expose the same condition model through the Rust and TypeScript bindings
- advance the local on-disk format to `localkv.v2` and update in-repo consumers

## Breaking changes

- Rust `Kv::get` now returns `KvEntry`, scans return entries, and `delete` accepts an optional version and returns whether it applied
- `PutOptions::if_not_exists` is replaced by `PutCondition`
- TypeScript reads return `KvEntry<T>`; `ifVersion: null` means create only when absent, while a version string performs compare-and-set
- existing Local stores and cloud rows written without version metadata are rejected rather than migrated

## Validation

- `cargo check --workspace --all-targets`
- `cargo check -p alien-bindings --no-default-features` and independently with `aws`, `gcp`, `azure`, and `local`
- `cargo clippy -p alien-bindings -p alien-bindings-node --all-targets`
- Rust binding, native binding, command-service, and local-service tests
- TypeScript typecheck and 86 package tests
- real conditional create, stale-version update/delete, concurrent-writer race, expiry takeover, and scan-version tests against Local KV, DynamoDB, Firestore, and Azure Table Storage

[ALIEN-441](https://linear.app/alienplatform/issue/ALIEN-441/add-versioned-compare-and-set-operations-to-kv-bindings)
