### PR TITLE
fix(email): protect inbound routing ownership

### DIFF
--- a/crates/alien-aws-clients/src/aws/mod.rs
+++ b/crates/alien-aws-clients/src/aws/mod.rs
@@ -65,6 +65,7 @@ pub mod rds;
 pub mod resourcegroupstagging;
 pub mod s3;
 pub mod secrets_manager;
+pub mod ses;
 pub mod sqs;
 pub mod ssm;
 pub mod sts;

--- a/crates/alien-aws-clients/src/aws/ses.rs
+++ b/crates/alien-aws-clients/src/aws/ses.rs
@@ -1,0 +1,148 @@
+//! AWS Simple Email Service (SES) v1 client.
+
+use std::fmt::Debug;
+
+use crate::aws::aws_request_utils::{AwsRequestBuilderExt, AwsSignConfig};
+use crate::aws::credential_provider::AwsCredentialProvider;
+use alien_client_core::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+#[cfg(feature = "test-utils")]
+use mockall::automock;
+
+/// Metadata for the active SES receipt rule set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveReceiptRuleSet {
+    /// Name of the active rule set, or `None` when receiving is inactive.
+    pub name: Option<String>,
+}
+
+/// Read-only SES operations used by resource health checks.
+#[cfg_attr(feature = "test-utils", automock)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait SesApi: Send + Sync + Debug {
+    /// Return the account's active receipt rule set in the configured region.
+    async fn describe_active_receipt_rule_set(&self) -> Result<ActiveReceiptRuleSet>;
+}
+
+/// AWS SES v1 Query API client.
+#[derive(Debug, Clone)]
+pub struct SesClient {
+    client: Client,
+    credentials: AwsCredentialProvider,
+}
+
+impl SesClient {
+    /// Create an SES client.
+    pub fn new(client: Client, credentials: AwsCredentialProvider) -> Self {
+        Self {
+            client,
+            credentials,
+        }
+    }
+
+    fn sign_config(&self) -> AwsSignConfig {
+        AwsSignConfig {
+            service_name: "ses".into(),
+            region: self.credentials.region().to_string(),
+            credentials: self.credentials.get_credentials(),
+            signing_region: None,
+        }
+    }
+
+    fn base_url(&self) -> String {
+        self.credentials
+            .get_service_endpoint_option("ses")
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("https://email.{}.amazonaws.com", self.credentials.region()))
+    }
+
+    fn host(&self) -> String {
+        format!("email.{}.amazonaws.com", self.credentials.region())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct DescribeActiveReceiptRuleSetResponse {
+    describe_active_receipt_rule_set_result: DescribeActiveReceiptRuleSetResult,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct DescribeActiveReceiptRuleSetResult {
+    metadata: Option<ReceiptRuleSetMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct ReceiptRuleSetMetadata {
+    name: String,
+}
+
+#[async_trait]
+impl SesApi for SesClient {
+    async fn describe_active_receipt_rule_set(&self) -> Result<ActiveReceiptRuleSet> {
+        self.credentials.ensure_fresh().await?;
+        let body = "Action=DescribeActiveReceiptRuleSet&Version=2010-12-01";
+        let builder = self
+            .client
+            .post(self.base_url())
+            .host(&self.host())
+            .content_type_form()
+            .body(body);
+        let response: DescribeActiveReceiptRuleSetResponse =
+            crate::aws::aws_request_utils::sign_send_xml(builder, &self.sign_config()).await?;
+
+        Ok(ActiveReceiptRuleSet {
+            name: response
+                .describe_active_receipt_rule_set_result
+                .metadata
+                .map(|metadata| metadata.name),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_active_rule_set() {
+        let response: DescribeActiveReceiptRuleSetResponse = quick_xml::de::from_str(
+            r#"<DescribeActiveReceiptRuleSetResponse>
+                <DescribeActiveReceiptRuleSetResult>
+                    <Metadata><Name>example-inbound</Name></Metadata>
+                </DescribeActiveReceiptRuleSetResult>
+            </DescribeActiveReceiptRuleSetResponse>"#,
+        )
+        .expect("response should parse");
+
+        assert_eq!(
+            response
+                .describe_active_receipt_rule_set_result
+                .metadata
+                .expect("metadata")
+                .name,
+            "example-inbound"
+        );
+    }
+
+    #[test]
+    fn parses_no_active_rule_set() {
+        let response: DescribeActiveReceiptRuleSetResponse = quick_xml::de::from_str(
+            r#"<DescribeActiveReceiptRuleSetResponse>
+                <DescribeActiveReceiptRuleSetResult />
+            </DescribeActiveReceiptRuleSetResponse>"#,
+        )
+        .expect("response should parse");
+
+        assert!(response
+            .describe_active_receipt_rule_set_result
+            .metadata
+            .is_none());
+    }
+}

--- a/crates/alien-aws-clients/src/lib.rs
+++ b/crates/alien-aws-clients/src/lib.rs
@@ -23,6 +23,7 @@ pub use aws::rds::{RdsApi, RdsClient};
 pub use aws::resourcegroupstagging::{ResourceGroupsTaggingApi, ResourceGroupsTaggingClient};
 pub use aws::s3::{S3Api, S3Client};
 pub use aws::secrets_manager::{SecretsManagerApi, SecretsManagerClient};
+pub use aws::ses::{SesApi, SesClient};
 pub use aws::sqs::{SqsApi, SqsClient};
 pub use aws::sts::{StsApi, StsClient};
 

--- a/crates/alien-cloudformation/src/emitters/aws/email.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/email.rs
@@ -60,7 +60,16 @@ def handler(event, context):
             if active == physical_id:
                 ses.set_active_receipt_rule_set()
         else:
-            ses.set_active_receipt_rule_set(RuleSetName=desired)
+            active = ses.describe_active_receipt_rule_set().get("Metadata", {}).get("Name")
+            if active and active != desired:
+                raise RuntimeError(
+                    f"SES receipt rule set '{active}' is already active in this account and region. "
+                    "Inbound email resources require exclusive ownership of SES receiving. "
+                    "Existing routing was not modified; choose an unused region or intentionally "
+                    "deactivate the existing rule set before retrying."
+                )
+            if active != desired:
+                ses.set_active_receipt_rule_set(RuleSetName=desired)
             physical_id = desired
         cfnresponse.send(
             event, context, cfnresponse.SUCCESS, {}, physicalResourceId=physical_id

--- a/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
@@ -165,6 +165,9 @@ fn aws_email_renders_ses_infrastructure() {
         ["ZipFile"]
         .as_str()
         .expect("inline custom-resource handler");
+    assert!(activator_code.contains("if active and active != desired:"));
+    assert!(activator_code.contains("Existing routing was not modified"));
+    assert!(activator_code.contains("if active != desired:"));
     assert!(activator_code.contains("ses.set_active_receipt_rule_set(RuleSetName=desired)"));
     assert!(activator_code.contains("if active == physical_id:"));
     assert!(activator_code.contains("ses.set_active_receipt_rule_set()"));

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_email_tests__aws_email.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_email_tests__aws_email.snap
@@ -363,7 +363,16 @@ Resources:
                       if active == physical_id:
                           ses.set_active_receipt_rule_set()
                   else:
-                      ses.set_active_receipt_rule_set(RuleSetName=desired)
+                      active = ses.describe_active_receipt_rule_set().get("Metadata", {}).get("Name")
+                      if active and active != desired:
+                          raise RuntimeError(
+                              f"SES receipt rule set '{active}' is already active in this account and region. "
+                              "Inbound email resources require exclusive ownership of SES receiving. "
+                              "Existing routing was not modified; choose an unused region or intentionally "
+                              "deactivate the existing rule set before retrying."
+                          )
+                      if active != desired:
+                          ses.set_active_receipt_rule_set(RuleSetName=desired)
                       physical_id = desired
                   cfnresponse.send(
                       event, context, cfnresponse.SUCCESS, {}, physicalResourceId=physical_id

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_full_stack_tests__aws_full_stack.snap
@@ -1341,7 +1341,16 @@ Resources:
                       if active == physical_id:
                           ses.set_active_receipt_rule_set()
                   else:
-                      ses.set_active_receipt_rule_set(RuleSetName=desired)
+                      active = ses.describe_active_receipt_rule_set().get("Metadata", {}).get("Name")
+                      if active and active != desired:
+                          raise RuntimeError(
+                              f"SES receipt rule set '{active}' is already active in this account and region. "
+                              "Inbound email resources require exclusive ownership of SES receiving. "
+                              "Existing routing was not modified; choose an unused region or intentionally "
+                              "deactivate the existing rule set before retrying."
+                          )
+                      if active != desired:
+                          ses.set_active_receipt_rule_set(RuleSetName=desired)
                       physical_id = desired
                   cfnresponse.send(
                       event, context, cfnresponse.SUCCESS, {}, physicalResourceId=physical_id

--- a/crates/alien-core/src/resources/email.rs
+++ b/crates/alien-core/src/resources/email.rs
@@ -35,8 +35,10 @@ use std::fmt::Debug;
 ///
 /// Alien activates the provisioned receipt rule set as part of setup. Because
 /// SES permits only one active receipt rule set per AWS account and region, an
-/// AWS stack may contain only one email resource with inbound delivery, and
-/// installing it makes its rule set the account's active rule set. SES email
+/// AWS stack may contain only one email resource with inbound delivery. The
+/// resource requires exclusive ownership of SES receiving in its account and
+/// region: setup refuses to replace an active rule set it does not own. Choose
+/// an unused region when the account already receives email through SES. SES email
 /// receiving is available only in a subset of AWS regions; deploying `inbound`
 /// to an unsupported region fails during setup.
 ///

--- a/crates/alien-infra/src/core/service_provider.rs
+++ b/crates/alien-infra/src/core/service_provider.rs
@@ -17,6 +17,7 @@ use alien_aws_clients::{
     rds::{RdsApi, RdsClient},
     s3::{S3Api, S3Client},
     secrets_manager::{SecretsManagerApi, SecretsManagerClient},
+    ses::{SesApi, SesClient},
     sqs::{SqsApi, SqsClient},
     ssm::{SsmApi, SsmClient},
     AwsClientConfig, AwsCredentialProvider,
@@ -94,6 +95,7 @@ pub trait PlatformServiceProvider: Send + Sync {
     async fn get_aws_iam_client(&self, config: &AwsClientConfig) -> Result<Arc<dyn IamApi>>;
     async fn get_aws_lambda_client(&self, config: &AwsClientConfig) -> Result<Arc<dyn LambdaApi>>;
     async fn get_aws_s3_client(&self, config: &AwsClientConfig) -> Result<Arc<dyn S3Api>>;
+    async fn get_aws_ses_client(&self, config: &AwsClientConfig) -> Result<Arc<dyn SesApi>>;
     async fn get_aws_cloudformation_client(
         &self,
         config: &AwsClientConfig,
@@ -469,6 +471,19 @@ impl PlatformServiceProvider for DefaultPlatformServiceProvider {
                 resource_id: None,
             })?;
         Ok(Arc::new(S3Client::new(reqwest::Client::new(), credentials)))
+    }
+
+    async fn get_aws_ses_client(&self, config: &AwsClientConfig) -> Result<Arc<dyn SesApi>> {
+        let credentials = AwsCredentialProvider::from_config(config.clone())
+            .await
+            .context(crate::error::ErrorData::CloudPlatformError {
+                message: "Failed to create AWS credential provider".to_string(),
+                resource_id: None,
+            })?;
+        Ok(Arc::new(SesClient::new(
+            reqwest::Client::new(),
+            credentials,
+        )))
     }
 
     async fn get_aws_cloudformation_client(

--- a/crates/alien-infra/src/email/aws.rs
+++ b/crates/alien-infra/src/email/aws.rs
@@ -8,10 +8,10 @@
 //! imported state through the deployment loop and expose
 //! [`alien_core::EmailOutputs`].
 //!
-//! The `Ready` handler is passive: there is no SES client in
-//! `alien-aws-clients` yet, so no liveness probe (`ses:GetConfigurationSet`,
-//! covered by the `email/management` permission set) is performed. Adding an
-//! active heartbeat is a follow-up that lands together with an SES client.
+//! The `Ready` handler verifies that an imported inbound receipt rule set
+//! remains active. This detects account-level SES routing changes that would
+//! otherwise leave the deployment apparently healthy while mail is no longer
+//! delivered to its storage binding.
 
 use std::collections::BTreeMap;
 use std::time::Duration;
@@ -19,12 +19,27 @@ use std::time::Duration;
 use crate::core::ResourceControllerContext;
 use crate::error::{ErrorData, Result};
 use alien_core::{Email, EmailDomainOutputs, EmailOutputs, ResourceOutputs, ResourceStatus};
-use alien_error::AlienError;
+use alien_error::{AlienError, Context};
 use alien_macros::controller;
 
-/// How often the passive `Ready` handler re-runs. There is no cloud probe
-/// behind it, so a long interval avoids pointless churn in the refresh loop.
+/// How often the active receipt-rule-set check runs.
 const READY_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+fn verify_active_rule_set(resource_id: &str, expected: &str, observed: Option<&str>) -> Result<()> {
+    if observed == Some(expected) {
+        return Ok(());
+    }
+
+    Err(AlienError::new(ErrorData::CloudPlatformError {
+        message: format!(
+            "Expected SES receipt rule set '{expected}' to be active, but observed {}",
+            observed
+                .map(|name| format!("'{name}'"))
+                .unwrap_or_else(|| "no active rule set".to_string())
+        ),
+        resource_id: Some(resource_id.to_string()),
+    }))
+}
 
 #[controller]
 pub struct AwsEmailController {
@@ -66,14 +81,31 @@ impl AwsEmailController {
     }
 
     // ─────────────── READY STATE ────────────────────────────────
-    /// Passive refresh: no SES client exists in `alien-aws-clients` yet, so
-    /// this performs no liveness probe. See the module docs.
+    /// Verify that SES still routes inbound mail through this resource.
     #[handler(
         state = Ready,
         on_failure = RefreshFailed,
         status = ResourceStatus::Running,
     )]
-    async fn ready(&mut self, _ctx: &ResourceControllerContext<'_>) -> Result<HandlerAction> {
+    async fn ready(&mut self, ctx: &ResourceControllerContext<'_>) -> Result<HandlerAction> {
+        if let Some(expected) = &self.rule_set_name {
+            let config = ctx.desired_resource_config::<Email>()?;
+            let client = ctx
+                .service_provider
+                .get_aws_ses_client(ctx.get_aws_config()?)
+                .await?;
+            let observed = client
+                .describe_active_receipt_rule_set()
+                .await
+                .context(ErrorData::CloudPlatformError {
+                    message: "Failed to verify the active SES receipt rule set".to_string(),
+                    resource_id: Some(config.id.clone()),
+                })?
+                .name;
+
+            verify_active_rule_set(&config.id, expected, observed.as_deref())?;
+        }
+
         Ok(HandlerAction::Continue {
             state: Ready,
             suggested_delay: Some(READY_REFRESH_INTERVAL),
@@ -120,5 +152,27 @@ impl AwsEmailController {
             binding["region"] = serde_json::Value::String(region.clone());
         }
         Ok(Some(binding))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verify_active_rule_set;
+
+    #[test]
+    fn active_rule_set_matches() {
+        verify_active_rule_set("mail", "expected", Some("expected")).unwrap();
+    }
+
+    #[test]
+    fn missing_active_rule_set_is_unhealthy() {
+        let error = verify_active_rule_set("mail", "expected", None).unwrap_err();
+        assert!(error.to_string().contains("observed no active rule set"));
+    }
+
+    #[test]
+    fn different_active_rule_set_is_unhealthy() {
+        let error = verify_active_rule_set("mail", "expected", Some("other")).unwrap_err();
+        assert!(error.to_string().contains("observed 'other'"));
     }
 }


### PR DESCRIPTION
## Summary
- refuse to replace an unrelated active SES receipt rule set during setup
- keep create, update, and delete activation behavior idempotent and ownership-safe
- verify the imported rule set on the Email resource heartbeat and surface drift through the existing refresh-failed state
- document the account-region exclusivity contract

## Validation
- `cargo check -p alien-aws-clients -p alien-cloudformation`
- `cargo check -p alien-infra --features all-platforms`
- `cargo test -p alien-aws-clients aws::ses::tests --lib`
- `cargo test -p alien-cloudformation aws_email --test generator`
- `cargo test -p alien-infra email::aws::tests --features all-platforms --lib`

Linear: ALIEN-477