### PR TITLE
fix(renovate): restore native automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "additionalBranchPrefix": "alien-370-",
-  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Automerge stable non-major updates independently after CI passes",


### PR DESCRIPTION
Linear: ALIEN-370

## Summary
- restore GitHub-native automerge for eligible Renovate PRs
- keep `All tests passed` required
- keep Greptile absent for `renovate[bot]` via the scoped ruleset bypass

## Why
Live verification showed that with `platformAutomerge: false`, Renovate sees the missing required Greptile context and will not attempt a direct merge, so the bypass is never exercised. GitHub-native automerge requests created by `app/renovate` already proved they merge successfully after CI through the scoped bypass.