### PR TITLE
fix: grant Email health controller its SES read permission

### DIFF
--- a/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_email_tests.rs
@@ -4,7 +4,8 @@
 use super::helpers::render_built_ins;
 use alien_cloudformation::{CfRegistry, RegistrationMode};
 use alien_core::{
-    import::EmitContext, AwsEmailImportData, Email, EmailEvents, EmailInbound, Platform, Queue,
+    import::EmitContext, permissions::ManagementPermissions, AwsEmailImportData, Email,
+    EmailEvents, EmailInbound, PermissionProfile, Platform, Queue, RemoteStackManagement,
     ResourceLifecycle, ResourceRef, Stack, StackSettings, Storage,
 };
 use indexmap::IndexMap;
@@ -26,6 +27,13 @@ fn email_stack() -> Stack {
         .build();
 
     Stack::new("email".to_string())
+        .management(ManagementPermissions::extend(
+            PermissionProfile::new().global(["email/heartbeat"]),
+        ))
+        .add(
+            RemoteStackManagement::new("management".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
         .add(mailbox, ResourceLifecycle::Frozen)
         .add(mail_events, ResourceLifecycle::Frozen)
         .add(email, ResourceLifecycle::Frozen)
@@ -160,6 +168,29 @@ fn aws_email_renders_ses_infrastructure() {
             "ses:DescribeActiveReceiptRuleSet",
             "ses:SetActiveReceiptRuleSet"
         ])
+    );
+
+    let management_has_receipt_rule_health_permission = resources
+        .as_object()
+        .expect("resources map")
+        .iter()
+        .filter(|(name, _)| name.starts_with("ManagementRoleManagementPolicy"))
+        .flat_map(|(_, resource)| {
+            resource["Properties"]["PolicyDocument"]["Statement"]
+                .as_array()
+                .into_iter()
+                .flatten()
+        })
+        .any(|statement| {
+            statement["Action"].as_array().is_some_and(|actions| {
+                actions
+                    .iter()
+                    .any(|action| action == "ses:DescribeActiveReceiptRuleSet")
+            })
+        });
+    assert!(
+        management_has_receipt_rule_health_permission,
+        "the remote management role must be able to run the Email health controller"
     );
     let activator_code = resources["MailerRuleSetActivatorFunction"]["Properties"]["Code"]
         ["ZipFile"]

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_email_tests__aws_email.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_email_tests__aws_email.snap
@@ -69,6 +69,56 @@ Parameters:
     - "off"
     - "on"
 Resources:
+  ManagementRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName:
+        Fn::Sub: ${AWS::StackName}-management
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Sid: AllowManagingRole
+          Effect: Allow
+          Principal:
+            AWS:
+              Ref: ManagingRoleArn
+          Action: sts:AssumeRole
+          Condition:
+            StringEquals:
+              aws:PrincipalArn:
+                Ref: ManagingRoleArn
+      Tags:
+      - Key: managed-by
+        Value: setup
+      - Key: deployment
+        Value:
+          Ref: AWS::StackName
+      - Key: resource
+        Value: management
+      - Key: resource-type
+        Value: management
+  ManagementRoleManagementPolicy1:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Application management permissions
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Action:
+          - ses:DescribeActiveReceiptRuleSet
+          Effect: Allow
+          Resource:
+          - '*'
+          Sid: EmailHeartbeat
+        - Sid: ReadOwnManagementRole
+          Effect: Allow
+          Action: iam:GetRole
+          Resource:
+            Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-management
+      Roles:
+      - Ref: ManagementRole
+    DependsOn:
+    - ManagementRole
   Mailbox:
     Type: AWS::S3::Bucket
     Properties:
@@ -460,6 +510,16 @@ Outputs:
   DeploymentResources:
     Value:
       Fn::ToJsonString:
+      - id: management
+        type: remote-stack-management
+        importData:
+          roleName:
+            Ref: ManagementRole
+          roleArn:
+            Fn::GetAtt:
+            - ManagementRole
+            - Arn
+          managementPermissionsApplied: true
       - id: mailbox
         type: storage
         importData:

--- a/crates/alien-permissions/permission-sets/email/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/email/heartbeat.jsonc
@@ -1,0 +1,22 @@
+{
+  "id": "email/heartbeat",
+  "description": "Allows readonly health checks for email receiving infrastructure",
+  "platforms": {
+    "aws": [
+      {
+        // SES v1 does not support resource-level scoping for receipt-rule inspection.
+        "grant": {
+          "actions": ["ses:DescribeActiveReceiptRuleSet"]
+        },
+        "binding": {
+          "stack": {
+            "resources": ["*"]
+          },
+          "resource": {
+            "resources": ["*"]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -131,6 +131,7 @@ mod tests {
         assert!(has_permission_set("build/provision"));
         assert!(has_permission_set("kubernetes-cluster/heartbeat"));
         assert!(has_permission_set("email/provision"));
+        assert!(has_permission_set("email/heartbeat"));
         assert!(has_permission_set("email/send"));
         assert!(has_permission_set("email/management"));
         assert!(has_permission_set("email/manage-identities"));

--- a/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
+++ b/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
@@ -129,6 +129,7 @@ fn management_differs_outside_gates(
     old_management: &ManagementPermissions,
     new_management: &ManagementPermissions,
     gated: &GatedContributions,
+    allow_email_heartbeat_migration: bool,
 ) -> bool {
     match (old_management, new_management) {
         (ManagementPermissions::Auto, ManagementPermissions::Auto) => false,
@@ -137,13 +138,14 @@ fn management_differs_outside_gates(
             ManagementPermissions::Extend(new_profile),
         ) => {
             profiles_differ_outside_gates(old_profile, new_profile, gated)
-                && !is_email_heartbeat_registration_migration(
-                    old_stack,
-                    new_stack,
-                    old_profile,
-                    new_profile,
-                    gated,
-                )
+                && !(allow_email_heartbeat_migration
+                    && is_email_heartbeat_registration_migration(
+                        old_stack,
+                        new_stack,
+                        old_profile,
+                        new_profile,
+                        gated,
+                    ))
         }
         (
             ManagementPermissions::Override(old_profile),
@@ -203,64 +205,86 @@ impl StackCompatibilityCheck for PermissionProfilesUnchangedCheck {
     }
 
     async fn check(&self, old_stack: &Stack, new_stack: &Stack) -> Result<CheckResult> {
-        let mut errors = Vec::new();
-        let mut warnings = Vec::new();
+        check_permission_profiles(old_stack, new_stack, false)
+    }
 
-        let gated = gated_contributions(old_stack, new_stack);
-
-        // Check if permission profiles have been added, removed, or modified
-        let old_profiles = &old_stack.permissions.profiles;
-        let new_profiles = &new_stack.permissions.profiles;
-
-        // Check for removed profiles
-        for (profile_name, _) in old_profiles {
-            if !new_profiles.contains_key(profile_name) {
-                errors.push(format!(
-                    "Permission profile '{}' was removed from the stack",
-                    profile_name
-                ));
-            }
-        }
-
-        // Check for modified or added profiles
-        for (profile_name, new_profile) in new_profiles {
-            if let Some(old_profile) = old_profiles.get(profile_name) {
-                // Profile exists in both - check if it was modified
-                if profiles_differ_outside_gates(old_profile, new_profile, &gated) {
-                    errors.push(format!(
-                        "Permission profile '{}' was modified",
-                        profile_name
-                    ));
-                }
-            } else {
-                // Profile is new
-                warnings.push(format!(
-                    "New permission profile '{}' was added",
-                    profile_name
-                ));
-            }
-        }
-
-        // Check management permissions
-        if management_differs_outside_gates(
+    async fn check_with_config(
+        &self,
+        old_stack: &Stack,
+        new_stack: &Stack,
+        config: &alien_core::DeploymentConfig,
+    ) -> Result<CheckResult> {
+        check_permission_profiles(
             old_stack,
             new_stack,
-            old_stack.management(),
-            new_stack.management(),
-            &gated,
-        ) {
-            errors.push("Management permissions configuration was modified".to_string());
-        }
+            config.stack_settings.heartbeats.is_enabled(),
+        )
+    }
+}
 
-        if errors.is_empty() {
-            if warnings.is_empty() {
-                Ok(CheckResult::success())
-            } else {
-                Ok(CheckResult::with_warnings(warnings))
+fn check_permission_profiles(
+    old_stack: &Stack,
+    new_stack: &Stack,
+    allow_email_heartbeat_migration: bool,
+) -> Result<CheckResult> {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    let gated = gated_contributions(old_stack, new_stack);
+
+    // Check if permission profiles have been added, removed, or modified
+    let old_profiles = &old_stack.permissions.profiles;
+    let new_profiles = &new_stack.permissions.profiles;
+
+    // Check for removed profiles
+    for (profile_name, _) in old_profiles {
+        if !new_profiles.contains_key(profile_name) {
+            errors.push(format!(
+                "Permission profile '{}' was removed from the stack",
+                profile_name
+            ));
+        }
+    }
+
+    // Check for modified or added profiles
+    for (profile_name, new_profile) in new_profiles {
+        if let Some(old_profile) = old_profiles.get(profile_name) {
+            // Profile exists in both - check if it was modified
+            if profiles_differ_outside_gates(old_profile, new_profile, &gated) {
+                errors.push(format!(
+                    "Permission profile '{}' was modified",
+                    profile_name
+                ));
             }
         } else {
-            Ok(CheckResult::failed_with_warnings(errors, warnings))
+            // Profile is new
+            warnings.push(format!(
+                "New permission profile '{}' was added",
+                profile_name
+            ));
         }
+    }
+
+    // Check management permissions
+    if management_differs_outside_gates(
+        old_stack,
+        new_stack,
+        old_stack.management(),
+        new_stack.management(),
+        &gated,
+        allow_email_heartbeat_migration,
+    ) {
+        errors.push("Management permissions configuration was modified".to_string());
+    }
+
+    if errors.is_empty() {
+        if warnings.is_empty() {
+            Ok(CheckResult::success())
+        } else {
+            Ok(CheckResult::with_warnings(warnings))
+        }
+    } else {
+        Ok(CheckResult::failed_with_warnings(errors, warnings))
     }
 }
 
@@ -535,17 +559,17 @@ mod tests {
         let old_stack = stack_with_management(&["storage/heartbeat"]);
         let new_stack = stack_with_management(&["email/heartbeat", "storage/heartbeat"]);
 
-        let migration = PermissionProfilesUnchangedCheck
-            .check(&old_stack, &new_stack)
-            .await
-            .expect("check should run");
+        let migration =
+            check_permission_profiles(&old_stack, &new_stack, true).expect("check should run");
         assert!(migration.success, "{:?}", migration.errors);
 
-        let removal = PermissionProfilesUnchangedCheck
-            .check(&new_stack, &old_stack)
-            .await
-            .expect("check should run");
+        let removal =
+            check_permission_profiles(&new_stack, &old_stack, true).expect("check should run");
         assert!(!removal.success);
+
+        let explicit_grant_with_heartbeats_disabled =
+            check_permission_profiles(&old_stack, &new_stack, false).expect("check should run");
+        assert!(!explicit_grant_with_heartbeats_disabled.success);
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
+++ b/crates/alien-preflights/src/compatibility/permission_profiles_unchanged.rs
@@ -124,6 +124,8 @@ fn profiles_differ_outside_gates(
 }
 
 fn management_differs_outside_gates(
+    old_stack: &Stack,
+    new_stack: &Stack,
     old_management: &ManagementPermissions,
     new_management: &ManagementPermissions,
     gated: &GatedContributions,
@@ -133,13 +135,65 @@ fn management_differs_outside_gates(
         (
             ManagementPermissions::Extend(old_profile),
             ManagementPermissions::Extend(new_profile),
-        )
-        | (
+        ) => {
+            profiles_differ_outside_gates(old_profile, new_profile, gated)
+                && !is_email_heartbeat_registration_migration(
+                    old_stack,
+                    new_stack,
+                    old_profile,
+                    new_profile,
+                    gated,
+                )
+        }
+        (
             ManagementPermissions::Override(old_profile),
             ManagementPermissions::Override(new_profile),
         ) => profiles_differ_outside_gates(old_profile, new_profile, gated),
         _ => true,
     }
+}
+
+/// Accepts the one-way profile migration caused by registering the formerly
+/// unresolved built-in Email heartbeat permission. Existing prepared stacks
+/// omitted this reference because unresolved built-ins are skipped. The first
+/// update after registration therefore adds it even when application code did
+/// not change.
+///
+/// This is deliberately narrow: both stack versions must contain Email, the
+/// old profile must lack the reference, the new profile must contain the
+/// canonical named reference, and removing only that reference must make the
+/// profiles otherwise identical. Removal and inline substitutions still fail.
+fn is_email_heartbeat_registration_migration(
+    old_stack: &Stack,
+    new_stack: &Stack,
+    old_profile: &PermissionProfile,
+    new_profile: &PermissionProfile,
+    gated: &GatedContributions,
+) -> bool {
+    const PERMISSION_ID: &str = "email/heartbeat";
+    let contains_email = |stack: &Stack| {
+        stack
+            .resources()
+            .any(|(_, entry)| entry.config.resource_type().as_ref() == "email")
+    };
+    if !contains_email(old_stack) || !contains_email(new_stack) {
+        return false;
+    }
+
+    let canonical = PermissionSetReference::from_name(PERMISSION_ID);
+    let old_global = old_profile.0.get("*");
+    let new_global = new_profile.0.get("*");
+    if old_global.is_some_and(|grants| grants.iter().any(|grant| grant.id() == PERMISSION_ID))
+        || !new_global.is_some_and(|grants| grants.iter().any(|grant| grant == &canonical))
+    {
+        return false;
+    }
+
+    let mut migrated_profile = new_profile.clone();
+    if let Some(grants) = migrated_profile.0.get_mut("*") {
+        grants.retain(|grant| grant != &canonical);
+    }
+    !profiles_differ_outside_gates(old_profile, &migrated_profile, gated)
 }
 
 #[async_trait::async_trait]
@@ -188,8 +242,13 @@ impl StackCompatibilityCheck for PermissionProfilesUnchangedCheck {
         }
 
         // Check management permissions
-        if management_differs_outside_gates(old_stack.management(), new_stack.management(), &gated)
-        {
+        if management_differs_outside_gates(
+            old_stack,
+            new_stack,
+            old_stack.management(),
+            new_stack.management(),
+            &gated,
+        ) {
             errors.push("Management permissions configuration was modified".to_string());
         }
 
@@ -209,7 +268,7 @@ impl StackCompatibilityCheck for PermissionProfilesUnchangedCheck {
 mod tests {
     use super::*;
     use alien_core::permissions::PermissionsConfig;
-    use alien_core::{Kv, ResourceLifecycle};
+    use alien_core::{Email, Kv, ResourceLifecycle};
     use indexmap::IndexMap;
 
     /// The deployer said no to a gated live resource: its scoped management
@@ -458,6 +517,35 @@ mod tests {
             .expect("check should run");
         assert!(!result.success);
         assert!(result.errors[0].contains("Management permissions"));
+    }
+
+    #[tokio::test]
+    async fn newly_registered_email_heartbeat_permission_migrates_existing_stacks() {
+        let stack_with_management = |grants: &[&str]| {
+            Stack::new("s".to_string())
+                .management(ManagementPermissions::Extend(
+                    PermissionProfile::new().global(grants.iter().copied()),
+                ))
+                .add(
+                    Email::new("mail".to_string()).build(),
+                    ResourceLifecycle::Frozen,
+                )
+                .build()
+        };
+        let old_stack = stack_with_management(&["storage/heartbeat"]);
+        let new_stack = stack_with_management(&["email/heartbeat", "storage/heartbeat"]);
+
+        let migration = PermissionProfilesUnchangedCheck
+            .check(&old_stack, &new_stack)
+            .await
+            .expect("check should run");
+        assert!(migration.success, "{:?}", migration.errors);
+
+        let removal = PermissionProfilesUnchangedCheck
+            .check(&new_stack, &old_stack)
+            .await
+            .expect("check should run");
+        assert!(!removal.success);
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/lib.rs
+++ b/crates/alien-preflights/src/lib.rs
@@ -253,6 +253,16 @@ pub trait StackCompatibilityCheck: Send + Sync {
 
     /// Compare old and new stacks for compatibility
     async fn check(&self, old_stack: &Stack, new_stack: &Stack) -> Result<CheckResult>;
+
+    /// Compare stacks with the deployment settings that govern derived state.
+    async fn check_with_config(
+        &self,
+        old_stack: &Stack,
+        new_stack: &Stack,
+        _config: &DeploymentConfig,
+    ) -> Result<CheckResult> {
+        self.check(old_stack, new_stack).await
+    }
 }
 
 /// Modifies the stack to ensure successful deployment.

--- a/crates/alien-preflights/src/mutations/management_permission_profile.rs
+++ b/crates/alien-preflights/src/mutations/management_permission_profile.rs
@@ -415,7 +415,7 @@ mod tests {
     use alien_core::{
         ArtifactRegistry, AzureContainerAppsEnvironment, AzureResourceGroup,
         AzureServiceBusNamespace, AzureStorageAccount, CapacityGroup, ComputeCluster, Container,
-        ContainerCode, DeploymentModel, EnvironmentVariablesSnapshot, ExternalBindings,
+        ContainerCode, DeploymentModel, Email, EnvironmentVariablesSnapshot, ExternalBindings,
         HeartbeatsMode, KubernetesCertificateMode, KubernetesCluster, KubernetesClusterOwnership,
         KubernetesClusterProvider, KubernetesExposureSettings, KubernetesHeartbeatMode,
         KubernetesIngressRouteProfile, KubernetesRouteProfile, KubernetesRouteProviderOptions,
@@ -452,6 +452,37 @@ mod tests {
             .allow_frozen_changes(false)
             .external_bindings(ExternalBindings::default())
             .build()
+    }
+
+    #[tokio::test]
+    async fn email_heartbeat_permission_is_added_to_management() {
+        let stack = Stack::new("test-stack".to_string())
+            .add(
+                Email::new("mail".to_string()).build(),
+                ResourceLifecycle::Frozen,
+            )
+            .build();
+        let stack_state = StackState::new(Platform::Aws);
+
+        let result_stack = ManagementPermissionProfileMutation
+            .mutate(
+                stack,
+                &stack_state,
+                &deployment_config_for_management_permission_test(),
+            )
+            .await
+            .expect("management permission mutation should succeed");
+
+        let permissions = result_stack
+            .management()
+            .profile()
+            .expect("auto management profile should be generated");
+        assert!(permissions
+            .0
+            .get("*")
+            .expect("global management permissions")
+            .iter()
+            .any(|permission| permission.id() == "email/heartbeat"));
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/runner.rs
+++ b/crates/alien-preflights/src/runner.rs
@@ -75,6 +75,7 @@ impl PreflightRunner {
         &self,
         old_stack: &Stack,
         new_stack: &Stack,
+        config: &DeploymentConfig,
     ) -> Result<PreflightSummary> {
         info!("Running stack compatibility checks");
 
@@ -84,14 +85,15 @@ impl PreflightRunner {
         for check in checks {
             debug!("Running compatibility check: {}", check.description());
 
-            let mut result = check.check(old_stack, new_stack).await.context(
-                ErrorData::StackCompatibilityCheckFailed {
+            let mut result = check
+                .check_with_config(old_stack, new_stack, config)
+                .await
+                .context(ErrorData::StackCompatibilityCheckFailed {
                     check_name: check.description().to_string(),
                     message: "Compatibility check execution failed".to_string(),
                     old_resource_id: None,
                     new_resource_id: None,
-                },
-            )?;
+                })?;
 
             result = result.with_check_metadata(check.code(), check.description());
 
@@ -413,7 +415,7 @@ impl PreflightRunner {
         if let Some(old_stack) = old_stack {
             if !setup_update_authorized {
                 let compatibility_summary = self
-                    .run_compatibility_checks(old_stack, &mutated_stack)
+                    .run_compatibility_checks(old_stack, &mutated_stack, config)
                     .await?;
                 all_results.extend(compatibility_summary.results);
             } else {


### PR DESCRIPTION
## Summary
- add a dedicated `email/heartbeat` permission set for inspecting the active SES receipt rule set
- include the permission automatically when Email heartbeats are enabled
- migrate existing prepared stacks that previously omitted the unresolved built-in permission
- verify the generated remote-management policy contains the read-only SES action

## Why
The Email health controller inspects the active SES receipt rule set. Frozen Email infrastructure correctly avoids broader management permissions, so this read-only capability belongs in the heartbeat permission set. Without it, the controller reports an authorization failure even when the Email infrastructure is healthy.

## Tests
- `cargo test -p alien-permissions --test permission_set_validation`
- `cargo test -p alien-preflights management_permission_profile::tests`
- `cargo test -p alien-preflights permission_profiles_unchanged::tests`
- `cargo test -p alien-cloudformation --test generator aws_email_tests`