### PR TITLE
chore(renovate): avoid unsafe 0.x minor upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "group:allNonMajor"],
+  "extends": ["config:recommended"],
   "additionalBranchPrefix": "alien-370-",
   "packageRules": [
     {
@@ -12,6 +12,12 @@
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
+    },
+    {
+      "description": "Do not treat potentially breaking 0.x minor releases as routine updates",
+      "matchUpdateTypes": ["minor"],
+      "matchCurrentVersion": "/^0\\./",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- stop grouping every non-major dependency update as safe
- keep stable minor/patch automerge behavior
- suppress 0.x minor jumps, which may contain breaking changes under SemVer

Tracks ALIEN-370.