### PR TITLE
chore(renovate): let Renovate perform automerges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "additionalBranchPrefix": "alien-370-",
+  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Automerge stable non-major updates independently",


### PR DESCRIPTION
## Summary

- disable GitHub-native automerge for Renovate
- let Renovate perform eligible PR merges with its GitHub App identity
- preserve the existing update eligibility, merge strategy, and required CI checks

## Why

GitHub-native auto-merge executes the merge as GitHub, so a ruleset bypass granted to the Renovate GitHub App is not used. With `platformAutomerge: false`, Renovate calls GitHub's merge API itself after the PR is ready.

This allows the Renovate App to bypass the separate Greptile review ruleset while the main CI ruleset remains enforced. The Renovate App still needs to be present in the Greptile ruleset's bypass list.

The accepted tradeoff is that eligible PRs merge on a Renovate run instead of immediately when GitHub sees all requirements pass.

## Validation

- `npx --yes --package renovate -- renovate-config-validator`
- `git diff --check`
