### PR TITLE
test(sdk): use a deployment id the schema pattern accepts

### DIFF
--- a/client-sdks/platform/rust/src/lib.rs
+++ b/client-sdks/platform/rust/src/lib.rs
@@ -379,7 +379,7 @@ mod tests {
         });
 
         let request = serde_json::json!({
-            "deploymentId": "dep_0c29fq4a2yjb7kx3smwdgxlc",
+            "deploymentId": "dep_0c29fq4a2yjb7kx3smwdgxlcm2q8",
             "state": state
         });
         let sdk_request: types::SyncReconcileRequest =


### PR DESCRIPTION
## Summary

The reconcile round-trip test added in #432 uses a 24-character deployment id, and the platform spec pins deployment ids to `dep_` + 28 characters, so the request never deserializes and `alien-platform-api`'s tests fail on `main`. This gives the test an id the schema accepts.

When the test runs:

1. It builds a reconcile request with a deployment id and a runtime-metadata state.
2. **The generated request type validates the id against the spec pattern before anything else** — with 24 characters that step fails and the test never reaches its assertions.
3. With a 28-character id it deserializes and the round-trip assertions run.

This changes the test's fixture id to one the schema pattern accepts.

## How I tested

- `cargo test -p alien-platform-api reconcile_state_preserves` — fails on `main` with `doesn't match pattern "dep_[0-9a-z]{28}$"`, passes with this change.
