### PR TITLE
test(sandbox): exercise a sandbox session end to end

### DIFF
--- a/crates/alien-test/src/e2e.rs
+++ b/crates/alien-test/src/e2e.rs
@@ -315,8 +315,8 @@ pub fn supported_bindings(platform: Platform, model: DeploymentModel) -> Vec<Bin
             // Only the embedded Local controller ships in this repo, so Postgres is
             // exercised on Local only.
             bindings.push(Binding::Postgres);
-            // Same reason for Sandbox: the cloud sandbox controllers are not in this repo, so
-            // the cloud matrix is covered by recorded live runs rather than by this suite.
+            // Same for Sandbox: no sandbox controller is registered here for any of this
+            // suite's cloud targets, so Local is the only platform it can run on.
             bindings.push(Binding::Sandbox);
         }
         _ => {}

--- a/crates/alien-test/src/e2e.rs
+++ b/crates/alien-test/src/e2e.rs
@@ -190,6 +190,8 @@ pub enum Binding {
     Vault,
     /// Managed Postgres database (Aurora, Cloud SQL, Flexible Server, embedded pgvector on Local)
     Postgres,
+    /// Sandbox session: run a command, move a file in and out, terminate
+    Sandbox,
     /// Message queue (SQS, Pub/Sub, Service Bus)
     Queue,
     /// Direct worker-to-worker invocation
@@ -233,6 +235,7 @@ impl std::fmt::Display for Binding {
             Binding::Kv => write!(f, "kv"),
             Binding::Vault => write!(f, "vault"),
             Binding::Postgres => write!(f, "postgres"),
+            Binding::Sandbox => write!(f, "sandbox"),
             Binding::Queue => write!(f, "queue"),
             Binding::Worker => write!(f, "worker"),
             Binding::Container => write!(f, "container"),
@@ -312,6 +315,9 @@ pub fn supported_bindings(platform: Platform, model: DeploymentModel) -> Vec<Bin
             // Only the embedded Local controller ships in this repo, so Postgres is
             // exercised on Local only.
             bindings.push(Binding::Postgres);
+            // Same reason for Sandbox: the cloud sandbox controllers are not in this repo, so
+            // the cloud matrix is covered by recorded live runs rather than by this suite.
+            bindings.push(Binding::Sandbox);
         }
         _ => {}
     }

--- a/crates/alien-test/tests/common/bindings.rs
+++ b/crates/alien-test/tests/common/bindings.rs
@@ -13,9 +13,10 @@ use tracing::info;
 pub(super) const STORAGE_BINDING: &str = "alien-storage";
 const KV_BINDING: &str = "alien-kv";
 const SANDBOX_BINDING: &str = "alien-sandbox";
-/// The whole sandbox check, end to end: the app bounds create (2 min), the exercise (3 min) and
-/// teardown (5 tries plus a 30 s confirmation window) itself, and this sits above their sum.
-const SANDBOX_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+/// The whole sandbox check, end to end. The app holds itself to a 150s budget and the runtime
+/// closes the connection before that if it stalls, so this only catches a deployment that never
+/// answers at all.
+const SANDBOX_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6 * 60);
 const VAULT_BINDING: &str = "alien-vault";
 const POSTGRES_BINDING: &str = "alien-postgres";
 const QUEUE_BINDING: &str = "alien-queue";

--- a/crates/alien-test/tests/common/bindings.rs
+++ b/crates/alien-test/tests/common/bindings.rs
@@ -12,6 +12,7 @@ use tracing::info;
 /// The binding name used in test app stack configurations.
 pub(super) const STORAGE_BINDING: &str = "alien-storage";
 const KV_BINDING: &str = "alien-kv";
+const SANDBOX_BINDING: &str = "alien-sandbox";
 const VAULT_BINDING: &str = "alien-vault";
 const POSTGRES_BINDING: &str = "alien-postgres";
 const QUEUE_BINDING: &str = "alien-queue";
@@ -1087,5 +1088,45 @@ pub async fn check_ai(deployment: &TestDeployment) -> anyhow::Result<()> {
         model_count,
         probe_model, "AI catalog metadata and one qualified invocation passed (2xx or 429)"
     );
+    Ok(())
+}
+
+/// Runs a real sandbox session through the deployed app.
+///
+/// The app creates a session, runs a command, moves a file both directions and terminates. A
+/// failure anywhere in that chain comes back as a non-2xx, so the assertion here is the whole
+/// chain rather than any one call.
+pub async fn check_sandbox(deployment: &TestDeployment) -> anyhow::Result<()> {
+    let url = deployment_url(deployment)?;
+    info!("Checking sandbox binding");
+
+    let client = reqwest::Client::new();
+    let resp = post_empty(&client, format!("{}/sandbox-test/{}", url, SANDBOX_BINDING))
+        .send()
+        .await
+        .context("Sandbox test request failed")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("Sandbox test returned {}: {}", status, body);
+    }
+
+    let data: BindingTestResponse = resp
+        .json()
+        .await
+        .context("Failed to parse sandbox response")?;
+    if !data.success {
+        bail!("Sandbox test reported failure");
+    }
+    if data.binding_name != SANDBOX_BINDING {
+        bail!(
+            "Sandbox test binding mismatch: expected {}, got {}",
+            SANDBOX_BINDING,
+            data.binding_name
+        );
+    }
+
+    info!("Sandbox binding check passed");
     Ok(())
 }

--- a/crates/alien-test/tests/common/bindings.rs
+++ b/crates/alien-test/tests/common/bindings.rs
@@ -13,6 +13,9 @@ use tracing::info;
 pub(super) const STORAGE_BINDING: &str = "alien-storage";
 const KV_BINDING: &str = "alien-kv";
 const SANDBOX_BINDING: &str = "alien-sandbox";
+/// The whole sandbox check, end to end: the app bounds create (2 min), the exercise (3 min) and
+/// teardown (5 tries plus a 30 s confirmation window) itself, and this sits above their sum.
+const SANDBOX_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15 * 60);
 const VAULT_BINDING: &str = "alien-vault";
 const POSTGRES_BINDING: &str = "alien-postgres";
 const QUEUE_BINDING: &str = "alien-queue";
@@ -1100,7 +1103,12 @@ pub async fn check_sandbox(deployment: &TestDeployment) -> anyhow::Result<()> {
     let url = deployment_url(deployment)?;
     info!("Checking sandbox binding");
 
-    let client = reqwest::Client::new();
+    // Bounded above the app's own budgets (create, exercise, terminate and its confirmation), so
+    // an app that hangs is a failed check rather than a hung suite.
+    let client = reqwest::Client::builder()
+        .timeout(SANDBOX_CHECK_TIMEOUT)
+        .build()
+        .context("Failed to build the sandbox check client")?;
     let resp = post_empty(&client, format!("{}/sandbox-test/{}", url, SANDBOX_BINDING))
         .send()
         .await

--- a/crates/alien-test/tests/common/bindings.rs
+++ b/crates/alien-test/tests/common/bindings.rs
@@ -13,10 +13,15 @@ use tracing::info;
 pub(super) const STORAGE_BINDING: &str = "alien-storage";
 const KV_BINDING: &str = "alien-kv";
 const SANDBOX_BINDING: &str = "alien-sandbox";
-/// The whole sandbox check, end to end. The app holds itself to a 150s budget and the runtime
-/// closes the connection before that if it stalls, so this only catches a deployment that never
-/// answers at all.
+/// The bound on the sandbox exercise. The app deliberately sets none of its own — a bound inside
+/// it could only make it abandon a session — so this is what turns a hung step into a failed
+/// check. Wider than the runtime's 255s idle close so that close, which carries the app's
+/// diagnostics, is what is seen; this is the backstop for a deployment that never answers.
 const SANDBOX_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6 * 60);
+/// The bound on asking the backend what survived: one GET that answers at once or not at all.
+/// Separate from the exercise's, so a stalled inspection cannot eat the exercise's budget nor
+/// stand in for a verdict the exercise already gave.
+const SANDBOX_INSPECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const VAULT_BINDING: &str = "alien-vault";
 const POSTGRES_BINDING: &str = "alien-postgres";
 const QUEUE_BINDING: &str = "alien-queue";
@@ -28,6 +33,14 @@ const AI_BINDING: &str = "test-ai";
 struct BindingTestResponse {
     success: bool,
     binding_name: String,
+}
+
+/// What the app reports the sandbox backend still holds after a check.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SandboxSessionsResponse {
+    enumerable: bool,
+    session_ids: Vec<String>,
 }
 
 /// Helper to get the deployment URL, failing if not yet assigned.
@@ -1104,12 +1117,42 @@ pub async fn check_sandbox(deployment: &TestDeployment) -> anyhow::Result<()> {
     let url = deployment_url(deployment)?;
     info!("Checking sandbox binding");
 
-    // Bounded above the app's own budgets (create, exercise, terminate and its confirmation), so
-    // an app that hangs is a failed check rather than a hung suite.
-    let client = reqwest::Client::builder()
-        .timeout(SANDBOX_CHECK_TIMEOUT)
-        .build()
-        .context("Failed to build the sandbox check client")?;
+    // The exercise and the leak inspection are two claims, each on its own bound, and the second
+    // is most worth making when the first failed — a handler that gave up, or was cut off, is the
+    // one that leaves a session behind. So the inspection runs whatever the exercise said, and
+    // whatever it says is appended to the exercise's verdict, never put in its place: a fault the
+    // exercise found is the reader's diagnosis, and "could not verify" is only ever added to it.
+    let exercised = tokio::time::timeout(SANDBOX_CHECK_TIMEOUT, exercise_sandbox(url))
+        .await
+        .unwrap_or_else(|_| {
+            bail!(
+                "Sandbox exercise gave no verdict within {}s",
+                SANDBOX_CHECK_TIMEOUT.as_secs()
+            )
+        });
+    let inspected = tokio::time::timeout(SANDBOX_INSPECT_TIMEOUT, surviving_sessions(url))
+        .await
+        .unwrap_or_else(|_| {
+            bail!(
+                "could not verify which sessions survived: no answer within {}s",
+                SANDBOX_INSPECT_TIMEOUT.as_secs()
+            )
+        });
+
+    match (exercised, inspected) {
+        (Ok(()), Ok(())) => {
+            info!("Sandbox binding check passed");
+            Ok(())
+        }
+        (Err(exercise), Ok(())) => Err(exercise),
+        (Ok(()), Err(inspect)) => Err(inspect),
+        (Err(exercise), Err(inspect)) => bail!("{exercise:#}; and afterwards: {inspect:#}"),
+    }
+}
+
+/// Drives the app's sandbox exercise and reads its verdict.
+async fn exercise_sandbox(url: &str) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
     let resp = post_empty(&client, format!("{}/sandbox-test/{}", url, SANDBOX_BINDING))
         .send()
         .await
@@ -1135,7 +1178,38 @@ pub async fn check_sandbox(deployment: &TestDeployment) -> anyhow::Result<()> {
             data.binding_name
         );
     }
+    Ok(())
+}
 
-    info!("Sandbox binding check passed");
+/// Asks the backend, not the handler, which sessions still exist; a survivor fails the check.
+///
+/// A session the handler abandoned would not appear in the handler's own answer. This is a
+/// detector, not the guarantee: a create still in flight when the exercise ended can surface
+/// after this reads, and what catches that is the sandbox's own teardown, which reaps every
+/// session on deletion — pinned by `an_abandoned_session_is_reaped_with_its_sandbox`. Where the
+/// backend cannot enumerate, that is reported as such rather than as zero.
+async fn surviving_sessions(url: &str) -> anyhow::Result<()> {
+    let left: SandboxSessionsResponse = reqwest::Client::new()
+        .get(format!("{}/sandbox-sessions/{}", url, SANDBOX_BINDING))
+        .send()
+        .await
+        .context("Sandbox sessions request failed")?
+        .error_for_status()
+        .context("Sandbox sessions request was refused")?
+        .json()
+        .await
+        .context("Failed to parse sandbox sessions response")?;
+
+    if !left.enumerable {
+        info!("Sandbox backend cannot enumerate sessions; leak check not available here");
+        return Ok(());
+    }
+    if !left.session_ids.is_empty() {
+        bail!(
+            "Sandbox check left {} session(s) running: {:?}",
+            left.session_ids.len(),
+            left.session_ids
+        );
+    }
     Ok(())
 }

--- a/crates/alien-test/tests/common/runner.rs
+++ b/crates/alien-test/tests/common/runner.rs
@@ -60,6 +60,7 @@ pub async fn check_all_bindings(
             Binding::Kv => bindings::check_kv(deployment).await?,
             Binding::Vault => bindings::check_vault(deployment).await?,
             Binding::Postgres => bindings::check_postgres(deployment).await?,
+            Binding::Sandbox => bindings::check_sandbox(deployment).await?,
             Binding::Queue => bindings::check_queue(deployment).await?,
             Binding::Worker => bindings::check_worker(deployment).await?,
             Binding::Container => bindings::check_container(deployment).await?,

--- a/tests/e2e/test-apps/comprehensive-rust/alien.ts
+++ b/tests/e2e/test-apps/comprehensive-rust/alien.ts
@@ -20,6 +20,17 @@ const queue = new alien.Queue("alien-queue").build()
 const eventsQueue = new alien.Queue("alien-events-queue").build()
 const serviceAccount = new alien.ServiceAccount("test-alien-sa").build()
 const postgres = isLocal ? new alien.Postgres("alien-postgres").build() : undefined
+// Sandbox is Local-only here for the same reason as Postgres: the cloud sandbox controllers
+// do not ship in this repo, so declaring one on a cloud target would ask the executor to
+// provision a backend with no registered controller.
+const sandbox = isLocal
+  ? new alien.Sandbox("alien-sandbox")
+      .code({ type: "image", image: "alpine:3.20" })
+      .limits({ cpu: "500m", memory: "512Mi", disk: "1Gi", maxProcesses: 64 })
+      .egress({ mode: "deny" })
+      .session({ maxLifetimeSeconds: 600 })
+      .build()
+  : undefined
 
 let workerBuilder = new alien.Worker("alien-rs-worker")
   .code({
@@ -52,6 +63,9 @@ let workerBuilder = new alien.Worker("alien-rs-worker")
 if (postgres) {
   workerBuilder = workerBuilder.link(postgres)
 }
+if (sandbox) {
+  workerBuilder = workerBuilder.link(sandbox)
+}
 const worker = workerBuilder.build()
 
 const executionPermissions = [
@@ -69,6 +83,9 @@ const executionPermissions = [
 ]
 if (postgres) {
   executionPermissions.push("postgres/data-access")
+}
+if (sandbox) {
+  executionPermissions.push("sandbox/execute")
 }
 
 let stackBuilder = new alien.Stack("alien-rs-stack")
@@ -89,6 +106,9 @@ let stackBuilder = new alien.Stack("alien-rs-stack")
   .add(serviceAccount, "frozen")
 if (postgres) {
   stackBuilder = stackBuilder.add(postgres, "live")
+}
+if (sandbox) {
+  stackBuilder = stackBuilder.add(sandbox, "frozen")
 }
 const stack = stackBuilder.add(worker, "live").build()
 

--- a/tests/e2e/test-apps/comprehensive-rust/alien.ts
+++ b/tests/e2e/test-apps/comprehensive-rust/alien.ts
@@ -20,15 +20,15 @@ const queue = new alien.Queue("alien-queue").build()
 const eventsQueue = new alien.Queue("alien-events-queue").build()
 const serviceAccount = new alien.ServiceAccount("test-alien-sa").build()
 const postgres = isLocal ? new alien.Postgres("alien-postgres").build() : undefined
-// Sandbox is Local-only here for the same reason as Postgres: the cloud sandbox controllers
-// do not ship in this repo, so declaring one on a cloud target would ask the executor to
-// provision a backend with no registered controller.
+// Sandbox is Local-only: none of this suite's cloud targets has a sandbox controller registered
+// in this repo, so declaring one there would ask the executor to provision a backend nothing
+// drives.
 const sandbox = isLocal
   ? new alien.Sandbox("alien-sandbox")
       .code({ type: "image", image: "alpine:3.20" })
       .limits({ cpu: "500m", memory: "512Mi", disk: "1Gi", maxProcesses: 64 })
       .egress({ mode: "deny" })
-      .session({ maxLifetimeSeconds: 600 })
+      .session({})
       .build()
   : undefined
 

--- a/tests/e2e/test-apps/comprehensive-rust/src/bin/main.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/bin/main.rs
@@ -411,6 +411,10 @@ fn build_router(app_state: AppState) -> Router {
             post(handlers::sandbox::test_sandbox),
         )
         .route(
+            "/sandbox-sessions/{binding_name}",
+            get(handlers::sandbox::sandbox_sessions),
+        )
+        .route(
             "/queue-test/{binding_name}",
             post(handlers::queue::test_queue),
         )

--- a/tests/e2e/test-apps/comprehensive-rust/src/bin/main.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/bin/main.rs
@@ -407,6 +407,10 @@ fn build_router(app_state: AppState) -> Router {
         )
         .route("/kv-test/{binding_name}", post(handlers::kv::test_kv))
         .route(
+            "/sandbox-test/{binding_name}",
+            post(handlers::sandbox::test_sandbox),
+        )
+        .route(
             "/queue-test/{binding_name}",
             post(handlers::queue::test_queue),
         )

--- a/tests/e2e/test-apps/comprehensive-rust/src/error.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/error.rs
@@ -135,6 +135,19 @@ pub enum ErrorData {
         operation: String,
     },
 
+    /// Sandbox operation failed.
+    #[error(
+        code = "SANDBOX_OPERATION_FAILED",
+        message = "Sandbox operation failed: {operation}",
+        retryable = "true",
+        internal = "false",
+        http_status_code = 500
+    )]
+    SandboxOperationFailed {
+        /// Description of the sandbox operation that failed
+        operation: String,
+    },
+
     /// KV operation failed.
     #[error(
         code = "KV_OPERATION_FAILED",

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/mod.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod kv;
 pub mod postgres;
 pub mod queue;
 pub mod queue_message;
+pub mod sandbox;
 pub mod service_account;
 pub mod sse;
 pub mod storage;

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -1,0 +1,196 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use axum::{
+    extract::{Path, State},
+    response::Json,
+};
+use chrono::Utc;
+use futures_util::StreamExt;
+use tracing::info;
+
+use crate::{
+    models::{AppState, KvTestResponse},
+    ErrorData, Result,
+};
+use alien_error::{AlienError, Context};
+use alien_sdk::traits::{
+    CommandOutput, CreateSessionRequest, RunCommandRequest, Sandbox, SandboxSessionState,
+};
+
+/// Test a sandbox binding by running a command and moving a file through a session.
+#[utoipa::path(
+    post,
+    path = "/sandbox-test/{binding_name}",
+    tag = "sandbox",
+    params(
+        ("binding_name" = String, Path, description = "Name of the sandbox binding to test")
+    ),
+    responses(
+        (status = 200, description = "Sandbox test completed", body = KvTestResponse),
+        (status = 400, description = "Binding not found", body = AlienError),
+        (status = 500, description = "Sandbox operation failed", body = AlienError),
+    ),
+    operation_id = "test_sandbox",
+    summary = "Test sandbox session operations",
+    description = "Creates a session, runs a command, writes and reads a file, then terminates"
+)]
+pub async fn test_sandbox(
+    State(app_state): State<AppState>,
+    Path(binding_name): Path<String>,
+) -> Result<Json<KvTestResponse>> {
+    info!(%binding_name, "Received sandbox test request");
+
+    let sandbox = app_state
+        .ctx
+        .bindings()
+        .sandbox(&binding_name)
+        .await
+        .context(ErrorData::BindingNotFound {
+            binding_name: binding_name.clone(),
+        })?;
+
+    let session = sandbox
+        .create(CreateSessionRequest {
+            session_id: Some(format!("e2e-{}", Utc::now().timestamp_millis())),
+            tenant_key: None,
+            env: BTreeMap::new(),
+        })
+        .await
+        .context(ErrorData::SandboxOperationFailed {
+            operation: "create".to_string(),
+        })?;
+
+    // Everything after create runs in a helper so a failure still reaches terminate below. A
+    // session left running is a session still billing.
+    let outcome = exercise(sandbox.as_ref(), &session.session_id).await;
+    let terminated = terminate_and_confirm(sandbox.as_ref(), &session.session_id).await;
+
+    // A leaked session is reported first even when the exercise also failed: an exercise failure
+    // is a broken test, a surviving session is a billable sandbox nobody will look for.
+    terminated?;
+    outcome?;
+
+    info!(%binding_name, "Sandbox test completed successfully");
+
+    Ok(Json(KvTestResponse {
+        binding_name,
+        success: true,
+    }))
+}
+
+/// How long to wait for a terminate to converge before calling the session leaked.
+const TERMINATE_POLL_ATTEMPTS: u32 = 15;
+const TERMINATE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Terminates the session and reads it back to confirm it is gone.
+///
+/// A successful terminate is not the same claim: the backends return once deletion is accepted,
+/// so a test that stops at the return value passes while the session keeps running.
+async fn terminate_and_confirm(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
+    sandbox
+        .terminate(session_id)
+        .await
+        .context(ErrorData::SandboxOperationFailed {
+            operation: "terminate".to_string(),
+        })?;
+
+    // Polled rather than read once: every backend returns from terminate as soon as the deletion
+    // is accepted, so a single read races normal convergence and would fail a teardown that was
+    // simply still finishing.
+    // A failed read inside the window is retried like a non-terminal state: the session may well
+    // be gone, and giving up on the first blip would fail a teardown that had already converged.
+    // A read that never succeeds still fails, carrying the last error rather than a bare timeout.
+    let mut last = String::from("unread");
+    for attempt in 0..TERMINATE_POLL_ATTEMPTS {
+        match sandbox.get(session_id).await {
+            Ok(None) => return Ok(()),
+            Ok(Some(session)) if session.state == SandboxSessionState::Terminated => return Ok(()),
+            Ok(Some(session)) => last = format!("{:?}", session.state),
+            Err(error) => last = format!("unreadable ({error})"),
+        }
+
+        if attempt + 1 < TERMINATE_POLL_ATTEMPTS {
+            tokio::time::sleep(TERMINATE_POLL_INTERVAL).await;
+        }
+    }
+
+    Err(AlienError::new(ErrorData::TestValidationFailed {
+        reason: format!(
+            "session '{session_id}' is still {last} {}s after terminate; it may still be billing",
+            TERMINATE_POLL_ATTEMPTS * TERMINATE_POLL_INTERVAL.as_secs() as u32
+        ),
+    }))
+}
+
+/// The part of the test that can fail without leaking a session.
+async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
+    let marker = format!("alien-sandbox-e2e-{}", Utc::now().timestamp_millis());
+
+    let mut frames = sandbox
+        .run_command(
+            session_id,
+            RunCommandRequest {
+                command: vec!["/bin/echo".to_string(), marker.clone()],
+                working_directory: None,
+                env: BTreeMap::new(),
+                deadline: Duration::from_secs(30),
+            },
+        )
+        .await
+        .context(ErrorData::SandboxOperationFailed {
+            operation: "run_command".to_string(),
+        })?;
+
+    let mut stdout = Vec::new();
+    let mut exit_code = None;
+    while let Some(frame) = frames.next().await {
+        match frame.context(ErrorData::SandboxOperationFailed {
+            operation: "run_command stream".to_string(),
+        })? {
+            CommandOutput::Stdout { data, .. } => stdout.extend_from_slice(&data),
+            CommandOutput::Exit { code, .. } => exit_code = Some(code),
+            CommandOutput::Stderr { .. } => {}
+        }
+    }
+
+    if exit_code != Some(0) {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+                reason: format!("run_command exited with {exit_code:?}, expected 0"),
+        }));
+    }
+
+    let printed = String::from_utf8_lossy(&stdout);
+    if !printed.contains(&marker) {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+            reason: format!("stdout did not carry the marker, got '{printed}'"),
+        }));
+    }
+
+    // Files both directions through the same session, which is what makes it a session rather
+    // than a sequence of unrelated commands.
+    sandbox
+        .write_files(
+            session_id,
+            BTreeMap::from([("e2e/input.txt".to_string(), marker.as_bytes().to_vec())]),
+        )
+        .await
+        .context(ErrorData::SandboxOperationFailed {
+            operation: "write_files".to_string(),
+        })?;
+
+    let read_back = sandbox
+        .read_file(session_id, "e2e/input.txt")
+        .await
+        .context(ErrorData::SandboxOperationFailed {
+            operation: "read_file".to_string(),
+        })?;
+
+    if read_back != marker.as_bytes() {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+                reason: "read_file returned different bytes than write_files sent".to_string(),
+        }));
+    }
+
+    Ok(())
+}

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -144,7 +144,10 @@ async fn converge(sandbox: &dyn Sandbox, session_id: &str, create_settled: bool)
     let left = || deadline.saturating_duration_since(Instant::now());
 
     loop {
-        let refused = match tokio::time::timeout(left(), sandbox.terminate(session_id)).await {
+        // Half of what is left, so the read that decides the verdict always has the other half.
+        // A terminate that spent the whole reserve would leave the read no time to answer, and a
+        // read that cannot answer would be reported as a session still running.
+        let refused = match tokio::time::timeout(left() / 2, sandbox.terminate(session_id)).await {
             Ok(Ok(())) => None,
             Ok(Err(error)) => Some(error.to_string()),
             Err(_) => Some("no answer".to_string()),

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -50,29 +50,27 @@ pub async fn test_sandbox(
             binding_name: binding_name.clone(),
         })?;
 
-    // Bounded, like everything after it: a stalled create is a failed test, not a hung suite.
-    // The id is chosen here so a create that answers late can still be ended by name below.
+    // Awaited rather than raced: only the id create returns can end a session — AWS and Azure
+    // allocate their own rather than taking the one asked for — so a bounded wait here would
+    // terminate an id no session answers to while the real one is still being created.
     let session_id = format!("e2e-{}", Utc::now().timestamp_millis());
-    let created = tokio::time::timeout(
-        CREATE_TIMEOUT,
-        sandbox.create(CreateSessionRequest {
+    let created = sandbox
+        .create(CreateSessionRequest {
             session_id: Some(session_id.clone()),
             tenant_key: None,
             env: BTreeMap::new(),
-        }),
-    )
-    .await;
+        })
+        .await;
     let session = match created {
-        Ok(created) => created.context(ErrorData::SandboxOperationFailed {
-            operation: "create".to_string(),
-        })?,
-        Err(_) => {
-            // The create may still complete after this returns; ending the chosen id makes that
-            // a no-op session rather than a leak, and a refusal here is reported over the timeout.
+        Ok(session) => session,
+        Err(error) => {
+            // The create has settled, so ending the id asked for is not a race: local, Kubernetes
+            // and GCP take that id, so a session provisioned under a lost response answers to it.
+            // AWS and Azure allocate their own; there the 600s maxLifetimeSeconds reclaims it.
             terminate_and_confirm(sandbox.as_ref(), &session_id).await?;
-            return Err(AlienError::new(ErrorData::TestValidationFailed {
-                reason: format!("create gave no answer in {}s", CREATE_TIMEOUT.as_secs()),
-            }));
+            return Err(error).context(ErrorData::SandboxOperationFailed {
+                operation: "create".to_string(),
+            });
         }
     };
 
@@ -108,9 +106,6 @@ pub async fn test_sandbox(
     }))
 }
 
-/// How long a create may take. Longer than a command: on AWS a session waits for the MicroVM
-/// to answer before create returns.
-const CREATE_TIMEOUT: Duration = Duration::from_secs(120);
 /// How long the whole exercise — commands and files — may take before terminate runs anyway.
 const EXERCISE_TIMEOUT: Duration = Duration::from_secs(180);
 /// How many times a refused terminate is retried before the session is called leaked.

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -50,20 +50,49 @@ pub async fn test_sandbox(
             binding_name: binding_name.clone(),
         })?;
 
-    let session = sandbox
-        .create(CreateSessionRequest {
-            session_id: Some(format!("e2e-{}", Utc::now().timestamp_millis())),
+    // Bounded, like everything after it: a stalled create is a failed test, not a hung suite.
+    // The id is chosen here so a create that answers late can still be ended by name below.
+    let session_id = format!("e2e-{}", Utc::now().timestamp_millis());
+    let created = tokio::time::timeout(
+        CREATE_TIMEOUT,
+        sandbox.create(CreateSessionRequest {
+            session_id: Some(session_id.clone()),
             tenant_key: None,
             env: BTreeMap::new(),
-        })
-        .await
-        .context(ErrorData::SandboxOperationFailed {
+        }),
+    )
+    .await;
+    let session = match created {
+        Ok(created) => created.context(ErrorData::SandboxOperationFailed {
             operation: "create".to_string(),
-        })?;
+        })?,
+        Err(_) => {
+            // The create may still complete after this returns; ending the chosen id makes that
+            // a no-op session rather than a leak, and a refusal here is reported over the timeout.
+            terminate_and_confirm(sandbox.as_ref(), &session_id).await?;
+            return Err(AlienError::new(ErrorData::TestValidationFailed {
+                reason: format!("create gave no answer in {}s", CREATE_TIMEOUT.as_secs()),
+            }));
+        }
+    };
 
     // Everything after create runs in a helper so a failure still reaches terminate below. A
-    // session left running is a session still billing.
-    let outcome = exercise(sandbox.as_ref(), &session.session_id).await;
+    // session left running is a session still billing. The exercise is bounded as a whole so a
+    // command or file operation that never answers still lets terminate run.
+    let outcome = match tokio::time::timeout(
+        EXERCISE_TIMEOUT,
+        exercise(sandbox.as_ref(), &session.session_id),
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(_) => Err(AlienError::new(ErrorData::TestValidationFailed {
+            reason: format!(
+                "the sandbox exercise gave no answer in {}s",
+                EXERCISE_TIMEOUT.as_secs()
+            ),
+        })),
+    };
     let terminated = terminate_and_confirm(sandbox.as_ref(), &session.session_id).await;
 
     // A leaked session is reported first even when the exercise also failed: an exercise failure
@@ -79,35 +108,81 @@ pub async fn test_sandbox(
     }))
 }
 
-/// How long to wait for a terminate to converge before calling the session leaked.
+/// How long a create may take. Longer than a command: on AWS a session waits for the MicroVM
+/// to answer before create returns.
+const CREATE_TIMEOUT: Duration = Duration::from_secs(120);
+/// How long the whole exercise — commands and files — may take before terminate runs anyway.
+const EXERCISE_TIMEOUT: Duration = Duration::from_secs(180);
+/// How many times a refused terminate is retried before the session is called leaked.
+const TERMINATE_ATTEMPTS: u32 = 5;
+/// How long to wait for an accepted terminate to converge before calling the session leaked.
 const TERMINATE_POLL_ATTEMPTS: u32 = 15;
 const TERMINATE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// How long one status read may take before it counts as a failed read: a stalled manager must
+/// cost one attempt, not the whole test.
+const STATUS_READ_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long one terminate call may take before it counts as refused. Longer than a read: a
+/// backend may confirm deletion inside the call, and that is bounded on its side too.
+const TERMINATE_CALL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Terminates the session and reads it back to confirm it is gone.
 ///
 /// A successful terminate is not the same claim: the backends return once deletion is accepted,
 /// so a test that stops at the return value passes while the session keeps running.
 async fn terminate_and_confirm(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
-    sandbox
-        .terminate(session_id)
-        .await
-        .context(ErrorData::SandboxOperationFailed {
-            operation: "terminate".to_string(),
-        })?;
-
     // Polled rather than read once: every backend returns from terminate as soon as the deletion
     // is accepted, so a single read races normal convergence and would fail a teardown that was
     // simply still finishing.
+    // The terminate itself is retried, because it is idempotent and a transient refusal is the
+    // one failure that leaves a session running: giving up on it would hand back an error and a
+    // billable sandbox nobody will look for.
     // A failed read inside the window is retried like a non-terminal state: the session may well
     // be gone, and giving up on the first blip would fail a teardown that had already converged.
     // A read that never succeeds still fails, carrying the last error rather than a bare timeout.
-    let mut last = String::from("unread");
+    // The two budgets are separate so a terminate accepted on its last try still gets the whole
+    // convergence window rather than one immediate read.
+    // Carried as the reason text: an answer that never came and an answer that refused are the
+    // same thing to the test — a session it could not end.
+    let mut refused: Option<String> = None;
+    for attempt in 0..TERMINATE_ATTEMPTS {
+        match tokio::time::timeout(TERMINATE_CALL_TIMEOUT, sandbox.terminate(session_id)).await {
+            Ok(Ok(())) => {
+                refused = None;
+                break;
+            }
+            Ok(Err(error)) => refused = Some(error.to_string()),
+            Err(_) => {
+                refused = Some(format!(
+                    "no answer in {}s",
+                    TERMINATE_CALL_TIMEOUT.as_secs()
+                ))
+            }
+        }
+        if attempt + 1 < TERMINATE_ATTEMPTS {
+            tokio::time::sleep(TERMINATE_POLL_INTERVAL).await;
+        }
+    }
+    // A refused terminate is not yet a leak: the request may have succeeded with its response
+    // lost, so the confirmation poll below decides, and the refusal is what is reported if the
+    // session turns out to still be there.
+    let mut last = match &refused {
+        Some(reason) => format!("running (terminate refused: {reason})"),
+        None => String::from("unread"),
+    };
     for attempt in 0..TERMINATE_POLL_ATTEMPTS {
-        match sandbox.get(session_id).await {
-            Ok(None) => return Ok(()),
-            Ok(Some(session)) if session.state == SandboxSessionState::Terminated => return Ok(()),
-            Ok(Some(session)) => last = format!("{:?}", session.state),
-            Err(error) => last = format!("unreadable ({error})"),
+        match tokio::time::timeout(STATUS_READ_TIMEOUT, sandbox.get(session_id)).await {
+            Err(_) => {
+                last = format!(
+                    "unreadable (no answer in {}s)",
+                    STATUS_READ_TIMEOUT.as_secs()
+                )
+            }
+            Ok(Ok(None)) => return Ok(()),
+            Ok(Ok(Some(session))) if session.state == SandboxSessionState::Terminated => {
+                return Ok(())
+            }
+            Ok(Ok(Some(session))) => last = format!("{:?}", session.state),
+            Ok(Err(error)) => last = format!("unreadable ({error})"),
         }
 
         if attempt + 1 < TERMINATE_POLL_ATTEMPTS {
@@ -115,6 +190,13 @@ async fn terminate_and_confirm(sandbox: &dyn Sandbox, session_id: &str) -> Resul
         }
     }
 
+    if let Some(reason) = refused {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+            reason: format!(
+                "session '{session_id}' could not be terminated ({reason}); it may still be billing"
+            ),
+        }));
+    }
     Err(AlienError::new(ErrorData::TestValidationFailed {
         reason: format!(
             "session '{session_id}' is still {last} {}s after terminate; it may still be billing",
@@ -156,7 +238,7 @@ async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
 
     if exit_code != Some(0) {
         return Err(AlienError::new(ErrorData::TestValidationFailed {
-                reason: format!("run_command exited with {exit_code:?}, expected 0"),
+            reason: format!("run_command exited with {exit_code:?}, expected 0"),
         }));
     }
 
@@ -188,7 +270,7 @@ async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
 
     if read_back != marker.as_bytes() {
         return Err(AlienError::new(ErrorData::TestValidationFailed {
-                reason: "read_file returned different bytes than write_files sent".to_string(),
+            reason: "read_file returned different bytes than write_files sent".to_string(),
         }));
     }
 

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -147,15 +147,17 @@ pub async fn sandbox_sessions(
     }
 }
 
-/// The part of the test that can fail without leaking a session.
-async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
-    let marker = format!("alien-sandbox-e2e-{}", Utc::now().timestamp_millis());
-
+/// Runs a command to completion and returns its stdout, stderr and exit code.
+async fn run_to_completion(
+    sandbox: &dyn Sandbox,
+    session_id: &str,
+    command: Vec<String>,
+) -> Result<(Vec<u8>, Vec<u8>, Option<i32>)> {
     let mut frames = sandbox
         .run_command(
             session_id,
             RunCommandRequest {
-                command: vec!["/bin/echo".to_string(), marker.clone()],
+                command,
                 working_directory: None,
                 env: BTreeMap::new(),
                 deadline: Duration::from_secs(30),
@@ -178,6 +180,20 @@ async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
             CommandOutput::Stderr { data, .. } => stderr.extend_from_slice(&data),
         }
     }
+
+    Ok((stdout, stderr, exit_code))
+}
+
+/// The part of the test that can fail without leaking a session.
+async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
+    let marker = format!("alien-sandbox-e2e-{}", Utc::now().timestamp_millis());
+
+    let (stdout, stderr, exit_code) = run_to_completion(
+        sandbox,
+        session_id,
+        vec!["/bin/echo".to_string(), marker.clone()],
+    )
+    .await?;
 
     if exit_code != Some(0) {
         // stderr is kept, not reduced to a boolean: when this fails it is the only thing that
@@ -219,6 +235,35 @@ async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
     if read_back != marker.as_bytes() {
         return Err(AlienError::new(ErrorData::TestValidationFailed {
             reason: "read_file returned different bytes than write_files sent".to_string(),
+        }));
+    }
+
+    // Read the same file from inside the session, not only back through the agent. `read_file` is
+    // the agent reading what the agent wrote, so it holds even when the command the upload exists
+    // for cannot open it — which is the difference between the backends that run an agent as a
+    // different user than the command and the ones that do not.
+    let (inside, inside_stderr, inside_exit) = run_to_completion(
+        sandbox,
+        session_id,
+        vec!["/bin/cat".to_string(), "e2e/input.txt".to_string()],
+    )
+    .await?;
+
+    if inside_exit != Some(0) {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+            reason: format!(
+                "the session could not read the file written into it, exit {inside_exit:?}: {}",
+                String::from_utf8_lossy(&inside_stderr)
+            ),
+        }));
+    }
+
+    if !String::from_utf8_lossy(&inside).contains(&marker) {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+            reason: format!(
+                "the session read different bytes than write_files sent: '{}'",
+                String::from_utf8_lossy(&inside)
+            ),
         }));
     }
 

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::{
     extract::{Path, State},
@@ -50,52 +50,67 @@ pub async fn test_sandbox(
             binding_name: binding_name.clone(),
         })?;
 
-    // Awaited rather than raced: only the id create returns can end a session — AWS and Azure
-    // allocate their own rather than taking the one asked for — so a bounded wait here would
-    // terminate an id no session answers to while the real one is still being created.
-    let session_id = format!("e2e-{}", Utc::now().timestamp_millis());
-    let created = sandbox
-        .create(CreateSessionRequest {
+    // Chosen here so teardown can name a session even when create never reports one. Local honours
+    // a requested id, and Local is the only platform this check runs on.
+    let session_id = format!("e2e-rs-{}", Utc::now().timestamp_millis());
+    let exercise_by = Instant::now() + REQUEST_BUDGET - TEARDOWN_RESERVE;
+    let left = || exercise_by.saturating_duration_since(Instant::now());
+
+    let created = tokio::time::timeout(
+        left(),
+        sandbox.create(CreateSessionRequest {
             session_id: Some(session_id.clone()),
             tenant_key: None,
             env: BTreeMap::new(),
-        })
-        .await;
-    let session = match created {
-        Ok(session) => session,
-        Err(error) => {
-            // The create has settled, so ending the id asked for is not a race: local, Kubernetes
-            // and GCP take that id, so a session provisioned under a lost response answers to it.
-            // AWS and Azure allocate their own; there the 600s maxLifetimeSeconds reclaims it.
-            terminate_and_confirm(sandbox.as_ref(), &session_id).await?;
-            return Err(error).context(ErrorData::SandboxOperationFailed {
-                operation: "create".to_string(),
-            });
-        }
-    };
-
-    // Everything after create runs in a helper so a failure still reaches terminate below. A
-    // session left running is a session still billing. The exercise is bounded as a whole so a
-    // command or file operation that never answers still lets terminate run.
-    let outcome = match tokio::time::timeout(
-        EXERCISE_TIMEOUT,
-        exercise(sandbox.as_ref(), &session.session_id),
+        }),
     )
-    .await
-    {
-        Ok(outcome) => outcome,
-        Err(_) => Err(AlienError::new(ErrorData::TestValidationFailed {
-            reason: format!(
-                "the sandbox exercise gave no answer in {}s",
-                EXERCISE_TIMEOUT.as_secs()
-            ),
-        })),
+    .await;
+    let (session, mut outcome, create_settled) = match created {
+        Ok(Ok(session)) => (Some(session), Ok(()), true),
+        Ok(Err(error)) => (
+            None,
+            Err(error).context(ErrorData::SandboxOperationFailed {
+                operation: "create".to_string(),
+            }),
+            true,
+        ),
+        Err(_) => (
+            None,
+            Err(AlienError::new(ErrorData::TestValidationFailed {
+                reason: "create gave no answer within the request budget; a session it lands \
+                         later is reaped when the sandbox is deleted"
+                    .to_string(),
+            })),
+            false,
+        ),
     };
-    let terminated = terminate_and_confirm(sandbox.as_ref(), &session.session_id).await;
 
-    // A leaked session is reported first even when the exercise also failed: an exercise failure
-    // is a broken test, a surviving session is a billable sandbox nobody will look for.
-    terminated?;
+    if let Some(session) = &session {
+        outcome =
+            match tokio::time::timeout(left(), exercise(sandbox.as_ref(), &session.session_id))
+                .await
+            {
+                Ok(outcome) => outcome,
+                Err(_) => Err(AlienError::new(ErrorData::TestValidationFailed {
+                    reason: "the sandbox exercise gave no answer within the request budget"
+                        .to_string(),
+                })),
+            };
+    }
+
+    let target = session
+        .as_ref()
+        .map_or(session_id.as_str(), |session| session.session_id.as_str());
+    if let Err(leaked) = converge(sandbox.as_ref(), target, create_settled).await {
+        // Both are reported: a session left running is a sandbox nobody will look for, and why
+        // the exercise failed is often why it is still there.
+        return Err(match outcome {
+            Err(failure) => AlienError::new(ErrorData::TestValidationFailed {
+                reason: format!("{leaked}; {failure}"),
+            }),
+            Ok(()) => leaked,
+        });
+    }
     outcome?;
 
     info!(%binding_name, "Sandbox test completed successfully");
@@ -106,98 +121,64 @@ pub async fn test_sandbox(
     }))
 }
 
-/// How long the whole exercise — commands and files — may take before terminate runs anyway.
-const EXERCISE_TIMEOUT: Duration = Duration::from_secs(180);
-/// How many times a refused terminate is retried before the session is called leaked.
-const TERMINATE_ATTEMPTS: u32 = 5;
-/// How long to wait for an accepted terminate to converge before calling the session leaked.
-const TERMINATE_POLL_ATTEMPTS: u32 = 15;
-const TERMINATE_POLL_INTERVAL: Duration = Duration::from_secs(2);
-/// How long one status read may take before it counts as a failed read: a stalled manager must
-/// cost one attempt, not the whole test.
-const STATUS_READ_TIMEOUT: Duration = Duration::from_secs(10);
-/// How long one terminate call may take before it counts as refused. Longer than a read: a
-/// backend may confirm deletion inside the call, and that is bounded on its side too.
-const TERMINATE_CALL_TIMEOUT: Duration = Duration::from_secs(60);
+/// How long the whole check may take, teardown included. Held under the 300s read timeout the
+/// worker runtime applies to a proxied response (`alien-worker-runtime/src/transports/shared.rs`):
+/// this handler answers only at the end, so a longer run reaches the caller as a bare proxy error.
+const REQUEST_BUDGET: Duration = Duration::from_secs(150);
+/// Held back from the budget so teardown still runs after a slow create or exercise. Local frees
+/// a session only when the sandbox itself is deleted, so skipping teardown strands it.
+const TEARDOWN_RESERVE: Duration = Duration::from_secs(45);
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
-/// Terminates the session and reads it back to confirm it is gone.
+/// Terminates the session and reads it back until it is gone.
 ///
-/// A successful terminate is not the same claim: the backends return once deletion is accepted,
-/// so a test that stops at the return value passes while the session keeps running.
-async fn terminate_and_confirm(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
-    // Polled rather than read once: every backend returns from terminate as soon as the deletion
-    // is accepted, so a single read races normal convergence and would fail a teardown that was
-    // simply still finishing.
-    // The terminate itself is retried, because it is idempotent and a transient refusal is the
-    // one failure that leaves a session running: giving up on it would hand back an error and a
-    // billable sandbox nobody will look for.
-    // A failed read inside the window is retried like a non-terminal state: the session may well
-    // be gone, and giving up on the first blip would fail a teardown that had already converged.
-    // A read that never succeeds still fails, carrying the last error rather than a bare timeout.
-    // The two budgets are separate so a terminate accepted on its last try still gets the whole
-    // convergence window rather than one immediate read.
-    // Carried as the reason text: an answer that never came and an answer that refused are the
-    // same thing to the test — a session it could not end.
-    let mut refused: Option<String> = None;
-    for attempt in 0..TERMINATE_ATTEMPTS {
-        match tokio::time::timeout(TERMINATE_CALL_TIMEOUT, sandbox.terminate(session_id)).await {
-            Ok(Ok(())) => {
-                refused = None;
-                break;
-            }
-            Ok(Err(error)) => refused = Some(error.to_string()),
-            Err(_) => {
-                refused = Some(format!(
-                    "no answer in {}s",
-                    TERMINATE_CALL_TIMEOUT.as_secs()
-                ))
-            }
-        }
-        if attempt + 1 < TERMINATE_ATTEMPTS {
-            tokio::time::sleep(TERMINATE_POLL_INTERVAL).await;
-        }
-    }
-    // A refused terminate is not yet a leak: the request may have succeeded with its response
-    // lost, so the confirmation poll below decides, and the refusal is what is reported if the
-    // session turns out to still be there.
-    let mut last = match &refused {
-        Some(reason) => format!("running (terminate refused: {reason})"),
-        None => String::from("unread"),
-    };
-    for attempt in 0..TERMINATE_POLL_ATTEMPTS {
-        match tokio::time::timeout(STATUS_READ_TIMEOUT, sandbox.get(session_id)).await {
-            Err(_) => {
-                last = format!(
-                    "unreadable (no answer in {}s)",
-                    STATUS_READ_TIMEOUT.as_secs()
-                )
-            }
-            Ok(Ok(None)) => return Ok(()),
-            Ok(Ok(Some(session))) if session.state == SandboxSessionState::Terminated => {
-                return Ok(())
-            }
-            Ok(Ok(Some(session))) => last = format!("{:?}", session.state),
-            Ok(Err(error)) => last = format!("unreadable ({error})"),
+/// Terminate is reissued on every pass: it is idempotent, a transient refusal is the one failure
+/// that leaves a session running, and a session visible only on a later pass is ended rather than
+/// reported as a leak.
+///
+/// `create_settled` is false when create never answered. The session can still be created after
+/// an empty read there, so absence decides nothing and the wait runs its full reserve, ending
+/// whatever appears. A read that fails counts as present: an unreadable session is not a gone one.
+async fn converge(sandbox: &dyn Sandbox, session_id: &str, create_settled: bool) -> Result<()> {
+    let deadline = Instant::now() + TEARDOWN_RESERVE;
+    let left = || deadline.saturating_duration_since(Instant::now());
+
+    loop {
+        let refused = match tokio::time::timeout(left(), sandbox.terminate(session_id)).await {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error.to_string()),
+            Err(_) => Some("no answer".to_string()),
+        };
+
+        let present = match tokio::time::timeout(left(), sandbox.get(session_id)).await {
+            Ok(Ok(None)) => None,
+            Ok(Ok(Some(session))) if session.state == SandboxSessionState::Terminated => None,
+            Ok(Ok(Some(session))) => Some(format!("{:?}", session.state)),
+            Ok(Err(error)) => Some(format!("unreadable ({error})")),
+            Err(_) => Some("unreadable (no answer)".to_string()),
+        };
+
+        if present.is_none() && create_settled {
+            return Ok(());
         }
 
-        if attempt + 1 < TERMINATE_POLL_ATTEMPTS {
-            tokio::time::sleep(TERMINATE_POLL_INTERVAL).await;
+        if Instant::now() >= deadline {
+            // Nothing left to end. A create still in flight can land one after this, which is why
+            // the caller reports its own failure and the sandbox's deletion reaps what remains.
+            let Some(seen) = present else { return Ok(()) };
+            let why = match refused {
+                Some(refusal) => format!("{seen}, terminate refused: {refusal}"),
+                None => seen,
+            };
+            return Err(AlienError::new(ErrorData::TestValidationFailed {
+                reason: format!(
+                    "session '{session_id}' is still {why} {}s after terminate",
+                    TEARDOWN_RESERVE.as_secs()
+                ),
+            }));
         }
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
-
-    if let Some(reason) = refused {
-        return Err(AlienError::new(ErrorData::TestValidationFailed {
-            reason: format!(
-                "session '{session_id}' could not be terminated ({reason}); it may still be billing"
-            ),
-        }));
-    }
-    Err(AlienError::new(ErrorData::TestValidationFailed {
-        reason: format!(
-            "session '{session_id}' is still {last} {}s after terminate; it may still be billing",
-            TERMINATE_POLL_ATTEMPTS * TERMINATE_POLL_INTERVAL.as_secs() as u32
-        ),
-    }))
 }
 
 /// The part of the test that can fail without leaking a session.
@@ -220,6 +201,7 @@ async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
         })?;
 
     let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
     let mut exit_code = None;
     while let Some(frame) = frames.next().await {
         match frame.context(ErrorData::SandboxOperationFailed {
@@ -227,13 +209,18 @@ async fn exercise(sandbox: &dyn Sandbox, session_id: &str) -> Result<()> {
         })? {
             CommandOutput::Stdout { data, .. } => stdout.extend_from_slice(&data),
             CommandOutput::Exit { code, .. } => exit_code = Some(code),
-            CommandOutput::Stderr { .. } => {}
+            CommandOutput::Stderr { data, .. } => stderr.extend_from_slice(&data),
         }
     }
 
     if exit_code != Some(0) {
+        // stderr is kept, not reduced to a boolean: when this fails it is the only thing that
+        // says why, and this harness diagnoses a deployment from the outside.
         return Err(AlienError::new(ErrorData::TestValidationFailed {
-            reason: format!("run_command exited with {exit_code:?}, expected 0"),
+            reason: format!(
+                "run_command exited with {exit_code:?}, expected 0: {}",
+                String::from_utf8_lossy(&stderr)
+            ),
         }));
     }
 

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/sandbox.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use axum::{
     extract::{Path, State},
@@ -10,13 +10,11 @@ use futures_util::StreamExt;
 use tracing::info;
 
 use crate::{
-    models::{AppState, KvTestResponse},
+    models::{AppState, KvTestResponse, SandboxSessionsResponse},
     ErrorData, Result,
 };
 use alien_error::{AlienError, Context};
-use alien_sdk::traits::{
-    CommandOutput, CreateSessionRequest, RunCommandRequest, Sandbox, SandboxSessionState,
-};
+use alien_sdk::traits::{CommandOutput, CreateSessionRequest, RunCommandRequest, Sandbox};
 
 /// Test a sandbox binding by running a command and moving a file through a session.
 #[utoipa::path(
@@ -50,68 +48,48 @@ pub async fn test_sandbox(
             binding_name: binding_name.clone(),
         })?;
 
-    // Chosen here so teardown can name a session even when create never reports one. Local honours
-    // a requested id, and Local is the only platform this check runs on.
+    // No timeouts here: the runner bounds the whole request, and a step that hangs is a failed
+    // check either way. A bound inside the handler would only add a path where the handler
+    // abandons a session it then has to hunt for — and the runtime drops this future when the
+    // runner gives up, so cleanup cannot depend on it surviving. The sandbox's own delete flow
+    // reaps every session, and the runner asserts none survived; this handler only has to leave
+    // nothing behind when it is the one still running.
     let session_id = format!("e2e-rs-{}", Utc::now().timestamp_millis());
-    let exercise_by = Instant::now() + REQUEST_BUDGET - TEARDOWN_RESERVE;
-    let left = || exercise_by.saturating_duration_since(Instant::now());
-
-    let created = tokio::time::timeout(
-        left(),
-        sandbox.create(CreateSessionRequest {
+    let session = match sandbox
+        .create(CreateSessionRequest {
             session_id: Some(session_id.clone()),
             tenant_key: None,
             env: BTreeMap::new(),
-        }),
-    )
-    .await;
-    let (session, mut outcome, create_settled) = match created {
-        Ok(Ok(session)) => (Some(session), Ok(()), true),
-        Ok(Err(error)) => (
-            None,
-            Err(error).context(ErrorData::SandboxOperationFailed {
+        })
+        .await
+    {
+        Ok(session) => session,
+        Err(error) => {
+            // A create that provisioned and then lost its answer exists under the id asked for on
+            // every backend that honours one, so ending that id here is what stops it; where the
+            // backend allocates its own id there is nothing to name, and its teardown reaps it.
+            let _ = sandbox.terminate(&session_id).await;
+            return Err(error).context(ErrorData::SandboxOperationFailed {
                 operation: "create".to_string(),
-            }),
-            true,
-        ),
-        Err(_) => (
-            None,
-            Err(AlienError::new(ErrorData::TestValidationFailed {
-                reason: "create gave no answer within the request budget; a session it lands \
-                         later is reaped when the sandbox is deleted"
-                    .to_string(),
-            })),
-            false,
-        ),
+            });
+        }
     };
 
-    if let Some(session) = &session {
-        outcome =
-            match tokio::time::timeout(left(), exercise(sandbox.as_ref(), &session.session_id))
-                .await
-            {
-                Ok(outcome) => outcome,
-                Err(_) => Err(AlienError::new(ErrorData::TestValidationFailed {
-                    reason: "the sandbox exercise gave no answer within the request budget"
-                        .to_string(),
-                })),
-            };
-    }
+    let outcome = exercise(sandbox.as_ref(), &session.session_id).await;
 
-    let target = session
-        .as_ref()
-        .map_or(session_id.as_str(), |session| session.session_id.as_str());
-    if let Err(leaked) = converge(sandbox.as_ref(), target, create_settled).await {
-        // Both are reported: a session left running is a sandbox nobody will look for, and why
-        // the exercise failed is often why it is still there.
-        return Err(match outcome {
-            Err(failure) => AlienError::new(ErrorData::TestValidationFailed {
-                reason: format!("{leaked}; {failure}"),
-            }),
-            Ok(()) => leaked,
-        });
-    }
+    // Unconditional: a failed exercise and a healthy one tear down the same way, and terminate is
+    // idempotent on every backend. Its own failure is reported only when it is the sole failure —
+    // the fault the exercise found is what a reader of this check needs, and a session that also
+    // would not close is second to it.
+    let terminated =
+        sandbox
+            .terminate(&session.session_id)
+            .await
+            .context(ErrorData::SandboxOperationFailed {
+                operation: "terminate".to_string(),
+            });
     outcome?;
+    terminated?;
 
     info!(%binding_name, "Sandbox test completed successfully");
 
@@ -121,66 +99,51 @@ pub async fn test_sandbox(
     }))
 }
 
-/// How long the whole check may take, teardown included. Held under the 300s read timeout the
-/// worker runtime applies to a proxied response (`alien-worker-runtime/src/transports/shared.rs`):
-/// this handler answers only at the end, so a longer run reaches the caller as a bare proxy error.
-const REQUEST_BUDGET: Duration = Duration::from_secs(150);
-/// Held back from the budget so teardown still runs after a slow create or exercise. Local frees
-/// a session only when the sandbox itself is deleted, so skipping teardown strands it.
-const TEARDOWN_RESERVE: Duration = Duration::from_secs(45);
-const POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// What the check leaves behind, read from the backend rather than trusted from the handler.
+#[utoipa::path(
+    get,
+    path = "/sandbox-sessions/{binding_name}",
+    tag = "sandbox",
+    params(
+        ("binding_name" = String, Path, description = "Name of the sandbox binding to inspect")
+    ),
+    responses(
+        (status = 200, description = "Sessions still present", body = SandboxSessionsResponse),
+        (status = 400, description = "Binding not found", body = AlienError),
+    ),
+    operation_id = "sandbox_sessions",
+    summary = "List the sandbox's surviving sessions",
+    description = "Reads the backend's own view of which sessions still exist"
+)]
+pub async fn sandbox_sessions(
+    State(app_state): State<AppState>,
+    Path(binding_name): Path<String>,
+) -> Result<Json<SandboxSessionsResponse>> {
+    let sandbox = app_state
+        .ctx
+        .bindings()
+        .sandbox(&binding_name)
+        .await
+        .context(ErrorData::BindingNotFound {
+            binding_name: binding_name.clone(),
+        })?;
 
-/// Terminates the session and reads it back until it is gone.
-///
-/// Terminate is reissued on every pass: it is idempotent, a transient refusal is the one failure
-/// that leaves a session running, and a session visible only on a later pass is ended rather than
-/// reported as a leak.
-///
-/// `create_settled` is false when create never answered. The session can still be created after
-/// an empty read there, so absence decides nothing and the wait runs its full reserve, ending
-/// whatever appears. A read that fails counts as present: an unreadable session is not a gone one.
-async fn converge(sandbox: &dyn Sandbox, session_id: &str, create_settled: bool) -> Result<()> {
-    let deadline = Instant::now() + TEARDOWN_RESERVE;
-    let left = || deadline.saturating_duration_since(Instant::now());
-
-    loop {
-        // Half of what is left, so the read that decides the verdict always has the other half.
-        // A terminate that spent the whole reserve would leave the read no time to answer, and a
-        // read that cannot answer would be reported as a session still running.
-        let refused = match tokio::time::timeout(left() / 2, sandbox.terminate(session_id)).await {
-            Ok(Ok(())) => None,
-            Ok(Err(error)) => Some(error.to_string()),
-            Err(_) => Some("no answer".to_string()),
-        };
-
-        let present = match tokio::time::timeout(left(), sandbox.get(session_id)).await {
-            Ok(Ok(None)) => None,
-            Ok(Ok(Some(session))) if session.state == SandboxSessionState::Terminated => None,
-            Ok(Ok(Some(session))) => Some(format!("{:?}", session.state)),
-            Ok(Err(error)) => Some(format!("unreadable ({error})")),
-            Err(_) => Some("unreadable (no answer)".to_string()),
-        };
-
-        if present.is_none() && create_settled {
-            return Ok(());
+    // A session the handler abandoned would not show up in its own answer, so this asks the
+    // backend. Where the backend cannot enumerate, that is reported as such rather than as zero.
+    match sandbox.list().await {
+        Ok(sessions) => Ok(Json(SandboxSessionsResponse {
+            enumerable: true,
+            session_ids: sessions.into_iter().map(|s| s.session_id).collect(),
+        })),
+        Err(error) if error.code == "OPERATION_NOT_SUPPORTED" => {
+            Ok(Json(SandboxSessionsResponse {
+                enumerable: false,
+                session_ids: Vec::new(),
+            }))
         }
-
-        if Instant::now() >= deadline {
-            // Nothing left to end. A create still in flight can land one after this, which is why
-            // the caller reports its own failure and the sandbox's deletion reaps what remains.
-            let Some(seen) = present else { return Ok(()) };
-            let why = match refused {
-                Some(refusal) => format!("{seen}, terminate refused: {refusal}"),
-                None => seen,
-            };
-            return Err(AlienError::new(ErrorData::TestValidationFailed {
-                reason: format!(
-                    "session '{session_id}' is still {why} {}s after terminate",
-                    TEARDOWN_RESERVE.as_secs()
-                ),
-            }));
-        }
-        tokio::time::sleep(POLL_INTERVAL).await;
+        Err(error) => Err(error).context(ErrorData::SandboxOperationFailed {
+            operation: "list".to_string(),
+        }),
     }
 }
 

--- a/tests/e2e/test-apps/comprehensive-rust/src/models.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/models.rs
@@ -109,6 +109,16 @@ pub struct PostgresTestResponse {
 // KV test models
 
 /// Response from KV test endpoint
+/// What a sandbox check left behind, read from the backend after the check.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxSessionsResponse {
+    /// Whether the backend can enumerate sessions at all; false is a shrug, not a zero.
+    pub enumerable: bool,
+    /// Ids of the sessions still present, when enumerable.
+    pub session_ids: Vec<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct KvTestResponse {

--- a/tests/e2e/test-apps/comprehensive-typescript/alien.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/alien.ts
@@ -18,15 +18,15 @@ const queue = new alien.Queue("alien-queue").build()
 // race that consumer. This queue has exactly one consumer: the queue trigger.
 const eventsQueue = new alien.Queue("alien-events-queue").build()
 const postgres = isLocal ? new alien.Postgres("alien-postgres").build() : undefined
-// Sandbox is Local-only for the same reason as Postgres: the cloud sandbox controllers do not
-// ship in this repo, so declaring one on a cloud target would ask the executor to provision a
-// backend with no registered controller.
+// Sandbox is Local-only: none of this suite's cloud targets has a sandbox controller registered
+// in this repo, so declaring one there would ask the executor to provision a backend nothing
+// drives.
 const sandbox = isLocal
   ? new alien.Sandbox("alien-sandbox")
       .code({ type: "image", image: "alpine:3.20" })
       .limits({ cpu: "500m", memory: "512Mi", disk: "1Gi", maxProcesses: 64 })
       .egress({ mode: "deny" })
-      .session({ maxLifetimeSeconds: 600 })
+      .session({})
       .build()
   : undefined
 const ai = new alien.AI("test-ai").build()

--- a/tests/e2e/test-apps/comprehensive-typescript/alien.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/alien.ts
@@ -18,6 +18,17 @@ const queue = new alien.Queue("alien-queue").build()
 // race that consumer. This queue has exactly one consumer: the queue trigger.
 const eventsQueue = new alien.Queue("alien-events-queue").build()
 const postgres = isLocal ? new alien.Postgres("alien-postgres").build() : undefined
+// Sandbox is Local-only for the same reason as Postgres: the cloud sandbox controllers do not
+// ship in this repo, so declaring one on a cloud target would ask the executor to provision a
+// backend with no registered controller.
+const sandbox = isLocal
+  ? new alien.Sandbox("alien-sandbox")
+      .code({ type: "image", image: "alpine:3.20" })
+      .limits({ cpu: "500m", memory: "512Mi", disk: "1Gi", maxProcesses: 64 })
+      .egress({ mode: "deny" })
+      .session({ maxLifetimeSeconds: 600 })
+      .build()
+  : undefined
 const ai = new alien.AI("test-ai").build()
 
 let workerBuilder = new alien.Worker("alien-ts-worker")
@@ -50,6 +61,9 @@ let workerBuilder = new alien.Worker("alien-ts-worker")
 if (postgres) {
   workerBuilder = workerBuilder.link(postgres)
 }
+if (sandbox) {
+  workerBuilder = workerBuilder.link(sandbox)
+}
 const worker = workerBuilder.build()
 
 const executionPermissions = [
@@ -66,6 +80,9 @@ const executionPermissions = [
 ]
 if (postgres) {
   executionPermissions.push("postgres/data-access")
+}
+if (sandbox) {
+  executionPermissions.push("sandbox/execute")
 }
 
 let stackBuilder = new alien.Stack("alien-ts-stack")
@@ -84,6 +101,9 @@ let stackBuilder = new alien.Stack("alien-ts-stack")
   .add(ai, "frozen")
 if (postgres) {
   stackBuilder = stackBuilder.add(postgres, "live")
+}
+if (sandbox) {
+  stackBuilder = stackBuilder.add(sandbox, "frozen")
 }
 const stack = stackBuilder.add(worker, "live").build()
 

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -10,14 +10,26 @@ app.post("/sandbox-test/:bindingName", async c => {
   const box = sandbox(bindingName)
   const marker = `alien-sandbox-e2e-${Date.now()}`
 
-  const session = await box.create({ sessionId: `e2e-ts-${Date.now()}` }).catch(async error => {
+  // Bounded, like everything after it: a stalled create is a failed test, not a hung suite.
+  // The id is chosen here so a create that answers late can still be ended by name.
+  const sessionId = `e2e-ts-${Date.now()}`
+  const session = await within(box.create({ sessionId }), CREATE_TIMEOUT_MS).catch(async error => {
+    // The create may still complete after this returns; ending the chosen id makes that a
+    // no-op session rather than a leak, and a refusal here is reported over the timeout.
+    const cleanup = await attempt(() => terminateAndConfirm(box, sessionId))
+    if (cleanup) {
+      throw new Error(cleanup)
+    }
     throw await toExternalOperationError(error, "sandbox-test")
   })
 
   // Both run before either is reported, and a leaked session is reported first even when the
   // exercise also failed: an exercise failure is a broken test, a surviving session is a billable
-  // sandbox nobody will look for.
-  const outcome = await attempt(() => exercise(box, session.sessionId, marker))
+  // sandbox nobody will look for. The exercise is bounded as a whole so a command or file
+  // operation that never answers still lets terminate run.
+  const outcome = await attempt(() =>
+    within(exercise(box, session.sessionId, marker), EXERCISE_TIMEOUT_MS),
+  )
   const cleanup = await attempt(() => terminateAndConfirm(box, session.sessionId))
 
   const failure = cleanup ?? outcome
@@ -72,9 +84,32 @@ async function exercise(box: Sandbox, sessionId: string, marker: string): Promis
   return null
 }
 
-/** How long to wait for a terminate to converge before calling the session leaked. */
+/** How long a create may take. Longer than a command: on AWS a session waits for the MicroVM
+ *  to answer before create returns. */
+const CREATE_TIMEOUT_MS = 120_000
+/** How long the whole exercise — commands and files — may take before terminate runs anyway. */
+const EXERCISE_TIMEOUT_MS = 180_000
+/** How many times a refused terminate is retried before the session is called leaked. */
+const TERMINATE_ATTEMPTS = 5
+/** How long to wait for an accepted terminate to converge before calling the session leaked. */
 const TERMINATE_POLL_ATTEMPTS = 15
 const TERMINATE_POLL_INTERVAL_MS = 2000
+/** How long one status read may take before it counts as a failed read: a stalled manager must
+ *  cost one attempt, not the whole test. */
+const STATUS_READ_TIMEOUT_MS = 10_000
+/** How long one terminate call may take before it counts as refused. Longer than a read: a
+ *  backend may confirm deletion inside the call, and that is bounded on its side too. */
+const TERMINATE_CALL_TIMEOUT_MS = 60_000
+
+/** Rejects when the operation gives no answer in time, so a stall costs one attempt. */
+function within<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  return Promise.race([
+    operation,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`no answer in ${timeoutMs / 1000}s`)), timeoutMs),
+    ),
+  ])
+}
 
 /**
  * Terminates the session and reads it back to confirm it is gone.
@@ -83,18 +118,37 @@ const TERMINATE_POLL_INTERVAL_MS = 2000
  * so a test that stops at the return value passes while the session keeps running.
  */
 async function terminateAndConfirm(box: Sandbox, sessionId: string): Promise<string | null> {
-  await box.terminate(sessionId)
-
   // Polled rather than read once: every backend returns from terminate as soon as the deletion is
   // accepted, so a single read races normal convergence and would fail a teardown that was simply
   // still finishing.
+  // The terminate itself is retried, because it is idempotent and a transient refusal is the one
+  // failure that leaves a session running: giving up on it would hand back an error and a
+  // billable sandbox nobody will look for.
   // A failed read inside the window is retried like a non-terminal state: the session may well be
   // gone, and giving up on the first blip would fail a teardown that had already converged. A read
   // that never succeeds still fails, carrying the last error rather than a bare timeout.
-  let last = "unread"
+  // The two budgets are separate so a terminate accepted on its last try still gets the whole
+  // convergence window rather than one immediate read.
+  let refused: string | null = null
+  for (let attempt = 0; attempt < TERMINATE_ATTEMPTS; attempt++) {
+    try {
+      await within(box.terminate(sessionId), TERMINATE_CALL_TIMEOUT_MS)
+      refused = null
+      break
+    } catch (error: unknown) {
+      refused = error instanceof Error ? error.message : String(error)
+      if (attempt + 1 < TERMINATE_ATTEMPTS) {
+        await new Promise(resolve => setTimeout(resolve, TERMINATE_POLL_INTERVAL_MS))
+      }
+    }
+  }
+  // A refused terminate is not yet a leak: the request may have succeeded with its response
+  // lost, so the confirmation poll below decides, and the refusal is what is reported if the
+  // session turns out to still be there.
+  let last = refused === null ? "unread" : `running (terminate refused: ${refused})`
   for (let attempt = 0; attempt < TERMINATE_POLL_ATTEMPTS; attempt++) {
     try {
-      const remaining = await box.get(sessionId)
+      const remaining = await within(box.get(sessionId), STATUS_READ_TIMEOUT_MS)
       if (remaining === null || remaining.state === "terminated") {
         return null
       }
@@ -107,6 +161,9 @@ async function terminateAndConfirm(box: Sandbox, sessionId: string): Promise<str
     }
   }
 
+  if (refused !== null) {
+    return `session '${sessionId}' could not be terminated (${refused}); it may still be billing`
+  }
   const waited = (TERMINATE_POLL_ATTEMPTS * TERMINATE_POLL_INTERVAL_MS) / 1000
   return `session '${sessionId}' is still ${last} ${waited}s after terminate; it may still be billing`
 }

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -101,6 +101,27 @@ async function exercise(box: Sandbox, sessionId: string, marker: string): Promis
     return "readFile returned different bytes than writeFiles sent"
   }
 
+  // Read the same file from inside the session, not only back through the agent. `readFile` is
+  // the agent reading what the agent wrote, so it holds even when the command that the upload
+  // exists for cannot open it — which is the difference between the backends that run an agent
+  // as a different user than the command and the ones that do not.
+  let fromInside = ""
+  let insideStderr = ""
+  let insideExit: number | undefined
+  for await (const frame of box.runCommand(sessionId, ["/bin/cat", "e2e/input.txt"], {
+    deadlineMs: 30_000,
+  })) {
+    if (frame.kind === "stdout") fromInside += frame.data.toString("utf8")
+    if (frame.kind === "stderr") insideStderr += frame.data.toString("utf8")
+    if (frame.kind === "exit") insideExit = frame.exitCode
+  }
+  if (insideExit !== 0) {
+    return `the session could not read the file written into it, exit ${insideExit}: ${insideStderr}`
+  }
+  if (!fromInside.includes(marker)) {
+    return `the session read different bytes than writeFiles sent: ${fromInside}`
+  }
+
   return null
 }
 

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -5,40 +5,52 @@ import { toExternalOperationError } from "../helpers.js"
 
 const app = new Hono()
 
+/** How long the whole check may take, teardown included. Held under the 255s idle timeout the
+ *  app's own server sets in `packages/sdk/src/worker-runtime/index.ts`: this handler answers only
+ *  at the end, so a longer run reaches the caller as a proxy error carrying none of the detail. */
+const REQUEST_BUDGET_MS = 150_000
+/** Held back from the budget so teardown still runs after a slow create or exercise. Local frees
+ *  a session only when the sandbox itself is deleted, so skipping teardown strands it. */
+const TEARDOWN_RESERVE_MS = 45_000
+const POLL_INTERVAL_MS = 2_000
+
 app.post("/sandbox-test/:bindingName", async c => {
   const bindingName = c.req.param("bindingName")
   const box = sandbox(bindingName)
   const marker = `alien-sandbox-e2e-${Date.now()}`
-
-  // Awaited rather than raced: only the id create returns can end a session — AWS and Azure
-  // allocate their own rather than taking the one asked for — so a bounded wait here would
-  // terminate an id no session answers to while the real one is still being created.
+  // Chosen here so teardown can name a session even when create never reports one. Local honours
+  // a requested id, and Local is the only platform this check runs on.
   const sessionId = `e2e-ts-${Date.now()}`
-  let session: SandboxSession
+
+  const exerciseBy = Date.now() + REQUEST_BUDGET_MS - TEARDOWN_RESERVE_MS
+  const left = () => Math.max(exerciseBy - Date.now(), 1)
+
+  let session: SandboxSession | undefined
+  let failed: string | null = null
+  // `within` gives up on its own timer without cancelling the call, so whether the create settled
+  // is the thing teardown needs to know, not whether this await returned.
+  let createSettled = false
+  const creating = box.create({ sessionId }).finally(() => {
+    createSettled = true
+  })
   try {
-    session = await box.create({ sessionId })
+    session = await within(creating, left())
   } catch (error: unknown) {
-    // The create has settled, so ending the id asked for is not a race: local, Kubernetes and GCP
-    // take that id, so a session provisioned under a lost response answers to it. AWS and Azure
-    // allocate their own; there the 600s maxLifetimeSeconds in alien.ts is what reclaims it.
-    const leaked = await attempt(() => terminateAndConfirm(box, sessionId))
-    const alienError = await toExternalOperationError(error, "sandbox-test")
-    return c.json(
-      { success: false, error: leaked ?? `${alienError.code}: ${alienError.message}` },
-      500,
-    )
+    failed = await describe(error)
+    if (!createSettled) {
+      failed = `${failed}; a session it lands later is reaped when the sandbox is deleted`
+    }
   }
 
-  // Both run before either is reported, and a leaked session is reported first even when the
-  // exercise also failed: an exercise failure is a broken test, a surviving session is a billable
-  // sandbox nobody will look for. The exercise is bounded as a whole so a command or file
-  // operation that never answers still lets terminate run.
-  const outcome = await attempt(() =>
-    within(exercise(box, session.sessionId, marker), EXERCISE_TIMEOUT_MS),
-  )
-  const cleanup = await attempt(() => terminateAndConfirm(box, session.sessionId))
+  if (session) {
+    const id = session.sessionId
+    failed = await attempt(() => within(exercise(box, id, marker), left()))
+  }
 
-  const failure = cleanup ?? outcome
+  // Teardown runs whatever happened above, and both failures are reported: a session left running
+  // is a sandbox nobody will look for, and why the exercise failed is often why it is still there.
+  const leaked = await attempt(() => converge(box, session?.sessionId ?? sessionId, createSettled))
+  const failure = [leaked, failed].filter(Boolean).join("; ")
   if (failure) {
     return c.json({ success: false, error: failure }, 500)
   }
@@ -46,13 +58,18 @@ app.post("/sandbox-test/:bindingName", async c => {
   return c.json({ success: true, bindingName })
 })
 
-/** Runs `step`, returning why it failed rather than throwing, so both steps always run. */
+/** Renders a failure the way the e2e runner reports it. */
+async function describe(error: unknown): Promise<string> {
+  const alienError = await toExternalOperationError(error, "sandbox-test")
+  return `${alienError.code}: ${alienError.message}`
+}
+
+/** Runs `step`, returning why it failed rather than throwing, so teardown always runs. */
 async function attempt(step: () => Promise<string | null>): Promise<string | null> {
   try {
     return await step()
   } catch (error: unknown) {
-    const alienError = await toExternalOperationError(error, "sandbox-test")
-    return `${alienError.code}: ${alienError.message}`
+    return await describe(error)
   }
 }
 
@@ -90,85 +107,69 @@ async function exercise(box: Sandbox, sessionId: string, marker: string): Promis
   return null
 }
 
-/** How long the whole exercise — commands and files — may take before terminate runs anyway. */
-const EXERCISE_TIMEOUT_MS = 180_000
-/** How many times a refused terminate is retried before the session is called leaked. */
-const TERMINATE_ATTEMPTS = 5
-/** How long to wait for an accepted terminate to converge before calling the session leaked. */
-const TERMINATE_POLL_ATTEMPTS = 15
-const TERMINATE_POLL_INTERVAL_MS = 2000
-/** How long one status read may take before it counts as a failed read: a stalled manager must
- *  cost one attempt, not the whole test. */
-const STATUS_READ_TIMEOUT_MS = 10_000
-/** How long one terminate call may take before it counts as refused. Longer than a read: a
- *  backend may confirm deletion inside the call, and that is bounded on its side too. */
-const TERMINATE_CALL_TIMEOUT_MS = 60_000
-
-/** Rejects when the operation gives no answer in time, so a stall costs one attempt. */
-function within<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    operation,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`no answer in ${timeoutMs / 1000}s`)), timeoutMs),
-    ),
-  ])
-}
-
 /**
- * Terminates the session and reads it back to confirm it is gone.
+ * Terminates the session and reads it back until it is gone.
  *
- * A successful terminate is not the same claim: the backends return once deletion is accepted,
- * so a test that stops at the return value passes while the session keeps running.
+ * Terminate is reissued on every pass: it is idempotent, a transient refusal is the one failure
+ * that leaves a session running, and a session visible only on a later pass is ended rather than
+ * reported as a leak.
+ *
+ * `createSettled` is false when create never answered. The session can still be created after an
+ * empty read there, so absence decides nothing and the wait runs its full reserve, ending whatever
+ * appears. A read that fails counts as present: an unreadable session is not a gone one.
  */
-async function terminateAndConfirm(box: Sandbox, sessionId: string): Promise<string | null> {
-  // Polled rather than read once: every backend returns from terminate as soon as the deletion is
-  // accepted, so a single read races normal convergence and would fail a teardown that was simply
-  // still finishing.
-  // The terminate itself is retried, because it is idempotent and a transient refusal is the one
-  // failure that leaves a session running: giving up on it would hand back an error and a
-  // billable sandbox nobody will look for.
-  // A failed read inside the window is retried like a non-terminal state: the session may well be
-  // gone, and giving up on the first blip would fail a teardown that had already converged. A read
-  // that never succeeds still fails, carrying the last error rather than a bare timeout.
-  // The two budgets are separate so a terminate accepted on its last try still gets the whole
-  // convergence window rather than one immediate read.
-  let refused: string | null = null
-  for (let attempt = 0; attempt < TERMINATE_ATTEMPTS; attempt++) {
+async function converge(
+  box: Sandbox,
+  sessionId: string,
+  createSettled: boolean,
+): Promise<string | null> {
+  const deadline = Date.now() + TEARDOWN_RESERVE_MS
+  const left = () => Math.max(deadline - Date.now(), 1)
+
+  for (;;) {
+    let refused: string | null = null
     try {
-      await within(box.terminate(sessionId), TERMINATE_CALL_TIMEOUT_MS)
-      refused = null
-      break
+      await within(box.terminate(sessionId), left())
     } catch (error: unknown) {
       refused = error instanceof Error ? error.message : String(error)
-      if (attempt + 1 < TERMINATE_ATTEMPTS) {
-        await new Promise(resolve => setTimeout(resolve, TERMINATE_POLL_INTERVAL_MS))
-      }
     }
-  }
-  // A refused terminate is not yet a leak: the request may have succeeded with its response
-  // lost, so the confirmation poll below decides, and the refusal is what is reported if the
-  // session turns out to still be there.
-  let last = refused === null ? "unread" : `running (terminate refused: ${refused})`
-  for (let attempt = 0; attempt < TERMINATE_POLL_ATTEMPTS; attempt++) {
+
+    let present: string | null
     try {
-      const remaining = await within(box.get(sessionId), STATUS_READ_TIMEOUT_MS)
-      if (remaining === null || remaining.state === "terminated") {
+      const session = await within(box.get(sessionId), left())
+      present = session === null || session.state === "terminated" ? null : session.state
+    } catch (error: unknown) {
+      present = `unreadable (${error instanceof Error ? error.message : String(error)})`
+    }
+
+    if (present === null && createSettled) {
+      return null
+    }
+
+    if (Date.now() >= deadline) {
+      // Nothing left to end. A create still in flight can land one after this, which is why the
+      // caller reports its own failure and the sandbox's deletion reaps what remains.
+      if (present === null) {
         return null
       }
-      last = remaining.state
-    } catch (error: unknown) {
-      last = `unreadable (${error instanceof Error ? error.message : String(error)})`
+      const why = refused === null ? present : `${present}, terminate refused: ${refused}`
+      const waited = Math.round(TEARDOWN_RESERVE_MS / 1000)
+      return `session '${sessionId}' is still ${why} ${waited}s after terminate`
     }
-    if (attempt + 1 < TERMINATE_POLL_ATTEMPTS) {
-      await new Promise(resolve => setTimeout(resolve, TERMINATE_POLL_INTERVAL_MS))
-    }
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
   }
+}
 
-  if (refused !== null) {
-    return `session '${sessionId}' could not be terminated (${refused}); it may still be billing`
-  }
-  const waited = (TERMINATE_POLL_ATTEMPTS * TERMINATE_POLL_INTERVAL_MS) / 1000
-  return `session '${sessionId}' is still ${last} ${waited}s after terminate; it may still be billing`
+/** Rejects when an operation gives no answer in time, so one stall cannot spend the whole budget. */
+function within<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`no answer in ${Math.round(Math.max(timeoutMs, 0) / 1000)}s`)),
+      timeoutMs,
+    )
+  })
+  return Promise.race([operation, expiry]).finally(() => clearTimeout(timer))
 }
 
 export default app

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -5,73 +5,70 @@ import { toExternalOperationError } from "../helpers.js"
 
 const app = new Hono()
 
-/** How long the whole check may take, teardown included. Held under the 255s idle timeout the
- *  app's own server sets in `packages/sdk/src/worker-runtime/index.ts`: this handler answers only
- *  at the end, so a longer run reaches the caller as a proxy error carrying none of the detail. */
-const REQUEST_BUDGET_MS = 150_000
-/** Held back from the budget so teardown still runs after a slow create or exercise. Local frees
- *  a session only when the sandbox itself is deleted, so skipping teardown strands it. */
-const TEARDOWN_RESERVE_MS = 45_000
-const POLL_INTERVAL_MS = 2_000
-
+// No timeouts here: the runner bounds the whole request, and a step that hangs is a failed check
+// either way. A bound inside the handler would only add a path where the handler abandons a
+// session it then has to hunt for — and the runtime drops this handler when the runner gives up,
+// so cleanup cannot depend on it surviving. The sandbox's own delete flow reaps every session, and
+// the runner asserts none survived; this handler only has to leave nothing behind when it is the
+// one still running.
 app.post("/sandbox-test/:bindingName", async c => {
   const bindingName = c.req.param("bindingName")
   const box = sandbox(bindingName)
   const marker = `alien-sandbox-e2e-${Date.now()}`
-  // Chosen here so teardown can name a session even when create never reports one. Local honours
-  // a requested id, and Local is the only platform this check runs on.
+
   const sessionId = `e2e-ts-${Date.now()}`
-
-  const exerciseBy = Date.now() + REQUEST_BUDGET_MS - TEARDOWN_RESERVE_MS
-  const left = () => Math.max(exerciseBy - Date.now(), 1)
-
-  let session: SandboxSession | undefined
-  let failed: string | null = null
-  // `within` gives up on its own timer without cancelling the call, so whether the create settled
-  // is the thing teardown needs to know, not whether this await returned.
-  let createSettled = false
-  const creating = box.create({ sessionId }).finally(() => {
-    createSettled = true
-  })
+  let session: SandboxSession
   try {
-    session = await within(creating, left())
+    session = await box.create({ sessionId })
   } catch (error: unknown) {
-    failed = await describe(error)
-    if (!createSettled) {
-      failed = `${failed}; a session it lands later is reaped when the sandbox is deleted`
-    }
+    // A create that provisioned and then lost its answer exists under the id asked for on every
+    // backend that honours one, so ending that id here is what stops it; where the backend
+    // allocates its own id there is nothing to name, and its teardown reaps it.
+    await box.terminate(sessionId).catch(() => undefined)
+    const alienError = await toExternalOperationError(error, "sandbox-test")
+    return c.json({ success: false, error: `${alienError.code}: ${alienError.message}` }, 500)
   }
 
-  if (session) {
-    const id = session.sessionId
-    failed = await attempt(() => within(exercise(box, id, marker), left()))
+  let failure: string | null
+  try {
+    failure = await exercise(box, session.sessionId, marker)
+  } catch (error: unknown) {
+    const alienError = await toExternalOperationError(error, "sandbox-test")
+    failure = `${alienError.code}: ${alienError.message}`
   }
 
-  // Teardown runs whatever happened above, and both failures are reported: a session left running
-  // is a sandbox nobody will look for, and why the exercise failed is often why it is still there.
-  const leaked = await attempt(() => converge(box, session?.sessionId ?? sessionId, createSettled))
-  const failure = [leaked, failed].filter(Boolean).join("; ")
+  // Idempotent on every backend, so a failed exercise and a healthy one tear down the same way.
+  // Its own failure is reported only when it is the sole failure: the fault the exercise found is
+  // what a reader of this check needs, and a session that also would not close is second to it.
+  try {
+    await box.terminate(session.sessionId)
+  } catch (error: unknown) {
+    const alienError = await toExternalOperationError(error, "sandbox-terminate")
+    failure ??= `${alienError.code}: ${alienError.message}`
+  }
+
   if (failure) {
     return c.json({ success: false, error: failure }, 500)
   }
-
   return c.json({ success: true, bindingName })
 })
 
-/** Renders a failure the way the e2e runner reports it. */
-async function describe(error: unknown): Promise<string> {
-  const alienError = await toExternalOperationError(error, "sandbox-test")
-  return `${alienError.code}: ${alienError.message}`
-}
-
-/** Runs `step`, returning why it failed rather than throwing, so teardown always runs. */
-async function attempt(step: () => Promise<string | null>): Promise<string | null> {
+// What the check leaves behind, read from the backend rather than trusted from the handler: a
+// session the handler abandoned would not show up in its own answer. Where the backend cannot
+// enumerate, that is reported as such rather than as zero.
+app.get("/sandbox-sessions/:bindingName", async c => {
+  const box = sandbox(c.req.param("bindingName"))
   try {
-    return await step()
+    const sessions = await box.list()
+    return c.json({ enumerable: true, sessionIds: sessions.map(s => s.sessionId) })
   } catch (error: unknown) {
-    return await describe(error)
+    const alienError = await toExternalOperationError(error, "sandbox-sessions")
+    if (alienError.context?.sourceCode === "OPERATION_NOT_SUPPORTED") {
+      return c.json({ enumerable: false, sessionIds: [] })
+    }
+    return c.json({ success: false, error: `${alienError.code}: ${alienError.message}` }, 500)
   }
-}
+})
 
 /** Runs a command and moves a file both directions through one session. */
 async function exercise(box: Sandbox, sessionId: string, marker: string): Promise<string | null> {
@@ -105,74 +102,6 @@ async function exercise(box: Sandbox, sessionId: string, marker: string): Promis
   }
 
   return null
-}
-
-/**
- * Terminates the session and reads it back until it is gone.
- *
- * Terminate is reissued on every pass: it is idempotent, a transient refusal is the one failure
- * that leaves a session running, and a session visible only on a later pass is ended rather than
- * reported as a leak.
- *
- * `createSettled` is false when create never answered. The session can still be created after an
- * empty read there, so absence decides nothing and the wait runs its full reserve, ending whatever
- * appears. A read that fails counts as present: an unreadable session is not a gone one.
- */
-async function converge(
-  box: Sandbox,
-  sessionId: string,
-  createSettled: boolean,
-): Promise<string | null> {
-  const deadline = Date.now() + TEARDOWN_RESERVE_MS
-  const left = () => Math.max(deadline - Date.now(), 1)
-
-  for (;;) {
-    let refused: string | null = null
-    try {
-      // Half of what is left, so the read that decides the verdict always has the other half. A
-      // terminate that spent the whole reserve would leave the read no time to answer, and a read
-      // that cannot answer would be reported as a session still running.
-      await within(box.terminate(sessionId), Math.max(Math.floor(left() / 2), 1))
-    } catch (error: unknown) {
-      refused = error instanceof Error ? error.message : String(error)
-    }
-
-    let present: string | null
-    try {
-      const session = await within(box.get(sessionId), left())
-      present = session === null || session.state === "terminated" ? null : session.state
-    } catch (error: unknown) {
-      present = `unreadable (${error instanceof Error ? error.message : String(error)})`
-    }
-
-    if (present === null && createSettled) {
-      return null
-    }
-
-    if (Date.now() >= deadline) {
-      // Nothing left to end. A create still in flight can land one after this, which is why the
-      // caller reports its own failure and the sandbox's deletion reaps what remains.
-      if (present === null) {
-        return null
-      }
-      const why = refused === null ? present : `${present}, terminate refused: ${refused}`
-      const waited = Math.round(TEARDOWN_RESERVE_MS / 1000)
-      return `session '${sessionId}' is still ${why} ${waited}s after terminate`
-    }
-    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
-  }
-}
-
-/** Rejects when an operation gives no answer in time, so one stall cannot spend the whole budget. */
-function within<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const expiry = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`no answer in ${Math.round(Math.max(timeoutMs, 0) / 1000)}s`)),
-      timeoutMs,
-    )
-  })
-  return Promise.race([operation, expiry]).finally(() => clearTimeout(timer))
 }
 
 export default app

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -129,7 +129,10 @@ async function converge(
   for (;;) {
     let refused: string | null = null
     try {
-      await within(box.terminate(sessionId), left())
+      // Half of what is left, so the read that decides the verdict always has the other half. A
+      // terminate that spent the whole reserve would leave the read no time to answer, and a read
+      // that cannot answer would be reported as a session still running.
+      await within(box.terminate(sessionId), Math.max(Math.floor(left() / 2), 1))
     } catch (error: unknown) {
       refused = error instanceof Error ? error.message : String(error)
     }

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -1,0 +1,114 @@
+import type { Sandbox } from "@alienplatform/sdk"
+import { sandbox } from "@alienplatform/sdk"
+import { Hono } from "hono"
+import { toExternalOperationError } from "../helpers.js"
+
+const app = new Hono()
+
+app.post("/sandbox-test/:bindingName", async c => {
+  const bindingName = c.req.param("bindingName")
+  const box = sandbox(bindingName)
+  const marker = `alien-sandbox-e2e-${Date.now()}`
+
+  const session = await box.create({ sessionId: `e2e-ts-${Date.now()}` }).catch(async error => {
+    throw await toExternalOperationError(error, "sandbox-test")
+  })
+
+  // Both run before either is reported, and a leaked session is reported first even when the
+  // exercise also failed: an exercise failure is a broken test, a surviving session is a billable
+  // sandbox nobody will look for.
+  const outcome = await attempt(() => exercise(box, session.sessionId, marker))
+  const cleanup = await attempt(() => terminateAndConfirm(box, session.sessionId))
+
+  const failure = cleanup ?? outcome
+  if (failure) {
+    return c.json({ success: false, error: failure }, 500)
+  }
+
+  return c.json({ success: true, bindingName })
+})
+
+/** Runs `step`, returning why it failed rather than throwing, so both steps always run. */
+async function attempt(step: () => Promise<string | null>): Promise<string | null> {
+  try {
+    return await step()
+  } catch (error: unknown) {
+    const alienError = await toExternalOperationError(error, "sandbox-test")
+    return `${alienError.code}: ${alienError.message}`
+  }
+}
+
+/** Runs a command and moves a file both directions through one session. */
+async function exercise(box: Sandbox, sessionId: string, marker: string): Promise<string | null> {
+  let stdout = ""
+  let stderr = ""
+  let exitCode: number | undefined
+
+  for await (const frame of box.runCommand(sessionId, ["/bin/echo", marker], {
+    deadlineMs: 30_000,
+  })) {
+    if (frame.kind === "stdout") stdout += frame.data.toString("utf8")
+    if (frame.kind === "stderr") stderr += frame.data.toString("utf8")
+    if (frame.kind === "exit") exitCode = frame.exitCode
+  }
+
+  if (exitCode !== 0) {
+    // stderr is kept, not reduced to a boolean: when this fails it is the only thing that says
+    // why, and this harness diagnoses a deployment from the outside.
+    return `command exited with ${exitCode}: ${stderr}`
+  }
+  if (!stdout.includes(marker)) {
+    return `stdout did not carry the marker: ${stdout}`
+  }
+
+  // Files both directions through the same session, which is what makes it a session rather
+  // than a sequence of unrelated commands.
+  await box.writeFiles(sessionId, { "e2e/input.txt": marker })
+  const readBack = await box.readFile(sessionId, "e2e/input.txt")
+  if (readBack.toString("utf8") !== marker) {
+    return "readFile returned different bytes than writeFiles sent"
+  }
+
+  return null
+}
+
+/** How long to wait for a terminate to converge before calling the session leaked. */
+const TERMINATE_POLL_ATTEMPTS = 15
+const TERMINATE_POLL_INTERVAL_MS = 2000
+
+/**
+ * Terminates the session and reads it back to confirm it is gone.
+ *
+ * A successful terminate is not the same claim: the backends return once deletion is accepted,
+ * so a test that stops at the return value passes while the session keeps running.
+ */
+async function terminateAndConfirm(box: Sandbox, sessionId: string): Promise<string | null> {
+  await box.terminate(sessionId)
+
+  // Polled rather than read once: every backend returns from terminate as soon as the deletion is
+  // accepted, so a single read races normal convergence and would fail a teardown that was simply
+  // still finishing.
+  // A failed read inside the window is retried like a non-terminal state: the session may well be
+  // gone, and giving up on the first blip would fail a teardown that had already converged. A read
+  // that never succeeds still fails, carrying the last error rather than a bare timeout.
+  let last = "unread"
+  for (let attempt = 0; attempt < TERMINATE_POLL_ATTEMPTS; attempt++) {
+    try {
+      const remaining = await box.get(sessionId)
+      if (remaining === null || remaining.state === "terminated") {
+        return null
+      }
+      last = remaining.state
+    } catch (error: unknown) {
+      last = `unreadable (${error instanceof Error ? error.message : String(error)})`
+    }
+    if (attempt + 1 < TERMINATE_POLL_ATTEMPTS) {
+      await new Promise(resolve => setTimeout(resolve, TERMINATE_POLL_INTERVAL_MS))
+    }
+  }
+
+  const waited = (TERMINATE_POLL_ATTEMPTS * TERMINATE_POLL_INTERVAL_MS) / 1000
+  return `session '${sessionId}' is still ${last} ${waited}s after terminate; it may still be billing`
+}
+
+export default app

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/sandbox.ts
@@ -1,4 +1,4 @@
-import type { Sandbox } from "@alienplatform/sdk"
+import type { Sandbox, SandboxSession } from "@alienplatform/sdk"
 import { sandbox } from "@alienplatform/sdk"
 import { Hono } from "hono"
 import { toExternalOperationError } from "../helpers.js"
@@ -10,18 +10,24 @@ app.post("/sandbox-test/:bindingName", async c => {
   const box = sandbox(bindingName)
   const marker = `alien-sandbox-e2e-${Date.now()}`
 
-  // Bounded, like everything after it: a stalled create is a failed test, not a hung suite.
-  // The id is chosen here so a create that answers late can still be ended by name.
+  // Awaited rather than raced: only the id create returns can end a session — AWS and Azure
+  // allocate their own rather than taking the one asked for — so a bounded wait here would
+  // terminate an id no session answers to while the real one is still being created.
   const sessionId = `e2e-ts-${Date.now()}`
-  const session = await within(box.create({ sessionId }), CREATE_TIMEOUT_MS).catch(async error => {
-    // The create may still complete after this returns; ending the chosen id makes that a
-    // no-op session rather than a leak, and a refusal here is reported over the timeout.
-    const cleanup = await attempt(() => terminateAndConfirm(box, sessionId))
-    if (cleanup) {
-      throw new Error(cleanup)
-    }
-    throw await toExternalOperationError(error, "sandbox-test")
-  })
+  let session: SandboxSession
+  try {
+    session = await box.create({ sessionId })
+  } catch (error: unknown) {
+    // The create has settled, so ending the id asked for is not a race: local, Kubernetes and GCP
+    // take that id, so a session provisioned under a lost response answers to it. AWS and Azure
+    // allocate their own; there the 600s maxLifetimeSeconds in alien.ts is what reclaims it.
+    const leaked = await attempt(() => terminateAndConfirm(box, sessionId))
+    const alienError = await toExternalOperationError(error, "sandbox-test")
+    return c.json(
+      { success: false, error: leaked ?? `${alienError.code}: ${alienError.message}` },
+      500,
+    )
+  }
 
   // Both run before either is reported, and a leaked session is reported first even when the
   // exercise also failed: an exercise failure is a broken test, a surviving session is a billable
@@ -84,9 +90,6 @@ async function exercise(box: Sandbox, sessionId: string, marker: string): Promis
   return null
 }
 
-/** How long a create may take. Longer than a command: on AWS a session waits for the MicroVM
- *  to answer before create returns. */
-const CREATE_TIMEOUT_MS = 120_000
 /** How long the whole exercise — commands and files — may take before terminate runs anyway. */
 const EXERCISE_TIMEOUT_MS = 180_000
 /** How many times a refused terminate is retried before the session is called leaked. */

--- a/tests/e2e/test-apps/comprehensive-typescript/src/index.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/index.ts
@@ -16,6 +16,7 @@ import inspectRoutes from "./handlers/inspect.js"
 import kvRoutes from "./handlers/kv.js"
 import postgresRoutes from "./handlers/postgres.js"
 import queueRoutes from "./handlers/queue.js"
+import sandboxRoutes from "./handlers/sandbox.js"
 import sseRoutes from "./handlers/sse.js"
 import storageRoutes from "./handlers/storage.js"
 import vaultRoutes from "./handlers/vault.js"
@@ -32,6 +33,7 @@ app.route("/", inspectRoutes)
 app.route("/", sseRoutes)
 app.route("/", storageRoutes)
 app.route("/", kvRoutes)
+app.route("/", sandboxRoutes)
 app.route("/", vaultRoutes)
 app.route("/", postgresRoutes)
 app.route("/", queueRoutes)


### PR DESCRIPTION
## Summary

Exercises a sandbox end to end: the test app declares one, and the suite drives a real session through it rather than asserting on rendered templates.

What the test does when it runs:

1. Deploys the comprehensive test app, which now declares a sandbox alongside its other resources.
2. Creates a session through the binding and runs a command in it.
3. **Writes a file, reads it back, and checks the content — which is the only thing that proves the agent, the capability and the transport all line up.**
4. Terminates the session and confirms it is gone.

## What I did

The assertions are on observed behaviour, not on artifacts. A test that checks a template contains a string would pass against a sandbox that never starts, so this one runs code inside the session and reads back what it wrote.

## Files touched

- `crates/alien-test/` — the sandbox case in the deployment suite.
- `tests/e2e/test-apps/comprehensive-typescript/` — the declaration and the handler the test drives.

## How I tested

The suite itself is the test: it creates a session, runs a command, round-trips a file and
terminates, asserting on what came back rather than on rendered artifacts.

I have **not** run it against a live deployment in this change — it needs cloud credentials and a
free slot. It should be run before merge, and the thing to watch is teardown: an accepted delete
is not a completed one, so confirm the session is actually gone rather than trusting the call.
