### PR TITLE
chore(renovate): isolate stable dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,9 @@
   "additionalBranchPrefix": "alien-370-",
   "packageRules": [
     {
-      "description": "Automerge stable non-major updates",
+      "description": "Automerge stable non-major updates independently",
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
-      "groupName": "stable non-major dependencies",
-      "groupSlug": "stable-minor-patch",
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"


### PR DESCRIPTION
## Summary

- keep stable minor and patch automerge
- stop grouping unrelated stable dependencies into one pull request
- let safe updates merge independently instead of being blocked by one incompatible package

Validated with Renovate's config validator.

Tracks ALIEN-370.