### PR TITLE
ci: add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What changed

- add a CodeQL advanced setup workflow for GitHub Actions, JavaScript/TypeScript, and Rust
- run analysis for pushes to `main`, pull requests targeting `main`, a weekly schedule, and manual dispatches
- use no-build analysis with the `security-extended` query suite
- limit workflow permissions to repository contents read access and code-scanning result uploads

## Why

The public repository does not currently run CodeQL. Adding it provides automated static security analysis across the repository's primary languages and its GitHub Actions workflows.

## Impact

The workflow adds three parallel security scanning jobs. It does not change application runtime behavior or release artifacts.

## Validation

- `actionlint -verbose .github/workflows/codeql.yml` (0 errors)
- `git diff --check`
- confirmed current stable action majors: `actions/checkout@v7` and `github/codeql-action@v4`

Linear: [ALIEN-454](https://linear.app/alienplatform/issue/ALIEN-454/add-codeql-scanning-to-the-oss-repository)
