### PR TITLE
perf(build): use native musl for matching Linux targets

### DIFF
--- a/crates/alien-build/src/toolchain/rust.rs
+++ b/crates/alien-build/src/toolchain/rust.rs
@@ -117,7 +117,7 @@ impl RustToolchain {
     async fn resolve_build_strategy(&self, target: BinaryTarget) -> Result<CargoBuildStrategy> {
         let host = BuildHost::current();
         if target == BinaryTarget::DarwinArm64
-            && !matches!(host, BuildHost::DarwinArm64 | BuildHost::DarwinX64)
+            && !matches!(host, BuildHost::DarwinArm64)
         {
             return Err(AlienError::new(ErrorData::ImageBuildFailed {
                 resource_name: self.binary_name.clone(),

--- a/crates/alien-build/src/toolchain/rust.rs
+++ b/crates/alien-build/src/toolchain/rust.rs
@@ -1,7 +1,7 @@
 use super::{cache_utils, Toolchain, ToolchainContext, ToolchainOutput};
 use crate::command_output::{image_build_error_with_output, wait_with_captured_output};
 use crate::error::{ErrorData, Result};
-use alien_core::{AlienEvent, CargoBuildStrategy};
+use alien_core::{AlienEvent, BinaryTarget, BuildHost, CargoBuildStrategy};
 use alien_error::{AlienError, Context, ContextError, IntoAlienError, IntoAlienErrorDirect};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -80,7 +80,11 @@ impl RustToolchain {
     }
 
     /// Generate cache key from Cargo.lock and build configuration
-    async fn generate_cache_key(&self, context: &ToolchainContext) -> Result<String> {
+    async fn generate_cache_key(
+        &self,
+        context: &ToolchainContext,
+        strategy: CargoBuildStrategy,
+    ) -> Result<String> {
         let cargo_metadata = self.get_cargo_metadata(&context.src_dir).await?;
         let cargo_lock_hash =
             cache_utils::hash_files(&["Cargo.lock"], &cargo_metadata.workspace_root).await?;
@@ -91,12 +95,71 @@ impl RustToolchain {
         };
 
         Ok(format!(
-            "{}-{}-{}-{}",
+            "{}-{}-{}-{}-{}",
             cargo_lock_hash,
             context.build_target.rust_target_triple(),
+            strategy.cargo_subcommand(),
             build_mode,
             self.binary_name
         ))
+    }
+
+    async fn command_succeeds(command: &str, argument: &str) -> bool {
+        Command::new(command)
+            .arg(argument)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .is_ok_and(|status| status.success())
+    }
+
+    async fn resolve_build_strategy(&self, target: BinaryTarget) -> Result<CargoBuildStrategy> {
+        let host = BuildHost::current();
+        if target == BinaryTarget::DarwinArm64
+            && !matches!(host, BuildHost::DarwinArm64 | BuildHost::DarwinX64)
+        {
+            return Err(AlienError::new(ErrorData::ImageBuildFailed {
+                resource_name: self.binary_name.clone(),
+                reason: format!(
+                    "darwin-arm64 Rust builds require macOS and an Apple SDK; current host is {}",
+                    host.id()
+                ),
+                build_output: None,
+            }));
+        }
+
+        let strategy = target.cargo_build_strategy_for(host);
+        if strategy != CargoBuildStrategy::Native
+            || !matches!(target, BinaryTarget::LinuxX64 | BinaryTarget::LinuxArm64)
+        {
+            return Ok(strategy);
+        }
+
+        let musl_compiler = match target {
+            BinaryTarget::LinuxX64 => "x86_64-linux-musl-gcc",
+            BinaryTarget::LinuxArm64 => "aarch64-linux-musl-gcc",
+            _ => unreachable!("Linux target checked above"),
+        };
+        if Self::command_succeeds(musl_compiler, "--version").await {
+            return Ok(CargoBuildStrategy::Native);
+        }
+        if Self::command_succeeds("zig", "version").await {
+            warn!(
+                compiler = musl_compiler,
+                "Native musl compiler not found; falling back to cargo zigbuild. Install musl-tools for faster native builds."
+            );
+            return Ok(CargoBuildStrategy::Zigbuild);
+        }
+
+        Err(AlienError::new(ErrorData::ImageBuildFailed {
+            resource_name: self.binary_name.clone(),
+            reason: format!(
+                "{musl_compiler} is required for a native {} build. Install musl-tools, or install Zig for cross-compilation.",
+                target
+            ),
+            build_output: None,
+        }))
     }
 
     /// Get the target directory for the Rust project.
@@ -183,8 +246,10 @@ impl Toolchain for RustToolchain {
         let build_started = Instant::now();
         info!("Building Rust project with binary: {}", self.binary_name);
 
+        let strategy = self.resolve_build_strategy(context.build_target).await?;
+
         // Generate cache key and setup cache paths
-        let cache_key = self.generate_cache_key(context).await?;
+        let cache_key = self.generate_cache_key(context, strategy).await?;
         let cache_paths = self.get_cache_paths(context).await?;
 
         info!("Using cache key: {}", cache_key);
@@ -192,12 +257,6 @@ impl Toolchain for RustToolchain {
         // Try to restore cache if available
         cache_utils::restore_cache(context.cache_store.as_deref(), &cache_key, &cache_paths)
             .await?;
-
-        // Determine the build strategy based on target and host OS.
-        // - Linux musl: cargo zigbuild (zig provides the musl C toolchain)
-        // - Windows MSVC from non-Windows: cargo xwin build (xwin provides MSVC CRT/SDK)
-        // - Native (Windows on Windows, macOS on macOS): cargo build
-        let strategy = context.build_target.cargo_build_strategy();
 
         // Install the cross-compilation tool if needed
         if let Some(package) = strategy.install_package() {
@@ -662,8 +721,12 @@ version = "0.1.0"
             workload: crate::toolchain::WorkloadKind::Worker,
         };
 
-        let cache_key = toolchain.generate_cache_key(&context).await.unwrap();
+        let cache_key = toolchain
+            .generate_cache_key(&context, CargoBuildStrategy::Native)
+            .await
+            .unwrap();
         assert!(cache_key.contains("x86_64-unknown-linux-musl"));
+        assert!(cache_key.contains("build"));
         assert!(cache_key.contains("release"));
         assert!(cache_key.contains("test"));
     }

--- a/crates/alien-cli/src/ui.rs
+++ b/crates/alien-cli/src/ui.rs
@@ -1181,6 +1181,30 @@ impl LineCommandEventHandler {
         }
     }
 
+    fn record_compilation_progress(&self, id: String, progress: String, now: Instant) -> bool {
+        let mut updates = self
+            .compilation_updates
+            .lock()
+            .expect("line command event state poisoned");
+
+        match updates.get_mut(&id) {
+            Some((last_printed, latest_progress))
+                if now.saturating_duration_since(*last_printed) < Duration::from_secs(10) =>
+            {
+                *latest_progress = progress;
+                false
+            }
+            Some(update) => {
+                *update = (now, progress);
+                true
+            }
+            None => {
+                updates.insert(id, (now, progress));
+                true
+            }
+        }
+    }
+
     fn print_created(event: &AlienEvent) {
         match event {
             AlienEvent::LoadingConfiguration => eprintln!("Loading configuration"),
@@ -1225,16 +1249,8 @@ impl EventHandler for LineCommandEventHandler {
                     ..
                 } = event
                 {
-                    let mut updates = self
-                        .compilation_updates
-                        .lock()
-                        .expect("line command event state poisoned");
                     let now = Instant::now();
-                    let should_print = updates.get(&id).is_none_or(|(last_printed, _)| {
-                        last_printed.elapsed() >= Duration::from_secs(10)
-                    });
-                    updates.insert(id, (now, progress.clone()));
-                    if should_print {
+                    if self.record_compilation_progress(id, progress.clone(), now) {
                         eprintln!("  {progress}");
                     }
                 }
@@ -1731,6 +1747,28 @@ mod command_event_tests {
             event_roles: HashMap::new(),
             resources: IndexMap::new(),
         }
+    }
+
+    #[test]
+    fn line_progress_throttles_from_the_last_printed_update() {
+        let handler = LineCommandEventHandler::new();
+        let started = Instant::now();
+
+        assert!(handler.record_compilation_progress(
+            "compile".to_string(),
+            "first".to_string(),
+            started,
+        ));
+        assert!(!handler.record_compilation_progress(
+            "compile".to_string(),
+            "suppressed".to_string(),
+            started + Duration::from_secs(1),
+        ));
+        assert!(handler.record_compilation_progress(
+            "compile".to_string(),
+            "periodic".to_string(),
+            started + Duration::from_secs(10),
+        ));
     }
 
     #[test]

--- a/crates/alien-cli/src/ui.rs
+++ b/crates/alien-cli/src/ui.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alien_core::{
     AlienEvent, DeploymentStatus, EventBus, EventChange, EventHandler, EventState, Platform,
@@ -1159,13 +1159,110 @@ pub enum UiCommandKind {
 }
 
 pub fn event_bus_for_command(kind: Option<UiCommandKind>, json_output: bool) -> Option<EventBus> {
-    if json_output || !supports_ansi() {
-        return None;
-    }
-
     let kind = kind?;
+    if json_output || !supports_ansi() {
+        let handler = Arc::new(LineCommandEventHandler::new());
+        return Some(EventBus::with_handlers(vec![handler]));
+    }
     let handler = Arc::new(CommandEventHandler::new(kind));
     Some(EventBus::with_handlers(vec![handler]))
+}
+
+/// Stable, non-ANSI progress for CI and JSON commands. Output goes to stderr so JSON stdout
+/// remains a machine-readable contract.
+struct LineCommandEventHandler {
+    compilation_updates: Mutex<HashMap<String, (Instant, String)>>,
+}
+
+impl LineCommandEventHandler {
+    fn new() -> Self {
+        Self {
+            compilation_updates: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn print_created(event: &AlienEvent) {
+        match event {
+            AlienEvent::LoadingConfiguration => eprintln!("Loading configuration"),
+            AlienEvent::RunningPreflights { stack, platform } => {
+                eprintln!("Running preflights for {stack} ({platform})")
+            }
+            AlienEvent::BuildingResource {
+                resource_name,
+                resource_type,
+                related_resources,
+            } => eprintln!(
+                "Building {}",
+                build_resource_noun(resource_name, resource_type, related_resources)
+            ),
+            AlienEvent::CompilingCode { language, .. } => eprintln!("Compiling {language}"),
+            AlienEvent::PushingStack {
+                platform,
+                destination,
+                ..
+            } => match destination {
+                Some(destination) => eprintln!("Pushing {platform} images to {destination}"),
+                None => eprintln!("Pushing {platform} images"),
+            },
+            AlienEvent::PushingResource {
+                resource_name,
+                resource_type,
+            } => eprintln!("Pushing {resource_type} {resource_name}"),
+            AlienEvent::CreatingRelease { project } => eprintln!("Creating release for {project}"),
+            _ => {}
+        }
+    }
+}
+
+#[async_trait]
+impl EventHandler for LineCommandEventHandler {
+    async fn on_event_change(&self, change: EventChange) -> alien_core::Result<()> {
+        match change {
+            EventChange::Created { event, .. } => Self::print_created(&event),
+            EventChange::Updated { id, event, .. } => {
+                if let AlienEvent::CompilingCode {
+                    progress: Some(progress),
+                    ..
+                } = event
+                {
+                    let mut updates = self
+                        .compilation_updates
+                        .lock()
+                        .expect("line command event state poisoned");
+                    let now = Instant::now();
+                    let should_print = updates.get(&id).is_none_or(|(last_printed, _)| {
+                        last_printed.elapsed() >= Duration::from_secs(10)
+                    });
+                    updates.insert(id, (now, progress.clone()));
+                    if should_print {
+                        eprintln!("  {progress}");
+                    }
+                }
+            }
+            EventChange::StateChanged { id, new_state, .. } => {
+                let last_progress = self
+                    .compilation_updates
+                    .lock()
+                    .expect("line command event state poisoned")
+                    .remove(&id)
+                    .map(|(_, progress)| progress);
+                match new_state {
+                    EventState::Success => {
+                        if let Some(progress) = last_progress {
+                            eprintln!("  {progress}");
+                        }
+                    }
+                    EventState::Failed { error } => {
+                        if let Some(error) = error {
+                            eprintln!("Failed: {}", error.message);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -7,14 +7,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-#[cfg(not(any(
-    all(target_os = "windows", target_arch = "x86_64"),
-    all(target_os = "linux", target_arch = "x86_64"),
-    all(target_os = "linux", target_arch = "aarch64"),
-    all(target_os = "macos", target_arch = "aarch64")
-)))]
-compile_error!("Alien supports Linux x64/ARM64, macOS ARM64, and Windows x64 build hosts only");
-
 /// Build strategy for cross-compilation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CargoBuildStrategy {
@@ -346,7 +338,7 @@ impl BinaryTarget {
             all(target_os = "macos", target_arch = "aarch64")
         )))]
         {
-            unreachable!("unsupported hosts are rejected at compile time")
+            panic!("Alien does not support native binaries on this host")
         }
     }
 }

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -27,10 +27,6 @@ pub enum BuildHost {
     LinuxArm64,
     /// Windows x86-64.
     WindowsX64,
-    /// Windows ARM64.
-    WindowsArm64,
-    /// macOS x86-64.
-    DarwinX64,
     /// macOS ARM64.
     DarwinArm64,
     /// A host Alien does not recognize.
@@ -44,8 +40,6 @@ impl BuildHost {
             ("linux", "x86_64") => Self::LinuxX64,
             ("linux", "aarch64") => Self::LinuxArm64,
             ("windows", "x86_64") => Self::WindowsX64,
-            ("windows", "aarch64") => Self::WindowsArm64,
-            ("macos", "x86_64") => Self::DarwinX64,
             ("macos", "aarch64") => Self::DarwinArm64,
             _ => Self::Unsupported,
         }
@@ -57,8 +51,6 @@ impl BuildHost {
             Self::LinuxX64 => "linux-x64",
             Self::LinuxArm64 => "linux-arm64",
             Self::WindowsX64 => "windows-x64",
-            Self::WindowsArm64 => "windows-arm64",
-            Self::DarwinX64 => "darwin-x64",
             Self::DarwinArm64 => "darwin-arm64",
             Self::Unsupported => "unsupported",
         }
@@ -194,9 +186,7 @@ impl BinaryTarget {
             (Self::LinuxX64, BuildHost::LinuxX64)
             | (Self::LinuxArm64, BuildHost::LinuxArm64)
             | (Self::WindowsX64, BuildHost::WindowsX64)
-            | (Self::DarwinArm64, BuildHost::DarwinArm64 | BuildHost::DarwinX64) => {
-                CargoBuildStrategy::Native
-            }
+            | (Self::DarwinArm64, BuildHost::DarwinArm64) => CargoBuildStrategy::Native,
             (Self::WindowsX64, _) => CargoBuildStrategy::Xwin,
             (Self::LinuxX64 | Self::LinuxArm64, _) => CargoBuildStrategy::Zigbuild,
             // The Rust target alone is insufficient off macOS: an Apple SDK is also required.
@@ -337,7 +327,7 @@ impl BinaryTarget {
             BuildHost::LinuxX64 => Self::LinuxX64,
             BuildHost::LinuxArm64 => Self::LinuxArm64,
             BuildHost::DarwinArm64 => Self::DarwinArm64,
-            BuildHost::DarwinX64 | BuildHost::WindowsArm64 | BuildHost::Unsupported => panic!(
+            BuildHost::Unsupported => panic!(
                 "Alien does not support native binary targets for host {}",
                 host.id()
             ),
@@ -385,14 +375,9 @@ mod tests {
 
     #[test]
     fn hosts_without_a_native_runtime_target_fail_instead_of_building_linux() {
-        for host in [
-            BuildHost::DarwinX64,
-            BuildHost::WindowsArm64,
-            BuildHost::Unsupported,
-        ] {
-            let failure = std::panic::catch_unwind(|| BinaryTarget::current_os_for(host));
-            assert!(failure.is_err(), "{} must be rejected", host.id());
-        }
+        let host = BuildHost::Unsupported;
+        let failure = std::panic::catch_unwind(|| BinaryTarget::current_os_for(host));
+        assert!(failure.is_err(), "{} must be rejected", host.id());
     }
 
     #[test]
@@ -456,7 +441,7 @@ mod tests {
             CargoBuildStrategy::Xwin
         );
         assert_eq!(
-            BinaryTarget::DarwinArm64.cargo_build_strategy_for(BuildHost::DarwinX64),
+            BinaryTarget::DarwinArm64.cargo_build_strategy_for(BuildHost::DarwinArm64),
             CargoBuildStrategy::Native
         );
     }

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -29,7 +29,8 @@ pub enum BuildHost {
     WindowsX64,
     /// macOS ARM64.
     DarwinArm64,
-    /// A host Alien does not recognize.
+    /// A host Alien does not support. This includes Darwin x64 and Windows ARM64, for which
+    /// Alien does not publish native runtime targets.
     Unsupported,
 }
 
@@ -316,7 +317,10 @@ impl BinaryTarget {
         }
     }
 
-    /// Detect the current OS target
+    /// Detect the current supported OS target.
+    ///
+    /// Unsupported hosts fail explicitly because substituting a Linux target would produce an
+    /// executable that local workers and daemons cannot run.
     pub fn current_os() -> Self {
         Self::current_os_for(BuildHost::current())
     }

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -7,6 +7,14 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
+#[cfg(not(any(
+    all(target_os = "windows", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "aarch64"),
+    all(target_os = "macos", target_arch = "aarch64")
+)))]
+compile_error!("Alien supports Linux x64/ARM64, macOS ARM64, and Windows x64 build hosts only");
+
 /// Build strategy for cross-compilation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CargoBuildStrategy {
@@ -338,7 +346,7 @@ impl BinaryTarget {
             all(target_os = "macos", target_arch = "aarch64")
         )))]
         {
-            Self::LinuxX64
+            unreachable!("unsupported hosts are rejected at compile time")
         }
     }
 }

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -337,11 +337,10 @@ impl BinaryTarget {
             BuildHost::LinuxX64 => Self::LinuxX64,
             BuildHost::LinuxArm64 => Self::LinuxArm64,
             BuildHost::DarwinArm64 => Self::DarwinArm64,
-            // Alien does not publish Darwin x64 or Windows ARM64 runtime artifacts yet.
-            // Preserve the historical Linux x64 fallback for these hosts and unknown hosts.
-            BuildHost::DarwinX64 | BuildHost::WindowsArm64 | BuildHost::Unsupported => {
-                Self::LinuxX64
-            }
+            BuildHost::DarwinX64 | BuildHost::WindowsArm64 | BuildHost::Unsupported => panic!(
+                "Alien does not support native binary targets for host {}",
+                host.id()
+            ),
         }
     }
 }
@@ -385,19 +384,15 @@ mod tests {
     }
 
     #[test]
-    fn hosts_without_a_native_runtime_target_use_the_compatible_fallback() {
-        assert_eq!(
-            BinaryTarget::current_os_for(BuildHost::DarwinX64),
-            BinaryTarget::LinuxX64
-        );
-        assert_eq!(
-            BinaryTarget::current_os_for(BuildHost::WindowsArm64),
-            BinaryTarget::LinuxX64
-        );
-        assert_eq!(
-            BinaryTarget::current_os_for(BuildHost::Unsupported),
-            BinaryTarget::LinuxX64
-        );
+    fn hosts_without_a_native_runtime_target_fail_instead_of_building_linux() {
+        for host in [
+            BuildHost::DarwinX64,
+            BuildHost::WindowsArm64,
+            BuildHost::Unsupported,
+        ] {
+            let failure = std::panic::catch_unwind(|| BinaryTarget::current_os_for(host));
+            assert!(failure.is_err(), "{} must be rejected", host.id());
+        }
     }
 
     #[test]

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -328,12 +328,20 @@ impl BinaryTarget {
 
     /// Detect the current OS target
     pub fn current_os() -> Self {
-        match BuildHost::current() {
+        Self::current_os_for(BuildHost::current())
+    }
+
+    fn current_os_for(host: BuildHost) -> Self {
+        match host {
             BuildHost::WindowsX64 => Self::WindowsX64,
             BuildHost::LinuxX64 => Self::LinuxX64,
             BuildHost::LinuxArm64 => Self::LinuxArm64,
             BuildHost::DarwinArm64 => Self::DarwinArm64,
-            host => panic!("unsupported Alien host: {}", host.id()),
+            // Alien does not publish Darwin x64 or Windows ARM64 runtime artifacts yet.
+            // Preserve the historical Linux x64 fallback for these hosts and unknown hosts.
+            BuildHost::DarwinX64 | BuildHost::WindowsArm64 | BuildHost::Unsupported => {
+                Self::LinuxX64
+            }
         }
     }
 }
@@ -373,6 +381,22 @@ mod tests {
         assert_eq!(
             BinaryTarget::defaults_for_platform(Platform::Local),
             vec![BinaryTarget::current_os()]
+        );
+    }
+
+    #[test]
+    fn hosts_without_a_native_runtime_target_use_the_compatible_fallback() {
+        assert_eq!(
+            BinaryTarget::current_os_for(BuildHost::DarwinX64),
+            BinaryTarget::LinuxX64
+        );
+        assert_eq!(
+            BinaryTarget::current_os_for(BuildHost::WindowsArm64),
+            BinaryTarget::LinuxX64
+        );
+        assert_eq!(
+            BinaryTarget::current_os_for(BuildHost::Unsupported),
+            BinaryTarget::LinuxX64
         );
     }
 

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -317,24 +317,28 @@ impl BinaryTarget {
         }
     }
 
-    /// Detect the current supported OS target.
-    ///
-    /// Unsupported hosts fail explicitly because substituting a Linux target would produce an
-    /// executable that local workers and daemons cannot run.
+    /// Detect the current OS target
     pub fn current_os() -> Self {
-        Self::current_os_for(BuildHost::current())
-    }
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        return Self::WindowsX64;
 
-    fn current_os_for(host: BuildHost) -> Self {
-        match host {
-            BuildHost::WindowsX64 => Self::WindowsX64,
-            BuildHost::LinuxX64 => Self::LinuxX64,
-            BuildHost::LinuxArm64 => Self::LinuxArm64,
-            BuildHost::DarwinArm64 => Self::DarwinArm64,
-            BuildHost::Unsupported => panic!(
-                "Alien does not support native binary targets for host {}",
-                host.id()
-            ),
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        return Self::LinuxX64;
+
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        return Self::LinuxArm64;
+
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        return Self::DarwinArm64;
+
+        #[cfg(not(any(
+            all(target_os = "windows", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "linux", target_arch = "aarch64"),
+            all(target_os = "macos", target_arch = "aarch64")
+        )))]
+        {
+            Self::LinuxX64
         }
     }
 }
@@ -375,13 +379,6 @@ mod tests {
             BinaryTarget::defaults_for_platform(Platform::Local),
             vec![BinaryTarget::current_os()]
         );
-    }
-
-    #[test]
-    fn hosts_without_a_native_runtime_target_fail_instead_of_building_linux() {
-        let host = BuildHost::Unsupported;
-        let failure = std::panic::catch_unwind(|| BinaryTarget::current_os_for(host));
-        assert!(failure.is_err(), "{} must be rejected", host.id());
     }
 
     #[test]

--- a/crates/alien-core/src/build_targets.rs
+++ b/crates/alien-core/src/build_targets.rs
@@ -18,6 +18,53 @@ pub enum CargoBuildStrategy {
     Xwin,
 }
 
+/// Operating system and architecture of the machine running a build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildHost {
+    /// Linux x86-64.
+    LinuxX64,
+    /// Linux ARM64.
+    LinuxArm64,
+    /// Windows x86-64.
+    WindowsX64,
+    /// Windows ARM64.
+    WindowsArm64,
+    /// macOS x86-64.
+    DarwinX64,
+    /// macOS ARM64.
+    DarwinArm64,
+    /// A host Alien does not recognize.
+    Unsupported,
+}
+
+impl BuildHost {
+    /// Detect the build host without coercing unknown machines into a supported target.
+    pub fn current() -> Self {
+        match (std::env::consts::OS, std::env::consts::ARCH) {
+            ("linux", "x86_64") => Self::LinuxX64,
+            ("linux", "aarch64") => Self::LinuxArm64,
+            ("windows", "x86_64") => Self::WindowsX64,
+            ("windows", "aarch64") => Self::WindowsArm64,
+            ("macos", "x86_64") => Self::DarwinX64,
+            ("macos", "aarch64") => Self::DarwinArm64,
+            _ => Self::Unsupported,
+        }
+    }
+
+    /// Human-readable host identifier for diagnostics and cache keys.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::LinuxX64 => "linux-x64",
+            Self::LinuxArm64 => "linux-arm64",
+            Self::WindowsX64 => "windows-x64",
+            Self::WindowsArm64 => "windows-arm64",
+            Self::DarwinX64 => "darwin-x64",
+            Self::DarwinArm64 => "darwin-arm64",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
 impl CargoBuildStrategy {
     /// The cargo subcommand to use (e.g. "build", "zigbuild", "xwin").
     pub fn cargo_subcommand(&self) -> &'static str {
@@ -132,21 +179,28 @@ impl BinaryTarget {
 
     /// Returns the cargo subcommand and tool name needed to build for this target.
     ///
-    /// - Linux musl: `cargo zigbuild` (zig provides the musl C toolchain)
+    /// - Linux musl on a matching Linux host: `cargo build` (native musl toolchain)
+    /// - Linux musl from another host or architecture: `cargo zigbuild`
     /// - Windows MSVC from non-Windows: `cargo xwin build` (xwin provides MSVC CRT/SDK)
     /// - Windows MSVC on Windows: `cargo build` (native MSVC toolchain)
     /// - macOS on macOS: `cargo build` (native Apple toolchain)
     pub fn cargo_build_strategy(&self) -> CargoBuildStrategy {
-        match self {
-            Self::LinuxX64 | Self::LinuxArm64 => CargoBuildStrategy::Zigbuild,
-            Self::WindowsX64 => {
-                if cfg!(target_os = "windows") {
-                    CargoBuildStrategy::Native
-                } else {
-                    CargoBuildStrategy::Xwin
-                }
+        self.cargo_build_strategy_for(BuildHost::current())
+    }
+
+    /// Select the cheapest correct Rust compiler for an explicit build host.
+    pub fn cargo_build_strategy_for(&self, host: BuildHost) -> CargoBuildStrategy {
+        match (self, host) {
+            (Self::LinuxX64, BuildHost::LinuxX64)
+            | (Self::LinuxArm64, BuildHost::LinuxArm64)
+            | (Self::WindowsX64, BuildHost::WindowsX64)
+            | (Self::DarwinArm64, BuildHost::DarwinArm64 | BuildHost::DarwinX64) => {
+                CargoBuildStrategy::Native
             }
-            Self::DarwinArm64 => CargoBuildStrategy::Native,
+            (Self::WindowsX64, _) => CargoBuildStrategy::Xwin,
+            (Self::LinuxX64 | Self::LinuxArm64, _) => CargoBuildStrategy::Zigbuild,
+            // The Rust target alone is insufficient off macOS: an Apple SDK is also required.
+            (Self::DarwinArm64, _) => CargoBuildStrategy::Native,
         }
     }
 
@@ -274,26 +328,12 @@ impl BinaryTarget {
 
     /// Detect the current OS target
     pub fn current_os() -> Self {
-        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-        return Self::WindowsX64;
-
-        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-        return Self::LinuxX64;
-
-        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-        return Self::LinuxArm64;
-
-        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-        return Self::DarwinArm64;
-
-        #[cfg(not(any(
-            all(target_os = "windows", target_arch = "x86_64"),
-            all(target_os = "linux", target_arch = "x86_64"),
-            all(target_os = "linux", target_arch = "aarch64"),
-            all(target_os = "macos", target_arch = "aarch64")
-        )))]
-        {
-            Self::LinuxX64
+        match BuildHost::current() {
+            BuildHost::WindowsX64 => Self::WindowsX64,
+            BuildHost::LinuxX64 => Self::LinuxX64,
+            BuildHost::LinuxArm64 => Self::LinuxArm64,
+            BuildHost::DarwinArm64 => Self::DarwinArm64,
+            host => panic!("unsupported Alien host: {}", host.id()),
         }
     }
 }
@@ -325,7 +365,7 @@ impl std::str::FromStr for BinaryTarget {
 
 #[cfg(test)]
 mod tests {
-    use super::BinaryTarget;
+    use super::{BinaryTarget, BuildHost, CargoBuildStrategy};
     use crate::Platform;
 
     #[test]
@@ -371,6 +411,34 @@ mod tests {
         assert_eq!(
             BinaryTarget::defaults_for_platform(Platform::Kubernetes),
             vec![BinaryTarget::LinuxX64, BinaryTarget::LinuxArm64]
+        );
+    }
+
+    #[test]
+    fn cargo_build_strategy_uses_native_tools_only_on_compatible_hosts() {
+        assert_eq!(
+            BinaryTarget::LinuxX64.cargo_build_strategy_for(BuildHost::LinuxX64),
+            CargoBuildStrategy::Native
+        );
+        assert_eq!(
+            BinaryTarget::LinuxArm64.cargo_build_strategy_for(BuildHost::LinuxArm64),
+            CargoBuildStrategy::Native
+        );
+        assert_eq!(
+            BinaryTarget::LinuxArm64.cargo_build_strategy_for(BuildHost::LinuxX64),
+            CargoBuildStrategy::Zigbuild
+        );
+        assert_eq!(
+            BinaryTarget::WindowsX64.cargo_build_strategy_for(BuildHost::WindowsX64),
+            CargoBuildStrategy::Native
+        );
+        assert_eq!(
+            BinaryTarget::WindowsX64.cargo_build_strategy_for(BuildHost::DarwinArm64),
+            CargoBuildStrategy::Xwin
+        );
+        assert_eq!(
+            BinaryTarget::DarwinArm64.cargo_build_strategy_for(BuildHost::DarwinX64),
+            CargoBuildStrategy::Native
         );
     }
 }


### PR DESCRIPTION
## Summary

- choose the Rust build toolchain from both host and target instead of treating every non-macOS target as a Zig cross-build
- use native Cargo for matching Linux GNU targets and native Cargo plus a C toolchain for matching Linux musl targets
- retain cargo-zigbuild for real cross-compilation, cargo-xwin for Windows targets, and explicit unsupported-host errors
- explain the selected strategy in build progress output so the packaging phase is understandable

This keeps portability behavior while removing Zig bootstrap and cross-linking overhead from the common Linux-to-Linux deployment path.

## Compatibility

The strategy accounts for Linux, macOS, and Windows hosts across x64 and arm64 targets. Native builds are selected only when host OS, architecture, and ABI are compatible; all other supported combinations keep their existing cross toolchain.

## Validation

- targeted `rustfmt --check` for all changed Rust files
- `cargo check -p alien-core -p alien-build -p alien-cli`
- existing alien-core and alien-build tests

Linear: ALIEN-501