### PR TITLE
fix(commands): support TypeScript 5.9 fetch bodies

### DIFF
--- a/packages/commands/src/presigned.ts
+++ b/packages/commands/src/presigned.ts
@@ -167,12 +167,15 @@ export async function uploadPresigned(
 
   if (request.backend.type === "http") {
     const fetchImpl = options.fetchImpl ?? fetch
+    // Copy into an ArrayBuffer-backed view. Callers may provide a view backed
+    // by SharedArrayBuffer, which is intentionally not accepted by BodyInit.
+    const body = new Uint8Array(bytes)
     let response: Response
     try {
       response = await fetchImpl(request.backend.url, {
         method: request.backend.method,
         headers: request.backend.headers,
-        body: bytes,
+        body,
         signal: transferSignal(options.signal),
       })
     } catch {


### PR DESCRIPTION
## Summary

- copy presigned upload bytes into an ArrayBuffer-backed view before passing them to fetch
- support TypeScript 5.9\x27s stricter BodyInit typing
- retain byte-for-byte upload behavior

Validated against the repaired TypeScript 5.9 Renovate branch; the original presigned upload type error is eliminated.

Tracks ALIEN-370.