### PR TITLE
fix(commands): authorize operator dispatch (ALIEN-428)

### DIFF
--- a/crates/alien-commands/src/server/command_registry.rs
+++ b/crates/alien-commands/src/server/command_registry.rs
@@ -153,9 +153,11 @@ pub const OPERATOR_COMMAND_TARGET_ID: &str = "operator";
 ///   id never falls back to shorthand. The reserved
 ///   [`OPERATOR_COMMAND_TARGET_ID`] always resolves to a pull-mode daemon
 ///   target for the operator, independent of the stack.
-/// - `requested = None` (single-target shorthand): exactly one target must
-///   exist, else `COMMAND_TARGET_AMBIGUOUS` (more than one) or
-///   `NO_COMMAND_TARGETS` (none).
+/// - `requested = None` (single-target shorthand): exactly one non-reserved
+///   stack target must exist, else `COMMAND_TARGET_AMBIGUOUS` (more than one)
+///   or `NO_COMMAND_TARGETS` (none). A registered target named
+///   [`OPERATOR_COMMAND_TARGET_ID`] is excluded so shorthand can never address
+///   the operator.
 ///
 /// The resolved target's own id is also validated, so a target registered with
 /// a `:`-bearing id can never resolve into the key grammar.
@@ -194,19 +196,22 @@ pub fn select_command_target(
                 })?
                 .clone()
         }
-        None => match targets {
-            [] => {
+        None => {
+            let mut candidates = targets
+                .iter()
+                .filter(|target| target.resource_id != OPERATOR_COMMAND_TARGET_ID);
+            let Some(single) = candidates.next() else {
                 return Err(AlienError::new(ErrorData::NoCommandTargets {
                     deployment_id: deployment_id.to_string(),
-                }))
-            }
-            [single] => single.clone(),
-            _ => {
+                }));
+            };
+            if candidates.next().is_some() {
                 return Err(AlienError::new(ErrorData::CommandTargetAmbiguous {
                     deployment_id: deployment_id.to_string(),
-                }))
+                }));
             }
-        },
+            single.clone()
+        }
     };
 
     // A registered target whose id breaks the key grammar must never resolve.
@@ -714,6 +719,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_shorthand_operator_only_is_no_targets() {
+        let registry = InMemoryCommandRegistry::new();
+        registry
+            .register_target(OPERATOR_COMMAND_TARGET_ID, CommandTargetType::Daemon)
+            .await
+            .unwrap();
+
+        let err = resolved(&registry, None).await.unwrap_err();
+        assert_eq!(err.code, "NO_COMMAND_TARGETS");
+        assert_eq!(err.http_status_code, Some(422));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_shorthand_ignores_operator_beside_one_stack_target() {
+        let registry = InMemoryCommandRegistry::new();
+        registry
+            .register_target(OPERATOR_COMMAND_TARGET_ID, CommandTargetType::Daemon)
+            .await
+            .unwrap();
+        registry
+            .register_target("daemon-1", CommandTargetType::Daemon)
+            .await
+            .unwrap();
+
+        let result = resolved(&registry, None).await.unwrap();
+        assert_eq!(
+            result.target,
+            CommandTarget::new("daemon-1", CommandTargetType::Daemon)
+        );
+    }
+
+    #[tokio::test]
     async fn test_delivery_mode_container_and_daemon_always_pull() {
         // Even with a Push-capable worker context, Container/Daemon are Pull.
         let registry =
@@ -926,8 +963,7 @@ mod tests {
         // The reserved operator id resolves to a pull-mode daemon target even
         // when no stack targets exist — operations commands address the operator
         // itself, which is never a stack resource.
-        let target =
-            select_command_target("dep-1", &[], Some(OPERATOR_COMMAND_TARGET_ID)).unwrap();
+        let target = select_command_target("dep-1", &[], Some(OPERATOR_COMMAND_TARGET_ID)).unwrap();
         assert_eq!(target.resource_id, OPERATOR_COMMAND_TARGET_ID);
         assert_eq!(target.resource_type, CommandTargetType::Daemon);
         // A daemon target always delivers via pull, regardless of worker mode.

--- a/crates/alien-commands/src/server/mod.rs
+++ b/crates/alien-commands/src/server/mod.rs
@@ -1035,6 +1035,14 @@ impl CommandServer {
         Ok(status.map(|s| s.deployment_id))
     }
 
+    /// Get the command registry's canonical status record for authorization.
+    pub async fn get_command_status_record(
+        &self,
+        command_id: &str,
+    ) -> Result<Option<CommandStatus>> {
+        self.command_registry.get_command_status(command_id).await
+    }
+
     /// Get the command's canonical ownership fields for route authorization.
     pub async fn get_command_access_context(
         &self,

--- a/crates/alien-commands/tests/integration_tests.rs
+++ b/crates/alien-commands/tests/integration_tests.rs
@@ -633,6 +633,44 @@ mod tests {
         assert_eq!(err.code, "COMMAND_TARGET_AMBIGUOUS");
     }
 
+    /// A registered target using the reserved operator id never becomes a
+    /// shorthand candidate. A targetless create routes to the sole stack
+    /// target, and the operator cannot lease that command.
+    #[tokio::test]
+    async fn test_create_shorthand_ignores_reserved_operator_target() {
+        let server = TestCommandServer::builder().with_pull_mode().build().await;
+        server
+            .registry
+            .register_target("operator", CommandTargetType::Daemon)
+            .await
+            .unwrap();
+
+        let request = test_inline_create_command("target-agent", "targeted-command");
+        let created = server.create_command(request).await.unwrap();
+
+        let operator_leases = server
+            .acquire_lease(
+                "target-agent",
+                LeaseRequest {
+                    deployment_id: "target-agent".to_string(),
+                    target: CommandTarget::new("operator", CommandTargetType::Daemon),
+                    max_leases: 1,
+                    lease_seconds: 60,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(operator_leases.leases.is_empty());
+
+        let lease = server
+            .acquire_single_lease("target-agent")
+            .await
+            .unwrap()
+            .expect("the normal target should lease the shorthand command");
+        assert_eq!(lease.command_id, created.command_id);
+        assert_eq!(lease.envelope.target, server.default_target);
+    }
+
     /// Each target leases only its own commands: two targets, two commands,
     /// each lease scan returns only the requester's command.
     #[tokio::test]

--- a/crates/alien-manager/src/auth/command_capability.rs
+++ b/crates/alien-manager/src/auth/command_capability.rs
@@ -2,14 +2,51 @@
 //!
 //! OSS and hosted managers have different policies for their normal subjects,
 //! but a commands capability must mean exactly the same thing in both:
-//! sender access is bound to one deployment, and receiver access is bound to
-//! one deployment plus one exact target.
+//! sender access is bound to one deployment, operations access is additionally
+//! bound to one exact command, and receiver access is bound to one deployment
+//! plus one exact target.
 
+use alien_commands::server::command_registry::OPERATOR_COMMAND_TARGET_ID;
 use alien_commands::server::CommandAccessContext;
 use alien_core::CommandTarget;
 
 use crate::auth::{CommandCapability, Role, Scope, Subject};
 use crate::traits::deployment_store::DeploymentRecord;
+
+/// Decide whether a commands-scoped subject may create this request.
+///
+/// Ordinary senders may address stack targets but never the reserved operations
+/// target. The operations capability has the inverse access: it is bound to one
+/// deployment and may address only the reserved target.
+pub fn create_request_decision(
+    subject: &Subject,
+    deployment_id: &str,
+    command: &str,
+    requested_target: Option<&str>,
+) -> Option<bool> {
+    let Scope::Commands {
+        deployment_id: scoped_deployment_id,
+        capability,
+        ..
+    } = &subject.scope
+    else {
+        return None;
+    };
+
+    let target_allowed = match capability {
+        CommandCapability::Send => requested_target != Some(OPERATOR_COMMAND_TARGET_ID),
+        CommandCapability::Operations {
+            command: scoped_command,
+        } => requested_target == Some(OPERATOR_COMMAND_TARGET_ID) && scoped_command == command,
+        CommandCapability::Receive { .. } => false,
+    };
+
+    Some(
+        subject.role == Role::CommandCapability
+            && scoped_deployment_id == deployment_id
+            && target_allowed,
+    )
+}
 
 /// Decide sender access from the signed deployment id before entity lookup.
 ///
@@ -58,7 +95,8 @@ pub fn receiver_request_decision(
                 capability,
                 CommandCapability::Receive { target } if target == requested_target
             )
-            && scoped_deployment_id == deployment_id,
+            && scoped_deployment_id == deployment_id
+            && requested_target.resource_id != OPERATOR_COMMAND_TARGET_ID,
     )
 }
 
@@ -131,6 +169,7 @@ pub fn receiver_deployment_decision(
                 capability,
                 CommandCapability::Receive { target } if target == requested_target
             )
+            && requested_target.resource_id != OPERATOR_COMMAND_TARGET_ID
             && subject.workspace_id == deployment.workspace_id
             && project_id == &deployment.project_id
             && deployment_id == &deployment.id,
@@ -146,9 +185,51 @@ pub fn receiver_context_allowed(subject: &Subject, command: &CommandAccessContex
             deployment_id,
             capability: CommandCapability::Receive { target },
         } if subject.role == Role::CommandCapability
+            && command.target.resource_id != OPERATOR_COMMAND_TARGET_ID
             && subject.workspace_id == command.workspace_id
             && project_id == &command.project_id
             && deployment_id == &command.deployment_id
             && target == &command.target
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::SubjectKind;
+
+    #[test]
+    fn operations_capability_cannot_read_or_update_command_records() {
+        let subject = Subject {
+            kind: SubjectKind::ServiceAccount {
+                id: "operations-dispatcher".to_string(),
+            },
+            workspace_id: "workspace-1".to_string(),
+            scope: Scope::Commands {
+                project_id: "project-1".to_string(),
+                deployment_id: "deployment-1".to_string(),
+                capability: CommandCapability::Operations {
+                    command: "postgres/health".to_string(),
+                },
+            },
+            role: Role::CommandCapability,
+            bearer_token: "bearer".to_string(),
+        };
+        let command = CommandAccessContext {
+            workspace_id: "workspace-1".to_string(),
+            project_id: "project-1".to_string(),
+            deployment_id: "deployment-1".to_string(),
+            target: CommandTarget::new(
+                OPERATOR_COMMAND_TARGET_ID,
+                alien_core::CommandTargetType::Daemon,
+            ),
+        };
+
+        assert_eq!(
+            sender_request_decision(&subject, "deployment-1"),
+            Some(false)
+        );
+        assert_eq!(sender_context_decision(&subject, &command), Some(false));
+        assert!(!receiver_context_allowed(&subject, &command));
+    }
 }

--- a/crates/alien-manager/src/auth/command_capability.rs
+++ b/crates/alien-manager/src/auth/command_capability.rs
@@ -6,9 +6,9 @@
 //! bound to one exact command, and receiver access is bound to one deployment
 //! plus one exact target.
 
-use alien_commands::server::command_registry::OPERATOR_COMMAND_TARGET_ID;
+use alien_commands::server::command_registry::{CommandStatus, OPERATOR_COMMAND_TARGET_ID};
 use alien_commands::server::CommandAccessContext;
-use alien_core::CommandTarget;
+use alien_core::{CommandTarget, CommandTargetType};
 
 use crate::auth::{CommandCapability, Role, Scope, Subject};
 use crate::traits::deployment_store::DeploymentRecord;
@@ -45,6 +45,26 @@ pub fn create_request_decision(
         subject.role == Role::CommandCapability
             && scoped_deployment_id == deployment_id
             && target_allowed,
+    )
+}
+
+/// Authorize completion of an operator command's presigned params upload.
+pub fn operator_upload_complete_allowed(subject: &Subject, command: &CommandStatus) -> bool {
+    matches!(
+        &subject.scope,
+        Scope::Commands {
+            project_id,
+            deployment_id,
+            capability: CommandCapability::Operations {
+                command: scoped_command,
+            },
+        } if subject.role == Role::CommandCapability
+            && subject.workspace_id == command.workspace_id
+            && project_id == &command.project_id
+            && deployment_id == &command.deployment_id
+            && scoped_command == &command.command
+            && command.target.resource_id == OPERATOR_COMMAND_TARGET_ID
+            && command.target.resource_type == CommandTargetType::Daemon
     )
 }
 
@@ -196,25 +216,62 @@ pub fn receiver_context_allowed(subject: &Subject, command: &CommandAccessContex
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alien_core::CommandState;
+    use chrono::Utc;
+
     use crate::auth::SubjectKind;
 
-    #[test]
-    fn operations_capability_cannot_read_or_update_command_records() {
-        let subject = Subject {
+    fn operations_subject(
+        workspace_id: &str,
+        project_id: &str,
+        deployment_id: &str,
+        command: &str,
+    ) -> Subject {
+        Subject {
             kind: SubjectKind::ServiceAccount {
                 id: "operations-dispatcher".to_string(),
             },
-            workspace_id: "workspace-1".to_string(),
+            workspace_id: workspace_id.to_string(),
             scope: Scope::Commands {
-                project_id: "project-1".to_string(),
-                deployment_id: "deployment-1".to_string(),
+                project_id: project_id.to_string(),
+                deployment_id: deployment_id.to_string(),
                 capability: CommandCapability::Operations {
-                    command: "postgres/health".to_string(),
+                    command: command.to_string(),
                 },
             },
             role: Role::CommandCapability,
             bearer_token: "bearer".to_string(),
-        };
+        }
+    }
+
+    fn operator_command_status() -> CommandStatus {
+        CommandStatus {
+            command_id: "command-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            project_id: "project-1".to_string(),
+            deployment_id: "deployment-1".to_string(),
+            command: "postgres/health".to_string(),
+            state: CommandState::PendingUpload,
+            attempt: 0,
+            deadline: None,
+            created_at: Utc::now(),
+            dispatched_at: None,
+            completed_at: None,
+            error: None,
+            request_size_bytes: Some(200_000),
+            response_size_bytes: None,
+            target: CommandTarget::new(OPERATOR_COMMAND_TARGET_ID, CommandTargetType::Daemon),
+        }
+    }
+
+    #[test]
+    fn operations_capability_cannot_read_or_update_command_records() {
+        let subject = operations_subject(
+            "workspace-1",
+            "project-1",
+            "deployment-1",
+            "postgres/health",
+        );
         let command = CommandAccessContext {
             workspace_id: "workspace-1".to_string(),
             project_id: "project-1".to_string(),
@@ -231,5 +288,57 @@ mod tests {
         );
         assert_eq!(sender_context_decision(&subject, &command), Some(false));
         assert!(!receiver_context_allowed(&subject, &command));
+    }
+
+    #[test]
+    fn operator_upload_complete_requires_exact_canonical_scope_command_and_target() {
+        let command = operator_command_status();
+        let exact = operations_subject(
+            "workspace-1",
+            "project-1",
+            "deployment-1",
+            "postgres/health",
+        );
+        assert!(operator_upload_complete_allowed(&exact, &command));
+
+        for subject in [
+            operations_subject(
+                "workspace-2",
+                "project-1",
+                "deployment-1",
+                "postgres/health",
+            ),
+            operations_subject(
+                "workspace-1",
+                "project-2",
+                "deployment-1",
+                "postgres/health",
+            ),
+            operations_subject(
+                "workspace-1",
+                "project-1",
+                "deployment-2",
+                "postgres/health",
+            ),
+            operations_subject(
+                "workspace-1",
+                "project-1",
+                "deployment-1",
+                "postgres/version",
+            ),
+        ] {
+            assert!(!operator_upload_complete_allowed(&subject, &command));
+        }
+
+        let mut wrong_target_id = command.clone();
+        wrong_target_id.target.resource_id = "daemon-1".to_string();
+        assert!(!operator_upload_complete_allowed(&exact, &wrong_target_id));
+
+        let mut wrong_target_type = command;
+        wrong_target_type.target.resource_type = CommandTargetType::Worker;
+        assert!(!operator_upload_complete_allowed(
+            &exact,
+            &wrong_target_type,
+        ));
     }
 }

--- a/crates/alien-manager/src/auth/subject.rs
+++ b/crates/alien-manager/src/auth/subject.rs
@@ -110,6 +110,8 @@ pub enum Scope {
 pub enum CommandCapability {
     /// Create commands and read their status.
     Send,
+    /// Create one exact command addressed to the manager's reserved operations target.
+    Operations { command: String },
     /// Lease and complete commands for one exact app-owned receiver target.
     Receive { target: CommandTarget },
 }
@@ -123,6 +125,7 @@ impl<'de> Deserialize<'de> for CommandCapability {
         #[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
         enum WireCapability {
             Send {},
+            Operations { command: String },
             Receive { target: WireTarget },
         }
 
@@ -135,6 +138,14 @@ impl<'de> Deserialize<'de> for CommandCapability {
 
         Ok(match WireCapability::deserialize(deserializer)? {
             WireCapability::Send {} => Self::Send,
+            WireCapability::Operations { command } => {
+                if command.is_empty() {
+                    return Err(serde::de::Error::custom(
+                        "operations capability command must not be empty",
+                    ));
+                }
+                Self::Operations { command }
+            }
             WireCapability::Receive { target } => Self::Receive {
                 target: CommandTarget::new(target.resource_id, target.resource_type),
             },
@@ -385,6 +396,43 @@ mod tests {
         }));
 
         assert!(result.is_err(), "send capabilities must not carry a target");
+    }
+
+    #[test]
+    fn operations_command_capability_has_a_strict_stable_wire_shape() {
+        let capability = CommandCapability::Operations {
+            command: "postgres/health".to_string(),
+        };
+        let json = serde_json::to_value(&capability).expect("serialize operations capability");
+        assert_eq!(
+            json,
+            serde_json::json!({ "type": "operations", "command": "postgres/health" })
+        );
+
+        assert_eq!(
+            serde_json::from_value::<CommandCapability>(json)
+                .expect("deserialize operations capability"),
+            capability
+        );
+        assert!(
+            serde_json::from_value::<CommandCapability>(serde_json::json!({
+                "type": "operations",
+                "command": "postgres/health",
+                "target": { "resourceId": "operator", "resourceType": "daemon" },
+            }))
+            .is_err(),
+            "operations capabilities must not carry caller-selected targets"
+        );
+    }
+
+    #[test]
+    fn operations_command_capability_rejects_an_empty_command() {
+        let result = serde_json::from_value::<CommandCapability>(serde_json::json!({
+            "type": "operations",
+            "command": "",
+        }));
+
+        assert!(result.is_err(), "operations command must be non-empty");
     }
 
     #[test]

--- a/crates/alien-manager/src/providers/oss_authz.rs
+++ b/crates/alien-manager/src/providers/oss_authz.rs
@@ -550,12 +550,24 @@ mod tests {
             &receiver,
             &alien_commands::server::CommandAccessContext {
                 target: other,
-                ..command
+                ..command.clone()
             },
         ));
         assert!(!OssAuthz.can_dispatch_command(&receiver, &own));
         assert!(!OssAuthz.can_read_command(&receiver, &own));
         assert!(!OssAuthz.can_read_deployment(&receiver, &own));
+
+        let operator = alien_core::CommandTarget::new(
+            alien_commands::server::command_registry::OPERATOR_COMMAND_TARGET_ID,
+            alien_core::CommandTargetType::Daemon,
+        );
+        let operator_receiver = command_receiver("d1", operator.clone());
+        let operator_command = alien_commands::server::CommandAccessContext {
+            target: operator.clone(),
+            ..command
+        };
+        assert!(!OssAuthz.can_receive_command(&operator_receiver, &own, &operator,));
+        assert!(!OssAuthz.can_execute_command_context(&operator_receiver, &operator_command,));
     }
 
     #[test]

--- a/crates/alien-manager/src/routes/commands.rs
+++ b/crates/alien-manager/src/routes/commands.rs
@@ -12,6 +12,7 @@ use axum::{
 };
 use serde::Deserialize;
 
+use alien_commands::server::command_registry::OPERATOR_COMMAND_TARGET_ID;
 use alien_commands::server::{CommandPayloadResponse, StorePayloadRequest};
 use alien_commands::types::*;
 
@@ -21,11 +22,13 @@ use super::{auth, AppState};
 
 // --- Helpers ---
 
-/// Look up the deployment_id that owns a command, for per-command auth checks.
-async fn get_command_owner(state: &AppState, command_id: &str) -> Result<String, Response> {
+async fn get_command_context(
+    state: &AppState,
+    command_id: &str,
+) -> Result<alien_commands::server::CommandAccessContext, Response> {
     state
         .command_server
-        .get_command_deployment_id(command_id)
+        .get_command_access_context(command_id)
         .await
         .map_err(|e| e.into_response())?
         .ok_or_else(|| {
@@ -34,6 +37,19 @@ async fn get_command_owner(state: &AppState, command_id: &str) -> Result<String,
             })
             .into_response()
         })
+}
+
+async fn require_command_mutation_access(
+    deployment_store: &dyn crate::traits::DeploymentStore,
+    authz: &dyn crate::auth::Authz,
+    subject: &crate::auth::Subject,
+    command: &alien_commands::server::CommandAccessContext,
+) -> Result<(), Response> {
+    if command.target.resource_id == OPERATOR_COMMAND_TARGET_ID {
+        return Err(ErrorData::forbidden("Access denied").into_response());
+    }
+
+    require_command_dispatch_access(deployment_store, authz, subject, &command.deployment_id).await
 }
 
 async fn get_command_deployment(
@@ -93,6 +109,39 @@ async fn require_command_auth(
     auth::require_auth(state, headers)
         .await
         .map_err(IntoResponse::into_response)
+}
+
+async fn require_command_create_access(
+    deployment_store: &dyn crate::traits::DeploymentStore,
+    authz: &dyn crate::auth::Authz,
+    subject: &crate::auth::Subject,
+    deployment_id: &str,
+    command: &str,
+    requested_target: Option<&str>,
+) -> Result<(), Response> {
+    if let Some(allowed) = crate::auth::command_capability::create_request_decision(
+        subject,
+        deployment_id,
+        command,
+        requested_target,
+    ) {
+        return if allowed {
+            Ok(())
+        } else {
+            Err(ErrorData::forbidden("Access denied").into_response())
+        };
+    }
+
+    if requested_target == Some(OPERATOR_COMMAND_TARGET_ID) {
+        return Err(ErrorData::forbidden("Access denied").into_response());
+    }
+
+    let deployment = get_command_deployment(deployment_store, subject, deployment_id).await?;
+    if authz.can_dispatch_command(subject, &deployment) {
+        Ok(())
+    } else {
+        Err(ErrorData::forbidden("Access denied").into_response())
+    }
 }
 
 async fn require_command_dispatch_access(
@@ -206,17 +255,9 @@ pub fn router() -> Router<AppState> {
 
 /// Create a new command.
 ///
-/// Auth: Admin or DeploymentGroup token (must own the target deployment's group).
-///
-/// Authorization is intentionally deployment-scoped. There is no
-/// per-resource auth primitive (the finest auth grain is the deployment), so
-/// naming a `targetResourceId` grants no extra access. Target selection is
-/// validated server-side by the registry as an EXISTENCE/CAPABILITY check
-/// (does this deployment have such a command-capable resource?), not as an
-/// authorization boundary — resolution failures surface as
-/// `COMMAND_TARGET_NOT_FOUND` (404), `COMMAND_TARGET_AMBIGUOUS` (409), or
-/// `NO_COMMAND_TARGETS` (422), which map to HTTP via each error's
-/// `http_status_code`.
+/// Auth: deployment-authorized callers may target stack resources. The reserved
+/// operations target additionally requires an exact commands capability bound
+/// to the deployment and command name.
 async fn create_command(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -226,11 +267,13 @@ async fn create_command(
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
-    if let Err(response) = require_command_dispatch_access(
+    if let Err(response) = require_command_create_access(
         state.deployment_store.as_ref(),
         state.authz.as_ref(),
         &subject,
         &request.deployment_id,
+        &request.command,
+        request.target_resource_id.as_deref(),
     )
     .await
     {
@@ -295,16 +338,16 @@ async fn upload_complete(
         Ok(subject) => subject,
         Err(response) => return response,
     };
-    let deployment_id = match get_command_owner(&state, &command_id).await {
-        Ok(id) => id,
+    let command = match get_command_context(&state, &command_id).await {
+        Ok(command) => command,
         Err(e) => return e,
     };
 
-    if let Err(response) = require_command_dispatch_access(
+    if let Err(response) = require_command_mutation_access(
         state.deployment_store.as_ref(),
         state.authz.as_ref(),
         &subject,
-        &deployment_id,
+        &command,
     )
     .await
     {
@@ -474,7 +517,20 @@ async fn store_command_payload(
     let subject = match auth::require_auth(&state, &headers).await {
         Ok(s) => s,
         Err(e) => return e.into_response(),
-    }; // Storing payload with no entity context is workspace-write only.
+    };
+    match state
+        .command_server
+        .get_command_access_context(&command_id)
+        .await
+    {
+        Ok(Some(command)) if command.target.resource_id == OPERATOR_COMMAND_TARGET_ID => {
+            return ErrorData::forbidden("Access denied").into_response();
+        }
+        Ok(_) => {}
+        Err(e) => return e.into_response(),
+    }
+
+    // Storing payload with no entity context is workspace-write only.
     if !matches!(subject.scope, crate::auth::Scope::Workspace)
         || !matches!(
             subject.role,
@@ -614,6 +670,36 @@ mod tests {
         }
     }
 
+    fn operations_subject(command: &str) -> Subject {
+        Subject {
+            kind: SubjectKind::ServiceAccount {
+                id: "operations-dispatcher".to_string(),
+            },
+            workspace_id: "workspace-1".to_string(),
+            scope: Scope::Commands {
+                project_id: "project-1".to_string(),
+                deployment_id: "deployment-1".to_string(),
+                capability: CommandCapability::Operations {
+                    command: command.to_string(),
+                },
+            },
+            role: Role::CommandCapability,
+            bearer_token: "bearer".to_string(),
+        }
+    }
+
+    fn workspace_admin_subject() -> Subject {
+        Subject {
+            kind: SubjectKind::ServiceAccount {
+                id: "workspace-admin".to_string(),
+            },
+            workspace_id: "workspace-1".to_string(),
+            scope: Scope::Workspace,
+            role: Role::WorkspaceAdmin,
+            bearer_token: "bearer".to_string(),
+        }
+    }
+
     #[tokio::test]
     async fn commands_dispatch_authorization_does_not_preflight_the_deployment() {
         let mut deployment_store = MockDeploymentStore::new();
@@ -625,6 +711,206 @@ mod tests {
         )
         .await
         .expect("signed deployment scope should authorize the sender");
+
+        deployment_store.checkpoint();
+    }
+
+    #[tokio::test]
+    async fn operations_capability_creates_only_its_exact_operator_command() {
+        let mut deployment_store = MockDeploymentStore::new();
+        let subject = operations_subject("postgres/health");
+
+        require_command_create_access(
+            &deployment_store,
+            &OssAuthz,
+            &subject,
+            "deployment-1",
+            "postgres/health",
+            Some(OPERATOR_COMMAND_TARGET_ID),
+        )
+        .await
+        .expect("exact operations capability should authorize create");
+
+        for (deployment_id, command, target) in [
+            (
+                "deployment-2",
+                "postgres/health",
+                Some(OPERATOR_COMMAND_TARGET_ID),
+            ),
+            (
+                "deployment-1",
+                "postgres/drop",
+                Some(OPERATOR_COMMAND_TARGET_ID),
+            ),
+            ("deployment-1", "postgres/health", Some("daemon-1")),
+            ("deployment-1", "postgres/health", None),
+        ] {
+            assert_eq!(
+                require_command_create_access(
+                    &deployment_store,
+                    &OssAuthz,
+                    &subject,
+                    deployment_id,
+                    command,
+                    target,
+                )
+                .await
+                .expect_err("operations capability must stay bound to its exact request")
+                .status(),
+                StatusCode::FORBIDDEN,
+            );
+        }
+
+        deployment_store.checkpoint();
+    }
+
+    #[tokio::test]
+    async fn ordinary_sender_cannot_create_operator_commands() {
+        let mut deployment_store = MockDeploymentStore::new();
+
+        assert_eq!(
+            require_command_create_access(
+                &deployment_store,
+                &OssAuthz,
+                &commands_sender_subject(),
+                "deployment-1",
+                "postgres/health",
+                Some(OPERATOR_COMMAND_TARGET_ID),
+            )
+            .await
+            .expect_err("sender capability must not address the operator")
+            .status(),
+            StatusCode::FORBIDDEN,
+        );
+
+        deployment_store.checkpoint();
+    }
+
+    #[tokio::test]
+    async fn deployment_level_subjects_cannot_create_operator_commands() {
+        let mut deployment_store = MockDeploymentStore::new();
+        let subjects = [
+            Subject {
+                kind: SubjectKind::User {
+                    id: "user-1".to_string(),
+                    email: "user@example.com".to_string(),
+                    workspace_name: Some("workspace-1".to_string()),
+                },
+                workspace_id: "workspace-1".to_string(),
+                scope: Scope::Workspace,
+                role: Role::WorkspaceAdmin,
+                bearer_token: "bearer".to_string(),
+            },
+            Subject {
+                kind: SubjectKind::ServiceAccount {
+                    id: "deployment-group-1".to_string(),
+                },
+                workspace_id: "workspace-1".to_string(),
+                scope: Scope::DeploymentGroup {
+                    project_id: "project-1".to_string(),
+                    deployment_group_id: "group-1".to_string(),
+                },
+                role: Role::DeploymentGroupDeployer,
+                bearer_token: "bearer".to_string(),
+            },
+            Subject {
+                kind: SubjectKind::ServiceAccount {
+                    id: "deployment-manager-1".to_string(),
+                },
+                workspace_id: "workspace-1".to_string(),
+                scope: Scope::Deployment {
+                    project_id: "project-1".to_string(),
+                    deployment_id: "deployment-1".to_string(),
+                },
+                role: Role::DeploymentManager,
+                bearer_token: "bearer".to_string(),
+            },
+        ];
+
+        for subject in &subjects {
+            assert_eq!(
+                require_command_create_access(
+                    &deployment_store,
+                    &OssAuthz,
+                    subject,
+                    "deployment-1",
+                    "postgres/health",
+                    Some(OPERATOR_COMMAND_TARGET_ID),
+                )
+                .await
+                .expect_err("deployment-level authorization must not reach the operator")
+                .status(),
+                StatusCode::FORBIDDEN,
+            );
+        }
+
+        deployment_store.checkpoint();
+    }
+
+    #[tokio::test]
+    async fn operations_capability_cannot_use_sender_or_receiver_paths() {
+        let mut deployment_store = MockDeploymentStore::new();
+        let subject = operations_subject("postgres/health");
+
+        assert_eq!(
+            require_command_dispatch_access(
+                &deployment_store,
+                &OssAuthz,
+                &subject,
+                "deployment-1",
+            )
+            .await
+            .expect_err("operations capability must not gain sender mutation access")
+            .status(),
+            StatusCode::FORBIDDEN,
+        );
+        assert_eq!(
+            require_command_receive_access(
+                &deployment_store,
+                &OssAuthz,
+                &subject,
+                "deployment-1",
+                &alien_core::CommandTarget::new(
+                    OPERATOR_COMMAND_TARGET_ID,
+                    alien_core::CommandTargetType::Daemon,
+                ),
+            )
+            .await
+            .expect_err("operations capability must not gain receiver access")
+            .status(),
+            StatusCode::FORBIDDEN,
+        );
+
+        deployment_store.checkpoint();
+    }
+
+    #[tokio::test]
+    async fn operator_command_payload_cannot_be_mutated_after_create() {
+        let mut deployment_store = MockDeploymentStore::new();
+        let command = alien_commands::server::CommandAccessContext {
+            workspace_id: "workspace-1".to_string(),
+            project_id: "project-1".to_string(),
+            deployment_id: "deployment-1".to_string(),
+            target: alien_core::CommandTarget::new(
+                OPERATOR_COMMAND_TARGET_ID,
+                alien_core::CommandTargetType::Daemon,
+            ),
+        };
+        let subjects = [
+            commands_sender_subject(),
+            operations_subject("postgres/health"),
+            workspace_admin_subject(),
+        ];
+
+        for subject in &subjects {
+            assert_eq!(
+                require_command_mutation_access(&deployment_store, &OssAuthz, subject, &command,)
+                    .await
+                    .expect_err("operator command payload must be immutable after creation")
+                    .status(),
+                StatusCode::FORBIDDEN,
+            );
+        }
 
         deployment_store.checkpoint();
     }

--- a/crates/alien-manager/src/routes/commands.rs
+++ b/crates/alien-manager/src/routes/commands.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use alien_commands::server::command_registry::OPERATOR_COMMAND_TARGET_ID;
+use alien_commands::server::command_registry::{CommandStatus, OPERATOR_COMMAND_TARGET_ID};
 use alien_commands::server::{CommandPayloadResponse, StorePayloadRequest};
 use alien_commands::types::*;
 
@@ -22,34 +22,43 @@ use super::{auth, AppState};
 
 // --- Helpers ---
 
-async fn get_command_context(
-    state: &AppState,
-    command_id: &str,
-) -> Result<alien_commands::server::CommandAccessContext, Response> {
-    state
-        .command_server
-        .get_command_access_context(command_id)
-        .await
-        .map_err(|e| e.into_response())?
-        .ok_or_else(|| {
-            alien_error::AlienError::new(alien_commands::error::ErrorData::CommandNotFound {
-                command_id: command_id.to_string(),
-            })
-            .into_response()
-        })
-}
-
-async fn require_command_mutation_access(
+async fn require_upload_complete_access(
     deployment_store: &dyn crate::traits::DeploymentStore,
     authz: &dyn crate::auth::Authz,
     subject: &crate::auth::Subject,
-    command: &alien_commands::server::CommandAccessContext,
+    command: &CommandStatus,
 ) -> Result<(), Response> {
     if command.target.resource_id == OPERATOR_COMMAND_TARGET_ID {
-        return Err(ErrorData::forbidden("Access denied").into_response());
+        return if crate::auth::command_capability::operator_upload_complete_allowed(
+            subject, command,
+        ) {
+            Ok(())
+        } else {
+            Err(ErrorData::forbidden("Access denied").into_response())
+        };
     }
 
     require_command_dispatch_access(deployment_store, authz, subject, &command.deployment_id).await
+}
+
+fn require_direct_payload_access(
+    subject: &crate::auth::Subject,
+    command: Option<&alien_commands::server::CommandAccessContext>,
+) -> Result<(), &'static str> {
+    if command.is_some_and(|command| command.target.resource_id == OPERATOR_COMMAND_TARGET_ID) {
+        return Err("Access denied");
+    }
+
+    if matches!(subject.scope, crate::auth::Scope::Workspace)
+        && matches!(
+            subject.role,
+            crate::auth::Role::WorkspaceAdmin | crate::auth::Role::WorkspaceMember
+        )
+    {
+        Ok(())
+    } else {
+        Err("Workspace-write access required")
+    }
 }
 
 async fn get_command_deployment(
@@ -327,7 +336,8 @@ async fn get_command_status(
 
 /// Mark upload as complete.
 ///
-/// Auth: Admin or DG (same as create — the command creator completes the upload).
+/// Auth: Same deployment-level rules as create. Reserved operator commands
+/// require the exact operations capability that created the command.
 async fn upload_complete(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -338,12 +348,24 @@ async fn upload_complete(
         Ok(subject) => subject,
         Err(response) => return response,
     };
-    let command = match get_command_context(&state, &command_id).await {
-        Ok(command) => command,
-        Err(e) => return e,
+    let command = match state
+        .command_server
+        .get_command_status_record(&command_id)
+        .await
+    {
+        Ok(Some(command)) => command,
+        Ok(None) => {
+            return alien_error::AlienError::new(
+                alien_commands::error::ErrorData::CommandNotFound {
+                    command_id: command_id.clone(),
+                },
+            )
+            .into_response()
+        }
+        Err(e) => return e.into_response(),
     };
 
-    if let Err(response) = require_command_mutation_access(
+    if let Err(response) = require_upload_complete_access(
         state.deployment_store.as_ref(),
         state.authz.as_ref(),
         &subject,
@@ -518,26 +540,17 @@ async fn store_command_payload(
         Ok(s) => s,
         Err(e) => return e.into_response(),
     };
-    match state
+    let command = match state
         .command_server
         .get_command_access_context(&command_id)
         .await
     {
-        Ok(Some(command)) if command.target.resource_id == OPERATOR_COMMAND_TARGET_ID => {
-            return ErrorData::forbidden("Access denied").into_response();
-        }
-        Ok(_) => {}
+        Ok(command) => command,
         Err(e) => return e.into_response(),
-    }
+    };
 
-    // Storing payload with no entity context is workspace-write only.
-    if !matches!(subject.scope, crate::auth::Scope::Workspace)
-        || !matches!(
-            subject.role,
-            crate::auth::Role::WorkspaceAdmin | crate::auth::Role::WorkspaceMember
-        )
-    {
-        return ErrorData::forbidden("Workspace-write access required").into_response();
+    if let Err(message) = require_direct_payload_access(&subject, command.as_ref()) {
+        return ErrorData::forbidden(message).into_response();
     }
 
     if let Some(params) = &request.params {
@@ -650,6 +663,11 @@ async fn release_lease(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alien_commands::test_utils::{
+        test_storage_create_command, test_upload_complete_request, TestCommandServer,
+    };
+    use chrono::Utc;
+
     use crate::auth::{CommandCapability, Role, Scope, Subject, SubjectKind};
     use crate::providers::OssAuthz;
     use crate::traits::deployment_store::MockDeploymentStore;
@@ -671,16 +689,46 @@ mod tests {
     }
 
     fn operations_subject(command: &str) -> Subject {
+        operations_subject_for("workspace-1", "project-1", "deployment-1", command)
+    }
+
+    fn operations_subject_for(
+        workspace_id: &str,
+        project_id: &str,
+        deployment_id: &str,
+        command: &str,
+    ) -> Subject {
         Subject {
             kind: SubjectKind::ServiceAccount {
                 id: "operations-dispatcher".to_string(),
+            },
+            workspace_id: workspace_id.to_string(),
+            scope: Scope::Commands {
+                project_id: project_id.to_string(),
+                deployment_id: deployment_id.to_string(),
+                capability: CommandCapability::Operations {
+                    command: command.to_string(),
+                },
+            },
+            role: Role::CommandCapability,
+            bearer_token: "bearer".to_string(),
+        }
+    }
+
+    fn commands_receiver_subject() -> Subject {
+        Subject {
+            kind: SubjectKind::ServiceAccount {
+                id: "commands-receiver".to_string(),
             },
             workspace_id: "workspace-1".to_string(),
             scope: Scope::Commands {
                 project_id: "project-1".to_string(),
                 deployment_id: "deployment-1".to_string(),
-                capability: CommandCapability::Operations {
-                    command: command.to_string(),
+                capability: CommandCapability::Receive {
+                    target: alien_core::CommandTarget::new(
+                        OPERATOR_COMMAND_TARGET_ID,
+                        alien_core::CommandTargetType::Daemon,
+                    ),
                 },
             },
             role: Role::CommandCapability,
@@ -697,6 +745,29 @@ mod tests {
             scope: Scope::Workspace,
             role: Role::WorkspaceAdmin,
             bearer_token: "bearer".to_string(),
+        }
+    }
+
+    fn operator_command_status(command: &str) -> CommandStatus {
+        CommandStatus {
+            command_id: "command-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            project_id: "project-1".to_string(),
+            deployment_id: "deployment-1".to_string(),
+            command: command.to_string(),
+            state: CommandState::PendingUpload,
+            attempt: 0,
+            deadline: None,
+            created_at: Utc::now(),
+            dispatched_at: None,
+            completed_at: None,
+            error: None,
+            request_size_bytes: Some(200_000),
+            response_size_bytes: None,
+            target: alien_core::CommandTarget::new(
+                OPERATOR_COMMAND_TARGET_ID,
+                alien_core::CommandTargetType::Daemon,
+            ),
         }
     }
 
@@ -885,8 +956,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn operator_command_payload_cannot_be_mutated_after_create() {
+    async fn operator_upload_complete_rejects_non_operations_subjects() {
         let mut deployment_store = MockDeploymentStore::new();
+        let command = operator_command_status("postgres/health");
+        let subjects = [
+            commands_sender_subject(),
+            commands_receiver_subject(),
+            workspace_admin_subject(),
+        ];
+
+        for subject in &subjects {
+            assert_eq!(
+                require_upload_complete_access(&deployment_store, &OssAuthz, subject, &command,)
+                    .await
+                    .expect_err("only an operations capability may complete an operator upload")
+                    .status(),
+                StatusCode::FORBIDDEN,
+            );
+        }
+
+        deployment_store.checkpoint();
+    }
+
+    #[tokio::test]
+    async fn operator_upload_complete_rejects_a_different_operation_command() {
+        let mut deployment_store = MockDeploymentStore::new();
+
+        assert_eq!(
+            require_upload_complete_access(
+                &deployment_store,
+                &OssAuthz,
+                &operations_subject("postgres/version"),
+                &operator_command_status("postgres/health"),
+            )
+            .await
+            .expect_err("operations capability must match the canonical command name")
+            .status(),
+            StatusCode::FORBIDDEN,
+        );
+
+        deployment_store.checkpoint();
+    }
+
+    #[test]
+    fn direct_operator_payload_put_remains_denied() {
         let command = alien_commands::server::CommandAccessContext {
             workspace_id: "workspace-1".to_string(),
             project_id: "project-1".to_string(),
@@ -896,23 +1009,79 @@ mod tests {
                 alien_core::CommandTargetType::Daemon,
             ),
         };
-        let subjects = [
-            commands_sender_subject(),
+
+        for subject in [
             operations_subject("postgres/health"),
             workspace_admin_subject(),
-        ];
-
-        for subject in &subjects {
+        ] {
             assert_eq!(
-                require_command_mutation_access(&deployment_store, &OssAuthz, subject, &command,)
-                    .await
-                    .expect_err("operator command payload must be immutable after creation")
-                    .status(),
-                StatusCode::FORBIDDEN,
+                require_direct_payload_access(&subject, Some(&command)),
+                Err("Access denied"),
             );
         }
+    }
+
+    #[tokio::test]
+    async fn oversized_operator_upload_becomes_leasable_for_exact_operations_capability() {
+        let mut server = TestCommandServer::builder().with_pull_mode().build().await;
+        let deployment_id = "deployment-1";
+        let command_name = "postgres/health";
+        let mut request = test_storage_create_command(deployment_id, command_name, 200_000);
+        request.target_resource_id = Some(OPERATOR_COMMAND_TARGET_ID.to_string());
+
+        let created = server
+            .create_command(request)
+            .await
+            .expect("create oversized operator command");
+        assert_eq!(created.state, CommandState::PendingUpload);
+
+        let command = server
+            .command_server
+            .get_command_status_record(&created.command_id)
+            .await
+            .expect("read canonical command status")
+            .expect("created command status");
+        let mut deployment_store = MockDeploymentStore::new();
+        require_upload_complete_access(
+            &deployment_store,
+            &OssAuthz,
+            &operations_subject_for("default", "default", deployment_id, command_name),
+            &command,
+        )
+        .await
+        .expect("exact operations capability should complete its params upload");
+
+        let completed = server
+            .upload_complete(&created.command_id, test_upload_complete_request(200_000))
+            .await
+            .expect("complete operator params upload");
+        assert_eq!(completed.state, CommandState::Pending);
+
+        let replay = server
+            .upload_complete(&created.command_id, test_upload_complete_request(200_000))
+            .await
+            .expect_err("upload completion must not replay after leaving PendingUpload");
+        assert_eq!(replay.code, "INVALID_STATE_TRANSITION");
+
+        let leases = server
+            .acquire_lease(
+                deployment_id,
+                LeaseRequest {
+                    deployment_id: deployment_id.to_string(),
+                    target: alien_core::CommandTarget::new(
+                        OPERATOR_COMMAND_TARGET_ID,
+                        alien_core::CommandTargetType::Daemon,
+                    ),
+                    max_leases: 1,
+                    lease_seconds: 60,
+                },
+            )
+            .await
+            .expect("lease uploaded operator command");
+        assert_eq!(leases.leases[0].command_id, created.command_id);
 
         deployment_store.checkpoint();
+        server.shutdown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a short-lived operations command capability bound to one deployment and exact command
- reserve the `operator` target for that capability while preserving existing stack-command shorthand
- prevent post-create operator payload mutation and keep external receiver capabilities off the internal operator queue
- exclude colliding stack targets named `operator`, with a real create-to-lease regression

## Verification

- `cargo test -p alien-commands --features test-utils` (62 unit, 31 integration, 2 doctests)
- `cargo test -p alien-manager --lib` (196 passed)
- focused create-to-lease regression
- package checks and no-deps Clippy
- rustfmt and `git diff --check`

Draft while the coordinated caller rollout and dependent CI complete.