### PR TITLE
chore(renovate): gate major updates in dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": "/^0\\./",
       "enabled": false
+    },
+    {
+      "description": "Require explicit dashboard approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- require explicit Dependency Dashboard approval before opening major-version PRs
- keep stable minor and patch updates automatic and independent
- reduce noisy red Renovate PRs while preserving visibility of available majors

Validated with Renovate's config validator.

Tracks ALIEN-370.