### PR TITLE
feat: add deployment event history command

### DIFF
--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -1,5 +1,7 @@
+use std::num::NonZeroU64;
 use std::time::{Duration, Instant};
 
+use crate::commands::event_display::{print_event_table, EventDisplayRow};
 use crate::error::{ErrorData, Result};
 use crate::execution_context::ExecutionMode;
 use crate::interaction::{ConfirmationMode, InteractionMode};
@@ -50,6 +52,7 @@ pub enum MonitoringMode {
     alien deployments list
     alien deployments describe production/api
     alien deployments resources production/api --json
+    alien deployments events production/api
     alien deployments wait production/api --for ready --timeout 10m
     alien deployments machines production/api --json
 
@@ -73,6 +76,7 @@ impl DeploymentsArgs {
             DeploymentsCmd::Ls { json: true, .. }
                 | DeploymentsCmd::Get { json: true, .. }
                 | DeploymentsCmd::Resources { json: true, .. }
+                | DeploymentsCmd::Events { json: true, .. }
                 | DeploymentsCmd::Wait { json: true, .. }
                 | DeploymentsCmd::Machines { json: true, .. }
                 | DeploymentsCmd::Retry { json: true, .. }
@@ -172,6 +176,19 @@ pub enum DeploymentsCmd {
         id: String,
 
         /// Print stable machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show deployment lifecycle and configuration events
+    Events {
+        /// Deployment ID, or <deployment-group-name>/<deployment-name>
+        id: String,
+
+        /// Maximum number of recent events to return
+        #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u64).range(1..=100))]
+        limit: u64,
+
+        /// Print the API response as machine-readable JSON
         #[arg(long)]
         json: bool,
     },
@@ -328,6 +345,28 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
             let manager = resolve_manager_client(&ctx, None, !json).await?;
             let deployment = resolve_deployment_reference(&manager, &id).await?;
             resources_task(&deployment, json)
+        }
+        DeploymentsCmd::Events { id, limit, json } => {
+            if !ctx.is_platform() {
+                return Err(AlienError::new(ErrorData::ValidationError {
+                    field: "command".to_string(),
+                    message: "Deployment event history requires platform mode.".to_string(),
+                }));
+            }
+            let workspace = ctx.resolve_workspace_with_bootstrap(!json).await?;
+            let client = ctx.sdk_client().await?;
+            let deployment = crate::platform_deployment_resolver::resolve(
+                &ctx, &client, &workspace, &id, None, !json,
+            )
+            .await?;
+            deployment_events_task(
+                &client,
+                workspace.as_str(),
+                &String::from(deployment.id),
+                limit,
+                json,
+            )
+            .await
         }
         DeploymentsCmd::Wait {
             id,
@@ -544,6 +583,53 @@ pub async fn deployments_task(args: DeploymentsArgs, ctx: ExecutionMode) -> Resu
             token_deployment_task(&client, &workspace_name, &id).await
         }
     }
+}
+
+async fn deployment_events_task(
+    client: &alien_platform_api::Client,
+    workspace: &str,
+    deployment_id: &str,
+    limit: u64,
+    json: bool,
+) -> Result<()> {
+    let limit = NonZeroU64::new(limit).ok_or_else(|| {
+        AlienError::new(ErrorData::ValidationError {
+            field: "limit".to_string(),
+            message: "event limit must be greater than zero".to_string(),
+        })
+    })?;
+    let response = client
+        .list_events()
+        .workspace(workspace)
+        .deployment_id(deployment_id)
+        .limit(limit)
+        .send()
+        .await
+        .into_sdk_error()
+        .context(ErrorData::ApiRequestFailed {
+            message: format!("listing events for deployment '{deployment_id}'"),
+            url: None,
+        })?
+        .into_inner();
+
+    if json {
+        return print_json(&response);
+    }
+
+    let rows = response
+        .items
+        .iter()
+        .map(|event| {
+            EventDisplayRow::try_new(
+                String::from(event.id.clone()),
+                event.created_at,
+                &event.data,
+                &event.state,
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    print_event_table(&rows);
+    Ok(())
 }
 
 async fn machines_inventory_task(
@@ -2275,6 +2361,24 @@ mod tests {
             DeploymentsCmd::Resources { json: true, .. }
         ));
 
+        let events = DeploymentsArgs::try_parse_from([
+            "deployments",
+            "events",
+            "production/api",
+            "--limit",
+            "50",
+            "--json",
+        ])
+        .expect("event history should parse");
+        assert!(matches!(
+            events.cmd,
+            DeploymentsCmd::Events {
+                limit: 50,
+                json: true,
+                ..
+            }
+        ));
+
         let wait = DeploymentsArgs::try_parse_from([
             "deployments",
             "wait",
@@ -2294,6 +2398,19 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn deployment_events_rejects_an_api_limit_above_the_maximum() {
+        let result = DeploymentsArgs::try_parse_from([
+            "deployments",
+            "events",
+            "production/api",
+            "--limit",
+            "101",
+        ]);
+
+        assert!(result.is_err(), "limits above the API maximum must fail");
     }
 
     #[test]

--- a/crates/alien-cli/src/commands/event_display.rs
+++ b/crates/alien-cli/src/commands/event_display.rs
@@ -1,0 +1,374 @@
+use crate::error::{ErrorData, Result};
+use crate::ui::{make_table, print_table, status_cell};
+use alien_error::{Context, IntoAlienError};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDisplayRow {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub state: String,
+    pub actor: String,
+    pub event: String,
+    pub details: String,
+    pub summary: String,
+}
+
+impl EventDisplayRow {
+    pub fn try_new<D, S>(id: String, created_at: DateTime<Utc>, data: &D, state: &S) -> Result<Self>
+    where
+        D: Serialize,
+        S: Serialize,
+    {
+        let data = serde_json::to_value(data)
+            .into_alien_error()
+            .context(ErrorData::JsonError {
+                operation: "format event data".to_string(),
+                reason: "event data could not be serialized".to_string(),
+            })?;
+        let state =
+            serde_json::to_value(state)
+                .into_alien_error()
+                .context(ErrorData::JsonError {
+                    operation: "format event state".to_string(),
+                    reason: "event state could not be serialized".to_string(),
+                })?;
+
+        let event = event_title(&data, &state);
+        let details = event_details(&data, &state);
+        let summary = if details.is_empty() {
+            event.clone()
+        } else {
+            format!("{event}: {details}")
+        };
+
+        Ok(Self {
+            id,
+            created_at,
+            state: event_state(&state),
+            actor: event_actor(&data),
+            event,
+            details,
+            summary,
+        })
+    }
+}
+
+pub fn print_event_table(rows: &[EventDisplayRow]) {
+    if rows.is_empty() {
+        println!("(no events)");
+        return;
+    }
+
+    let mut table = make_table(&["Time", "State", "Actor", "Event", "Details"]);
+    for row in rows {
+        table.add_row(vec![
+            row.created_at
+                .format("%Y-%m-%d %H:%M:%S UTC")
+                .to_string()
+                .into(),
+            status_cell(&row.state),
+            row.actor.clone().into(),
+            row.event.clone().into(),
+            row.details.clone().into(),
+        ]);
+    }
+    print_table(table);
+}
+
+pub fn print_event_lines(rows: &[EventDisplayRow]) {
+    for row in rows {
+        let details = if row.details.is_empty() {
+            String::new()
+        } else {
+            format!(" — {}", row.details)
+        };
+        println!(
+            "[{}] {} {}{} ({})",
+            row.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+            row.actor,
+            row.event,
+            details,
+            row.state
+        );
+    }
+}
+
+fn event_state(state: &Value) -> String {
+    match state {
+        Value::String(value) => value.clone(),
+        Value::Object(object) if object.contains_key("failed") => "failed".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn event_actor(data: &Value) -> String {
+    let Some(actor) = data.get("actor").and_then(Value::as_object) else {
+        return if is_user_intent(data) {
+            "Unknown".to_string()
+        } else {
+            "System".to_string()
+        };
+    };
+
+    match actor.get("kind").and_then(Value::as_str) {
+        Some("user") => actor
+            .get("email")
+            .and_then(Value::as_str)
+            .or_else(|| actor.get("id").and_then(Value::as_str))
+            .unwrap_or("Unknown user")
+            .to_string(),
+        Some("serviceAccount") => actor
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|id| format!("Service account {id}"))
+            .unwrap_or_else(|| "Service account".to_string()),
+        _ => "System".to_string(),
+    }
+}
+
+fn is_user_intent(data: &Value) -> bool {
+    matches!(
+        data.get("type").and_then(Value::as_str),
+        Some(
+            "ReleaseChannelUpdated"
+                | "DeploymentReleaseChannelChanged"
+                | "DeploymentRetryRequested"
+                | "DeploymentRedeployRequested"
+                | "DeploymentReleasePinned"
+                | "DeploymentReleaseUnpinned"
+                | "DeploymentEnvironmentUpdated"
+                | "DeploymentDeletionRequested"
+        )
+    )
+}
+
+fn event_title(data: &Value, state: &Value) -> String {
+    let event_type = data.get("type").and_then(Value::as_str).unwrap_or("Event");
+    let state = event_state(state);
+
+    match (event_type, state.as_str()) {
+        ("DeploymentEnvironmentUpdated", "failed") => "Configuration Update Failed".to_string(),
+        ("DeploymentEnvironmentUpdated", "success") => "Configuration Applied".to_string(),
+        ("DeploymentEnvironmentUpdated", "started") => {
+            "Configuration Update In Progress".to_string()
+        }
+        ("DeploymentRedeployRequested", "failed") => "Redeployment Failed".to_string(),
+        ("DeploymentRedeployRequested", "success") => "Deployment Redeployed".to_string(),
+        ("DeploymentRedeployRequested", "started") => "Redeployment In Progress".to_string(),
+        ("DeploymentCreated", _) => "Deployment Created".to_string(),
+        ("DeploymentReleased", _)
+            if data.get("previousReleaseId").is_some_and(Value::is_string) =>
+        {
+            "Release Updated".to_string()
+        }
+        ("DeploymentReleased", _) => "Initial Release".to_string(),
+        ("DeploymentFailed", _) => "Deployment Failed".to_string(),
+        ("DeploymentDegraded", _) => "Deployment Degraded".to_string(),
+        ("DeploymentRecovered", _) => "Deployment Recovered".to_string(),
+        ("DeploymentDeleted", _) => "Deployment Deleted".to_string(),
+        ("ReleaseChannelUpdated", _) => "Release Channel Updated".to_string(),
+        ("DeploymentReleaseChannelChanged", _) => "Release Channel Changed".to_string(),
+        ("DeploymentRetryRequested", _) => "Deployment Retry Requested".to_string(),
+        ("DeploymentRedeployRequested", _) => "Deployment Redeploy Requested".to_string(),
+        ("DeploymentReleasePinned", _) => "Release Pinned".to_string(),
+        ("DeploymentReleaseUnpinned", _) => "Release Unpinned".to_string(),
+        ("DeploymentEnvironmentUpdated", _) => "Configuration Update Requested".to_string(),
+        ("DeploymentDeletionRequested", _) => "Deployment Deletion Requested".to_string(),
+        _ => humanize_event_type(event_type),
+    }
+}
+
+fn event_details(data: &Value, state: &Value) -> String {
+    let event_type = data.get("type").and_then(Value::as_str).unwrap_or_default();
+
+    match event_type {
+        "DeploymentEnvironmentUpdated" => data
+            .get("changedKeys")
+            .and_then(Value::as_array)
+            .map(|keys| {
+                let keys = keys.iter().filter_map(Value::as_str).collect::<Vec<_>>();
+                if keys.is_empty() {
+                    "Configuration updated".to_string()
+                } else {
+                    format!("Changed: {}", keys.join(", "))
+                }
+            })
+            .unwrap_or_else(|| "Configuration updated".to_string()),
+        "DeploymentReleased" => match (
+            data.get("previousReleaseId").and_then(Value::as_str),
+            data.get("releaseId").and_then(Value::as_str),
+        ) {
+            (Some(previous), Some(current)) => format!("{previous} → {current}"),
+            (_, Some(current)) => format!("Initial release: {current}"),
+            _ => String::new(),
+        },
+        "DeploymentFailed" => failure_details(data, state),
+        "DeploymentDegraded" => failure_details(data, state),
+        "DeploymentRecovered" => string_detail(data, "releaseId", "Now running"),
+        "DeploymentRetryRequested" => string_detail(data, "attemptedReleaseId", "Retrying release"),
+        "DeploymentRedeployRequested" => string_detail(data, "releaseId", "Release"),
+        "DeploymentReleasePinned" => string_detail(data, "pinnedReleaseId", "Pinned to"),
+        "DeploymentReleaseUnpinned" => {
+            string_detail(data, "previousPinnedReleaseId", "Was pinned to")
+        }
+        "ReleaseChannelUpdated" => string_detail(data, "channel", "Channel"),
+        "DeploymentReleaseChannelChanged" => match (
+            data.get("previousChannel").and_then(Value::as_str),
+            data.get("channel").and_then(Value::as_str),
+        ) {
+            (Some(previous), Some(current)) => format!("{previous} → {current}"),
+            _ => String::new(),
+        },
+        "DeploymentDeleted" => "Resources torn down".to_string(),
+        "DeploymentDeletionRequested" => "Deletion enqueued".to_string(),
+        _ => generic_event_details(data),
+    }
+}
+
+fn failure_details(data: &Value, state: &Value) -> String {
+    let phase = data.get("phase").and_then(Value::as_str);
+    let error = data.get("error").or_else(|| state.pointer("/failed/error"));
+    let code = error
+        .and_then(|value| value.get("code"))
+        .and_then(Value::as_str);
+    let message = error
+        .and_then(|value| value.get("message"))
+        .and_then(Value::as_str);
+
+    [phase, code, message]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(": ")
+}
+
+fn generic_event_details(data: &Value) -> String {
+    const DETAILS: &[(&str, &str)] = &[
+        ("stack", "Stack"),
+        ("image", "Image"),
+        ("resourceName", "Resource"),
+        ("platform", "Platform"),
+        ("targetTriple", "Target"),
+        ("stackName", "Stack"),
+        ("cfnStackName", "Stack"),
+        ("project", "Project"),
+    ];
+
+    DETAILS
+        .iter()
+        .find_map(|(field, label)| {
+            data.get(*field)
+                .and_then(Value::as_str)
+                .map(|value| format!("{label}: {value}"))
+        })
+        .unwrap_or_default()
+}
+
+fn string_detail(data: &Value, field: &str, label: &str) -> String {
+    data.get(field)
+        .and_then(Value::as_str)
+        .map(|value| format!("{label}: {value}"))
+        .unwrap_or_default()
+}
+
+fn humanize_event_type(event_type: &str) -> String {
+    let mut result = String::with_capacity(event_type.len() + 8);
+    for (index, character) in event_type.chars().enumerate() {
+        if index > 0 && character.is_uppercase() {
+            result.push(' ');
+        }
+        result.push(character);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configuration_event_includes_user_and_changed_keys() {
+        let row = EventDisplayRow::try_new(
+            "event_1".to_string(),
+            DateTime::parse_from_rfc3339("2026-08-20T06:26:10Z")
+                .expect("timestamp should parse")
+                .with_timezone(&Utc),
+            &serde_json::json!({
+                "type": "DeploymentEnvironmentUpdated",
+                "deploymentId": "dep_1",
+                "changedKeys": ["BETA", "ALPHA"],
+                "actor": { "kind": "user", "id": "usr_1", "email": "dev@example.com" }
+            }),
+            &"success",
+        )
+        .expect("event should format");
+
+        assert_eq!(row.state, "success");
+        assert_eq!(row.actor, "dev@example.com");
+        assert_eq!(row.event, "Configuration Applied");
+        assert_eq!(row.details, "Changed: BETA, ALPHA");
+    }
+
+    #[test]
+    fn asynchronous_event_without_actor_is_system_authored() {
+        let row = EventDisplayRow::try_new(
+            "event_2".to_string(),
+            Utc::now(),
+            &serde_json::json!({
+                "type": "DeploymentReleased",
+                "deploymentId": "dep_1",
+                "previousReleaseId": "rel_old",
+                "releaseId": "rel_new"
+            }),
+            &"success",
+        )
+        .expect("event should format");
+
+        assert_eq!(row.actor, "System");
+        assert_eq!(row.event, "Release Updated");
+        assert_eq!(row.details, "rel_old → rel_new");
+    }
+
+    #[test]
+    fn historical_user_intent_without_actor_is_not_labeled_as_system() {
+        let row = EventDisplayRow::try_new(
+            "event_legacy".to_string(),
+            Utc::now(),
+            &serde_json::json!({
+                "type": "DeploymentReleasePinned",
+                "deploymentId": "dep_1",
+                "pinnedReleaseId": "rel_new"
+            }),
+            &"none",
+        )
+        .expect("event should format");
+
+        assert_eq!(row.actor, "Unknown");
+        assert_eq!(row.event, "Release Pinned");
+    }
+
+    #[test]
+    fn failed_event_includes_phase_code_and_message() {
+        let row = EventDisplayRow::try_new(
+            "event_3".to_string(),
+            Utc::now(),
+            &serde_json::json!({
+                "type": "DeploymentFailed",
+                "phase": "updating",
+                "error": { "code": "UPDATE_FAILED", "message": "candidate did not become ready" }
+            }),
+            &serde_json::json!({ "failed": { "error": null } }),
+        )
+        .expect("event should format");
+
+        assert_eq!(row.state, "failed");
+        assert_eq!(
+            row.details,
+            "updating: UPDATE_FAILED: candidate did not become ready"
+        );
+    }
+}

--- a/crates/alien-cli/src/commands/manager.rs
+++ b/crates/alien-cli/src/commands/manager.rs
@@ -1,6 +1,7 @@
 //! Platform-only commands for managing workspace private managers.
 
 use crate::auth::AuthHttp;
+use crate::commands::event_display::{print_event_lines, print_event_table, EventDisplayRow};
 use crate::error::{ErrorData, Result};
 use crate::execution_context::ExecutionMode;
 use crate::interaction::{ConfirmationMode, InteractionMode};
@@ -297,15 +298,6 @@ struct ManagerSetupOutput {
     deployment_link: String,
     setup: serde_json::Value,
     files_written: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ManagerEventSummary {
-    id: String,
-    created_at: String,
-    state: String,
-    summary: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1367,52 +1359,6 @@ where
         })
 }
 
-/// Format an event's data as a human-readable summary.
-fn format_event_data(data: &alien_platform_api::types::EventData) -> String {
-    use alien_platform_api::types::EventData;
-
-    match data {
-        EventData::LoadingConfiguration => "Loading configuration".to_string(),
-        EventData::Finished => "Finished".to_string(),
-        EventData::BuildingStack { stack } => format!("Building stack: {}", stack),
-        EventData::RunningPreflights { platform, stack } => {
-            format!("Running preflights: {} ({})", stack, platform)
-        }
-        EventData::DownloadingAlienRuntime { target_triple, .. } => {
-            format!("Downloading alien-worker-runtime ({})", target_triple)
-        }
-        EventData::BuildingResource {
-            resource_name,
-            resource_type,
-            ..
-        } => format!("Building {} '{}'", resource_type, resource_name),
-        EventData::BuildingImage { image } => format!("Building image: {}", image),
-        EventData::PushingImage { image, .. } => format!("Pushing image: {}", image),
-        EventData::PushingStack {
-            stack, platform, ..
-        } => {
-            format!("Pushing stack: {} ({})", stack, platform)
-        }
-        EventData::PushingResource {
-            resource_name,
-            resource_type,
-        } => format!("Pushing {} '{}'", resource_type, resource_name),
-        EventData::CreatingRelease { .. } => "Creating release".to_string(),
-        other => format!("{:?}", other),
-    }
-}
-
-fn format_event_state(state: &alien_platform_api::types::EventState) -> &'static str {
-    use alien_platform_api::types::EventState;
-
-    match state {
-        EventState::Started => "started",
-        EventState::Success => "success",
-        EventState::Failed { .. } => "FAILED",
-        EventState::None => "",
-    }
-}
-
 async fn events_manager_task(
     client: &alien_platform_api::Client,
     workspace: &str,
@@ -1455,33 +1401,33 @@ async fn events_manager_task(
             None => events.to_vec(),
         };
 
+        let rows = new_events
+            .iter()
+            .map(|event| {
+                EventDisplayRow::try_new(
+                    String::from(event.id.clone()),
+                    event.created_at,
+                    &event.data,
+                    &event.state,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
         if json {
-            let payload: Vec<ManagerEventSummary> = new_events
-                .iter()
-                .map(|event| ManagerEventSummary {
-                    id: (*event.id).clone(),
-                    created_at: event.created_at.to_string(),
-                    state: format_event_state(&event.state).to_string(),
-                    summary: format_event_data(&event.data),
-                })
-                .collect();
-            return print_json(&payload);
+            return print_json(&rows);
         }
 
-        if events.is_empty() && last_event_id.is_none() {
-            println!("(no events)");
-        }
-
-        for event in &new_events {
-            let state = format_event_state(&event.state);
-            let data = format_event_data(&event.data);
-            let timestamp = event.created_at.format("%H:%M:%S");
-            if state.is_empty() {
-                println!("[{}] {}", timestamp, data);
-            } else {
-                println!("[{}] {} ({})", timestamp, data, state);
+        if follow {
+            if events.is_empty() && last_event_id.is_none() {
+                println!("(no events; waiting for new events)");
             }
-            last_event_id = Some((*event.id).clone());
+            print_event_lines(&rows);
+        } else {
+            print_event_table(&rows);
+        }
+
+        if let Some(event) = events.last() {
+            last_event_id = Some(String::from(event.id.clone()));
         }
 
         if !follow {

--- a/crates/alien-cli/src/commands/mod.rs
+++ b/crates/alien-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod deploy;
 pub mod deployments;
 pub mod destroy;
 pub mod dev_helpers;
+mod event_display;
 #[cfg(feature = "platform")]
 pub mod examples;
 pub mod init;


### PR DESCRIPTION
## Summary

- add `alien deployments events <id-or-group/name>` for platform deployment history
- render state, actor, event, and useful details in a shared formatter
- reuse the formatter for `alien managers events` while preserving its JSON summary field
- distinguish attributed users/service accounts, automated system events, and unattributed historical user actions

## Examples

```console
alien deployments events production/api
alien deployments events dep_123 --limit 50
alien deployments events production/api --json
```

## Verification

- `cargo check -p alien-cli`
- `cargo nextest run -p alien-cli -E 'test(event_display) | test(deployment_events) | test(agent_friendly_status_and_resource_commands_parse)'` (6 passed)\n- `cargo build -p alien-platform-api`\n- `cargo fmt --all -- --check`\n\nLinear: [ALIEN-566](https://linear.app/alienplatform/issue/ALIEN-566/expose-deployment-events-in-the-cli-with-actor-attribution)