### PR TITLE
chore: release v3.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "alien-ai-gateway"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-bindings",
  "alien-error",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "base64 0.23.1",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "aegis",
  "alien-aws-clients",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error",
  "chrono",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error",
  "chrono",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-ai-gateway",
  "alien-aws-clients",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.3.12"
+version = "3.3.13"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.3.12"
+version = "3.3.13"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -63,39 +63,39 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.3.12", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.3.13", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.3.12", default-features = false }
-alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.12" }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.12" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.3.12", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.12" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.3.13", default-features = false }
+alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.13" }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.13" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.3.13", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.13" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.3.12" }
-alien-infra = { path = "crates/alien-infra", version = "3.3.12" }
-alien-build = { path = "crates/alien-build", version = "3.3.12" }
-alien-macros = { path = "crates/alien-macros", version = "3.3.12" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.3.12" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.3.12" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.12" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.12" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.12" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.12" }
-alien-error = { path = "crates/alien-error", version = "3.3.12", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.12" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.3.12" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.3.12" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.3.12" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.12" }
-alien-local = { path = "crates/alien-local", version = "3.3.12" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.12" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.3.12" }
-alien-helm = { path = "crates/alien-helm", version = "3.3.12" }
-alien-manager = { path = "crates/alien-manager", version = "3.3.12" }
-alien-observer = { path = "crates/alien-observer", version = "3.3.12" }
+alien-core = { path = "crates/alien-core", version = "3.3.13" }
+alien-infra = { path = "crates/alien-infra", version = "3.3.13" }
+alien-build = { path = "crates/alien-build", version = "3.3.13" }
+alien-macros = { path = "crates/alien-macros", version = "3.3.13" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.3.13" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.3.13" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.13" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.13" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.13" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.13" }
+alien-error = { path = "crates/alien-error", version = "3.3.13", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.13" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.3.13" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.3.13" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.3.13" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.13" }
+alien-local = { path = "crates/alien-local", version = "3.3.13" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.13" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.3.13" }
+alien-helm = { path = "crates/alien-helm", version = "3.3.13" }
+alien-manager = { path = "crates/alien-manager", version = "3.3.13" }
+alien-observer = { path = "crates/alien-observer", version = "3.3.13" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.12", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.12", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.13", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.13", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/.speakeasy/gen.lock
+++ b/client-sdks/manager/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.12
+  releaseVersion: 3.3.13
   configChecksum: 44d827c044b50072551da66b6620ad00
   repoURL: https://github.com/alienplatform/alien.git
   repoSubDirectory: client-sdks/manager/typescript

--- a/client-sdks/manager/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/manager/typescript/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: automatic
 typescript:
-  version: 3.3.12
+  version: 3.3.13
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/manager/typescript/jsr.json
+++ b/client-sdks/manager/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/.speakeasy/gen.lock
+++ b/client-sdks/platform/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.12
+  releaseVersion: 3.3.13
   configChecksum: 4943c4f3559a7eb4428396d568a54c29
 persistentEdits:
   generation_id: db6ac3e5-6bcc-4de5-a81f-eb659048385d

--- a/client-sdks/platform/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/platform/typescript/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.12
+  version: 3.3.13
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/platform/typescript/jsr.json
+++ b/client-sdks/platform/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/platform/typescript/package-lock.json
+++ b/client-sdks/platform/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alienplatform/platform-api",
-      "version": "3.3.12",
+      "version": "3.3.13",
       "license": "FSL-1.1-Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/ai-gateway",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "type": "module",
   "files": [
     "dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "type": "module",
   "files": [
     "dist"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Version-only release PR generated by the stable release workflow. The **Release qualification** check builds and records the exact artifact set. After every required check passes and this merges, run the stable **publish** action from `main` to promote those qualified artifacts.