### PR TITLE
test(sdk): use stable reconcile request type

### DIFF
--- a/client-sdks/platform/rust/src/lib.rs
+++ b/client-sdks/platform/rust/src/lib.rs
@@ -378,10 +378,14 @@ mod tests {
             }
         });
 
-        let sdk_state: types::SyncReconcileRequestState =
-            serde_json::from_value(state).expect("deployment state should deserialize");
+        let request = serde_json::json!({
+            "deploymentId": "dep_0c29fq4a2yjb7kx3smwdgxlc",
+            "state": state
+        });
+        let sdk_request: types::SyncReconcileRequest =
+            serde_json::from_value(request).expect("reconcile request should deserialize");
         let serialized =
-            serde_json::to_value(sdk_state).expect("deployment state should serialize");
+            serde_json::to_value(sdk_request.state).expect("deployment state should serialize");
 
         assert_eq!(
             serialized["runtimeMetadata"]["pendingPreparedStack"]["id"],


### PR DESCRIPTION
## Summary

- deserialize the generated `SyncReconcileRequest` in the SDK round-trip test
- avoid referencing the removed inline `SyncReconcileRequestState` type after model deduplication

## Validation

- this is the focused fix from local commit `b2b40f402` for the E0425 release-PR failure
- `git diff --check`

Linear: [ALIEN-525](https://linear.app/alienplatform/issue/ALIEN-525/redesign-external-ai-provider-health-and-explicit-model-checks)