### PR TITLE
fix(release): refresh sandbox agent lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sandbox-agent"
-version = "3.3.14"
+version = "3.3.15"
 dependencies = [
  "alien-core",
  "alien-error",


### PR DESCRIPTION
Summary
- Refresh the generated Cargo.lock entry for alien-sandbox-agent from 3.3.14 to the workspace version 3.3.15.
- Unblock the stable v3.3.15 release validation.

Verification
- cargo metadata --format-version 1 --locked
- git diff --check

Context
- The stable release stopped before publishing because the merged release commit had this single stale generated entry.