### PR TITLE
feat(sdk): expose the sandbox binding to TypeScript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ name = "alien-bindings-node"
 version = "3.3.14"
 dependencies = [
  "alien-bindings",
+ "alien-core",
  "alien-error",
  "chrono",
  "futures",

--- a/crates/alien-bindings-node/Cargo.toml
+++ b/crates/alien-bindings-node/Cargo.toml
@@ -27,6 +27,7 @@ platform-sdk = ["alien-bindings/platform-sdk"]
 # so the gRPC feature is never pulled in transitively; platform features are
 # forwarded explicitly above.
 alien-bindings = { workspace = true }
+alien-core = { workspace = true }
 alien-error = { workspace = true }
 futures = { workspace = true }
 napi = { workspace = true }

--- a/crates/alien-bindings-node/src/lib.rs
+++ b/crates/alien-bindings-node/src/lib.rs
@@ -14,6 +14,7 @@ mod key;
 mod kv;
 mod postgres;
 mod queue;
+mod sandbox;
 #[cfg(feature = "platform-sdk")]
 mod remote_storage;
 mod storage;
@@ -31,6 +32,7 @@ pub use key::KeyHandle;
 pub use kv::KvHandle;
 pub use postgres::{PostgresConnectionJs, PostgresHandle};
 pub use queue::QueueHandle;
+pub use sandbox::{CommandFrameJs, CommandStreamHandle, SandboxHandle, SandboxSessionJs};
 #[cfg(feature = "platform-sdk")]
 pub use remote_storage::RemoteStorageHandle;
 pub use storage::StorageHandle;
@@ -109,6 +111,14 @@ impl BindingsHandle {
         let inner = self.inner.clone();
         let vault = inner.vault(&name).await.map_err(map_alien_error)?;
         Ok(VaultHandle::new(vault))
+    }
+
+    /// Resolve the sandbox binding named `name`.
+    #[napi]
+    pub async fn sandbox(&self, name: String) -> napi::Result<SandboxHandle> {
+        let inner = self.inner.clone();
+        let sandbox = inner.sandbox(&name).await.map_err(map_alien_error)?;
+        Ok(SandboxHandle::new(sandbox))
     }
 
     /// Resolve the linked-container binding named `name`.

--- a/crates/alien-bindings-node/src/sandbox.rs
+++ b/crates/alien-bindings-node/src/sandbox.rs
@@ -174,10 +174,10 @@ impl CommandStreamHandle {
         {
             let _ = close.send(());
         }
-        // Drop the stream here when nobody holds it; a parked `next()` drops it on the signal.
-        if let Some(mut frames) = self.frames.try_lock() {
-            *frames = None;
-        }
+        // Acquiring after the signal is what makes this terminate: a parked `next()` wakes on
+        // `closed` and releases, and one arriving later finds the stream already gone. Returning
+        // without the stream released would leave the command running to its deadline.
+        *self.frames.lock().await = None;
     }
 }
 
@@ -506,6 +506,28 @@ mod tests {
             assert!(
                 handle.frames.lock().await.is_none(),
                 "the stream must be dropped, that is what reaches the backend"
+            );
+        });
+    }
+
+    /// A reader that already passed its own close check holds the lock with a frame in hand and
+    /// will not release the stream, so `close()` returning at that moment would report a command
+    /// cancelled that still runs to its deadline. Returning has to mean the stream is gone.
+    #[test]
+    fn close_does_not_return_while_a_reader_holds_the_stream() {
+        let handle = CommandStreamHandle::new(futures::stream::pending().boxed());
+        futures::executor::block_on(async {
+            let held = handle.frames.lock().await;
+            assert!(
+                handle.close().now_or_never().is_none(),
+                "close reported the command cancelled while its stream was still held"
+            );
+            drop(held);
+
+            handle.close().await;
+            assert!(
+                handle.frames.lock().await.is_none(),
+                "close returned without releasing the stream"
             );
         });
     }

--- a/crates/alien-bindings-node/src/sandbox.rs
+++ b/crates/alien-bindings-node/src/sandbox.rs
@@ -141,7 +141,18 @@ impl CommandStreamHandle {
             return Ok(None);
         };
 
-        match select(stream.next(), self.closed.clone()).await {
+        let next = select(stream.next(), self.closed.clone()).await;
+
+        // Whatever won the select, a close that has already fired means the caller has cancelled:
+        // the stream is released, not whatever the stream was about to say. Checked once, here,
+        // rather than in the arm that happened to win — a frame and an error race the signal the
+        // same way, and delivering either would keep the command alive until its deadline.
+        if self.closed.clone().now_or_never().is_some() {
+            *frames = None;
+            return Ok(None);
+        }
+
+        match next {
             Either::Left((Some(Ok(frame)), _)) => Ok(Some(frame_to_js(frame))),
             Either::Left((Some(Err(error)), _)) => Err(map_alien_error(error)),
             Either::Left((None, _)) | Either::Right(_) => {
@@ -403,6 +414,100 @@ mod tests {
             futures::executor::block_on(handle.frames.lock()).is_none(),
             "the stream must be dropped, that is what reaches the backend"
         );
+    }
+
+    /// A frame that becomes ready in the same instant as the close signal wins the select. The
+    /// caller has already cancelled, so the frame is not the answer — the stream is, and it must
+    /// be dropped, or the command it feeds runs on until its deadline with nobody left to stop it.
+    ///
+    /// The race is only reachable while `next()` holds the frames lock, so `close()` cannot drop
+    /// the stream itself; that is arranged by parking `next()` on a stream that yields its frame
+    /// only after the close has been sent.
+    #[test]
+    fn close_racing_a_ready_frame_still_releases_the_stream() {
+        let (release, released) = oneshot::channel::<()>();
+        // The frame arrives only once `released` fires — after close() has been called while
+        // next() is parked inside the select holding the lock.
+        let gated = futures::stream::once(async move {
+            let _ = released.await;
+            Ok(CommandOutput::Stdout {
+                seq: 0,
+                data: b"late".to_vec(),
+            })
+        })
+        .chain(futures::stream::pending());
+        let handle = Arc::new(CommandStreamHandle::new(gated.boxed()));
+
+        futures::executor::block_on(async {
+            let reader = {
+                let handle = Arc::clone(&handle);
+                async move { handle.next().await }
+            };
+            let closer = {
+                let handle = Arc::clone(&handle);
+                async move {
+                    // Let next() take the lock and park; then close, then release the frame so
+                    // both the frame and the close signal are ready in the same poll.
+                    futures::future::ready(()).await;
+                    handle.close().await;
+                    let _ = release.send(());
+                }
+            };
+            let (frame, ()) = futures::future::join(reader, closer).await;
+            assert!(
+                frame.expect("close is not an error").is_none(),
+                "a cancelled command's frame is not delivered: the stream is released instead"
+            );
+            assert!(
+                handle.frames.lock().await.is_none(),
+                "the stream must be dropped, that is what reaches the backend"
+            );
+        });
+    }
+
+    /// The same race with an error instead of a frame: a stream failure that lands in the same
+    /// instant as the close must not be delivered either — the caller has cancelled, and what it
+    /// needs is the stream released, not the stream's last word.
+    #[test]
+    fn close_racing_a_ready_error_still_releases_the_stream() {
+        let (release, released) = oneshot::channel::<()>();
+        let gated = futures::stream::once(async move {
+            let _ = released.await;
+            Err(alien_error::AlienError::new(
+                alien_bindings::error::ErrorData::SandboxUnreachable {
+                    operation: "sandbox.runCommand".to_string(),
+                    reason: "late".to_string(),
+                },
+            ))
+        })
+        .chain(futures::stream::pending());
+        let handle = Arc::new(CommandStreamHandle::new(gated.boxed()));
+
+        futures::executor::block_on(async {
+            let reader = {
+                let handle = Arc::clone(&handle);
+                async move { handle.next().await }
+            };
+            let closer = {
+                let handle = Arc::clone(&handle);
+                async move {
+                    futures::future::ready(()).await;
+                    handle.close().await;
+                    let _ = release.send(());
+                }
+            };
+            let (result, ()) = futures::future::join(reader, closer).await;
+            assert!(
+                result
+                    .expect("a cancelled read is the end, not an error")
+                    .is_none(),
+                "a cancelled command's stream error is not delivered: the stream is released"
+            );
+            assert!(
+                handle.frames.lock().await.is_none(),
+                "the stream must be dropped, that is what reaches the backend"
+            );
+        });
     }
 
     /// Closing before or after the end is a no-op; a caller need not track which came first.

--- a/crates/alien-bindings-node/src/sandbox.rs
+++ b/crates/alien-bindings-node/src/sandbox.rs
@@ -1,0 +1,358 @@
+//! Sandbox binding handle. Thin argument/error translation over the `Sandbox` trait.
+//!
+//! One thing here is not thin: a command's output is a stream, and every other handle in this
+//! crate drains its stream before returning. Collecting frames would make the resource useless
+//! for what it exists for, which is agent loops that print as they go, and a collect-only API
+//! cannot be widened later without a breaking change.
+//!
+//! So a command returns a [`CommandStreamHandle`] whose `next()` yields one frame at a time.
+//! Pull-based on purpose: nothing is produced until JavaScript asks, which is exact backpressure
+//! with no callback plumbing, and it maps onto an async iterator on the TypeScript side.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alien_bindings::traits::{
+    CommandOutput, CreateSessionRequest, RunCommandRequest, Sandbox, SandboxSession,
+};
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use napi::bindgen_prelude::Buffer;
+use napi_derive::napi;
+use futures::lock::Mutex;
+
+use crate::error::map_alien_error;
+
+/// Environment as the Rust side wants it. A `BTreeMap` so the order a caller supplied does not
+/// change what the sandbox sees.
+fn into_env(env: Option<std::collections::HashMap<String, String>>) -> BTreeMap<String, String> {
+    env.map(|env| env.into_iter().collect()).unwrap_or_default()
+}
+
+/// A live sandbox session.
+#[napi(object)]
+pub struct SandboxSessionJs {
+    /// Session id, which is what every later call addresses.
+    pub session_id: String,
+    /// Lifecycle state: `starting`, `running`, `suspended` or `terminated`.
+    pub state: String,
+    /// Increments when a session is replaced, so a stale handle is detectable.
+    pub generation: i64,
+}
+
+fn session_to_js(session: SandboxSession) -> SandboxSessionJs {
+    SandboxSessionJs {
+        session_id: session.session_id,
+        state: match session.state {
+            alien_bindings::traits::SandboxSessionState::Starting => "starting",
+            alien_bindings::traits::SandboxSessionState::Running => "running",
+            alien_bindings::traits::SandboxSessionState::Suspended => "suspended",
+            alien_bindings::traits::SandboxSessionState::Terminated => "terminated",
+        }
+        .to_string(),
+        generation: session.generation as i64,
+    }
+}
+
+/// One frame of a running command's output.
+///
+/// Exactly one of `data` or `exitCode` is set. A frame with neither would be a frame that says
+/// nothing, and the terminal frame is the one that carries the exit code.
+#[napi(object)]
+pub struct CommandFrameJs {
+    /// `stdout`, `stderr` or `exit`
+    pub kind: String,
+    /// Monotonic across both streams, so a caller can reconstruct production order. Absent on
+    /// the terminal frame.
+    pub seq: Option<i64>,
+    /// Raw bytes. Not a string: command output is not necessarily UTF-8.
+    pub data: Option<Buffer>,
+    /// Process exit code, on the terminal frame only.
+    pub exit_code: Option<i32>,
+    /// Set when output was cut short by a bound rather than by the command ending.
+    pub truncated: Option<bool>,
+}
+
+fn frame_to_js(frame: CommandOutput) -> CommandFrameJs {
+    match frame {
+        CommandOutput::Stdout { seq, data } => CommandFrameJs {
+            kind: "stdout".to_string(),
+            seq: Some(seq as i64),
+            data: Some(Buffer::from(data)),
+            exit_code: None,
+            truncated: None,
+        },
+        CommandOutput::Stderr { seq, data } => CommandFrameJs {
+            kind: "stderr".to_string(),
+            seq: Some(seq as i64),
+            data: Some(Buffer::from(data)),
+            exit_code: None,
+            truncated: None,
+        },
+        CommandOutput::Exit { code, truncated } => CommandFrameJs {
+            kind: "exit".to_string(),
+            seq: None,
+            data: None,
+            exit_code: Some(code),
+            truncated: Some(truncated),
+        },
+    }
+}
+
+/// A running command's output, pulled one frame at a time.
+///
+/// The stream is held in an `Option` so it can be dropped on demand: a caller that stops reading
+/// half way through leaves a command running, and dropping the stream closes the transport
+/// carrying its output, which is what tells the backend nobody is listening.
+#[napi]
+pub struct CommandStreamHandle {
+    frames: Arc<Mutex<Option<BoxStream<'static, alien_bindings::error::Result<CommandOutput>>>>>,
+}
+
+#[napi]
+impl CommandStreamHandle {
+    /// Returns the next frame, or `null` once the command has produced its last.
+    ///
+    /// The terminal frame is delivered like any other, so a caller reads until `null` and finds
+    /// the exit code in the frame before it.
+    #[napi]
+    pub async fn next(&self) -> napi::Result<Option<CommandFrameJs>> {
+        let mut frames = self.frames.lock().await;
+        let Some(stream) = frames.as_mut() else {
+            return Ok(None);
+        };
+
+        match stream.next().await {
+            Some(Ok(frame)) => Ok(Some(frame_to_js(frame))),
+            Some(Err(error)) => Err(map_alien_error(error)),
+            None => {
+                *frames = None;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Releases the stream. Idempotent, and `next()` returns `null` afterwards.
+    #[napi]
+    pub async fn close(&self) {
+        *self.frames.lock().await = None;
+    }
+}
+
+/// Handle to a resolved sandbox binding.
+#[napi]
+pub struct SandboxHandle {
+    inner: Arc<dyn Sandbox>,
+}
+
+impl SandboxHandle {
+    pub(crate) fn new(inner: Arc<dyn Sandbox>) -> Self {
+        Self { inner }
+    }
+}
+
+#[napi]
+impl SandboxHandle {
+    /// Which operations this platform's sandbox supports.
+    ///
+    /// Worth calling: capabilities differ per cloud, and an unsupported one raises rather than
+    /// silently doing nothing.
+    /// What this binding can actually do on the current platform.
+    ///
+    /// The point of publishing capabilities is that a caller branches on them instead of
+    /// discovering a gap through an error, so a capability with no method to call is worse than
+    /// one that is absent. `preview` and `snapshot` are true on some platforms but have no method
+    /// here yet, so they are not advertised until they do.
+    ///
+    /// Destructured rather than read field by field: a capability added to the set then fails to
+    /// compile here instead of being silently dropped, which is how `egressDeny` went missing.
+    #[napi]
+    pub fn capabilities(&self) -> Vec<String> {
+        let alien_core::SandboxCapabilities {
+            files,
+            reconnect,
+            preview: _,
+            suspend_resume,
+            snapshot: _,
+            domain_egress_rules,
+            egress_deny,
+            enforced_limits,
+            process_limit,
+            session_lifetime,
+            supervisor_pid_namespace,
+        } = self.inner.capabilities();
+
+        [
+            (files, "files"),
+            (reconnect, "reconnect"),
+            (suspend_resume, "suspendResume"),
+            (domain_egress_rules, "domainEgressRules"),
+            (egress_deny, "egressDeny"),
+            (enforced_limits, "enforcedLimits"),
+            (process_limit, "processLimit"),
+            (session_lifetime, "sessionLifetime"),
+            (supervisor_pid_namespace, "supervisorPidNamespace"),
+        ]
+        .into_iter()
+        .filter(|(supported, _)| *supported)
+        .map(|(_, name)| name.to_string())
+        .collect()
+    }
+
+    /// Creates a session.
+    #[napi]
+    pub async fn create(
+        &self,
+        session_id: Option<String>,
+        tenant_key: Option<String>,
+        env: Option<std::collections::HashMap<String, String>>,
+    ) -> napi::Result<SandboxSessionJs> {
+        let sandbox = self.inner.clone();
+        let session = sandbox
+            .create(CreateSessionRequest {
+                session_id,
+                tenant_key,
+                env: into_env(env),
+            })
+            .await
+            .map_err(map_alien_error)?;
+        Ok(session_to_js(session))
+    }
+
+    /// Fetches a session, or `null` if it does not exist.
+    #[napi]
+    pub async fn get(&self, session_id: String) -> napi::Result<Option<SandboxSessionJs>> {
+        let sandbox = self.inner.clone();
+        let session = sandbox.get(&session_id).await.map_err(map_alien_error)?;
+        Ok(session.map(session_to_js))
+    }
+
+    /// Fetches a session, creating it if absent.
+    #[napi]
+    pub async fn get_or_create(
+        &self,
+        session_id: Option<String>,
+        tenant_key: Option<String>,
+        env: Option<std::collections::HashMap<String, String>>,
+    ) -> napi::Result<SandboxSessionJs> {
+        let sandbox = self.inner.clone();
+        let session = sandbox
+            .get_or_create(CreateSessionRequest {
+                session_id,
+                tenant_key,
+                env: into_env(env),
+            })
+            .await
+            .map_err(map_alien_error)?;
+        Ok(session_to_js(session))
+    }
+
+    /// Lists this sandbox's sessions.
+    #[napi]
+    pub async fn list(&self) -> napi::Result<Vec<SandboxSessionJs>> {
+        let sandbox = self.inner.clone();
+        let sessions = sandbox.list().await.map_err(map_alien_error)?;
+        Ok(sessions.into_iter().map(session_to_js).collect())
+    }
+
+    /// Runs a command, returning a stream of output frames.
+    ///
+    /// `deadlineMs` is required rather than defaulted: a defaulted deadline is a hang waiting
+    /// for a slow day, in a process the caller shares with untrusted code. It bounds the command
+    /// rather than the call: backends with no timeout of their own end the session and return
+    /// once that is confirmed, others kill the process group and leave the session usable.
+    #[napi]
+    pub async fn run_command(
+        &self,
+        session_id: String,
+        command: Vec<String>,
+        deadline_ms: u32,
+        working_directory: Option<String>,
+        env: Option<std::collections::HashMap<String, String>>,
+    ) -> napi::Result<CommandStreamHandle> {
+        let sandbox = self.inner.clone();
+        let frames = sandbox
+            .run_command(
+                &session_id,
+                RunCommandRequest {
+                    command,
+                    working_directory,
+                    env: into_env(env),
+                    deadline: Duration::from_millis(u64::from(deadline_ms)),
+                },
+            )
+            .await
+            .map_err(map_alien_error)?;
+
+        Ok(CommandStreamHandle {
+            frames: Arc::new(Mutex::new(Some(frames))),
+        })
+    }
+
+    /// Reads a file out of the sandbox.
+    #[napi]
+    pub async fn read_file(&self, session_id: String, path: String) -> napi::Result<Buffer> {
+        let sandbox = self.inner.clone();
+        let contents = sandbox
+            .read_file(&session_id, &path)
+            .await
+            .map_err(map_alien_error)?;
+        Ok(Buffer::from(contents))
+    }
+
+    /// Writes one file into the sandbox.
+    ///
+    /// One at a time rather than a map: napi has no natural shape for a map of buffers, and the
+    /// TypeScript wrapper batches on this side of the boundary.
+    #[napi]
+    pub async fn write_file(
+        &self,
+        session_id: String,
+        path: String,
+        contents: Buffer,
+    ) -> napi::Result<()> {
+        let sandbox = self.inner.clone();
+        sandbox
+            .write_files(
+                &session_id,
+                BTreeMap::from([(path, contents.to_vec())]),
+            )
+            .await
+            .map_err(map_alien_error)
+    }
+
+    /// Creates a directory inside the sandbox.
+    #[napi]
+    pub async fn mkdir(&self, session_id: String, path: String) -> napi::Result<()> {
+        let sandbox = self.inner.clone();
+        sandbox
+            .mkdir(&session_id, &path)
+            .await
+            .map_err(map_alien_error)
+    }
+
+    /// Suspends a session, preserving its state. Requires the `suspendResume` capability.
+    #[napi]
+    pub async fn suspend(&self, session_id: String) -> napi::Result<()> {
+        let sandbox = self.inner.clone();
+        sandbox.suspend(&session_id).await.map_err(map_alien_error)
+    }
+
+    /// Resumes a suspended session. Requires the `suspendResume` capability.
+    #[napi]
+    pub async fn resume(&self, session_id: String) -> napi::Result<()> {
+        let sandbox = self.inner.clone();
+        sandbox.resume(&session_id).await.map_err(map_alien_error)
+    }
+
+    /// Destroys a session. Idempotent: a session already gone is the desired end state.
+    #[napi]
+    pub async fn terminate(&self, session_id: String) -> napi::Result<()> {
+        let sandbox = self.inner.clone();
+        sandbox
+            .terminate(&session_id)
+            .await
+            .map_err(map_alien_error)
+    }
+}

--- a/crates/alien-bindings-node/src/sandbox.rs
+++ b/crates/alien-bindings-node/src/sandbox.rs
@@ -16,11 +16,13 @@ use std::time::Duration;
 use alien_bindings::traits::{
     CommandOutput, CreateSessionRequest, RunCommandRequest, Sandbox, SandboxSession,
 };
+use futures::channel::oneshot;
+use futures::future::{select, Either, FutureExt, Shared};
+use futures::lock::Mutex;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
-use futures::lock::Mutex;
 
 use crate::error::map_alien_error;
 
@@ -104,10 +106,26 @@ fn frame_to_js(frame: CommandOutput) -> CommandFrameJs {
 ///
 /// The stream is held in an `Option` so it can be dropped on demand: a caller that stops reading
 /// half way through leaves a command running, and dropping the stream closes the transport
-/// carrying its output, which is what tells the backend nobody is listening.
+/// carrying its output, which is what tells the backend to kill the command. `close()` is that
+/// signal, and it has to land even while a `next()` is parked on a command that prints nothing —
+/// that `next()` holds the lock, so `close()` cannot wait for it; it fires `closed` and the
+/// parked `next()` drops the stream itself.
 #[napi]
 pub struct CommandStreamHandle {
     frames: Arc<Mutex<Option<BoxStream<'static, alien_bindings::error::Result<CommandOutput>>>>>,
+    closed: Shared<oneshot::Receiver<()>>,
+    close: Arc<std::sync::Mutex<Option<oneshot::Sender<()>>>>,
+}
+
+impl CommandStreamHandle {
+    fn new(frames: BoxStream<'static, alien_bindings::error::Result<CommandOutput>>) -> Self {
+        let (close, closed) = oneshot::channel();
+        Self {
+            frames: Arc::new(Mutex::new(Some(frames))),
+            closed: closed.shared(),
+            close: Arc::new(std::sync::Mutex::new(Some(close))),
+        }
+    }
 }
 
 #[napi]
@@ -115,7 +133,7 @@ impl CommandStreamHandle {
     /// Returns the next frame, or `null` once the command has produced its last.
     ///
     /// The terminal frame is delivered like any other, so a caller reads until `null` and finds
-    /// the exit code in the frame before it.
+    /// the exit code in the frame before it. A `close()` while this waits ends it with `null`.
     #[napi]
     pub async fn next(&self) -> napi::Result<Option<CommandFrameJs>> {
         let mut frames = self.frames.lock().await;
@@ -123,20 +141,32 @@ impl CommandStreamHandle {
             return Ok(None);
         };
 
-        match stream.next().await {
-            Some(Ok(frame)) => Ok(Some(frame_to_js(frame))),
-            Some(Err(error)) => Err(map_alien_error(error)),
-            None => {
+        match select(stream.next(), self.closed.clone()).await {
+            Either::Left((Some(Ok(frame)), _)) => Ok(Some(frame_to_js(frame))),
+            Either::Left((Some(Err(error)), _)) => Err(map_alien_error(error)),
+            Either::Left((None, _)) | Either::Right(_) => {
                 *frames = None;
                 Ok(None)
             }
         }
     }
 
-    /// Releases the stream. Idempotent, and `next()` returns `null` afterwards.
+    /// Cancels the command by releasing its stream. Idempotent, and `next()` returns `null`
+    /// afterwards — including a `next()` already waiting when this is called.
     #[napi]
     pub async fn close(&self) {
-        *self.frames.lock().await = None;
+        if let Some(close) = self
+            .close
+            .lock()
+            .expect("close sender lock poisoned")
+            .take()
+        {
+            let _ = close.send(());
+        }
+        // Drop the stream here when nobody holds it; a parked `next()` drops it on the signal.
+        if let Some(mut frames) = self.frames.try_lock() {
+            *frames = None;
+        }
     }
 }
 
@@ -285,9 +315,7 @@ impl SandboxHandle {
             .await
             .map_err(map_alien_error)?;
 
-        Ok(CommandStreamHandle {
-            frames: Arc::new(Mutex::new(Some(frames))),
-        })
+        Ok(CommandStreamHandle::new(frames))
     }
 
     /// Reads a file out of the sandbox.
@@ -314,10 +342,7 @@ impl SandboxHandle {
     ) -> napi::Result<()> {
         let sandbox = self.inner.clone();
         sandbox
-            .write_files(
-                &session_id,
-                BTreeMap::from([(path, contents.to_vec())]),
-            )
+            .write_files(&session_id, BTreeMap::from([(path, contents.to_vec())]))
             .await
             .map_err(map_alien_error)
     }
@@ -354,5 +379,41 @@ impl SandboxHandle {
             .terminate(&session_id)
             .await
             .map_err(map_alien_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A command that never prints parks `next()` on the lock; `close()` must still end it,
+    /// or the caller that gave up cannot cancel a silent command.
+    #[test]
+    fn close_ends_a_next_parked_on_a_silent_command() {
+        let handle = CommandStreamHandle::new(futures::stream::pending().boxed());
+        let (frame, ()) =
+            futures::executor::block_on(futures::future::join(handle.next(), async {
+                handle.close().await;
+            }));
+        assert!(
+            frame.expect("close is not an error").is_none(),
+            "a closed stream reports its end, not a frame"
+        );
+        assert!(
+            futures::executor::block_on(handle.frames.lock()).is_none(),
+            "the stream must be dropped, that is what reaches the backend"
+        );
+    }
+
+    /// Closing before or after the end is a no-op; a caller need not track which came first.
+    #[test]
+    fn close_is_idempotent_and_next_stays_null() {
+        let handle = CommandStreamHandle::new(futures::stream::empty().boxed());
+        futures::executor::block_on(async {
+            handle.close().await;
+            handle.close().await;
+            assert!(handle.next().await.expect("closed").is_none());
+            assert!(handle.next().await.expect("closed").is_none());
+        });
     }
 }

--- a/packages/bindings/src/__tests__/factories.test.ts
+++ b/packages/bindings/src/__tests__/factories.test.ts
@@ -5,6 +5,7 @@ import type {
   NativeAddon,
   RawBindingsHandle,
   RawCommandFrame,
+  RawCommandStreamHandle,
   RawContainerHandle,
   RawKeyHandle,
   RawKvHandle,
@@ -632,9 +633,6 @@ describe("createFactories postgres surface", () => {
 })
 
 describe("sandbox streaming", () => {
-  // Every other binding drains its stream before returning. This one must not: the resource
-  // exists for agent loops that print as they go, and a caller has to see a frame before the
-  // command ends.
   it("yields frames one at a time and ends after the terminal frame", async () => {
     const { addon } = fakeAddon()
     const { sandbox } = createFactories(() => addon)
@@ -651,9 +649,63 @@ describe("sandbox streaming", () => {
     expect(seen).toEqual(["hello", "problem", "exit:3"])
   })
 
-  // A caller that never iterates must never start a command: the handle is opened on the first
-  // pull, which is also what makes the loop apply backpressure.
-  it("does not run the command until the iteration starts", async () => {
+  it("starts one command when two pulls race the setup", async () => {
+    const { addon } = fakeAddon()
+    let opened = 0
+    let finishSetup: () => void = () => {}
+    let setupStarted: () => void = () => {}
+    const setup = new Promise<void>(resolve => {
+      finishSetup = resolve
+    })
+    const started = new Promise<void>(resolve => {
+      setupStarted = resolve
+    })
+
+    class CountingBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async (...args: Parameters<RawSandboxHandle["runCommand"]>) => {
+            opened += 1
+            setupStarted()
+            await setup
+            return await inner.runCommand(...args)
+          },
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: CountingBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+    const first = iterator.next()
+    const second = iterator.next()
+
+    await started
+    expect(opened).toBe(1)
+
+    finishSetup()
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        done: false,
+        value: { kind: "stdout", seq: 0, data: Buffer.from("hello\n") },
+      },
+      {
+        done: false,
+        value: { kind: "stderr", seq: 1, data: Buffer.from("problem\n") },
+      },
+    ])
+
+    expect(opened).toBe(1)
+  })
+
+  it("does not start a command when the caller never pulls", async () => {
     const { addon } = fakeAddon()
     let opened = 0
 
@@ -674,19 +726,535 @@ describe("sandbox streaming", () => {
       ...addon,
       BindingsHandle: CountingBindingsHandle as unknown as NativeAddon["BindingsHandle"],
     }))
-    const iterable = sandbox("sbx").runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
-    expect(opened).toBe(0)
 
-    for await (const _ of iterable) {
-      break
-    }
-    expect(opened).toBe(1)
+    sandbox("sbx").runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(opened).toBe(0)
   })
 
-  // Leaving the loop early is the ordinary way to stop reading — "run until the first match",
-  // an error part way through, a caller that gives up. The command keeps running and keeps
-  // costing until the stream is released, so leaving that to garbage collection is a leak
-  // measured in sandbox minutes.
+  it("closes a parked read before return waits for it", async () => {
+    const { addon } = fakeAddon()
+    let closed = 0
+    let readStarted: () => void = () => {}
+    let finishRead: (frame: RawCommandFrame | null) => void = () => {}
+    const reading = new Promise<void>(resolve => {
+      readStarted = resolve
+    })
+    const parked = new Promise<RawCommandFrame | null>(resolve => {
+      finishRead = resolve
+    })
+
+    class SilentBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => {
+            return {
+              next: () => {
+                readStarted()
+                return parked
+              },
+              close: async () => {
+                closed += 1
+                finishRead(null)
+              },
+            }
+          },
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: SilentBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/sleep"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+    const pull = iterator.next()
+    await reading
+
+    const returned = iterator.return?.()
+    if (!returned) throw new Error("iterator return is missing")
+
+    expect(closed).toBe(1)
+    await expect(returned).resolves.toEqual({ done: true, value: undefined })
+    await expect(pull).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  it("closes a command that finishes setup after return", async () => {
+    const { addon } = fakeAddon()
+    let allowSetup: () => void = () => {}
+    let setupStarted: () => void = () => {}
+    const setup = new Promise<void>(resolve => {
+      allowSetup = resolve
+    })
+    const started = new Promise<void>(resolve => {
+      setupStarted = resolve
+    })
+    let closed = 0
+    const next = vi.fn<RawCommandStreamHandle["next"]>(async () => ({
+      kind: "stdout",
+      seq: 0,
+      data: Buffer.from("too late"),
+    }))
+    const runCommand = vi.fn<RawSandboxHandle["runCommand"]>(async () => {
+      setupStarted()
+      await setup
+      return {
+        next,
+        close: async () => {
+          closed += 1
+        },
+      }
+    })
+
+    class SlowStartBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return { ...inner, runCommand }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: SlowStartBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/sleep"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+    const pull = iterator.next()
+    await started
+
+    // return() must not resolve while the command it is cancelling is still being started:
+    // a caller told the cancel is complete would otherwise leave a command about to run.
+    let returned = false
+    const returning = iterator.return?.().then(result => {
+      returned = true
+      return result
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(returned).toBe(false)
+    expect(closed).toBe(0)
+
+    allowSetup()
+
+    await expect(returning).resolves.toEqual({ done: true, value: undefined })
+    expect(closed).toBe(1)
+    await expect(pull).resolves.toEqual({ done: true, value: undefined })
+    expect(next).not.toHaveBeenCalled()
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined })
+    expect(runCommand).toHaveBeenCalledTimes(1)
+    expect(closed).toBe(1)
+  })
+
+  // A pull in flight when the caller cancels only observes the cancel. The close failure belongs
+  // to the throw() that caused it, and must not surface a second time on the pending pull.
+  it("completes a pending pull as done when throw() closes and the close fails", async () => {
+    const { addon } = fakeAddon()
+    let unpark: (frame: RawCommandFrame | null) => void = () => {}
+    const parked = new Promise<RawCommandFrame | null>(resolve => {
+      unpark = resolve
+    })
+
+    class ParkedFailingCloseBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: () => parked,
+            close: async () => {
+              unpark(null)
+              throw new Error("close exploded")
+            },
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: ParkedFailingCloseBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/sleep"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+    const pending = iterator.next()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const original = new Error("caller gave up")
+    await expect(iterator.throw?.(original)).rejects.toBe(original)
+    await expect(pending).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  // Same rule where the stream itself fails: the read error ended iteration, and the close
+  // that follows must not overwrite it even if that close also fails.
+  it("reports the read error, not the close error, when both fail", async () => {
+    const { addon } = fakeAddon()
+    let closeAttempts = 0
+
+    class DoubleFaultBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: async () => {
+              throw new Error("read exploded")
+            },
+            close: async () => {
+              closeAttempts += 1
+              throw new Error("close exploded")
+            },
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: DoubleFaultBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+
+    await expect(iterator.next()).rejects.toThrow("read exploded")
+    expect(closeAttempts).toBe(1)
+  })
+
+  // The caller's error is what iteration failed on; a close that also fails must not replace it.
+  it("rethrows the caller's error from throw() even when the native close fails", async () => {
+    const { addon } = fakeAddon()
+    let closeAttempts = 0
+
+    class FailingCloseBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: async () => ({ kind: "stdout", seq: 0, data: Buffer.from("x") }),
+            close: async () => {
+              closeAttempts += 1
+              throw new Error("close exploded")
+            },
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: FailingCloseBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+    await iterator.next()
+
+    const original = new Error("caller gave up")
+    await expect(iterator.throw?.(original)).rejects.toBe(original)
+    expect(closeAttempts).toBe(1)
+  })
+
+  it("serializes overlapping pulls after the stream opens", async () => {
+    const { addon } = fakeAddon()
+    let active = false
+    let reentered = false
+    let finishSecond: () => void = () => {}
+    let secondStarted: () => void = () => {}
+    const second = new Promise<void>(resolve => {
+      finishSecond = resolve
+    })
+    const started = new Promise<void>(resolve => {
+      secondStarted = resolve
+    })
+    const close = vi.fn<RawCommandStreamHandle["close"]>(async () => {})
+    const next = vi.fn<RawCommandStreamHandle["next"]>(async () => {
+      const call = next.mock.calls.length
+      if (active) reentered = true
+      active = true
+      try {
+        if (call === 1) {
+          return { kind: "stdout", seq: 0, data: Buffer.from("first") }
+        }
+        if (call === 2) {
+          secondStarted()
+          await second
+          return { kind: "stderr", seq: 1, data: Buffer.from("second") }
+        }
+        return { kind: "exit", exitCode: 0, truncated: false }
+      } finally {
+        active = false
+      }
+    })
+
+    class SerializedBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({ next, close }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: SerializedBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 10_000 })
+      [Symbol.asyncIterator]()
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { kind: "stdout", seq: 0, data: Buffer.from("first") },
+    })
+
+    const secondPull = iterator.next()
+    await started
+    const thirdPull = iterator.next()
+    await Promise.resolve()
+
+    expect(next).toHaveBeenCalledTimes(2)
+    expect(reentered).toBe(false)
+
+    finishSecond()
+
+    await expect(secondPull).resolves.toEqual({
+      done: false,
+      value: { kind: "stderr", seq: 1, data: Buffer.from("second") },
+    })
+    await expect(thirdPull).resolves.toEqual({
+      done: false,
+      value: { kind: "exit", exitCode: 0, truncated: false },
+    })
+    await iterator.return?.()
+
+    expect(reentered).toBe(false)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it("finishes after setup rejects without retaining the rejection", async () => {
+    const { addon } = fakeAddon()
+    const nativeError = new Error(
+      JSON.stringify({
+        code: "SANDBOX_SETUP_FAILED",
+        message: "sandbox setup failed",
+        retryable: true,
+        internal: false,
+      }),
+    )
+    const runCommand = vi.fn<RawSandboxHandle["runCommand"]>(async () => {
+      throw nativeError
+    })
+
+    class FailingBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return { ...inner, runCommand }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: FailingBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
+      [Symbol.asyncIterator]()
+    const error = await iterator.next().catch((caught: unknown) => caught)
+
+    expect(error).not.toBe(nativeError)
+    expect(error).toBeInstanceOf(AlienError)
+    expect((error as AlienError).code).toBe("SANDBOX_SETUP_FAILED")
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined })
+    await expect(iterator.return?.()).resolves.toEqual({ done: true, value: undefined })
+    expect(runCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes the stream and unwraps a rejected native read", async () => {
+    const { addon } = fakeAddon()
+    const nativeError = new Error(
+      JSON.stringify({
+        code: "SANDBOX_READ_FAILED",
+        message: "sandbox read failed",
+        retryable: false,
+        internal: false,
+      }),
+    )
+    const close = vi.fn<RawCommandStreamHandle["close"]>(async () => {})
+
+    class FailingReadBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: async () => {
+              throw nativeError
+            },
+            close,
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: FailingReadBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
+      [Symbol.asyncIterator]()
+    const error = await iterator.next().catch((caught: unknown) => caught)
+
+    expect(error).not.toBe(nativeError)
+    expect(error).toBeInstanceOf(AlienError)
+    expect((error as AlienError).code).toBe("SANDBOX_READ_FAILED")
+    expect(close).toHaveBeenCalledTimes(1)
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  it("closes the stream when frame conversion rejects", async () => {
+    const { addon } = fakeAddon()
+    const close = vi.fn<RawCommandStreamHandle["close"]>(async () => {})
+
+    class UnknownFrameBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: async () => ({ kind: "future-output", seq: 0, data: Buffer.from("unknown") }),
+            close,
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: UnknownFrameBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
+      [Symbol.asyncIterator]()
+    const error = await iterator.next().catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(AlienError)
+    expect((error as AlienError).code).toBe("UNKNOWN_SANDBOX_VALUE")
+    expect(close).toHaveBeenCalledTimes(1)
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined })
+  })
+
+  it("drops a buffered frame returned while a parked read is closing", async () => {
+    const { addon } = fakeAddon()
+    let readStarted: () => void = () => {}
+    let finishRead: (frame: RawCommandFrame | null) => void = () => {}
+    let closed = false
+    const reading = new Promise<void>(resolve => {
+      readStarted = resolve
+    })
+    const parked = new Promise<RawCommandFrame | null>(resolve => {
+      finishRead = resolve
+    })
+    const close = vi.fn<RawCommandStreamHandle["close"]>(async () => {
+      if (closed) return
+      closed = true
+      finishRead({ kind: "stdout", seq: 0, data: Buffer.from("buffered") })
+    })
+
+    class BufferedFrameBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: () => {
+              readStarted()
+              return parked
+            },
+            close,
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: BufferedFrameBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/sleep"], { deadlineMs: 1000 })
+      [Symbol.asyncIterator]()
+    const pull = iterator.next()
+    await reading
+
+    await expect(iterator.return?.()).resolves.toEqual({ done: true, value: undefined })
+    await expect(pull).resolves.toEqual({ done: true, value: undefined })
+    expect(close).toHaveBeenCalled()
+  })
+
+  it("rejects return when the native close fails", async () => {
+    const { addon } = fakeAddon()
+    const nativeError = new Error(
+      JSON.stringify({
+        code: "SANDBOX_CLOSE_FAILED",
+        message: "sandbox close failed",
+        retryable: false,
+        internal: false,
+      }),
+    )
+    const close = vi.fn<RawCommandStreamHandle["close"]>(async () => {
+      throw nativeError
+    })
+
+    class FailingCloseBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async () => ({
+            next: async () => ({ kind: "stdout", seq: 0, data: Buffer.from("started") }),
+            close,
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: FailingCloseBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    const iterator = sandbox("sbx")
+      .runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
+      [Symbol.asyncIterator]()
+    await iterator.next()
+    const error = await iterator.return?.().catch((caught: unknown) => caught)
+
+    expect(error).not.toBe(nativeError)
+    expect(error).toBeInstanceOf(AlienError)
+    expect((error as AlienError).code).toBe("SANDBOX_CLOSE_FAILED")
+    expect(close).toHaveBeenCalledTimes(1)
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined })
+  })
+
   it.each([
     [
       "the loop is broken out of",
@@ -739,8 +1307,6 @@ describe("sandbox streaming", () => {
     expect(closed).toBe(1)
   })
 
-  // env is the one option a caller cannot work around: without it reaching the addon there is no
-  // way to configure a session's environment from TypeScript at all.
   it("passes env through to the addon on create and on a command", async () => {
     const { addon } = fakeAddon()
     const seen: Array<Record<string, string> | null | undefined> = []

--- a/packages/bindings/src/__tests__/factories.test.ts
+++ b/packages/bindings/src/__tests__/factories.test.ts
@@ -4,15 +4,18 @@ import { createFactories } from "../factories.js"
 import type {
   NativeAddon,
   RawBindingsHandle,
+  RawCommandFrame,
   RawContainerHandle,
   RawKeyHandle,
   RawKvHandle,
   RawPostgresConnection,
   RawPostgresHandle,
   RawQueueHandle,
+  RawSandboxHandle,
   RawStorageHandle,
   RawVaultHandle,
 } from "../loader.js"
+import type { CommandFrame } from "../types.js"
 
 function unusedRemoteBindingsHandle(): NativeAddon["RemoteBindingsHandle"] {
   return {
@@ -120,6 +123,33 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
     connection: () => rawConnection("verify-full"),
   }
 
+  const sandboxHandle: RawSandboxHandle = {
+    capabilities: () => ["reconnect"],
+    create: async sessionId => ({ sessionId: sessionId ?? "s1", state: "running", generation: 1 }),
+    get: async sessionId => ({ sessionId, state: "running", generation: 1 }),
+    getOrCreate: async sessionId => ({
+      sessionId: sessionId ?? "s1",
+      state: "running",
+      generation: 1,
+    }),
+    list: async () => [],
+    runCommand: async () => {
+      const frames: RawCommandFrame[] = [
+        { kind: "stdout", seq: 0, data: Buffer.from("hello\n") },
+        { kind: "stderr", seq: 1, data: Buffer.from("problem\n") },
+        { kind: "exit", exitCode: 3, truncated: false },
+      ]
+      let index = 0
+      return { next: async () => frames[index++] ?? null, close: async () => {} }
+    },
+    readFile: async () => Buffer.from("contents"),
+    writeFile: async () => {},
+    mkdir: async () => {},
+    suspend: async () => {},
+    resume: async () => {},
+    terminate: async () => {},
+  }
+
   const bindings: RawBindingsHandle = {
     storage: async () => storageHandle,
     key: async () => keyHandle,
@@ -128,6 +158,7 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
     vault: async () => vaultHandle,
     container: async () => containerHandle,
     postgres: async () => postgresHandle,
+    sandbox: async () => sandboxHandle,
   }
 
   class FakeBindingsHandle {
@@ -141,6 +172,7 @@ function fakeAddon(): { addon: NativeAddon; constructions: unknown[] } {
     vault = bindings.vault
     container = bindings.container
     postgres = bindings.postgres
+    sandbox = bindings.sandbox
   }
 
   return {
@@ -596,5 +628,161 @@ describe("createFactories postgres surface", () => {
     expect((error as AlienError).retryable).toBe(false)
     expect((error as AlienError).message).toContain("prefer")
     expect((error as AlienError).message).toContain("disable, verify-ca, verify-full")
+  })
+})
+
+describe("sandbox streaming", () => {
+  // Every other binding drains its stream before returning. This one must not: the resource
+  // exists for agent loops that print as they go, and a caller has to see a frame before the
+  // command ends.
+  it("yields frames one at a time and ends after the terminal frame", async () => {
+    const { addon } = fakeAddon()
+    const { sandbox } = createFactories(() => addon)
+
+    const seen: string[] = []
+    for await (const frame of sandbox("sbx").runCommand("s1", ["/bin/echo"], {
+      deadlineMs: 10_000,
+    })) {
+      seen.push(
+        frame.kind === "exit" ? `exit:${frame.exitCode}` : frame.data.toString("utf8").trim(),
+      )
+    }
+
+    expect(seen).toEqual(["hello", "problem", "exit:3"])
+  })
+
+  // A caller that never iterates must never start a command: the handle is opened on the first
+  // pull, which is also what makes the loop apply backpressure.
+  it("does not run the command until the iteration starts", async () => {
+    const { addon } = fakeAddon()
+    let opened = 0
+
+    class CountingBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: (...args: Parameters<RawSandboxHandle["runCommand"]>) => {
+            opened += 1
+            return inner.runCommand(...args)
+          },
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: CountingBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+    const iterable = sandbox("sbx").runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 })
+    expect(opened).toBe(0)
+
+    for await (const _ of iterable) {
+      break
+    }
+    expect(opened).toBe(1)
+  })
+
+  // Leaving the loop early is the ordinary way to stop reading — "run until the first match",
+  // an error part way through, a caller that gives up. The command keeps running and keeps
+  // costing until the stream is released, so leaving that to garbage collection is a leak
+  // measured in sandbox minutes.
+  it.each([
+    [
+      "the loop is broken out of",
+      async (frames: AsyncIterable<CommandFrame>) => {
+        for await (const _ of frames) break
+      },
+    ],
+    [
+      "the loop throws",
+      async (frames: AsyncIterable<CommandFrame>) => {
+        await expect(
+          (async () => {
+            for await (const _ of frames) throw new Error("caller gave up")
+          })(),
+        ).rejects.toThrow("caller gave up")
+      },
+    ],
+    [
+      "the command ends on its own",
+      async (frames: AsyncIterable<CommandFrame>) => {
+        for await (const _ of frames);
+      },
+    ],
+  ])("closes the stream when %s", async (_case, consume) => {
+    const { addon } = fakeAddon()
+    let closed = 0
+
+    class ClosingBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          runCommand: async (...args: Parameters<RawSandboxHandle["runCommand"]>) => ({
+            ...(await inner.runCommand(...args)),
+            close: async () => {
+              closed += 1
+            },
+          }),
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: ClosingBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    await consume(sandbox("sbx").runCommand("s1", ["/bin/echo"], { deadlineMs: 1000 }))
+
+    expect(closed).toBe(1)
+  })
+
+  // env is the one option a caller cannot work around: without it reaching the addon there is no
+  // way to configure a session's environment from TypeScript at all.
+  it("passes env through to the addon on create and on a command", async () => {
+    const { addon } = fakeAddon()
+    const seen: Array<Record<string, string> | null | undefined> = []
+
+    class RecordingBindingsHandle {
+      async sandbox(name: string): Promise<RawSandboxHandle> {
+        const inner = await new addon.BindingsHandle().sandbox(name)
+        return {
+          ...inner,
+          create: (sessionId, tenantKey, env) => {
+            seen.push(env)
+            return inner.create(sessionId, tenantKey, env)
+          },
+          runCommand: (sessionId, command, deadlineMs, workingDirectory, env) => {
+            seen.push(env)
+            return inner.runCommand(sessionId, command, deadlineMs, workingDirectory, env)
+          },
+        }
+      }
+    }
+
+    const { sandbox } = createFactories(() => ({
+      ...addon,
+      BindingsHandle: RecordingBindingsHandle as unknown as NativeAddon["BindingsHandle"],
+    }))
+
+    await sandbox("sbx").create({ env: { TOKEN: "s3cret" } })
+    for await (const _ of sandbox("sbx").runCommand("s1", ["/bin/echo"], {
+      deadlineMs: 1000,
+      env: { EXTRA: "1" },
+    }));
+
+    expect(seen).toEqual([{ TOKEN: "s3cret" }, { EXTRA: "1" }])
+  })
+
+  it("writes files one call per path and reads them back as bytes", async () => {
+    const { addon } = fakeAddon()
+    const { sandbox } = createFactories(() => addon)
+
+    await sandbox("sbx").writeFiles("s1", { "a.txt": "text", "b.bin": Buffer.from([1, 2]) })
+    const read = await sandbox("sbx").readFile("s1", "a.txt")
+
+    expect(Buffer.isBuffer(read)).toBe(true)
   })
 })

--- a/packages/bindings/src/__tests__/loader.test.ts
+++ b/packages/bindings/src/__tests__/loader.test.ts
@@ -25,6 +25,9 @@ function addonReporting(version: string): NativeAddon {
     postgres(): never {
       throw new Error("not used by version validation")
     }
+    sandbox(): never {
+      throw new Error("not used by version validation")
+    }
   }
 
   const RemoteBindingsHandle: NativeAddon["RemoteBindingsHandle"] = {

--- a/packages/bindings/src/__tests__/remote.test.ts
+++ b/packages/bindings/src/__tests__/remote.test.ts
@@ -91,6 +91,10 @@ function fakeRemoteAddon() {
     async postgres(): Promise<RawPostgresHandle> {
       throw new Error("unused")
     }
+
+    async sandbox(): Promise<never> {
+      throw new Error("unused")
+    }
   }
 
   class FakeRemoteBindingsHandle implements RawRemoteBindingsHandle {

--- a/packages/bindings/src/errors.ts
+++ b/packages/bindings/src/errors.ts
@@ -80,6 +80,27 @@ export const InvalidPostgresTlsConfigError = defineError({
   internal: false,
 })
 
+/**
+ * Thrown when the native addon reports a sandbox session state or output frame kind this wrapper
+ * does not know.
+ *
+ * Casting instead would put a value outside the declared union behind a type that says otherwise,
+ * so a `switch` a caller wrote against the union would fall through silently. Version skew has to
+ * fail loudly, and retrying cannot repair it.
+ */
+export const UnknownSandboxValueError = defineError({
+  code: "UNKNOWN_SANDBOX_VALUE",
+  context: z.object({
+    field: z.string(),
+    value: z.string(),
+    expected: z.array(z.string()),
+  }),
+  message: ({ field, value, expected }) =>
+    `@alienplatform/bindings received an unknown sandbox ${field} '${value}' from the native addon; expected one of ${expected.join(", ")}.`,
+  retryable: false,
+  internal: false,
+})
+
 /** Fallback code for napi-internal errors whose message is not an envelope. */
 const GENERIC_BINDINGS_CODE = "BINDINGS_ERROR"
 

--- a/packages/bindings/src/factories.ts
+++ b/packages/bindings/src/factories.ts
@@ -17,11 +17,13 @@ import {
   AlienError,
   InvalidPostgresTlsConfigError,
   UnknownPostgresSslModeError,
+  UnknownSandboxValueError,
   unwrapNapiError,
 } from "./errors.js"
 import type {
   NativeAddon,
   RawBindingsHandle,
+  RawCommandFrame,
   RawContainerHandle,
   RawKeyHandle,
   RawKvHandle,
@@ -30,10 +32,13 @@ import type {
   RawQueueHandle,
   RawRemoteBindingsHandle,
   RawRemoteStorageHandle,
+  RawSandboxHandle,
+  RawSandboxSession,
   RawStorageHandle,
   RawVaultHandle,
 } from "./loader.js"
 import type {
+  CommandFrame,
   Container,
   Key,
   KeyOptions,
@@ -48,6 +53,8 @@ import type {
   Queue,
   QueueMessage,
   RemoteStorage,
+  Sandbox,
+  SandboxSession,
   SignedUrlOptions,
   Storage,
   StoragePutOptions,
@@ -130,6 +137,123 @@ function makeRemoteStorage(handle: () => Promise<RawRemoteStorageHandle>): Remot
     delete: path => guard(handle, raw => raw.delete(path)),
     list: prefix => guard(handle, raw => raw.list(prefix ?? null)),
     head: path => guard(handle, raw => raw.head(path)),
+  }
+}
+
+/** The session states the addon and this wrapper agree on. */
+const SANDBOX_SESSION_STATES = ["starting", "running", "suspended", "terminated"] as const
+
+/** The output frame kinds that carry data; `exit` is handled separately. */
+const SANDBOX_STREAM_KINDS = ["stdout", "stderr"] as const
+
+/**
+ * Narrows a value the addon produced into a declared union, or throws.
+ *
+ * Casting would put a value outside the union behind a type claiming otherwise, and a caller's
+ * `switch` over the union would then fall through with no error. This is the same version-skew
+ * argument `toPostgresConnection` makes for `sslmode`.
+ */
+function narrow<T extends string>(field: string, value: string, expected: readonly T[]): T {
+  if ((expected as readonly string[]).includes(value)) {
+    return value as T
+  }
+  throw new AlienError(
+    UnknownSandboxValueError.create({ field, value, expected: [...expected] }).toOptions(),
+  )
+}
+
+function makeSandbox(handle: () => Promise<RawSandboxHandle>): Sandbox {
+  const session = (raw: RawSandboxSession): SandboxSession => ({
+    sessionId: raw.sessionId,
+    state: narrow("session state", raw.state, SANDBOX_SESSION_STATES),
+    generation: raw.generation,
+  })
+
+  const frame = (raw: RawCommandFrame): CommandFrame =>
+    raw.kind === "exit"
+      ? { kind: "exit", exitCode: raw.exitCode ?? -1, truncated: raw.truncated ?? false }
+      : {
+          kind: narrow("frame kind", raw.kind, SANDBOX_STREAM_KINDS),
+          seq: raw.seq ?? 0,
+          data: raw.data ?? Buffer.alloc(0),
+        }
+
+  return {
+    capabilities: () => guard(handle, async raw => raw.capabilities()),
+    create: options =>
+      guard(handle, async raw =>
+        session(
+          await raw.create(
+            options?.sessionId ?? null,
+            options?.tenantKey ?? null,
+            options?.env ?? null,
+          ),
+        ),
+      ),
+    get: sessionId =>
+      guard(handle, async raw => {
+        const found = await raw.get(sessionId)
+        return found === null ? null : session(found)
+      }),
+    getOrCreate: options =>
+      guard(handle, async raw =>
+        session(
+          await raw.getOrCreate(
+            options?.sessionId ?? null,
+            options?.tenantKey ?? null,
+            options?.env ?? null,
+          ),
+        ),
+      ),
+    list: () => guard(handle, async raw => (await raw.list()).map(session)),
+    // Not `async function*` over a resolved stream: the handle is opened on the first pull, so
+    // a caller that never iterates never starts a command.
+    runCommand: (sessionId, command, options) => ({
+      async *[Symbol.asyncIterator]() {
+        const stream = await guard(handle, raw =>
+          raw.runCommand(
+            sessionId,
+            command,
+            options.deadlineMs,
+            options.workingDirectory ?? null,
+            options.env ?? null,
+          ),
+        )
+
+        // A caller that breaks out of the loop, returns, or throws still leaves a command
+        // running in the sandbox. `for await` calls the generator's `return()` on every one of
+        // those, so closing here is what stops paying for output nobody is reading.
+        try {
+          while (true) {
+            let next: RawCommandFrame | null
+            try {
+              next = await stream.next()
+            } catch (err) {
+              throw unwrapNapiError(err)
+            }
+            if (next === null) return
+            yield frame(next)
+          }
+        } finally {
+          await stream.close()
+        }
+      },
+    }),
+    readFile: (sessionId, path) => guard(handle, raw => raw.readFile(sessionId, path)),
+    writeFiles: (sessionId, files) =>
+      guard(handle, async raw => {
+        for (const [path, contents] of Object.entries(files)) {
+          await raw.writeFile(
+            sessionId,
+            path,
+            typeof contents === "string" ? Buffer.from(contents, "utf8") : contents,
+          )
+        }
+      }),
+    mkdir: (sessionId, path) => guard(handle, raw => raw.mkdir(sessionId, path)),
+    suspend: sessionId => guard(handle, raw => raw.suspend(sessionId)),
+    resume: sessionId => guard(handle, raw => raw.resume(sessionId)),
+    terminate: sessionId => guard(handle, raw => raw.terminate(sessionId)),
   }
 }
 
@@ -348,6 +472,7 @@ export interface Factories {
   vault(name: string): Vault
   container(name: string): Container
   postgres(name: string): Postgres
+  sandbox(name: string): Sandbox
 }
 
 /** Build the factories bound to a given addon provider. */
@@ -361,6 +486,7 @@ export function createFactories(getAddon: () => NativeAddon): Factories {
     vault: name => makeVault(lazyHandle(async () => (await getBindings()).vault(name))),
     container: name => makeContainer(lazyHandle(async () => (await getBindings()).container(name))),
     postgres: name => makePostgres(lazyHandle(async () => (await getBindings()).postgres(name))),
+    sandbox: name => makeSandbox(lazyHandle(async () => (await getBindings()).sandbox(name))),
   }
 }
 

--- a/packages/bindings/src/factories.ts
+++ b/packages/bindings/src/factories.ts
@@ -24,6 +24,7 @@ import type {
   NativeAddon,
   RawBindingsHandle,
   RawCommandFrame,
+  RawCommandStreamHandle,
   RawContainerHandle,
   RawKeyHandle,
   RawKvHandle,
@@ -206,36 +207,113 @@ function makeSandbox(handle: () => Promise<RawSandboxHandle>): Sandbox {
         ),
       ),
     list: () => guard(handle, async raw => (await raw.list()).map(session)),
-    // Not `async function*` over a resolved stream: the handle is opened on the first pull, so
-    // a caller that never iterates never starts a command.
     runCommand: (sessionId, command, options) => ({
-      async *[Symbol.asyncIterator]() {
-        const stream = await guard(handle, raw =>
-          raw.runCommand(
-            sessionId,
-            command,
-            options.deadlineMs,
-            options.workingDirectory ?? null,
-            options.env ?? null,
-          ),
-        )
+      [Symbol.asyncIterator](): AsyncIterator<CommandFrame, undefined> {
+        let stream: RawCommandStreamHandle | null = null
+        let starting: Promise<RawCommandStreamHandle> | null = null
+        let tail: Promise<unknown> = Promise.resolve()
+        let finished = false
 
-        // A caller that breaks out of the loop, returns, or throws still leaves a command
-        // running in the sandbox. `for await` calls the generator's `return()` on every one of
-        // those, so closing here is what stops paying for output nobody is reading.
-        try {
-          while (true) {
-            let next: RawCommandFrame | null
+        // A cancel that lands during setup has no handle yet, so it waits for the one being made:
+        // resolving sooner would report a command stopped that is about to start.
+        let closing: Promise<void> | null = null
+        const close = () => {
+          closing ??= (async () => {
+            const open = stream ?? (await starting?.catch(() => null)) ?? null
+            if (open === null) return
             try {
-              next = await stream.next()
+              await open.close()
             } catch (err) {
               throw unwrapNapiError(err)
             }
-            if (next === null) return
-            yield frame(next)
-          }
-        } finally {
-          await stream.close()
+          })()
+          return closing
+        }
+
+        // Cancellation bypasses the pull queue so it can release a native read waiting for output.
+        const finish = async () => {
+          finished = true
+          await close()
+        }
+
+        // The fault iteration ended on is what the caller must see; a close that also fails is
+        // reported only when it is the sole failure, from `return()`.
+        const fail = async (err: unknown): Promise<never> => {
+          await finish().catch(() => undefined)
+          throw err
+        }
+
+        // A pull that observes a cancel only reports `done`: the `return()` or `throw()` that
+        // cancelled is where a failed close is reported, and it must not be reported twice.
+        const cancelled = async (): Promise<IteratorResult<CommandFrame, undefined>> => {
+          await finish().catch(() => undefined)
+          return { done: true, value: undefined }
+        }
+
+        return {
+          next() {
+            const pull = tail.then(async (): Promise<IteratorResult<CommandFrame, undefined>> => {
+              if (finished) {
+                return { done: true, value: undefined }
+              }
+              let open = stream
+              if (open === null) {
+                starting = guard(handle, raw =>
+                  raw.runCommand(
+                    sessionId,
+                    command,
+                    options.deadlineMs,
+                    options.workingDirectory ?? null,
+                    options.env ?? null,
+                  ),
+                )
+                try {
+                  open = await starting
+                  stream = open
+                } catch (err) {
+                  finished = true
+                  throw err
+                }
+              }
+
+              // A return during setup cannot close a handle until this pull receives it.
+              if (finished) {
+                return cancelled()
+              }
+
+              let next: RawCommandFrame | null
+              try {
+                next = await open.next()
+              } catch (err) {
+                return fail(unwrapNapiError(err))
+              }
+
+              if (finished) {
+                return cancelled()
+              }
+              if (next === null) {
+                await finish()
+                return { done: true, value: undefined }
+              }
+
+              let value: CommandFrame
+              try {
+                value = frame(next)
+              } catch (err) {
+                return fail(unwrapNapiError(err))
+              }
+              return { done: false, value }
+            })
+
+            // A rejected pull must not poison the queue behind it.
+            tail = pull.catch(() => undefined)
+            return pull
+          },
+          async return() {
+            await finish()
+            return { done: true, value: undefined }
+          },
+          throw: (err: unknown) => fail(err),
         }
       },
     }),

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -37,6 +37,9 @@ export const container = factories.container
 /** Resolve the Postgres binding named `name`. */
 export const postgres = factories.postgres
 
+/** Create an isolated environment for running untrusted code. */
+export const sandbox = factories.sandbox
+
 export {
   AlienError,
   BindingNotConfiguredError,
@@ -44,9 +47,11 @@ export {
   defineError,
   InvalidPostgresTlsConfigError,
   UnknownPostgresSslModeError,
+  UnknownSandboxValueError,
 } from "./errors.js"
 
 export type {
+  CommandFrame,
   Container,
   Key,
   KeyOptions,
@@ -65,6 +70,9 @@ export type {
   Queue,
   QueueMessage,
   RemoteStorage,
+  RunCommandOptions,
+  Sandbox,
+  SandboxSession,
   SignedUrlMethod,
   SignedUrlOptions,
   Storage,

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -174,6 +174,58 @@ export interface RawVaultHandle {
   listSecrets(): Promise<string[]>
 }
 
+/** One frame of a running command's output, as the addon returns it. */
+export interface RawCommandFrame {
+  kind: string
+  seq?: number
+  data?: Buffer
+  exitCode?: number
+  truncated?: boolean
+}
+
+/** Raw napi command stream, pulled one frame at a time. */
+export interface RawCommandStreamHandle {
+  next(): Promise<RawCommandFrame | null>
+  close(): Promise<void>
+}
+
+/** A live sandbox session, as the addon returns it. */
+export interface RawSandboxSession {
+  sessionId: string
+  state: string
+  generation: number
+}
+
+/** Raw napi sandbox handle. */
+export interface RawSandboxHandle {
+  capabilities(): string[]
+  create(
+    sessionId?: string | null,
+    tenantKey?: string | null,
+    env?: Record<string, string> | null,
+  ): Promise<RawSandboxSession>
+  get(sessionId: string): Promise<RawSandboxSession | null>
+  getOrCreate(
+    sessionId?: string | null,
+    tenantKey?: string | null,
+    env?: Record<string, string> | null,
+  ): Promise<RawSandboxSession>
+  list(): Promise<RawSandboxSession[]>
+  runCommand(
+    sessionId: string,
+    command: string[],
+    deadlineMs: number,
+    workingDirectory?: string | null,
+    env?: Record<string, string> | null,
+  ): Promise<RawCommandStreamHandle>
+  readFile(sessionId: string, path: string): Promise<Buffer>
+  writeFile(sessionId: string, path: string, contents: Buffer): Promise<void>
+  mkdir(sessionId: string, path: string): Promise<void>
+  suspend(sessionId: string): Promise<void>
+  resume(sessionId: string): Promise<void>
+  terminate(sessionId: string): Promise<void>
+}
+
 /** Raw napi bindings entry point. Construction validates the environment. */
 export interface RawBindingsHandle {
   storage(name: string): Promise<RawStorageHandle>
@@ -183,6 +235,7 @@ export interface RawBindingsHandle {
   vault(name: string): Promise<RawVaultHandle>
   container(name: string): Promise<RawContainerHandle>
   postgres(name: string): Promise<RawPostgresHandle>
+  sandbox(name: string): Promise<RawSandboxHandle>
 }
 
 /** Raw napi remote bindings entry point. */

--- a/packages/bindings/src/types.ts
+++ b/packages/bindings/src/types.ts
@@ -374,3 +374,92 @@ export interface Vault {
   /** List the names of all secrets in this vault. */
   list(): Promise<string[]>
 }
+
+/** A live sandbox session. */
+export interface SandboxSession {
+  /** Session id, which is what every later call addresses. */
+  sessionId: string
+  /** Lifecycle state. */
+  state: "starting" | "running" | "suspended" | "terminated"
+  /** Increments when a session is replaced, so a stale handle is detectable. */
+  generation: number
+}
+
+/** One frame of a running command's output. */
+export type CommandFrame =
+  | { kind: "stdout" | "stderr"; seq: number; data: Buffer }
+  | { kind: "exit"; exitCode: number; truncated: boolean }
+
+/** What a command needs to run. */
+export interface RunCommandOptions {
+  /**
+   * How long the command may run, in milliseconds. Required rather than defaulted: a defaulted
+   * deadline is a hang waiting for a slow day, in a sandbox running code you do not control.
+   *
+   * It bounds the command, not the call. What expiry does to the session differs by backend:
+   * where the backend has no timeout of its own the only lever is ending the session, so the
+   * iterator raises once that is confirmed, somewhat after the deadline. Where the agent
+   * supervises the process it kills the process group and the session stays usable. Either way
+   * the command is stopped; only the session's fate differs.
+   */
+  deadlineMs: number
+  /** Working directory inside the sandbox. */
+  workingDirectory?: string
+  /** Environment for this command, on top of whatever the session was created with. */
+  env?: Record<string, string>
+}
+
+/**
+ * An isolated environment for running untrusted code.
+ *
+ * Capabilities differ per platform. Call `capabilities()` and branch, or call and handle the
+ * error: an unsupported operation raises rather than silently doing nothing.
+ */
+export interface Sandbox {
+  /** Which operations this platform supports. */
+  capabilities(): Promise<string[]>
+  /** Creates a session. */
+  create(options?: {
+    sessionId?: string
+    tenantKey?: string
+    /** Environment every command in the session starts with. */
+    env?: Record<string, string>
+  }): Promise<SandboxSession>
+  /** Fetches a session, or `null` if it does not exist. Requires `reconnect`. */
+  get(sessionId: string): Promise<SandboxSession | null>
+  /** Fetches a session, creating it if absent. */
+  getOrCreate(options?: {
+    sessionId?: string
+    tenantKey?: string
+    /** Environment every command in the session starts with. */
+    env?: Record<string, string>
+  }): Promise<SandboxSession>
+  /**
+   * Lists this sandbox's sessions. Not offered on AWS, Azure or GCP — those raise rather than
+   * enumerate. Reach a session whose id you hold with `get`.
+   */
+  list(): Promise<SandboxSession[]>
+  /**
+   * Runs a command, yielding frames as the command produces them.
+   *
+   * The iterator is pull-based all the way down: nothing is read from the sandbox until the
+   * loop asks for the next frame, so a slow consumer slows the producer instead of buffering.
+   */
+  runCommand(
+    sessionId: string,
+    command: string[],
+    options: RunCommandOptions,
+  ): AsyncIterable<CommandFrame>
+  /** Reads a file out of the sandbox. Requires `files`. */
+  readFile(sessionId: string, path: string): Promise<Buffer>
+  /** Writes files into the sandbox. Requires `files`. */
+  writeFiles(sessionId: string, files: Record<string, Buffer | string>): Promise<void>
+  /** Creates a directory inside the sandbox. Requires `files`. */
+  mkdir(sessionId: string, path: string): Promise<void>
+  /** Suspends a session, preserving state. Requires `suspendResume`. */
+  suspend(sessionId: string): Promise<void>
+  /** Resumes a suspended session. Requires `suspendResume`. */
+  resume(sessionId: string): Promise<void>
+  /** Destroys a session. Idempotent. */
+  terminate(sessionId: string): Promise<void>
+}

--- a/packages/bindings/tests/sandbox.test.ts
+++ b/packages/bindings/tests/sandbox.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Sandbox binding tests through the REAL napi addon.
+ *
+ * Only the paths that need no cloud credentials and no running sandbox are covered here: how a
+ * binding is resolved from the environment, and what a caller sees when one is missing or
+ * malformed. Creating a session needs a backend — Local needs Docker, and the four cloud backends
+ * need real credentials — so session behaviour is covered by `crates/alien-local/tests/` against
+ * real Docker and by the e2e apps against a deployed stack.
+ *
+ * The value of this file is the boundary the other suites skip: an unconfigured or wrong-shaped
+ * binding must produce a typed error naming the binding, not a panic crossing the addon.
+ *
+ * Run locally with a built addon:
+ * `ALIEN_BINDINGS_ADDON_PATH=<path to the .node> pnpm vitest run tests/sandbox.test.ts`
+ */
+
+import { describe, expect, it } from "vitest"
+import { AlienError, sandbox } from "../src/index.js"
+
+/** Puts a binding into the environment the way the runtime supplies one. */
+function setBinding(name: string, value: unknown): void {
+  // Resolving a binding also reads the deployment type, as the runtime would supply it.
+  process.env.ALIEN_DEPLOYMENT_TYPE = "local"
+  const variable = `ALIEN_${name.toUpperCase().replace(/-/g, "_")}_BINDING`
+  process.env[variable] = JSON.stringify(value)
+}
+
+describe("sandbox binding resolution", () => {
+  it("names the binding and its environment variable when none is configured", async () => {
+    // The failure a developer actually hits first: a sandbox declared in the stack but the
+    // workload started without its binding. The message has to say which one.
+    await expect(sandbox("not-configured").capabilities()).rejects.toThrow(/not-configured/i)
+  })
+
+  it("refuses a binding whose provider is unknown rather than guessing one", async () => {
+    setBinding("sandbox-bad-provider", { provider: "not-a-cloud", imageArn: "arn:aws:lambda:::x" })
+
+    const error = await sandbox("sandbox-bad-provider")
+      .capabilities()
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      )
+
+    expect(error).toBeInstanceOf(AlienError)
+  })
+
+  it("refuses an AWS binding that is missing a required field", async () => {
+    // imageVersion is load-bearing: image plus version is the session identity, so a binding
+    // without it would enumerate the wrong scope rather than fail.
+    setBinding("sandbox-incomplete", {
+      provider: "aws",
+      imageArn: "arn:aws:lambda:us-west-2:123456789012:microvm-image:sbx",
+      region: "us-west-2",
+    })
+
+    await expect(sandbox("sandbox-incomplete").capabilities()).rejects.toBeInstanceOf(AlienError)
+  })
+})

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,7 +3,8 @@
  *
  * It provides the Worker handler APIs (`command`, `onStorageEvent`,
  * `onCronEvent`, `onQueueMessage`, `waitUntil`) and re-exports the app-facing
- * binding factories (`storage`, `kv`, `queue`, `vault`, `container`, `postgres`) from
+ * binding factories (`storage`, `kv`, `queue`, `vault`, `container`, `postgres`,
+ * `sandbox`) from
  * `@alienplatform/bindings`, so a Worker author installs one package.
  *
  * Worker protocol dependencies (nice-grpc, generated Worker protocol clients)
@@ -55,16 +56,20 @@ export {
 // ============================================================================
 
 export type {
+  CommandFrame,
   Container,
   Kv,
   Postgres,
   PostgresConnection,
   PostgresSslMode,
   Queue,
+  RunCommandOptions,
+  Sandbox,
+  SandboxSession,
   Storage,
   Vault,
 } from "@alienplatform/bindings"
-export { container, kv, postgres, queue, storage, vault } from "@alienplatform/bindings"
+export { container, kv, postgres, queue, sandbox, storage, vault } from "@alienplatform/bindings"
 
 // ============================================================================
 // AI: re-exported from @alienplatform/ai-gateway (a spawned Rust gateway process)


### PR DESCRIPTION
## Summary

Exposes the sandbox binding to TypeScript, so an application written in TypeScript can create a session, run a command, move files and stop it through the same contract the Rust bindings use.

When a TypeScript application asks for a sandbox binding:

1. The generated N-API layer hands back the same binding the Rust provider resolved.
2. The SDK wraps it in a typed surface — `create`, `runCommand`, `readFile`, `writeFiles`, `terminate`.
3. **A capability the platform does not support is a typed error naming both the platform and the capability, not a silent no-op.**

## What I did

The published capability set is the interesting part. A portable application cannot assume every backend does everything — preview exists only on AWS, hostname allowlists exist nowhere, and ceilings are enforced on some platforms and refused on others. Rather than let a call fail somewhere deep in a cloud SDK, the capability set is exposed to TypeScript as data, so an application can branch before it calls.

The types are generated from the Rust definitions rather than hand-written, so the two languages cannot drift: the binding JSON is the cross-language contract.

## Files touched

- `crates/alien-bindings-node/` — the N-API surface.
- `packages/bindings/src/types.ts` — the generated binding types.
- `packages/sdk/src/index.ts` — the public export.

## How I tested

- `packages/bindings/tests/sandbox.test.ts` — the binding shape and the capability set as TypeScript sees them.
- `pnpm generate` — confirms the committed types match the Rust definitions; CI fails the build if they drift.


## What changed since the last review

The Node binding now advertises `files`, so a TypeScript caller can branch on it before calling
`readFile`, `writeFiles` or `mkdir`.

1. `capabilities()` destructures the capability set by field name, with no `..`.
2. **The new field had to be named there or the crate would not compile** — which is why the
   destructure is written that way, and is what caught it.
3. `"files"` joins the returned list on every backend that supports it.

The three file operations now document the capability they need, matching how `suspend` and
`resume` already document `suspendResume`.

### Files touched

- `crates/alien-bindings-node/src/sandbox.rs` — `files` in the destructure and the advertised list
- `packages/bindings/src/types.ts` — the capability requirement on the three operations

### How I tested

- `cargo test -p alien-bindings-node` — 28 pass
- `npx vitest run src/__tests__/factories.test.ts` — 40 pass
- Checked out an intermediate commit of this branch and ran `cargo check -p alien-bindings-node`
  to confirm every commit compiles, not just the tip
