### PR TITLE
fix(renovate): let bot perform bypass merges (ALIEN-370)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "additionalBranchPrefix": "alien-370-",
+  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Automerge stable non-major updates independently",


### PR DESCRIPTION
## Summary

- disable GitHub platform-native auto-merge for Renovate PRs
- let the Renovate app perform green merges itself so its Greptile-only ruleset bypass applies
- retain all required CI enforcement through the separate main ruleset

## Verification

- `jq empty renovate.json`
- `git diff --check`

Linear: ALIEN-370