### PR TITLE
ci: prevent platform SDK release OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -714,7 +714,7 @@ jobs:
   publish-client-sdks:
     needs: [prepare]
     if: ${{ inputs.mode == 'stable' && needs.prepare.outputs.ready == 'true' }}
-    runs-on: depot-ubuntu-24.04-arm-4
+    runs-on: depot-ubuntu-24.04-arm-16
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -737,7 +737,7 @@ jobs:
         if: ${{ inputs.stable_action == 'qualification' }}
         working-directory: client-sdks/platform/typescript
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: "--max-old-space-size=14336"
         run: |
           npm install
           npm run build


### PR DESCRIPTION
## Summary

- move client SDK qualification from the 4-core to the 16-core ARM runner
- raise the platform SDK TypeScript heap limit from 8 GiB to 14 GiB

## Validation

- `git diff --check`
- Release qualification will be retriggered for v3.3.13 after this merges

Failed run: https://github.com/alienplatform/alien/actions/runs/31932228460
Linear: https://linear.app/alienplatform/issue/ALIEN-522/fix-platform-sdk-release-qualification-oom