### PR TITLE
fix: sync only vault-backed workload secrets

### DIFF
--- a/crates/alien-deployment/src/deleting.rs
+++ b/crates/alien-deployment/src/deleting.rs
@@ -30,7 +30,13 @@ pub async fn handle_delete_pending(
 
     if stack_state.resources.contains_key("secrets") {
         let runtime_metadata = next.runtime_metadata.get_or_insert_default();
+        let prepared_stack = runtime_metadata.prepared_stack.clone().ok_or_else(|| {
+            AlienError::new(ErrorData::MissingConfiguration {
+                message: "Prepared stack required for vault secret deletion".to_string(),
+            })
+        })?;
         crate::helpers::delete_deployment_vault_secrets(
+            &prepared_stack,
             &stack_state,
             &client_config,
             &config,

--- a/crates/alien-deployment/src/helpers.rs
+++ b/crates/alien-deployment/src/helpers.rs
@@ -5,7 +5,7 @@ use alien_core::{
     AwsEnvironmentInfo, AzureEnvironmentInfo, ClientConfig, ComputeKind, DeploymentConfig,
     EnvironmentInfo, EnvironmentVariable, EnvironmentVariableType, EnvironmentVariablesSnapshot,
     GcpEnvironmentInfo, LocalEnvironmentInfo, OtlpConfig, Platform, ResourceStatus, SecretDelivery,
-    Stack, StackState, TestEnvironmentInfo, Vault, ENV_ALIEN_COMMANDS_TOKEN,
+    Stack, StackState, TestEnvironmentInfo, Vault, Worker, ENV_ALIEN_COMMANDS_TOKEN,
     ENV_ALIEN_RUNTIME_SECRETS, ENV_ALIEN_SECRETS,
 };
 use alien_error::{AlienError, Context, IntoAlienError as _};
@@ -26,7 +26,7 @@ const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 // no-migration option and keep the wire keys stable.
 const RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET: &str = "__alien_runtime_otlp_logs_auth_header";
 const RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET: &str = "__alien_runtime_otlp_metrics_auth_header";
-const SECRETS_SYNC_SCHEMA_VERSION: &[u8] = b"\0vault-sync:no-app-command-token:v2\0";
+const SECRETS_SYNC_SCHEMA_VERSION: &[u8] = b"\0vault-sync:vault-backed-consumers:v3\0";
 
 /// Collect environment information from cloud platforms
 pub async fn collect_environment_info(
@@ -556,13 +556,14 @@ fn matches_resource_pattern(resource_name: &str, target_resources: &Option<Vec<S
 ///
 /// Returns true if sync was performed, false if skipped (already synced).
 pub async fn sync_secrets_to_vault(
+    stack: &Stack,
     stack_state: &StackState,
     client_config: &ClientConfig,
     config: &DeploymentConfig,
     runtime_metadata: &mut alien_core::RuntimeMetadata,
 ) -> Result<bool> {
-    let sync_hash = secrets_sync_hash(config);
-    let desired_secrets = desired_vault_secrets(config);
+    let desired_secrets = desired_vault_secrets(stack, client_config.platform(), config);
+    let sync_hash = secrets_sync_hash(&desired_secrets);
     let desired_secret_names = desired_secrets.keys().cloned().collect::<Vec<_>>();
 
     if client_config.platform() == Platform::Machines {
@@ -672,6 +673,7 @@ pub async fn sync_secrets_to_vault(
 /// Ownership comes from the persisted sync inventory plus the current config, which also lets
 /// deployments created before the inventory field was introduced clean up their active keys.
 pub async fn delete_deployment_vault_secrets(
+    stack: &Stack,
     stack_state: &StackState,
     client_config: &ClientConfig,
     config: &DeploymentConfig,
@@ -685,7 +687,7 @@ pub async fn delete_deployment_vault_secrets(
         .last_synced_secret_names
         .iter()
         .cloned()
-        .chain(desired_vault_secrets(config).into_keys())
+        .chain(desired_vault_secrets(stack, client_config.platform(), config).into_keys())
         .collect::<Vec<_>>();
     if !has_secrets_vault(stack_state) && owned_names.is_empty() {
         runtime_metadata.last_synced_env_vars_hash = None;
@@ -739,17 +741,38 @@ fn has_secrets_vault(stack_state: &StackState) -> bool {
         .is_some_and(|resource| resource.resource_type == Vault::RESOURCE_TYPE.as_ref())
 }
 
-fn desired_vault_secrets(config: &DeploymentConfig) -> BTreeMap<String, String> {
+fn desired_vault_secrets(
+    stack: &Stack,
+    platform: Platform,
+    config: &DeploymentConfig,
+) -> BTreeMap<String, String> {
+    let vault_backed_workers = stack
+        .resources
+        .iter()
+        .filter(|(_, entry)| entry.config.resource_type() == Worker::RESOURCE_TYPE)
+        .filter(|_| !SecretDelivery::resolve(platform, ComputeKind::Worker).is_native_projection())
+        .map(|(resource_id, _)| resource_id.as_str())
+        .collect::<Vec<_>>();
+
     let mut desired = config
         .environment_variables
         .variables
         .iter()
         .filter(|var| var.var_type == EnvironmentVariableType::Secret)
         .filter(|var| var.name != ENV_ALIEN_COMMANDS_TOKEN)
+        .filter(|var| {
+            vault_backed_workers
+                .iter()
+                .any(|resource_id| matches_resource_pattern(resource_id, &var.target_resources))
+        })
         .map(|var| (var.name.clone(), var.value.clone()))
         .collect::<BTreeMap<_, _>>();
 
-    if let Some(monitoring) = &config.monitoring {
+    if let Some(monitoring) = config
+        .monitoring
+        .as_ref()
+        .filter(|_| !vault_backed_workers.is_empty())
+    {
         desired.insert(
             RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string(),
             monitoring.logs_auth_header.clone(),
@@ -799,13 +822,14 @@ fn runtime_monitoring_secrets_hash(monitoring: &OtlpConfig) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-fn secrets_sync_hash(config: &DeploymentConfig) -> String {
+fn secrets_sync_hash(desired_secrets: &BTreeMap<String, String>) -> String {
     let mut hasher = Sha256::new();
     hasher.update(SECRETS_SYNC_SCHEMA_VERSION);
-    hasher.update(config.environment_variables.hash.as_bytes());
-    if let Some(monitoring) = &config.monitoring {
-        hasher.update(b"\0runtime-monitoring\0");
-        hasher.update(runtime_monitoring_secrets_hash(monitoring).as_bytes());
+    for (name, value) in desired_secrets {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(value.as_bytes());
+        hasher.update(b"\0");
     }
     format!("{:x}", hasher.finalize())
 }
@@ -1557,10 +1581,11 @@ mod tests {
     async fn machines_skips_stack_vault_secret_sync() {
         let mut config = make_config(make_snapshot(&[], &[("API_TOKEN", "secret")]));
         config.monitoring = Some(make_monitoring_with_metrics());
-        let expected_hash = secrets_sync_hash(&config);
+        let expected_hash = secrets_sync_hash(&BTreeMap::new());
         let mut runtime_metadata = RuntimeMetadata::default();
 
         let synced = sync_secrets_to_vault(
+            &make_single_function_stack("worker"),
             &StackState::new(Platform::Machines),
             &ClientConfig::Machines,
             &config,
@@ -1581,10 +1606,11 @@ mod tests {
     async fn deployment_without_secrets_vault_skips_empty_reconcile_and_deletion() {
         let stack_state = StackState::new(Platform::Test);
         let config = make_config(make_snapshot(&[], &[]));
-        let expected_hash = secrets_sync_hash(&config);
+        let expected_hash = secrets_sync_hash(&BTreeMap::new());
         let mut runtime_metadata = RuntimeMetadata::default();
 
         let synced = sync_secrets_to_vault(
+            &Stack::new("empty".to_string()).build(),
             &stack_state,
             &ClientConfig::Test,
             &config,
@@ -1599,6 +1625,7 @@ mod tests {
             Some(expected_hash.as_str())
         );
         assert!(!delete_deployment_vault_secrets(
+            &Stack::new("empty".to_string()).build(),
             &stack_state,
             &ClientConfig::Test,
             &config,
@@ -1615,6 +1642,7 @@ mod tests {
 
         assert!(
             sync_secrets_to_vault(
+                &make_single_function_stack("worker"),
                 &StackState::new(Platform::Test),
                 &ClientConfig::Test,
                 &config,
@@ -1623,6 +1651,61 @@ mod tests {
             .await
             .is_err(),
             "a missing vault must remain an error when secrets need persistence"
+        );
+    }
+
+    #[tokio::test]
+    async fn container_only_secret_does_not_require_stack_vault() {
+        let mut stack = make_compute_stack();
+        stack.resources.shift_remove("worker");
+        let config = make_config(make_snapshot(&[], &[("API_TOKEN", "secret")]));
+        let mut metadata = RuntimeMetadata::default();
+
+        let synced = sync_secrets_to_vault(
+            &stack,
+            &StackState::new(Platform::Aws),
+            &ClientConfig::Test,
+            &config,
+            &mut metadata,
+        )
+        .await
+        .expect("Container secrets use native projection without the stack vault");
+
+        assert!(!synced);
+        assert!(metadata.last_synced_secret_names.is_empty());
+    }
+
+    #[test]
+    fn vault_contains_only_secrets_targeted_to_vault_backed_workers() {
+        let mut config = make_config(EnvironmentVariablesSnapshot {
+            variables: vec![
+                EnvironmentVariable {
+                    name: "WORKER_TOKEN".to_string(),
+                    value: "worker-secret".to_string(),
+                    var_type: EnvironmentVariableType::Secret,
+                    target_resources: Some(vec!["worker".to_string()]),
+                },
+                EnvironmentVariable {
+                    name: "CONTAINER_TOKEN".to_string(),
+                    value: "container-secret".to_string(),
+                    var_type: EnvironmentVariableType::Secret,
+                    target_resources: Some(vec!["web".to_string()]),
+                },
+            ],
+            hash: "targeted".to_string(),
+            created_at: "now".to_string(),
+        });
+        config.monitoring = Some(make_monitoring_with_metrics());
+
+        let desired = desired_vault_secrets(&make_compute_stack(), Platform::Aws, &config);
+
+        assert_eq!(
+            desired.keys().cloned().collect::<Vec<_>>(),
+            vec![
+                "WORKER_TOKEN".to_string(),
+                RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string(),
+                RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET.to_string(),
+            ]
         );
     }
 
@@ -1636,7 +1719,11 @@ mod tests {
             metrics_auth_header: None,
             resource_attributes: HashMap::new(),
         });
-        let desired = desired_vault_secrets(&config);
+        let desired = desired_vault_secrets(
+            &make_single_function_stack("worker"),
+            Platform::Aws,
+            &config,
+        );
         let previously_owned = vec![
             "KEEP".to_string(),
             "REMOVED".to_string(),
@@ -1675,7 +1762,11 @@ mod tests {
             ],
         ));
 
-        let desired = desired_vault_secrets(&config);
+        let desired = desired_vault_secrets(
+            &make_single_function_stack("worker"),
+            Platform::Aws,
+            &config,
+        );
 
         assert_eq!(desired.get("APP_SECRET"), Some(&"app-value".to_string()));
         assert!(!desired.contains_key(ENV_ALIEN_COMMANDS_TOKEN));
@@ -1728,12 +1819,13 @@ mod tests {
         first.environment_variables.hash = "first".to_string();
         first.monitoring = Some(make_monitoring_with_metrics());
         let mut metadata = RuntimeMetadata::default();
+        let stack = make_single_function_stack("worker");
         // This is the real pre-inventory upgrade case: the old hash exists, but there is no list
         // of owned names. The reserved token still has to be deleted from the shared vault.
         metadata.last_synced_env_vars_hash = Some("legacy".to_string());
         metadata.last_synced_secret_names.clear();
         assert!(
-            sync_secrets_to_vault(&stack_state, &client_config, &first, &mut metadata)
+            sync_secrets_to_vault(&stack, &stack_state, &client_config, &first, &mut metadata)
                 .await
                 .expect("first sync")
         );
@@ -1758,11 +1850,15 @@ mod tests {
             metrics_auth_header: None,
             resource_attributes: HashMap::new(),
         });
-        assert!(
-            sync_secrets_to_vault(&stack_state, &client_config, &second, &mut metadata)
-                .await
-                .expect("second sync")
-        );
+        assert!(sync_secrets_to_vault(
+            &stack,
+            &stack_state,
+            &client_config,
+            &second,
+            &mut metadata
+        )
+        .await
+        .expect("second sync"));
 
         assert_eq!(vault.get_secret("KEEP").await.expect("kept value"), "v2");
         assert_eq!(
@@ -1788,7 +1884,7 @@ mod tests {
         let mut third = make_config(make_snapshot(&[], &[]));
         third.environment_variables.hash = "third".to_string();
         assert!(
-            sync_secrets_to_vault(&stack_state, &client_config, &third, &mut metadata)
+            sync_secrets_to_vault(&stack, &stack_state, &client_config, &third, &mut metadata)
                 .await
                 .expect("delete-only sync")
         );
@@ -1819,12 +1915,13 @@ mod tests {
         ));
         token_only.environment_variables.hash = "token-only".to_string();
         let old_hash = pre_v2_snapshot_only_sync_hash(&token_only);
-        let policy_hash = secrets_sync_hash(&token_only);
+        let policy_hash = secrets_sync_hash(&BTreeMap::new());
         assert_ne!(old_hash, policy_hash);
         let mut legacy_metadata = RuntimeMetadata::default();
         legacy_metadata.last_synced_env_vars_hash = Some(old_hash);
 
         assert!(sync_secrets_to_vault(
+            &stack,
             &stack_state,
             &client_config,
             &token_only,
@@ -1839,6 +1936,7 @@ mod tests {
             Some(policy_hash.as_str())
         );
         assert!(!sync_secrets_to_vault(
+            &stack,
             &stack_state,
             &client_config,
             &token_only,
@@ -1903,6 +2001,7 @@ mod tests {
         };
 
         assert!(delete_deployment_vault_secrets(
+            &make_single_function_stack("worker"),
             &stack_state,
             &client_config,
             &config,

--- a/crates/alien-deployment/src/helpers.rs
+++ b/crates/alien-deployment/src/helpers.rs
@@ -746,13 +746,18 @@ fn desired_vault_secrets(
     platform: Platform,
     config: &DeploymentConfig,
 ) -> BTreeMap<String, String> {
-    let vault_backed_workers = stack
+    let workers = stack
         .resources
         .iter()
         .filter(|(_, entry)| entry.config.resource_type() == Worker::RESOURCE_TYPE)
-        .filter(|_| !SecretDelivery::resolve(platform, ComputeKind::Worker).is_native_projection())
         .map(|(resource_id, _)| resource_id.as_str())
         .collect::<Vec<_>>();
+    let vault_backed_workers =
+        if SecretDelivery::resolve(platform, ComputeKind::Worker).is_native_projection() {
+            Vec::new()
+        } else {
+            workers.clone()
+        };
 
     let mut desired = config
         .environment_variables
@@ -771,7 +776,7 @@ fn desired_vault_secrets(
     if let Some(monitoring) = config
         .monitoring
         .as_ref()
-        .filter(|_| !vault_backed_workers.is_empty())
+        .filter(|_| platform != Platform::Machines && !workers.is_empty())
     {
         desired.insert(
             RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string(),
@@ -1703,6 +1708,26 @@ mod tests {
             desired.keys().cloned().collect::<Vec<_>>(),
             vec![
                 "WORKER_TOKEN".to_string(),
+                RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string(),
+                RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET.to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn kubernetes_worker_keeps_runtime_monitoring_secrets_in_vault() {
+        let mut config = make_config(make_snapshot(&[], &[("APP_TOKEN", "app-secret")]));
+        config.monitoring = Some(make_monitoring_with_metrics());
+
+        let desired = desired_vault_secrets(
+            &make_single_function_stack("worker"),
+            Platform::Kubernetes,
+            &config,
+        );
+
+        assert_eq!(
+            desired.keys().cloned().collect::<Vec<_>>(),
+            vec![
                 RUNTIME_OTLP_LOGS_AUTH_HEADER_SECRET.to_string(),
                 RUNTIME_OTLP_METRICS_AUTH_HEADER_SECRET.to_string(),
             ]

--- a/crates/alien-deployment/src/initial_setup.rs
+++ b/crates/alien-deployment/src/initial_setup.rs
@@ -80,6 +80,7 @@ pub async fn handle_initial_setup(
 
     if vault_is_running {
         let synced = crate::helpers::sync_secrets_to_vault(
+            &target_stack,
             &stack_state,
             &client_config,
             &config,

--- a/crates/alien-deployment/src/provisioning.rs
+++ b/crates/alien-deployment/src/provisioning.rs
@@ -92,6 +92,7 @@ pub async fn handle_provisioning(
     // The vault was deployed during InitialSetup and is now Running.
     // Hash check inside sync_secrets_to_vault prevents redundant cloud calls.
     let synced = crate::helpers::sync_secrets_to_vault(
+        &target_stack,
         &stack_state,
         &client_config,
         &config,

--- a/crates/alien-deployment/src/updating.rs
+++ b/crates/alien-deployment/src/updating.rs
@@ -281,6 +281,7 @@ pub async fn handle_updating(
     // This checks the hash and only syncs if needed
     info!("Syncing secrets to vault before updating live resources");
     let synced = crate::helpers::sync_secrets_to_vault(
+        &target_stack,
         &stack_state,
         &client_config,
         &config,

--- a/crates/alien-deployment/tests/test_platform.rs
+++ b/crates/alien-deployment/tests/test_platform.rs
@@ -223,10 +223,12 @@ fn create_env_vars_snapshot(hash: &str, include_secret: bool) -> EnvironmentVari
     }
 }
 
-fn expected_secrets_sync_hash(snapshot_hash: &str) -> String {
+fn expected_secrets_sync_hash(secret_value: &str) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"\0vault-sync:no-app-command-token:v2\0");
-    hasher.update(snapshot_hash.as_bytes());
+    hasher.update(b"\0vault-sync:vault-backed-consumers:v3\0");
+    hasher.update(b"SECRET_VAR\0");
+    hasher.update(secret_value.as_bytes());
+    hasher.update(b"\0");
     format!("{:x}", hasher.finalize())
 }
 
@@ -417,7 +419,7 @@ async fn test_provisioning_syncs_secrets_before_live_compute() {
             .unwrap()
             .last_synced_env_vars_hash
             .as_deref(),
-        Some(expected_secrets_sync_hash("hash_v1").as_str()),
+        Some(expected_secrets_sync_hash("secret_value").as_str()),
         "Secrets should be synced before live compute is stepped"
     );
 }
@@ -449,7 +451,7 @@ async fn test_deploy_with_secrets_reaches_running() {
             .unwrap()
             .last_synced_env_vars_hash
             .as_deref(),
-        Some(expected_secrets_sync_hash("hash_v1").as_str()),
+        Some(expected_secrets_sync_hash("secret_value").as_str()),
     );
 }
 
@@ -484,7 +486,7 @@ async fn test_provisioning_syncs_secrets_once_per_hash() {
             .last_synced_env_vars_hash
             .as_ref()
             .unwrap(),
-        &expected_secrets_sync_hash("hash_v1")
+        &expected_secrets_sync_hash("secret_value")
     );
 
     // Run another step with same config (should skip sync)
@@ -502,7 +504,7 @@ async fn test_provisioning_syncs_secrets_once_per_hash() {
             .last_synced_env_vars_hash
             .as_ref()
             .unwrap(),
-        &expected_secrets_sync_hash("hash_v1")
+        &expected_secrets_sync_hash("secret_value")
     );
 
     // Should continue progressing (no error from skipped sync)
@@ -539,11 +541,13 @@ async fn test_provisioning_resyncs_when_hash_changes() {
             .last_synced_env_vars_hash
             .as_ref()
             .unwrap(),
-        &expected_secrets_sync_hash("hash_v1")
+        &expected_secrets_sync_hash("secret_value")
     );
 
-    // Now change config to hash_v2
-    let config2 = create_test_config("hash_v2", true);
+    // Now change the desired secret value. Snapshot-only changes intentionally
+    // do not trigger vault writes when the desired vault contents are unchanged.
+    let mut config2 = create_test_config("hash_v2", true);
+    config2.environment_variables.variables[1].value = "secret_value_v2".to_string();
 
     // If provisioning already completed (transitioned to Running), set state
     // back to Provisioning to test the resync behavior.
@@ -566,7 +570,7 @@ async fn test_provisioning_resyncs_when_hash_changes() {
             .last_synced_env_vars_hash
             .as_ref()
             .unwrap(),
-        &expected_secrets_sync_hash("hash_v2")
+        &expected_secrets_sync_hash("secret_value_v2")
     );
 }
 


### PR DESCRIPTION
## Summary

- derive vault contents from active workloads that actually use vault-backed secret delivery
- respect each secret environment variable's resource targets
- hash only the desired vault contents, avoiding reconciles for native-projected secrets
- retain cleanup of secrets that were previously owned by the deployment

Fixes ALIEN-445.

## Testing

- `cargo test -p alien-deployment --lib` (92 passed)