### PR TITLE
chore: regenerate platform TypeScript SDK

### DIFF
--- a/client-sdks/platform/typescript/.speakeasy/gen.lock
+++ b/client-sdks/platform/typescript/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: bc51eaa5-3f88-4290-b64f-cae16746dd5d
 management:
-  docChecksum: 82b8443d364fb4c6b6bf06331ec47238
+  docChecksum: 91e8297b768a6260d33e37cdd7d1928f
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.12
-  configChecksum: 4943c4f3559a7eb4428396d568a54c29
+  releaseVersion: 3.3.13
+  configChecksum: e0a5367383df83ca5b7df2dc71a3ea48
 persistentEdits:
   generation_id: db6ac3e5-6bcc-4de5-a81f-eb659048385d
   pristine_commit_hash: 13c44a72093f4387918cbb07b6c85d4fbfa92cc6
@@ -29119,7 +29119,7 @@ trackedFiles:
     last_write_checksum: sha1:1c40c7e0f780db1d457c815315405596efa3baf0
   docs/sdks/apikeys/README.md:
     id: e2bd25998427
-    last_write_checksum: sha1:e9209e6b7dd3328c10dcc9b055ceeb1c65243115
+    last_write_checksum: sha1:e59f0d523dd049a7735fbd2d90df07fc2f0e0c33
     pristine_git_object: 97b46298306e977cd9920e7765b37579ad2cf627
   docs/sdks/auth/README.md:
     id: e9724f17945f
@@ -29135,13 +29135,13 @@ trackedFiles:
     pristine_git_object: dae98b8c1aea029f9db42ff73ab2c996e8443b69
   docs/sdks/commands/README.md:
     id: 8951f1925b1f
-    last_write_checksum: sha1:f7d142e737eae417b1c50d4106f41642250c75a7
+    last_write_checksum: sha1:35e8bdc5b4fe119d4a26ae86886a9e62dcbbaaac
     pristine_git_object: 1dcf7d6de2b07ecfb661652b78f4cf26adf2cfaf
   docs/sdks/containerregistry/README.md:
     last_write_checksum: sha1:f6bd98b0571e49fefd9f85162b1e6b3432110258
   docs/sdks/debugsessions/README.md:
     id: a03f3215c473
-    last_write_checksum: sha1:a0cec008448ab1db45812e7efd6315b1d08cdf06
+    last_write_checksum: sha1:df98b64c396c8f3c8c1dcf32aa304f6cf1b94c6c
     pristine_git_object: 0ad9d69175d8519e9b8bc35cefb4dbdfb9f8d123
   docs/sdks/deployment/README.md:
     id: 5cb544abed28
@@ -29149,7 +29149,7 @@ trackedFiles:
     pristine_git_object: 3e791cad7f6102a7a2aaffeddcb40990d20ff890
   docs/sdks/deploymentgroups/README.md:
     id: 5df9f1e7770b
-    last_write_checksum: sha1:2ac3273b8e80ea77395c0c216cad3b3dc8ab3f67
+    last_write_checksum: sha1:aecfda635a5293dbec2d2cc83bb58fac01ade440
     pristine_git_object: 3ab72dac669daa20a387032aeff49aecfdbf7c91
   docs/sdks/deployments/README.md:
     id: e7c5559ab768
@@ -29165,11 +29165,11 @@ trackedFiles:
     pristine_git_object: 5ef7391e033f9b93f9da7878b3899057b201b6c8
   docs/sdks/machines/README.md:
     id: ab83178bf481
-    last_write_checksum: sha1:344009ff516a881dcb1500b0700e93f00fae62c4
+    last_write_checksum: sha1:da6c6956337070fefcb72e0fb31026417f31d6e1
     pristine_git_object: 91ba63257de1e5cfe068cb6e5a71b87317301288
   docs/sdks/managers/README.md:
     id: bd852d1f1428
-    last_write_checksum: sha1:fe4b5c8c8a4a417cae14beb999163cbd1c6b1614
+    last_write_checksum: sha1:45d8b9ab404260589c8962262373191fe0728e1e
     pristine_git_object: 8bfe2a424a7d98d235de9f1038cefa0a23b92c35
   docs/sdks/operations/README.md:
     last_write_checksum: sha1:8446089e31338b71826e7138ab38125437d3b65e
@@ -29183,7 +29183,7 @@ trackedFiles:
     pristine_git_object: 8d4e7433cafb9ebc326a02a52886fc5049e664bf
   docs/sdks/projects/README.md:
     id: 1c5f71754e17
-    last_write_checksum: sha1:c4c0ac6d67a8c6b9c22ce309007ec2fc5c9ed861
+    last_write_checksum: sha1:ce7457f97b26bb27e0d98085d518b5e9737962a1
     pristine_git_object: 3d554d47e2892987cf35e9d387a75e9916e35f7a
   docs/sdks/releasechannels/README.md:
     last_write_checksum: sha1:6c59eadd7156666c086f84701afafbada1d1b69d
@@ -29215,7 +29215,7 @@ trackedFiles:
     pristine_git_object: 8f39a20a53fa575fcde3b3ce407fa79609d58ad7
   docs/sdks/workspaces/README.md:
     id: 1f5b051a6380
-    last_write_checksum: sha1:408c9a2b59a13282e50dc185981139f1d48ed7c3
+    last_write_checksum: sha1:1925257070fd40cbfc1518c9b05ad039aab73d7c
     pristine_git_object: ea607887b5585d511b732faf8676225f51ec743b
   eslint.config.mjs:
     id: 461c8d07f6da
@@ -29237,11 +29237,11 @@ trackedFiles:
     pristine_git_object: 91b9336926d9e04ff3216ceb7f6e1d29f96c3a19
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:503916d4ed28162653832962b408ca71270ff19d
+    last_write_checksum: sha1:6f21f6fe0e5df7c5fc2c0d0157ea624d83357907
     pristine_git_object: b27d1739aa21f6dfb0a2772ceda2defdbe7bc6c9
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:9b2b8f6e13b479f513a6b1b1b4649ca16bf960a1
+    last_write_checksum: sha1:7c47b22a0bee7e346d1f42d355f57a0d820901f9
     pristine_git_object: 65db061a4e545903e4d3aa5cb5630a83fd28ce36
   src/core.ts:
     id: f431fdbcd144
@@ -29967,7 +29967,7 @@ trackedFiles:
     pristine_git_object: 962ea486e17eabe13bcf068493a556110c944df8
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:04cb52a238e8164d070101f183b110be647a9a73
+    last_write_checksum: sha1:f28f9fc9a4d16301a9a80a29ec84f4a6c345dfe5
     pristine_git_object: ea094ae0489afa7a35285ade4b0a06cabb5ca361
   src/lib/dlv.ts:
     id: b1988214835a
@@ -31699,7 +31699,7 @@ trackedFiles:
     last_write_checksum: sha1:82095832872be40a4fc31395bdc9d6d83cc1dbe1
   src/sdk/apikeys.ts:
     id: 5dda931501e1
-    last_write_checksum: sha1:cbcb15319256712fd1b49b8a27b84c17dae3851c
+    last_write_checksum: sha1:255b4d98f2b63d51ef2933a29850f3d3f87f604d
     pristine_git_object: 4fdd45d437f5dfbfe577c40d7649ae7ba7bab669
   src/sdk/auth.ts:
     id: b29b1fc6bdf5
@@ -31715,13 +31715,13 @@ trackedFiles:
     pristine_git_object: 463f753a9752a8b8728449ee8f8c55f4bb959721
   src/sdk/commands.ts:
     id: 31ec805cf614
-    last_write_checksum: sha1:7c865c8f08894b3b76969a59c7b7de988555334e
+    last_write_checksum: sha1:0921aee11b353b6ff0bfa6dab69ff237098663d3
     pristine_git_object: 900d5e87bb79dd9bfb22083ddc8892c5c62e09a6
   src/sdk/containerregistry.ts:
     last_write_checksum: sha1:a839b76e82543dedf67d6ff93e3e0df19c8e562d
   src/sdk/debugsessions.ts:
     id: bd8512987e15
-    last_write_checksum: sha1:8b637966a9c257a40ed82a0e971dc52fee3b1f8f
+    last_write_checksum: sha1:2e98c6e84d4b9623a29980bddf81284457d8a936
     pristine_git_object: f617673ef882c2bae2db3cc655872deae4a86e79
   src/sdk/deployment.ts:
     id: 80068e3b9d71
@@ -31729,7 +31729,7 @@ trackedFiles:
     pristine_git_object: 65c560e796087c8b49528a38a952aaab78f8de9d
   src/sdk/deploymentgroups.ts:
     id: fee2f374fda2
-    last_write_checksum: sha1:3eba0607d49b650e4003e5660a3cc244259a1ffa
+    last_write_checksum: sha1:c7cd54fddfa2f6f2c4e0ada764e2f8015a72b380
     pristine_git_object: b2c398b7a128be6b3796824d57748fcdc8f28b17
   src/sdk/deployments.ts:
     id: 80d6fb28a717
@@ -31749,11 +31749,11 @@ trackedFiles:
     pristine_git_object: ecac2264817bb369ff2dbf0f0e9029807e67ff77
   src/sdk/machines.ts:
     id: 687f768b8f3a
-    last_write_checksum: sha1:d7c315111b5d2d0473182ced3ef4d5782edbcc7b
+    last_write_checksum: sha1:c19b5129eb34ef45b3b42c200b07e60210eca35c
     pristine_git_object: 2aede3b701b6ce0734f343a89f5b6ad791657d12
   src/sdk/managers.ts:
     id: f8108bd423d0
-    last_write_checksum: sha1:954cc67d81aec951906503a1462537b1b4bc4008
+    last_write_checksum: sha1:7374e58e1bed800dc71043220000c6bbace9a307
     pristine_git_object: e590e4d280df175a26d76b9757972f9d2aef4534
   src/sdk/operations.ts:
     last_write_checksum: sha1:a2e0b841b0ab2182734e742311620062ae35747d
@@ -31767,7 +31767,7 @@ trackedFiles:
     pristine_git_object: 29b4adde951522a39053a9afdf0a8d4d4834e814
   src/sdk/projects.ts:
     id: 28088373a118
-    last_write_checksum: sha1:c24936e12fa1aaceef7143d35e2c2357294c4661
+    last_write_checksum: sha1:ce08d579a15d15e4e1b01975a945900a59db855f
     pristine_git_object: 83cbdca96c0c28e99fe168c029bb34191db6c1ff
   src/sdk/releasechannels.ts:
     last_write_checksum: sha1:aad78dc6028873b860598d129cea7556baf86da2
@@ -31803,7 +31803,7 @@ trackedFiles:
     pristine_git_object: 23e0f1cd9c59146e7276fcfd864cd87f8c156108
   src/sdk/workspaces.ts:
     id: 72b45379c8d9
-    last_write_checksum: sha1:cf998dd8c92b8d1857706cecc5829d542fb129e1
+    last_write_checksum: sha1:598d6a1399adfd41b56d48984db1e28b638564ce
     pristine_git_object: 70087d48457356adaa2a0e443f870eabc8ff8865
   src/types/async.ts:
     id: fac8da972f86

--- a/client-sdks/platform/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/platform/typescript/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.12
+  version: 3.3.13
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/platform/typescript/README.md
+++ b/client-sdks/platform/typescript/README.md
@@ -181,8 +181,8 @@ run();
 * [list](docs/sdks/apikeys/README.md#list) - Retrieve all API keys for the current workspace.
 * [create](docs/sdks/apikeys/README.md#create) - Create a new API key.
 * [get](docs/sdks/apikeys/README.md#get) - Retrieve a specific API key.
-* [update](docs/sdks/apikeys/README.md#update) - Update an API key (enable/disable, change description).
 * [revoke](docs/sdks/apikeys/README.md#revoke) - Revoke (soft delete) an API key.
+* [update](docs/sdks/apikeys/README.md#update) - Update an API key (enable/disable, change description).
 * [deleteMultiple](docs/sdks/apikeys/README.md#deletemultiple) - Permanently delete multiple API keys.
 
 ### [Auth](docs/sdks/auth/README.md)
@@ -206,8 +206,8 @@ run();
 * [listNames](docs/sdks/commands/README.md#listnames) - List distinct command names. Use for filter dropdowns in the dashboard.
 * [listDeployments](docs/sdks/commands/README.md#listdeployments) - List distinct deployments that have commands, including deployment group info. Use for filter dropdowns in the dashboard.
 * [resolveTarget](docs/sdks/commands/README.md#resolvetarget) - Resolve which resource a command for this deployment would be addressed to, and how it would be delivered. Fails when the deployment has no command-capable resources, or more than one and no explicit target was named.
-* [update](docs/sdks/commands/README.md#update) - Update command state. Called by manager when command is dispatched or completes.
 * [get](docs/sdks/commands/README.md#get) - Retrieve a command by ID.
+* [update](docs/sdks/commands/README.md#update) - Update command state. Called by manager when command is dispatched or completes.
 * [dispatch](docs/sdks/commands/README.md#dispatch) - Atomically mark a command DISPATCHED unless it is already terminal. Returns whether the transition was applied.
 * [complete](docs/sdks/commands/README.md#complete) - Atomically transition a command to a terminal state (SUCCEEDED, FAILED, or EXPIRED) unless it is already terminal. Returns whether the transition was applied.
 * [incrementAttempt](docs/sdks/commands/README.md#incrementattempt) - Atomically increment the command's attempt counter and return the new value.
@@ -229,8 +229,8 @@ run();
 
 * [list](docs/sdks/debugsessions/README.md#list) - Retrieve debug sessions for dashboard audit. Filters: project, deployment, state, mode.
 * [create](docs/sdks/debugsessions/README.md#create) - Create a debug-session audit row. Called by the manager when a pull or push debug tunnel is opened. Workspace + project derived from deployment.
-* [update](docs/sdks/debugsessions/README.md#update) - Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
 * [get](docs/sdks/debugsessions/README.md#get) - Retrieve a debug session by ID.
+* [update](docs/sdks/debugsessions/README.md#update) - Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
 
 ### [Deployment](docs/sdks/deployment/README.md)
 
@@ -240,14 +240,14 @@ run();
 
 ### [DeploymentGroups](docs/sdks/deploymentgroups/README.md)
 
-* [createDeploymentGroup](docs/sdks/deploymentgroups/README.md#createdeploymentgroup) - Create a new deployment group
 * [listDeploymentGroups](docs/sdks/deploymentgroups/README.md#listdeploymentgroups) - List deployment groups
+* [createDeploymentGroup](docs/sdks/deploymentgroups/README.md#createdeploymentgroup) - Create a new deployment group
 * [ensureDeploymentGroupByName](docs/sdks/deploymentgroups/README.md#ensuredeploymentgroupbyname) - Get or create a deployment group by project and name
-* [ensureDeploymentGroupByExternalId](docs/sdks/deploymentgroups/README.md#ensuredeploymentgroupbyexternalid) - Get or create a deployment group by project and external ID
 * [getDeploymentGroupByExternalId](docs/sdks/deploymentgroups/README.md#getdeploymentgroupbyexternalid) - Get a deployment group by project and external ID
+* [ensureDeploymentGroupByExternalId](docs/sdks/deploymentgroups/README.md#ensuredeploymentgroupbyexternalid) - Get or create a deployment group by project and external ID
 * [getDeploymentGroup](docs/sdks/deploymentgroups/README.md#getdeploymentgroup) - Get deployment group details
-* [updateDeploymentGroup](docs/sdks/deploymentgroups/README.md#updatedeploymentgroup) - Update deployment group
 * [deleteDeploymentGroup](docs/sdks/deploymentgroups/README.md#deletedeploymentgroup) - Delete deployment group
+* [updateDeploymentGroup](docs/sdks/deploymentgroups/README.md#updatedeploymentgroup) - Update deployment group
 * [setDeploymentGroupExternalId](docs/sdks/deploymentgroups/README.md#setdeploymentgroupexternalid) - Set or clear a deployment group's external ID
 * [createDeploymentGroupToken](docs/sdks/deploymentgroups/README.md#createdeploymentgrouptoken) - Create deployment group token
 * [createFirstPartyDeploymentSession](docs/sdks/deploymentgroups/README.md#createfirstpartydeploymentsession) - Create first-party deployment session
@@ -299,14 +299,14 @@ run();
 * [rotateJoinToken](docs/sdks/machines/README.md#rotatejointoken)
 * [revokeJoinToken](docs/sdks/machines/README.md#revokejointoken)
 * [listInventory](docs/sdks/machines/README.md#listinventory)
-* [cancelMachineDrain](docs/sdks/machines/README.md#cancelmachinedrain)
 * [drainMachine](docs/sdks/machines/README.md#drainmachine)
+* [cancelMachineDrain](docs/sdks/machines/README.md#cancelmachinedrain)
 * [removeMachine](docs/sdks/machines/README.md#removemachine)
 
 ### [Managers](docs/sdks/managers/README.md)
 
-* [create](docs/sdks/managers/README.md#create) - Create a new manager.
 * [list](docs/sdks/managers/README.md#list) - Retrieve all managers.
+* [create](docs/sdks/managers/README.md#create) - Create a new manager.
 * [retrySetup](docs/sdks/managers/README.md#retrysetup) - Revoke previous private-manager setup tokens and issue a fresh setup token/config.
 * [retry](docs/sdks/managers/README.md#retry) - Retry private-manager setup. Returns a fresh setup action before the internal deployment exists, or requests retry for the internal deployment after it exists.
 * [cancelSetup](docs/sdks/managers/README.md#cancelsetup) - Cancel pending private-manager setup, revoke setup/runtime tokens, and remove the undeployed manager record.
@@ -354,8 +354,8 @@ run();
 * [list](docs/sdks/projects/README.md#list) - Retrieve all projects.
 * [create](docs/sdks/projects/README.md#create) - Create a new project.
 * [get](docs/sdks/projects/README.md#get) - Retrieve a project by ID or name.
-* [update](docs/sdks/projects/README.md#update) - Update a project.
 * [delete](docs/sdks/projects/README.md#delete) - Delete a project. The project must have no deployments.
+* [update](docs/sdks/projects/README.md#update) - Update a project.
 * [getGcpOAuthProvider](docs/sdks/projects/README.md#getgcpoauthprovider) - Retrieve redacted project-level Google Cloud OAuth provider settings.
 * [updateGcpOAuthProvider](docs/sdks/projects/README.md#updategcpoauthprovider) - Update project-level Google Cloud OAuth provider settings.
 * [configureSource](docs/sdks/projects/README.md#configuresource) - Connect a GitHub repository or Alien template to an existing project and configure its release workflow.
@@ -440,12 +440,12 @@ run();
 
 * [list](docs/sdks/workspaces/README.md#list) - Retrieve all workspaces.
 * [get](docs/sdks/workspaces/README.md#get) - Retrieve a workspace by ID.
-* [update](docs/sdks/workspaces/README.md#update) - Update a workspace.
 * [delete](docs/sdks/workspaces/README.md#delete) - Delete a workspace. The workspace must have no projects.
+* [update](docs/sdks/workspaces/README.md#update) - Update a workspace.
 * [listMembers](docs/sdks/workspaces/README.md#listmembers) - List all members of a workspace.
 * [addMember](docs/sdks/workspaces/README.md#addmember) - Add a member to a workspace by email. The user must already have an account.
-* [updateMember](docs/sdks/workspaces/README.md#updatemember) - Update a workspace member's role.
 * [removeMember](docs/sdks/workspaces/README.md#removemember) - Remove a member from a workspace.
+* [updateMember](docs/sdks/workspaces/README.md#updatemember) - Update a workspace member's role.
 * [dismissOnboarding](docs/sdks/workspaces/README.md#dismissonboarding) - Mark the Getting Started walkthrough as dismissed for a workspace. The dashboard stops auto-promoting onboarding once this is set; users can still re-enter the walkthrough via the help menu.
 * [getSettings](docs/sdks/workspaces/README.md#getsettings) - Read the ai-agent settings for a workspace. Returns defaults (`enabled: true`, `debugPermissionMode: auto`) when the workspace has never customized them.
 * [updateSettings](docs/sdks/workspaces/README.md#updatesettings) - Update the ai-agent settings for a workspace. Supports `debugPermissionMode` (`ask` requires human approval on every ai-agent debug command, `auto` runs them without asking) and `enabled` (`false` turns the ai-agent off so incoming triggers are rejected before any session runs).

--- a/client-sdks/platform/typescript/docs/sdks/apikeys/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/apikeys/README.md
@@ -7,8 +7,8 @@
 * [list](#list) - Retrieve all API keys for the current workspace.
 * [create](#create) - Create a new API key.
 * [get](#get) - Retrieve a specific API key.
-* [update](#update) - Update an API key (enable/disable, change description).
 * [revoke](#revoke) - Revoke (soft delete) an API key.
+* [update](#update) - Update an API key (enable/disable, change description).
 * [deleteMultiple](#deletemultiple) - Permanently delete multiple API keys.
 
 ## list
@@ -259,83 +259,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## update
-
-Update an API key (enable/disable, change description).
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="updateAPIKey" method="patch" path="/v1/api-keys/{id}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.apiKeys.update({
-    id: "apikey_ye96yxs1tjnrrwulp8frh",
-    workspace: "my-workspace",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { apiKeysUpdate } from "@alienplatform/platform-api/funcs/apiKeysUpdate.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await apiKeysUpdate(alien, {
-    id: "apikey_ye96yxs1tjnrrwulp8frh",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("apiKeysUpdate failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.UpdateAPIKeyRequest](../../models/operations/updateapikeyrequest.md)                                                                                               | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.APIKey](../../models/apikey.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 404                      | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## revoke
 
 Revoke (soft delete) an API key.
@@ -404,6 +327,83 @@ run();
 ### Response
 
 **Promise\<void\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 404                      | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## update
+
+Update an API key (enable/disable, change description).
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="updateAPIKey" method="patch" path="/v1/api-keys/{id}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.apiKeys.update({
+    id: "apikey_ye96yxs1tjnrrwulp8frh",
+    workspace: "my-workspace",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { apiKeysUpdate } from "@alienplatform/platform-api/funcs/apiKeysUpdate.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await apiKeysUpdate(alien, {
+    id: "apikey_ye96yxs1tjnrrwulp8frh",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("apiKeysUpdate failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.UpdateAPIKeyRequest](../../models/operations/updateapikeyrequest.md)                                                                                               | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.APIKey](../../models/apikey.md)\>**
 
 ### Errors
 

--- a/client-sdks/platform/typescript/docs/sdks/commands/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/commands/README.md
@@ -10,8 +10,8 @@
 * [listNames](#listnames) - List distinct command names. Use for filter dropdowns in the dashboard.
 * [listDeployments](#listdeployments) - List distinct deployments that have commands, including deployment group info. Use for filter dropdowns in the dashboard.
 * [resolveTarget](#resolvetarget) - Resolve which resource a command for this deployment would be addressed to, and how it would be delivered. Fails when the deployment has no command-capable resources, or more than one and no explicit target was named.
-* [update](#update) - Update command state. Called by manager when command is dispatched or completes.
 * [get](#get) - Retrieve a command by ID.
+* [update](#update) - Update command state. Called by manager when command is dispatched or completes.
 * [dispatch](#dispatch) - Atomically mark a command DISPATCHED unless it is already terminal. Returns whether the transition was applied.
 * [complete](#complete) - Atomically transition a command to a terminal state (SUCCEEDED, FAILED, or EXPIRED) unless it is already terminal. Returns whether the transition was applied.
 * [incrementAttempt](#incrementattempt) - Atomically increment the command's attempt counter and return the new value.
@@ -485,83 +485,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## update
-
-Update command state. Called by manager when command is dispatched or completes.
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="updateCommand" method="patch" path="/v1/commands/{id}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.commands.update({
-    id: "cmd_2sxjXxvOYct7IohT3ukliAzf",
-    workspace: "my-workspace",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { commandsUpdate } from "@alienplatform/platform-api/funcs/commandsUpdate.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await commandsUpdate(alien, {
-    id: "cmd_2sxjXxvOYct7IohT3ukliAzf",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("commandsUpdate failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.UpdateCommandRequest](../../models/operations/updatecommandrequest.md)                                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.Command](../../models/command.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 404                      | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## get
 
 Retrieve a command by ID.
@@ -623,6 +546,83 @@ run();
 | Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `request`                                                                                                                                                                      | [operations.GetCommandRequest](../../models/operations/getcommandrequest.md)                                                                                                   | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.Command](../../models/command.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 404                      | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## update
+
+Update command state. Called by manager when command is dispatched or completes.
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="updateCommand" method="patch" path="/v1/commands/{id}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.commands.update({
+    id: "cmd_2sxjXxvOYct7IohT3ukliAzf",
+    workspace: "my-workspace",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { commandsUpdate } from "@alienplatform/platform-api/funcs/commandsUpdate.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await commandsUpdate(alien, {
+    id: "cmd_2sxjXxvOYct7IohT3ukliAzf",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("commandsUpdate failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.UpdateCommandRequest](../../models/operations/updatecommandrequest.md)                                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
 | `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
 | `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
 | `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |

--- a/client-sdks/platform/typescript/docs/sdks/debugsessions/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/debugsessions/README.md
@@ -6,8 +6,8 @@
 
 * [list](#list) - Retrieve debug sessions for dashboard audit. Filters: project, deployment, state, mode.
 * [create](#create) - Create a debug-session audit row. Called by the manager when a pull or push debug tunnel is opened. Workspace + project derived from deployment.
-* [update](#update) - Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
 * [get](#get) - Retrieve a debug session by ID.
+* [update](#update) - Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
 
 ## list
 
@@ -172,83 +172,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## update
-
-Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="updateDebugSession" method="patch" path="/v1/debug-sessions/{id}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.debugSessions.update({
-    id: "dbg_HOXmkmT9UPYlsnxqSNlEGoXL",
-    workspace: "my-workspace",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { debugSessionsUpdate } from "@alienplatform/platform-api/funcs/debugSessionsUpdate.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await debugSessionsUpdate(alien, {
-    id: "dbg_HOXmkmT9UPYlsnxqSNlEGoXL",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("debugSessionsUpdate failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.UpdateDebugSessionRequest](../../models/operations/updatedebugsessionrequest.md)                                                                                   | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.DebugSession](../../models/debugsession.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 404                      | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## get
 
 Retrieve a debug session by ID.
@@ -310,6 +233,83 @@ run();
 | Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `request`                                                                                                                                                                      | [operations.GetDebugSessionRequest](../../models/operations/getdebugsessionrequest.md)                                                                                         | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.DebugSession](../../models/debugsession.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 404                      | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## update
+
+Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="updateDebugSession" method="patch" path="/v1/debug-sessions/{id}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.debugSessions.update({
+    id: "dbg_HOXmkmT9UPYlsnxqSNlEGoXL",
+    workspace: "my-workspace",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { debugSessionsUpdate } from "@alienplatform/platform-api/funcs/debugSessionsUpdate.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await debugSessionsUpdate(alien, {
+    id: "dbg_HOXmkmT9UPYlsnxqSNlEGoXL",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("debugSessionsUpdate failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.UpdateDebugSessionRequest](../../models/operations/updatedebugsessionrequest.md)                                                                                   | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
 | `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
 | `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
 | `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |

--- a/client-sdks/platform/typescript/docs/sdks/deploymentgroups/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/deploymentgroups/README.md
@@ -4,20 +4,96 @@
 
 ### Available Operations
 
-* [createDeploymentGroup](#createdeploymentgroup) - Create a new deployment group
 * [listDeploymentGroups](#listdeploymentgroups) - List deployment groups
+* [createDeploymentGroup](#createdeploymentgroup) - Create a new deployment group
 * [ensureDeploymentGroupByName](#ensuredeploymentgroupbyname) - Get or create a deployment group by project and name
-* [ensureDeploymentGroupByExternalId](#ensuredeploymentgroupbyexternalid) - Get or create a deployment group by project and external ID
 * [getDeploymentGroupByExternalId](#getdeploymentgroupbyexternalid) - Get a deployment group by project and external ID
+* [ensureDeploymentGroupByExternalId](#ensuredeploymentgroupbyexternalid) - Get or create a deployment group by project and external ID
 * [getDeploymentGroup](#getdeploymentgroup) - Get deployment group details
-* [updateDeploymentGroup](#updatedeploymentgroup) - Update deployment group
 * [deleteDeploymentGroup](#deletedeploymentgroup) - Delete deployment group
+* [updateDeploymentGroup](#updatedeploymentgroup) - Update deployment group
 * [setDeploymentGroupExternalId](#setdeploymentgroupexternalid) - Set or clear a deployment group's external ID
 * [createDeploymentGroupToken](#createdeploymentgrouptoken) - Create deployment group token
 * [createFirstPartyDeploymentSession](#createfirstpartydeploymentsession) - Create first-party deployment session
 * [getExternalAIBinding](#getexternalaibinding) - Get external AI connection state
 * [putExternalAIBinding](#putexternalaibinding) - Connect or rotate an external AI provider key
 * [deleteExternalAIBinding](#deleteexternalaibinding) - Revoke the external AI connection
+
+## listDeploymentGroups
+
+List deployment groups
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="listDeploymentGroups" method="get" path="/v1/deployment-groups" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.deploymentGroups.listDeploymentGroups({
+    workspace: "my-workspace",
+    project: "my-project",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { deploymentGroupsListDeploymentGroups } from "@alienplatform/platform-api/funcs/deploymentGroupsListDeploymentGroups.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await deploymentGroupsListDeploymentGroups(alien, {
+    workspace: "my-workspace",
+    project: "my-project",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("deploymentGroupsListDeploymentGroups failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.ListDeploymentGroupsRequest](../../models/operations/listdeploymentgroupsrequest.md)                                                                               | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[operations.ListDeploymentGroupsResponse](../../models/operations/listdeploymentgroupsresponse.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
 ## createDeploymentGroup
 
@@ -104,82 +180,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## listDeploymentGroups
-
-List deployment groups
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="listDeploymentGroups" method="get" path="/v1/deployment-groups" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.deploymentGroups.listDeploymentGroups({
-    workspace: "my-workspace",
-    project: "my-project",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { deploymentGroupsListDeploymentGroups } from "@alienplatform/platform-api/funcs/deploymentGroupsListDeploymentGroups.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await deploymentGroupsListDeploymentGroups(alien, {
-    workspace: "my-workspace",
-    project: "my-project",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("deploymentGroupsListDeploymentGroups failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.ListDeploymentGroupsRequest](../../models/operations/listdeploymentgroupsrequest.md)                                                                               | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[operations.ListDeploymentGroupsResponse](../../models/operations/listdeploymentgroupsresponse.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## ensureDeploymentGroupByName
 
 Get or create a deployment group by project and name
@@ -247,6 +247,83 @@ run();
 | Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `request`                                                                                                                                                                      | [operations.EnsureDeploymentGroupByNameRequest](../../models/operations/ensuredeploymentgroupbynamerequest.md)                                                                 | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.DeploymentGroup](../../models/deploymentgroup.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 404                      | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## getDeploymentGroupByExternalId
+
+Get a deployment group by project and external ID
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="getDeploymentGroupByExternalId" method="get" path="/v1/deployment-groups/by-external-id" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.deploymentGroups.getDeploymentGroupByExternalId({
+    workspace: "my-workspace",
+    externalId: "ext_example_01",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { deploymentGroupsGetDeploymentGroupByExternalId } from "@alienplatform/platform-api/funcs/deploymentGroupsGetDeploymentGroupByExternalId.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await deploymentGroupsGetDeploymentGroupByExternalId(alien, {
+    workspace: "my-workspace",
+    externalId: "ext_example_01",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("deploymentGroupsGetDeploymentGroupByExternalId failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.GetDeploymentGroupByExternalIdRequest](../../models/operations/getdeploymentgroupbyexternalidrequest.md)                                                           | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
 | `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
 | `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
 | `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
@@ -348,83 +425,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## getDeploymentGroupByExternalId
-
-Get a deployment group by project and external ID
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="getDeploymentGroupByExternalId" method="get" path="/v1/deployment-groups/by-external-id" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.deploymentGroups.getDeploymentGroupByExternalId({
-    workspace: "my-workspace",
-    externalId: "ext_example_01",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { deploymentGroupsGetDeploymentGroupByExternalId } from "@alienplatform/platform-api/funcs/deploymentGroupsGetDeploymentGroupByExternalId.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await deploymentGroupsGetDeploymentGroupByExternalId(alien, {
-    workspace: "my-workspace",
-    externalId: "ext_example_01",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("deploymentGroupsGetDeploymentGroupByExternalId failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.GetDeploymentGroupByExternalIdRequest](../../models/operations/getdeploymentgroupbyexternalidrequest.md)                                                           | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.DeploymentGroup](../../models/deploymentgroup.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 404                      | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## getDeploymentGroup
 
 Get deployment group details
@@ -499,6 +499,83 @@ run();
 | Error Type               | Status Code              | Content Type             |
 | ------------------------ | ------------------------ | ------------------------ |
 | errors.APIError          | 404                      | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## deleteDeploymentGroup
+
+Delete deployment group
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="deleteDeploymentGroup" method="delete" path="/v1/deployment-groups/{id}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  await alien.deploymentGroups.deleteDeploymentGroup({
+    id: "dg_r27ict8c7vcgsumpj90ackf7b",
+    workspace: "my-workspace",
+  });
+
+
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { deploymentGroupsDeleteDeploymentGroup } from "@alienplatform/platform-api/funcs/deploymentGroupsDeleteDeploymentGroup.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await deploymentGroupsDeleteDeploymentGroup(alien, {
+    id: "dg_r27ict8c7vcgsumpj90ackf7b",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+
+  } else {
+    console.log("deploymentGroupsDeleteDeploymentGroup failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.DeleteDeploymentGroupRequest](../../models/operations/deletedeploymentgrouprequest.md)                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<void\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 400, 404                 | application/json         |
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
@@ -582,83 +659,6 @@ run();
 | Error Type               | Status Code              | Content Type             |
 | ------------------------ | ------------------------ | ------------------------ |
 | errors.APIError          | 404, 409                 | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
-## deleteDeploymentGroup
-
-Delete deployment group
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="deleteDeploymentGroup" method="delete" path="/v1/deployment-groups/{id}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  await alien.deploymentGroups.deleteDeploymentGroup({
-    id: "dg_r27ict8c7vcgsumpj90ackf7b",
-    workspace: "my-workspace",
-  });
-
-
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { deploymentGroupsDeleteDeploymentGroup } from "@alienplatform/platform-api/funcs/deploymentGroupsDeleteDeploymentGroup.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await deploymentGroupsDeleteDeploymentGroup(alien, {
-    id: "dg_r27ict8c7vcgsumpj90ackf7b",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-
-  } else {
-    console.log("deploymentGroupsDeleteDeploymentGroup failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.DeleteDeploymentGroupRequest](../../models/operations/deletedeploymentgrouprequest.md)                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<void\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 400, 404                 | application/json         |
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 

--- a/client-sdks/platform/typescript/docs/sdks/machines/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/machines/README.md
@@ -9,8 +9,8 @@
 * [rotateJoinToken](#rotatejointoken)
 * [revokeJoinToken](#revokejointoken)
 * [listInventory](#listinventory)
-* [cancelMachineDrain](#cancelmachinedrain)
 * [drainMachine](#drainmachine)
+* [cancelMachineDrain](#cancelmachinedrain)
 * [removeMachine](#removemachine)
 
 ## listJoinTokens
@@ -390,83 +390,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## cancelMachineDrain
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="cancelMachinesMachineDrain" method="delete" path="/v1/machines/deployments/{id}/machines/{machineId}/drain" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.machines.cancelMachineDrain({
-    id: "dep_0c29fq4a2yjb7kx3smwdgxlc",
-    machineId: "<id>",
-    workspace: "my-workspace",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { machinesCancelMachineDrain } from "@alienplatform/platform-api/funcs/machinesCancelMachineDrain.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await machinesCancelMachineDrain(alien, {
-    id: "dep_0c29fq4a2yjb7kx3smwdgxlc",
-    machineId: "<id>",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("machinesCancelMachineDrain failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.CancelMachinesMachineDrainRequest](../../models/operations/cancelmachinesmachinedrainrequest.md)                                                                   | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.CancelMachinesMachineDrainResponse](../../models/cancelmachinesmachinedrainresponse.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 400, 404                 | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## drainMachine
 
 ### Example Usage
@@ -535,6 +458,83 @@ run();
 ### Response
 
 **Promise\<[models.DrainMachinesMachineResponse](../../models/drainmachinesmachineresponse.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 400, 404                 | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## cancelMachineDrain
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="cancelMachinesMachineDrain" method="delete" path="/v1/machines/deployments/{id}/machines/{machineId}/drain" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.machines.cancelMachineDrain({
+    id: "dep_0c29fq4a2yjb7kx3smwdgxlc",
+    machineId: "<id>",
+    workspace: "my-workspace",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { machinesCancelMachineDrain } from "@alienplatform/platform-api/funcs/machinesCancelMachineDrain.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await machinesCancelMachineDrain(alien, {
+    id: "dep_0c29fq4a2yjb7kx3smwdgxlc",
+    machineId: "<id>",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("machinesCancelMachineDrain failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.CancelMachinesMachineDrainRequest](../../models/operations/cancelmachinesmachinedrainrequest.md)                                                                   | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.CancelMachinesMachineDrainResponse](../../models/cancelmachinesmachinedrainresponse.md)\>**
 
 ### Errors
 

--- a/client-sdks/platform/typescript/docs/sdks/managers/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/managers/README.md
@@ -4,8 +4,8 @@
 
 ### Available Operations
 
-* [create](#create) - Create a new manager.
 * [list](#list) - Retrieve all managers.
+* [create](#create) - Create a new manager.
 * [retrySetup](#retrysetup) - Revoke previous private-manager setup tokens and issue a fresh setup token/config.
 * [retry](#retry) - Retry private-manager setup. Returns a fresh setup action before the internal deployment exists, or requests retry for the internal deployment after it exists.
 * [cancelSetup](#cancelsetup) - Cancel pending private-manager setup, revoke setup/runtime tokens, and remove the undeployed manager record.
@@ -22,6 +22,80 @@
 * [resolveGcpOAuthProvider](#resolvegcpoauthprovider) - Resolve decrypted project-level Google Cloud OAuth provider settings for a manager-side deployment bootstrap.
 * [reportHeartbeat](#reportheartbeat) - Report Manager health status and metrics.
 * [getDeployment](#getdeployment) - Get deployment details for a private manager (internal deployment platform, status, resources).
+
+## list
+
+Retrieve all managers.
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="listManagers" method="get" path="/v1/managers" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.managers.list({
+    workspace: "my-workspace",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { managersList } from "@alienplatform/platform-api/funcs/managersList.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await managersList(alien, {
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("managersList failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.ListManagersRequest](../../models/operations/listmanagersrequest.md)                                                                                               | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.Manager[]](../../models/.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
 ## create
 
@@ -95,80 +169,6 @@ run();
 | Error Type               | Status Code              | Content Type             |
 | ------------------------ | ------------------------ | ------------------------ |
 | errors.APIError          | 400, 409                 | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
-## list
-
-Retrieve all managers.
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="listManagers" method="get" path="/v1/managers" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.managers.list({
-    workspace: "my-workspace",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { managersList } from "@alienplatform/platform-api/funcs/managersList.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await managersList(alien, {
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("managersList failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.ListManagersRequest](../../models/operations/listmanagersrequest.md)                                                                                               | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.Manager[]](../../models/.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 

--- a/client-sdks/platform/typescript/docs/sdks/projects/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/projects/README.md
@@ -7,8 +7,8 @@
 * [list](#list) - Retrieve all projects.
 * [create](#create) - Create a new project.
 * [get](#get) - Retrieve a project by ID or name.
-* [update](#update) - Update a project.
 * [delete](#delete) - Delete a project. The project must have no deployments.
+* [update](#update) - Update a project.
 * [getGcpOAuthProvider](#getgcpoauthprovider) - Retrieve redacted project-level Google Cloud OAuth provider settings.
 * [updateGcpOAuthProvider](#updategcpoauthprovider) - Update project-level Google Cloud OAuth provider settings.
 * [configureSource](#configuresource) - Connect a GitHub repository or Alien template to an existing project and configure its release workflow.
@@ -266,6 +266,83 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
+## delete
+
+Delete a project. The project must have no deployments.
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="deleteProject" method="delete" path="/v1/projects/{idOrName}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  await alien.projects.delete({
+    idOrName: "my-project",
+    workspace: "my-workspace",
+  });
+
+
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { projectsDelete } from "@alienplatform/platform-api/funcs/projectsDelete.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await projectsDelete(alien, {
+    idOrName: "my-project",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+
+  } else {
+    console.log("projectsDelete failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.DeleteProjectRequest](../../models/operations/deleteprojectrequest.md)                                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<void\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 400, 404                 | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
 ## update
 
 Update a project.
@@ -350,83 +427,6 @@ run();
 | Error Type               | Status Code              | Content Type             |
 | ------------------------ | ------------------------ | ------------------------ |
 | errors.APIError          | 404                      | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
-## delete
-
-Delete a project. The project must have no deployments.
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="deleteProject" method="delete" path="/v1/projects/{idOrName}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  await alien.projects.delete({
-    idOrName: "my-project",
-    workspace: "my-workspace",
-  });
-
-
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { projectsDelete } from "@alienplatform/platform-api/funcs/projectsDelete.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await projectsDelete(alien, {
-    idOrName: "my-project",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-
-  } else {
-    console.log("projectsDelete failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.DeleteProjectRequest](../../models/operations/deleteprojectrequest.md)                                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<void\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 400, 404                 | application/json         |
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 

--- a/client-sdks/platform/typescript/docs/sdks/workspaces/README.md
+++ b/client-sdks/platform/typescript/docs/sdks/workspaces/README.md
@@ -6,12 +6,12 @@
 
 * [list](#list) - Retrieve all workspaces.
 * [get](#get) - Retrieve a workspace by ID.
-* [update](#update) - Update a workspace.
 * [delete](#delete) - Delete a workspace. The workspace must have no projects.
+* [update](#update) - Update a workspace.
 * [listMembers](#listmembers) - List all members of a workspace.
 * [addMember](#addmember) - Add a member to a workspace by email. The user must already have an account.
-* [updateMember](#updatemember) - Update a workspace member's role.
 * [removeMember](#removemember) - Remove a member from a workspace.
+* [updateMember](#updatemember) - Update a workspace member's role.
 * [dismissOnboarding](#dismissonboarding) - Mark the Getting Started walkthrough as dismissed for a workspace. The dashboard stops auto-promoting onboarding once this is set; users can still re-enter the walkthrough via the help menu.
 * [getSettings](#getsettings) - Read the ai-agent settings for a workspace. Returns defaults (`enabled: true`, `debugPermissionMode: auto`) when the workspace has never customized them.
 * [updateSettings](#updatesettings) - Update the ai-agent settings for a workspace. Supports `debugPermissionMode` (`ask` requires human approval on every ai-agent debug command, `auto` runs them without asking) and `enabled` (`false` turns the ai-agent off so incoming triggers are rejected before any session runs).
@@ -167,83 +167,6 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
-## update
-
-Update a workspace.
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="updateWorkspace" method="patch" path="/v1/workspaces/{id}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await alien.workspaces.update({
-    id: "ws_It13CUaGEhLLAB87simX0",
-    workspace: "my-workspace",
-  });
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { workspacesUpdate } from "@alienplatform/platform-api/funcs/workspacesUpdate.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await workspacesUpdate(alien, {
-    id: "ws_It13CUaGEhLLAB87simX0",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("workspacesUpdate failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.UpdateWorkspaceRequest](../../models/operations/updateworkspacerequest.md)                                                                                         | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[models.Workspace](../../models/workspace.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 404                      | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
 ## delete
 
 Delete a workspace. The workspace must have no projects.
@@ -318,6 +241,83 @@ run();
 | Error Type               | Status Code              | Content Type             |
 | ------------------------ | ------------------------ | ------------------------ |
 | errors.APIError          | 400, 404                 | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
+## update
+
+Update a workspace.
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="updateWorkspace" method="patch" path="/v1/workspaces/{id}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const result = await alien.workspaces.update({
+    id: "ws_It13CUaGEhLLAB87simX0",
+    workspace: "my-workspace",
+  });
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { workspacesUpdate } from "@alienplatform/platform-api/funcs/workspacesUpdate.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await workspacesUpdate(alien, {
+    id: "ws_It13CUaGEhLLAB87simX0",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("workspacesUpdate failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.UpdateWorkspaceRequest](../../models/operations/updateworkspacerequest.md)                                                                                         | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[models.Workspace](../../models/workspace.md)\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 404                      | application/json         |
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
@@ -483,6 +483,85 @@ run();
 | errors.APIError          | 500                      | application/json         |
 | errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
 
+## removeMember
+
+Remove a member from a workspace.
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="removeWorkspaceMember" method="delete" path="/v1/workspaces/{id}/members/{userId}" -->
+```typescript
+import { Alien } from "@alienplatform/platform-api";
+
+const alien = new Alien({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  await alien.workspaces.removeMember({
+    id: "ws_It13CUaGEhLLAB87simX0",
+    userId: "<id>",
+    workspace: "my-workspace",
+  });
+
+
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { AlienCore } from "@alienplatform/platform-api/core.js";
+import { workspacesRemoveMember } from "@alienplatform/platform-api/funcs/workspacesRemoveMember.js";
+
+// Use `AlienCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const alien = new AlienCore({
+  apiKey: process.env["ALIEN_API_KEY"] ?? "",
+});
+
+async function run() {
+  const res = await workspacesRemoveMember(alien, {
+    id: "ws_It13CUaGEhLLAB87simX0",
+    userId: "<id>",
+    workspace: "my-workspace",
+  });
+  if (res.ok) {
+    const { value: result } = res;
+
+  } else {
+    console.log("workspacesRemoveMember failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `request`                                                                                                                                                                      | [operations.RemoveWorkspaceMemberRequest](../../models/operations/removeworkspacememberrequest.md)                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<void\>**
+
+### Errors
+
+| Error Type               | Status Code              | Content Type             |
+| ------------------------ | ------------------------ | ------------------------ |
+| errors.APIError          | 400, 404                 | application/json         |
+| errors.APIError          | 500                      | application/json         |
+| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
+
 ## updateMember
 
 Update a workspace member's role.
@@ -559,85 +638,6 @@ run();
 ### Response
 
 **Promise\<[models.WorkspaceMember](../../models/workspacemember.md)\>**
-
-### Errors
-
-| Error Type               | Status Code              | Content Type             |
-| ------------------------ | ------------------------ | ------------------------ |
-| errors.APIError          | 400, 404                 | application/json         |
-| errors.APIError          | 500                      | application/json         |
-| errors.AlienDefaultError | 4XX, 5XX                 | \*/\*                    |
-
-## removeMember
-
-Remove a member from a workspace.
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="removeWorkspaceMember" method="delete" path="/v1/workspaces/{id}/members/{userId}" -->
-```typescript
-import { Alien } from "@alienplatform/platform-api";
-
-const alien = new Alien({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  await alien.workspaces.removeMember({
-    id: "ws_It13CUaGEhLLAB87simX0",
-    userId: "<id>",
-    workspace: "my-workspace",
-  });
-
-
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { AlienCore } from "@alienplatform/platform-api/core.js";
-import { workspacesRemoveMember } from "@alienplatform/platform-api/funcs/workspacesRemoveMember.js";
-
-// Use `AlienCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const alien = new AlienCore({
-  apiKey: process.env["ALIEN_API_KEY"] ?? "",
-});
-
-async function run() {
-  const res = await workspacesRemoveMember(alien, {
-    id: "ws_It13CUaGEhLLAB87simX0",
-    userId: "<id>",
-    workspace: "my-workspace",
-  });
-  if (res.ok) {
-    const { value: result } = res;
-
-  } else {
-    console.log("workspacesRemoveMember failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `request`                                                                                                                                                                      | [operations.RemoveWorkspaceMemberRequest](../../models/operations/removeworkspacememberrequest.md)                                                                             | :heavy_check_mark:                                                                                                                                                             | The request object to use for the request.                                                                                                                                     |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<void\>**
 
 ### Errors
 

--- a/client-sdks/platform/typescript/jsr.json
+++ b/client-sdks/platform/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/platform/typescript/package-lock.json
+++ b/client-sdks/platform/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alienplatform/platform-api",
-      "version": "3.3.12",
+      "version": "3.3.13",
       "license": "FSL-1.1-Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@eslint/js": "^9.19.0",
         "eslint": "^9.19.0",
-        "globals": "^17.10.0",
+        "globals": "^15.14.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.26.0"
       }
@@ -301,6 +301,7 @@
       "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.67.0",
         "@typescript-eslint/types": "8.67.0",
@@ -544,6 +545,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -732,6 +734,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -984,9 +987,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1280,6 +1283,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1428,6 +1432,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "eslint": "^9.19.0",
-    "globals": "^17.10.0",
+    "globals": "^15.14.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.26.0"
   },

--- a/client-sdks/platform/typescript/src/lib/config.ts
+++ b/client-sdks/platform/typescript/src/lib/config.ts
@@ -61,8 +61,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "3.3.12",
+  sdkVersion: "3.3.13",
   genVersion: "2.788.15",
   userAgent:
-    "speakeasy-sdk/typescript 3.3.12 2.788.15 1.0.0 @alienplatform/platform-api",
+    "speakeasy-sdk/typescript 3.3.13 2.788.15 1.0.0 @alienplatform/platform-api",
 } as const;

--- a/client-sdks/platform/typescript/src/sdk/apikeys.ts
+++ b/client-sdks/platform/typescript/src/sdk/apikeys.ts
@@ -57,20 +57,6 @@ export class ApiKeys extends ClientSDK {
   }
 
   /**
-   * Update an API key (enable/disable, change description).
-   */
-  async update(
-    request: operations.UpdateAPIKeyRequest,
-    options?: RequestOptions,
-  ): Promise<models.APIKey> {
-    return unwrapAsync(apiKeysUpdate(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Revoke (soft delete) an API key.
    */
   async revoke(
@@ -78,6 +64,20 @@ export class ApiKeys extends ClientSDK {
     options?: RequestOptions,
   ): Promise<void> {
     return unwrapAsync(apiKeysRevoke(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update an API key (enable/disable, change description).
+   */
+  async update(
+    request: operations.UpdateAPIKeyRequest,
+    options?: RequestOptions,
+  ): Promise<models.APIKey> {
+    return unwrapAsync(apiKeysUpdate(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/commands.ts
+++ b/client-sdks/platform/typescript/src/sdk/commands.ts
@@ -104,20 +104,6 @@ export class Commands extends ClientSDK {
   }
 
   /**
-   * Update command state. Called by manager when command is dispatched or completes.
-   */
-  async update(
-    request: operations.UpdateCommandRequest,
-    options?: RequestOptions,
-  ): Promise<models.Command> {
-    return unwrapAsync(commandsUpdate(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Retrieve a command by ID.
    */
   async get(
@@ -125,6 +111,20 @@ export class Commands extends ClientSDK {
     options?: RequestOptions,
   ): Promise<models.Command> {
     return unwrapAsync(commandsGet(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update command state. Called by manager when command is dispatched or completes.
+   */
+  async update(
+    request: operations.UpdateCommandRequest,
+    options?: RequestOptions,
+  ): Promise<models.Command> {
+    return unwrapAsync(commandsUpdate(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/debugsessions.ts
+++ b/client-sdks/platform/typescript/src/sdk/debugsessions.ts
@@ -41,20 +41,6 @@ export class DebugSessions extends ClientSDK {
   }
 
   /**
-   * Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
-   */
-  async update(
-    request: operations.UpdateDebugSessionRequest,
-    options?: RequestOptions,
-  ): Promise<models.DebugSession> {
-    return unwrapAsync(debugSessionsUpdate(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Retrieve a debug session by ID.
    */
   async get(
@@ -62,6 +48,20 @@ export class DebugSessions extends ClientSDK {
     options?: RequestOptions,
   ): Promise<models.DebugSession> {
     return unwrapAsync(debugSessionsGet(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update debug-session state. Called by manager on tunnel attach, close, or deadline expiry.
+   */
+  async update(
+    request: operations.UpdateDebugSessionRequest,
+    options?: RequestOptions,
+  ): Promise<models.DebugSession> {
+    return unwrapAsync(debugSessionsUpdate(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/deploymentgroups.ts
+++ b/client-sdks/platform/typescript/src/sdk/deploymentgroups.ts
@@ -23,20 +23,6 @@ import { unwrapAsync } from "../types/fp.js";
 
 export class DeploymentGroups extends ClientSDK {
   /**
-   * Create a new deployment group
-   */
-  async createDeploymentGroup(
-    request?: operations.CreateDeploymentGroupRequest | undefined,
-    options?: RequestOptions,
-  ): Promise<models.DeploymentGroup> {
-    return unwrapAsync(deploymentGroupsCreateDeploymentGroup(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * List deployment groups
    */
   async listDeploymentGroups(
@@ -44,6 +30,20 @@ export class DeploymentGroups extends ClientSDK {
     options?: RequestOptions,
   ): Promise<operations.ListDeploymentGroupsResponse> {
     return unwrapAsync(deploymentGroupsListDeploymentGroups(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Create a new deployment group
+   */
+  async createDeploymentGroup(
+    request?: operations.CreateDeploymentGroupRequest | undefined,
+    options?: RequestOptions,
+  ): Promise<models.DeploymentGroup> {
+    return unwrapAsync(deploymentGroupsCreateDeploymentGroup(
       this,
       request,
       options,
@@ -65,20 +65,6 @@ export class DeploymentGroups extends ClientSDK {
   }
 
   /**
-   * Get or create a deployment group by project and external ID
-   */
-  async ensureDeploymentGroupByExternalId(
-    request: operations.EnsureDeploymentGroupByExternalIdRequest,
-    options?: RequestOptions,
-  ): Promise<models.DeploymentGroup> {
-    return unwrapAsync(deploymentGroupsEnsureDeploymentGroupByExternalId(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Get a deployment group by project and external ID
    */
   async getDeploymentGroupByExternalId(
@@ -86,6 +72,20 @@ export class DeploymentGroups extends ClientSDK {
     options?: RequestOptions,
   ): Promise<models.DeploymentGroup> {
     return unwrapAsync(deploymentGroupsGetDeploymentGroupByExternalId(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Get or create a deployment group by project and external ID
+   */
+  async ensureDeploymentGroupByExternalId(
+    request: operations.EnsureDeploymentGroupByExternalIdRequest,
+    options?: RequestOptions,
+  ): Promise<models.DeploymentGroup> {
+    return unwrapAsync(deploymentGroupsEnsureDeploymentGroupByExternalId(
       this,
       request,
       options,
@@ -107,20 +107,6 @@ export class DeploymentGroups extends ClientSDK {
   }
 
   /**
-   * Update deployment group
-   */
-  async updateDeploymentGroup(
-    request: operations.UpdateDeploymentGroupRequest,
-    options?: RequestOptions,
-  ): Promise<models.DeploymentGroup> {
-    return unwrapAsync(deploymentGroupsUpdateDeploymentGroup(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Delete deployment group
    */
   async deleteDeploymentGroup(
@@ -128,6 +114,20 @@ export class DeploymentGroups extends ClientSDK {
     options?: RequestOptions,
   ): Promise<void> {
     return unwrapAsync(deploymentGroupsDeleteDeploymentGroup(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update deployment group
+   */
+  async updateDeploymentGroup(
+    request: operations.UpdateDeploymentGroupRequest,
+    options?: RequestOptions,
+  ): Promise<models.DeploymentGroup> {
+    return unwrapAsync(deploymentGroupsUpdateDeploymentGroup(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/machines.ts
+++ b/client-sdks/platform/typescript/src/sdk/machines.ts
@@ -71,22 +71,22 @@ export class Machines extends ClientSDK {
     ));
   }
 
-  async cancelMachineDrain(
-    request: operations.CancelMachinesMachineDrainRequest,
+  async drainMachine(
+    request: operations.DrainMachinesMachineRequest,
     options?: RequestOptions,
-  ): Promise<models.CancelMachinesMachineDrainResponse> {
-    return unwrapAsync(machinesCancelMachineDrain(
+  ): Promise<models.DrainMachinesMachineResponse> {
+    return unwrapAsync(machinesDrainMachine(
       this,
       request,
       options,
     ));
   }
 
-  async drainMachine(
-    request: operations.DrainMachinesMachineRequest,
+  async cancelMachineDrain(
+    request: operations.CancelMachinesMachineDrainRequest,
     options?: RequestOptions,
-  ): Promise<models.DrainMachinesMachineResponse> {
-    return unwrapAsync(machinesDrainMachine(
+  ): Promise<models.CancelMachinesMachineDrainResponse> {
+    return unwrapAsync(machinesCancelMachineDrain(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/managers.ts
+++ b/client-sdks/platform/typescript/src/sdk/managers.ts
@@ -27,20 +27,6 @@ import { unwrapAsync } from "../types/fp.js";
 
 export class Managers extends ClientSDK {
   /**
-   * Create a new manager.
-   */
-  async create(
-    request?: operations.CreateManagerRequest | undefined,
-    options?: RequestOptions,
-  ): Promise<models.CreateManagerResponse> {
-    return unwrapAsync(managersCreate(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Retrieve all managers.
    */
   async list(
@@ -48,6 +34,20 @@ export class Managers extends ClientSDK {
     options?: RequestOptions,
   ): Promise<Array<models.Manager>> {
     return unwrapAsync(managersList(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Create a new manager.
+   */
+  async create(
+    request?: operations.CreateManagerRequest | undefined,
+    options?: RequestOptions,
+  ): Promise<models.CreateManagerResponse> {
+    return unwrapAsync(managersCreate(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/projects.ts
+++ b/client-sdks/platform/typescript/src/sdk/projects.ts
@@ -72,20 +72,6 @@ export class Projects extends ClientSDK {
   }
 
   /**
-   * Update a project.
-   */
-  async update(
-    request: operations.UpdateProjectRequest,
-    options?: RequestOptions,
-  ): Promise<models.Project> {
-    return unwrapAsync(projectsUpdate(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Delete a project. The project must have no deployments.
    */
   async delete(
@@ -93,6 +79,20 @@ export class Projects extends ClientSDK {
     options?: RequestOptions,
   ): Promise<void> {
     return unwrapAsync(projectsDelete(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update a project.
+   */
+  async update(
+    request: operations.UpdateProjectRequest,
+    options?: RequestOptions,
+  ): Promise<models.Project> {
+    return unwrapAsync(projectsUpdate(
       this,
       request,
       options,

--- a/client-sdks/platform/typescript/src/sdk/workspaces.ts
+++ b/client-sdks/platform/typescript/src/sdk/workspaces.ts
@@ -48,20 +48,6 @@ export class Workspaces extends ClientSDK {
   }
 
   /**
-   * Update a workspace.
-   */
-  async update(
-    request: operations.UpdateWorkspaceRequest,
-    options?: RequestOptions,
-  ): Promise<models.Workspace> {
-    return unwrapAsync(workspacesUpdate(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Delete a workspace. The workspace must have no projects.
    */
   async delete(
@@ -69,6 +55,20 @@ export class Workspaces extends ClientSDK {
     options?: RequestOptions,
   ): Promise<void> {
     return unwrapAsync(workspacesDelete(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update a workspace.
+   */
+  async update(
+    request: operations.UpdateWorkspaceRequest,
+    options?: RequestOptions,
+  ): Promise<models.Workspace> {
+    return unwrapAsync(workspacesUpdate(
       this,
       request,
       options,
@@ -104,20 +104,6 @@ export class Workspaces extends ClientSDK {
   }
 
   /**
-   * Update a workspace member's role.
-   */
-  async updateMember(
-    request: operations.UpdateWorkspaceMemberRequest,
-    options?: RequestOptions,
-  ): Promise<models.WorkspaceMember> {
-    return unwrapAsync(workspacesUpdateMember(
-      this,
-      request,
-      options,
-    ));
-  }
-
-  /**
    * Remove a member from a workspace.
    */
   async removeMember(
@@ -125,6 +111,20 @@ export class Workspaces extends ClientSDK {
     options?: RequestOptions,
   ): Promise<void> {
     return unwrapAsync(workspacesRemoveMember(
+      this,
+      request,
+      options,
+    ));
+  }
+
+  /**
+   * Update a workspace member's role.
+   */
+  async updateMember(
+    request: operations.UpdateWorkspaceMemberRequest,
+    options?: RequestOptions,
+  ): Promise<models.WorkspaceMember> {
+    return unwrapAsync(workspacesUpdateMember(
       this,
       request,
       options,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^9.19.0
         version: 9.39.5(jiti@2.7.0)
       globals:
-        specifier: ^17.10.0
-        version: 17.10.0
+        specifier: ^15.14.0
+        version: 15.15.0
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -79,7 +79,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.0.0
-        version: 3.8.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.13.3)
+        version: 3.8.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.13.3)
 
   packages/ai-gateway:
     dependencies:
@@ -2796,6 +2796,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
   globals@17.10.0:
     resolution: {integrity: sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==}
     engines: {node: '>=18'}
@@ -5188,6 +5192,37 @@ snapshots:
       - '@types/node'
       - supports-color
 
+  '@napi-rs/cli@3.8.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
+      '@napi-rs/cross-toolchain': 1.0.3
+      '@napi-rs/wasm-tools': 1.1.0
+      '@octokit/rest': 22.0.1
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      colorette: 2.0.20
+      es-toolkit: 1.50.0
+      js-yaml: 4.3.1
+      obug: 2.1.4
+      semver: 7.8.5
+      typanion: 3.14.0
+      typescript: 6.0.3
+    optionalDependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+    transitivePeerDependencies:
+      - '@napi-rs/cross-toolchain-arm64-target-aarch64'
+      - '@napi-rs/cross-toolchain-arm64-target-armv7'
+      - '@napi-rs/cross-toolchain-arm64-target-ppc64le'
+      - '@napi-rs/cross-toolchain-arm64-target-s390x'
+      - '@napi-rs/cross-toolchain-arm64-target-x86_64'
+      - '@napi-rs/cross-toolchain-x64-target-aarch64'
+      - '@napi-rs/cross-toolchain-x64-target-armv7'
+      - '@napi-rs/cross-toolchain-x64-target-ppc64le'
+      - '@napi-rs/cross-toolchain-x64-target-s390x'
+      - '@napi-rs/cross-toolchain-x64-target-x86_64'
+      - '@types/node'
+      - supports-color
+
   '@napi-rs/cross-toolchain@1.0.3':
     dependencies:
       '@napi-rs/lzma': 1.5.1
@@ -6642,6 +6677,8 @@ snapshots:
       path-scurry: 1.11.1
 
   globals@14.0.0: {}
+
+  globals@15.15.0: {}
 
   globals@17.10.0: {}
 


### PR DESCRIPTION
## Summary

- regenerate the platform TypeScript SDK from the current checked-in OpenAPI schema
- advance generated SDK metadata to 3.3.13 before the workspace release candidate
- prevent stale SDK-version telemetry in the v3.3.13 package

## Validation

- `pnpm generate:platform-api` (includes TypeScript build)
- full CI is required before merge

This prepares release artifacts only. It does not publish or deploy anything.