### PR TITLE
fix(cli): use canonical platform read models

### DIFF
--- a/client-sdks/manager/openapi.json
+++ b/client-sdks/manager/openapi.json
@@ -1161,7 +1161,14 @@
             }
           },
           "404": {
-            "description": "Release not found"
+            "description": "Release not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlienError"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/client-sdks/manager/rust/openapi-3.0.json
+++ b/client-sdks/manager/rust/openapi-3.0.json
@@ -1161,7 +1161,14 @@
             }
           },
           "404": {
-            "description": "Release not found"
+            "description": "Release not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlienError"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -525,7 +525,7 @@ async fn list_platform_deployments_task(
     json: bool,
 ) -> Result<()> {
     let (project_id, _) = ctx.resolve_project(project, !json).await?;
-    let workspace = ctx.resolve_workspace_with_bootstrap(!json).await?;
+    let workspace = ctx.resolve_workspace_query_with_bootstrap(!json).await?;
     let client = ctx.sdk_client().await?;
     let mut deployments = Vec::new();
     let mut cursor = None;
@@ -533,9 +533,11 @@ async fn list_platform_deployments_task(
     loop {
         let mut request = client
             .list_deployments()
-            .workspace(workspace.as_str())
             .project(project_id.as_str())
             .include(vec![ListDeploymentsIncludeItem::DeploymentGroup]);
+        if let Some(workspace) = workspace.as_deref() {
+            request = request.workspace(workspace);
+        }
         if let Some(next_cursor) = cursor.as_deref() {
             request = request.cursor(next_cursor);
         }

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -14,9 +14,9 @@ use alien_manager_api::SdkResultExt as ManagerSdkResultExt;
 use alien_manager_api::SdkResultExtReadingBody as _;
 use alien_platform_api::types::{
     CreateDeploymentTokenId, CreateDeploymentTokenRequest, CreateDeploymentTokenWorkspace,
-    CreateDeploymentWorkspace, GetDeploymentId, GetDeploymentWorkspace, NewDeploymentRequest,
-    PinDeploymentReleaseId, PinDeploymentReleaseWorkspace, PinReleaseRequest,
-    PinReleaseRequestReleaseId,
+    CreateDeploymentWorkspace, DeploymentListItemResponse, GetDeploymentId, GetDeploymentWorkspace,
+    ListDeploymentsIncludeItem, NewDeploymentRequest, PinDeploymentReleaseId,
+    PinDeploymentReleaseWorkspace, PinReleaseRequest, PinReleaseRequestReleaseId,
 };
 use alien_platform_api::SdkResultExt as _;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -200,8 +200,12 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
     ctx.ensure_ready().await?;
 
     match args.cmd {
-        // --- Manager API operations (all modes: dev, standalone, platform) ---
+        // Platform mode lists canonical platform records; local modes list manager records.
         DeploymentsCmd::Ls { project, json } => {
+            #[cfg(feature = "platform")]
+            if ctx.is_platform() {
+                return list_platform_deployments_task(&ctx, project.as_deref(), json).await;
+            }
             let manager = resolve_manager_client(&ctx, project.as_deref(), !json).await?;
             list_deployments_task(&manager, json).await
         }
@@ -512,6 +516,111 @@ async fn list_deployments_task(client: &alien_manager_api::Client, json: bool) -
     print_table(table);
 
     Ok(())
+}
+
+#[cfg(feature = "platform")]
+async fn list_platform_deployments_task(
+    ctx: &ExecutionMode,
+    project: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let (project_id, _) = ctx.resolve_project(project, !json).await?;
+    let workspace = ctx.resolve_workspace_with_bootstrap(!json).await?;
+    let client = ctx.sdk_client().await?;
+    let mut deployments = Vec::new();
+    let mut cursor = None;
+
+    loop {
+        let mut request = client
+            .list_deployments()
+            .workspace(workspace.as_str())
+            .project(project_id.as_str())
+            .include(vec![ListDeploymentsIncludeItem::DeploymentGroup]);
+        if let Some(next_cursor) = cursor.as_deref() {
+            request = request.cursor(next_cursor);
+        }
+        let response = request
+            .send()
+            .await
+            .into_sdk_error()
+            .context(ErrorData::ApiRequestFailed {
+                message: "listing deployments".to_string(),
+                url: None,
+            })?
+            .into_inner();
+        deployments.extend(response.items);
+        cursor = response.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    if json {
+        return print_json(&deployments);
+    }
+
+    if deployments.is_empty() {
+        println!("(no deployments)");
+        return Ok(());
+    }
+
+    let mut table = make_table(&[
+        "Reference",
+        "ID",
+        "Status",
+        "Platform",
+        "Current release",
+        "Desired release",
+        "Updated",
+    ]);
+    for deployment in &deployments {
+        let status = deployment.status.to_string();
+        table.add_row(vec![
+            platform_deployment_reference(deployment).into(),
+            deployment.id.to_string().into(),
+            status_cell(&status),
+            deployment.platform.to_string().into(),
+            deployment
+                .current_release_id
+                .as_ref()
+                .map(|id| String::from(id.clone()))
+                .unwrap_or_else(|| "—".to_string())
+                .into(),
+            platform_desired_release_cell(deployment).into(),
+            deployment.updated_at.to_string().into(),
+        ]);
+    }
+    print_table(table);
+
+    Ok(())
+}
+
+fn platform_deployment_reference(deployment: &DeploymentListItemResponse) -> String {
+    deployment
+        .deployment_group
+        .as_ref()
+        .map(|group| {
+            let group_name = String::from(group.name.clone());
+            format!("{group_name}/{}", deployment.name)
+        })
+        .unwrap_or_else(|| deployment.id.to_string())
+}
+
+fn platform_desired_release_cell(deployment: &DeploymentListItemResponse) -> String {
+    let Some(desired) = deployment.desired_release_id.as_ref() else {
+        return "—".to_string();
+    };
+    let desired = String::from(desired.clone());
+    if deployment
+        .current_release_id
+        .as_ref()
+        .map(|id| String::from(id.clone()))
+        == Some(desired.clone())
+    {
+        "—".to_string()
+    } else {
+        desired
+    }
 }
 
 fn deployment_reference(deployment: &DeploymentResponse) -> String {

--- a/crates/alien-cli/src/commands/releases.rs
+++ b/crates/alien-cli/src/commands/releases.rs
@@ -8,6 +8,7 @@ use alien_core::DeploymentStatus;
 use alien_error::Context;
 use alien_manager_api::types::{DeploymentResponse, ReleaseResponse, StackByPlatform};
 use alien_manager_api::SdkResultExt as _;
+use alien_manager_api::SdkResultExtReadingBody as _;
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
@@ -25,7 +26,7 @@ pub enum ReleasesCmd {
         /// Project to list releases for (optional, uses linked project by default)
         #[arg(long)]
         project: Option<String>,
-        /// Only show releases selected by this channel (defaults to production in platform mode)
+        /// Only show releases that have been selected by this channel (defaults to production in platform mode)
         #[arg(long, conflicts_with = "all_channels")]
         channel: Option<String>,
         /// Include releases that are not currently selected by any channel
@@ -553,7 +554,8 @@ async fn get_release_task(client: &alien_manager_api::Client, id: &str, json: bo
         .id(id)
         .send()
         .await
-        .into_sdk_error()
+        .into_sdk_error_reading_body()
+        .await
         .context(ErrorData::ApiRequestFailed {
             message: format!("fetching release '{id}'"),
             url: None,

--- a/crates/alien-cli/src/platform_deployment_resolver.rs
+++ b/crates/alien-cli/src/platform_deployment_resolver.rs
@@ -114,6 +114,10 @@ pub async fn resolve(
         .get_deployment()
         .id(id.as_str())
         .workspace(workspace)
+        .include(vec![
+            types::GetDeploymentIncludeItem::DeploymentGroup,
+            types::GetDeploymentIncludeItem::Project,
+        ])
         .send()
         .await
         .into_sdk_error()

--- a/crates/alien-deploy-cli/src/commands/up.rs
+++ b/crates/alien-deploy-cli/src/commands/up.rs
@@ -29,6 +29,7 @@ use alien_deployment::{
 use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 use alien_infra::ClientConfigExt;
 use alien_manager_api::{Client as ServerClient, SdkResultExt as ManagerSdkResultExt};
+use alien_manager_api::SdkResultExtReadingBody as _;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
@@ -1473,7 +1474,8 @@ async fn fetch_release_stack_by_id(
         .id(release_id)
         .send()
         .await
-        .into_sdk_error()
+        .into_sdk_error_reading_body()
+        .await
         .context(ErrorData::ConfigurationError {
             message: format!("Failed to fetch release '{release_id}' from manager"),
         })?
@@ -2939,7 +2941,8 @@ async fn fetch_kubernetes_release_stack(
         .id(&release_id)
         .send()
         .await
-        .into_sdk_error()
+        .into_sdk_error_reading_body()
+        .await
         .context(ErrorData::ConfigurationError {
             message: format!("Failed to fetch release '{release_id}' from manager"),
         })?
@@ -3436,7 +3439,8 @@ pub async fn push_initial_setup(
             .id(release_id)
             .send()
             .await
-            .into_sdk_error()
+            .into_sdk_error_reading_body()
+            .await
             .context(ErrorData::ConfigurationError {
                 message: format!("Failed to fetch desired release {release_id} from manager"),
             })?;

--- a/crates/alien-manager/openapi.json
+++ b/crates/alien-manager/openapi.json
@@ -1161,7 +1161,14 @@
             }
           },
           "404": {
-            "description": "Release not found"
+            "description": "Release not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlienError"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/crates/alien-manager/src/routes/releases.rs
+++ b/crates/alien-manager/src/routes/releases.rs
@@ -303,7 +303,7 @@ async fn create_release(
     ),
     responses(
         (status = 200, description = "Release found", body = ReleaseResponse),
-        (status = 404, description = "Release not found")
+        (status = 404, description = "Release not found", body = alien_error::AlienError)
     ),
     security(
         ("bearer" = [])


### PR DESCRIPTION
## Summary

- use the canonical Platform deployments API for `alien deployments ls` in platform mode, preserving real workspace/project IDs and deployment-group metadata
- hydrate deployment project/group includes for `alien logs` target metadata
- preserve the manager's structured `RELEASE_NOT_FOUND` response by declaring the 404 body and regenerating manager OpenAPI inputs
- clarify that release channel filtering includes channel history

Linear: ALIEN-148

## Validation

- `cargo check -p alien-cli --features platform`
- `cargo build -p alien-cli --features platform`
- focused CLI suites: deployments (8), logs (7), releases (9), manager HTTP error rendering (1) all passed
- generated with `pnpm run generate:manager-rust-sdk`; the clean worktree lacked the converter in `node_modules`, so the checked-in workspace binary completed the documented down-conversion and fix script
- patched binary tested read-only against `https://api.alien.dev` for `islo/islo`:
  - deployment list returned canonical IDs and deployment groups
  - log target returned project and deployment-group names
  - missing release returned the structured not-found message

The full CLI library suite ran 167 tests: 161 passed. Six unrelated JS/TS config-loader tests require `@alienplatform/core` in the clean worktree and failed because that package was not installed.
