### PR TITLE
feat(bindings): let a hosted caller drive a customer sandbox

### DIFF
--- a/client-sdks/manager/openapi.json
+++ b/client-sdks/manager/openapi.json
@@ -14367,6 +14367,63 @@
         },
         "additionalProperties": false
       },
+      "RemoteAwsSandboxBinding": {
+        "type": "object",
+        "description": "Concrete MicroVM sandbox topology returned to remote clients.\n\nDeliberately without the execution role and the egress connectors of the in-cloud binding: the\nprovider passes no role, and a binding carrying connectors is refused before it reaches here.",
+        "required": [
+          "imageArn",
+          "imageVersion",
+          "region",
+          "previewPorts",
+          "allowEgress"
+        ],
+        "properties": {
+          "allowEgress": {
+            "type": "boolean",
+            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied so the client's own fail-open check on an empty connector list still has an answer."
+          },
+          "idleSuspendSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Idle seconds after which a session suspends, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "imageArn": {
+            "type": "string",
+            "description": "MicroVM image the credential lease authorizes sessions against."
+          },
+          "imageVersion": {
+            "type": "string",
+            "description": "Image version sessions are enumerated by together with the image."
+          },
+          "maxLifetimeSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Wall-clock ceiling on a session, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "previewPorts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Ports a session capability may be minted for."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region the MicroVMs run in."
+          }
+        },
+        "additionalProperties": false
+      },
       "RemoteAzureClientConfig": {
         "type": "object",
         "description": "Response-safe Azure client configuration containing one storage-audience\naccess token for the stack's Remote Bindings identity.",
@@ -14990,6 +15047,33 @@
                 "type": "string",
                 "enum": [
                   "foundry"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "AWS Lambda MicroVM sandbox and an AWS session.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteAwsSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteAwsClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-aws"
                 ]
               }
             }

--- a/client-sdks/manager/rust/openapi-3.0.json
+++ b/client-sdks/manager/rust/openapi-3.0.json
@@ -12424,6 +12424,59 @@
         },
         "additionalProperties": false
       },
+      "RemoteAwsSandboxBinding": {
+        "type": "object",
+        "description": "Concrete MicroVM sandbox topology returned to remote clients.\n\nDeliberately without the execution role and the egress connectors of the in-cloud binding: the\nprovider passes no role, and a binding carrying connectors is refused before it reaches here.",
+        "required": [
+          "imageArn",
+          "imageVersion",
+          "region",
+          "previewPorts",
+          "allowEgress"
+        ],
+        "properties": {
+          "allowEgress": {
+            "type": "boolean",
+            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied so the client's own fail-open check on an empty connector list still has an answer."
+          },
+          "idleSuspendSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Idle seconds after which a session suspends, where the declaration asked for one.",
+            "minimum": 0,
+            "nullable": true
+          },
+          "imageArn": {
+            "type": "string",
+            "description": "MicroVM image the credential lease authorizes sessions against."
+          },
+          "imageVersion": {
+            "type": "string",
+            "description": "Image version sessions are enumerated by together with the image."
+          },
+          "maxLifetimeSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Wall-clock ceiling on a session, where the declaration asked for one.",
+            "minimum": 0,
+            "nullable": true
+          },
+          "previewPorts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Ports a session capability may be minted for."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region the MicroVMs run in."
+          }
+        },
+        "additionalProperties": false
+      },
       "RemoteAzureClientConfig": {
         "type": "object",
         "description": "Response-safe Azure client configuration containing one storage-audience\naccess token for the stack's Remote Bindings identity.",
@@ -13033,6 +13086,33 @@
                 "type": "string",
                 "enum": [
                   "foundry"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "AWS Lambda MicroVM sandbox and an AWS session.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteAwsSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteAwsClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-aws"
                 ]
               }
             }

--- a/crates/alien-bindings-node/src/lib.rs
+++ b/crates/alien-bindings-node/src/lib.rs
@@ -154,7 +154,7 @@ pub struct RemoteBindingsHandle {
 impl RemoteBindingsHandle {
     /// Select a customer's Storage deployment by Project and external ID.
     #[napi(factory)]
-    pub async fn for_environment(
+    pub async fn for_customer(
         project: String,
         external_id: String,
         token: String,

--- a/crates/alien-bindings-node/src/lib.rs
+++ b/crates/alien-bindings-node/src/lib.rs
@@ -203,6 +203,13 @@ impl RemoteBindingsHandle {
         Ok(KeyHandle::new(key))
     }
 
+    /// Resolve the sandbox binding named `name`.
+    #[napi]
+    pub async fn sandbox(&self, name: String) -> napi::Result<SandboxHandle> {
+        let sandbox = self.inner.sandbox(&name).await.map_err(map_alien_error)?;
+        Ok(SandboxHandle::new(sandbox))
+    }
+
     /// Resolve the deployment's unique managed AI binding.
     #[napi]
     pub async fn ai(&self) -> napi::Result<RemoteAiLeaseJs> {

--- a/crates/alien-bindings/src/providers/sandbox/aws.rs
+++ b/crates/alien-bindings/src/providers/sandbox/aws.rs
@@ -73,8 +73,9 @@ pub struct AwsSandbox {
     /// Connectors every session starts with. Empty means the public internet is reachable, so
     /// `deny` is a connector rather than the absence of one.
     egress_connector_arns: Vec<String>,
-    /// Ports preview may be minted for. `CreateMicrovmAuthToken` grants whatever port it is
-    /// asked for, so this list is where "a port not listed can never be exposed" is enforced.
+    /// Ports preview may be minted for. `CreateMicrovmAuthToken` carries no port condition key
+    /// and grants whatever port it is asked for, so this list bounds callers that go through this
+    /// provider; a Remote Bindings caller holding the raw credential is not bounded by it.
     preview_ports: Vec<u16>,
     /// Idle seconds before AWS suspends the MicroVM, where the declaration asked for it.
     idle_suspend_seconds: Option<u32>,
@@ -886,9 +887,9 @@ mod tests {
         assert_eq!(capability.expires_in_seconds, 1800);
     }
 
-    /// The declared list is where ingress is bounded: `CreateMicrovmAuthToken` mints a token for
-    /// whatever port it is handed, so an unlisted port must be refused before the call rather
-    /// than after it.
+    /// The declared list is what bounds ingress for callers on this path: `CreateMicrovmAuthToken`
+    /// mints a token for whatever port it is handed and has no port condition key, so an unlisted
+    /// port must be refused before the call rather than after it.
     #[tokio::test]
     async fn a_port_the_stack_did_not_declare_is_refused_before_a_token_exists() {
         let mut client = MockLambdaMicrovmsApi::new();

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -18,12 +18,12 @@ use tracing::debug;
 use crate::error::{ErrorData, Result};
 use crate::provider::BindingsProvider;
 use crate::refreshing::{KeyProviderApi, RefreshingKey, RefreshingStorage, StorageProviderApi};
-use crate::traits::{BindingsProviderApi, Key, Storage};
+use crate::traits::{BindingsProviderApi, Key, Sandbox, Storage};
 
 mod access;
 mod manager_conversion;
 
-use access::{ManagerResolverKind, RemoteBindingSource};
+use access::{ManagerResolverKind, RemoteBindingCapability, RemoteBindingSource};
 
 #[cfg(test)]
 use access::{
@@ -78,11 +78,12 @@ impl RemoteBindingsProvider {
         Self::discover(deployment_id, token, api_base_url, Arc::new(SystemClock)).await
     }
 
-    /// Selects a external environment's Storage deployment by Project and external ID and
-    /// creates a lazy remote provider.
+    /// Selects a external environment's deployment for one capability by Project and external
+    /// ID and creates a lazy remote provider.
     pub(crate) async fn for_remote_environment(
         project: &str,
         external_id: &str,
+        capability: RemoteBindingCapability,
         token: &str,
         api_base_url: Option<&str>,
     ) -> Result<Self> {
@@ -92,6 +93,7 @@ impl RemoteBindingsProvider {
                 RemoteBindingSource::discover_external_environment(
                     project,
                     external_id,
+                    capability,
                     token,
                     api_base_url,
                     ManagerResolverKind::Generated,
@@ -296,6 +298,7 @@ impl RemoteBindings {
                 RemoteBindingsProvider::for_remote_environment(
                     project,
                     external_id,
+                    RemoteBindingCapability::Storage,
                     token,
                     api_base_url,
                 )
@@ -362,6 +365,20 @@ impl RemoteBindings {
             self.provider.clone(),
             resource_id.to_string(),
         )))
+    }
+
+    /// Loads a Sandbox binding for running untrusted code in the customer's cloud.
+    ///
+    /// No refreshing wrapper, mirroring the in-cloud accessor: a sandbox handle addresses a
+    /// control plane rather than holding data-plane credentials, and each session capability is
+    /// minted per call. The handle keeps the credential lease that was current when it was
+    /// created, so call this again once that lease expires.
+    ///
+    /// The cached lease is served while it is unexpired even if a refresh fails, as Storage
+    /// does: a caller already holding the handle keeps that authority either way, so refusing
+    /// during a Manager blip withholds nothing.
+    pub async fn sandbox(&self, resource_id: &str) -> Result<Arc<dyn Sandbox>> {
+        self.provider.resolver(resource_id).await.sandbox().await
     }
 
     /// Loads one short-lived managed AI binding lease.
@@ -439,6 +456,14 @@ enum ResolvedRemoteBinding {
         binding: alien_core::FoundryAiBinding,
         #[serde(rename = "clientConfig")]
         client_config: Box<alien_core::AzureClientConfig>,
+        #[serde(rename = "expiresAt")]
+        expires_at: DateTime<Utc>,
+    },
+    #[serde(rename = "sandbox-aws")]
+    SandboxAws {
+        binding: Box<alien_core::AwsSandboxBinding>,
+        #[serde(rename = "clientConfig")]
+        client_config: Box<alien_core::AwsClientConfig>,
         #[serde(rename = "expiresAt")]
         expires_at: DateTime<Utc>,
     },
@@ -603,9 +628,21 @@ impl ResolvedRemoteBinding {
                     expires_at,
                 )
             }
+            Self::SandboxAws {
+                binding,
+                client_config,
+                expires_at,
+            } => {
+                validate_aws_remote_client_config(&client_config, expires_at)?;
+                (
+                    alien_core::ClientConfig::Aws(client_config),
+                    serialize_remote_binding(alien_core::SandboxBinding::Aws(*binding))?,
+                    expires_at,
+                )
+            }
             Self::Bedrock { .. } | Self::Vertex { .. } | Self::Foundry { .. } => {
                 return Err(AlienError::new(ErrorData::RemoteAccessFailed {
-                    operation: "use an AI lease as a Storage or Key binding".to_string(),
+                    operation: "use an AI lease as a Storage, Key or Sandbox binding".to_string(),
                 }));
             }
             #[cfg(test)]
@@ -635,7 +672,7 @@ fn serialize_remote_binding(binding: impl Serialize) -> Result<serde_json::Value
 
 fn invalid_remote_lease(provider: &str, reason: &str) -> AlienError<ErrorData> {
     AlienError::new(ErrorData::RemoteAccessFailed {
-        operation: format!("validate {provider} remote Storage credential lease: {reason}"),
+        operation: format!("validate {provider} remote credential lease: {reason}"),
     })
 }
 
@@ -798,6 +835,7 @@ struct RemoteStorageResolver {
 enum RequestedBindingKind {
     Storage,
     Key,
+    Sandbox,
 }
 
 impl fmt::Debug for RemoteStorageResolver {
@@ -822,6 +860,14 @@ impl RemoteStorageResolver {
     async fn key(&self) -> Result<Arc<dyn Key>> {
         BindingsProviderApi::load_key(
             &*self.provider(RequestedBindingKind::Key).await?,
+            &self.resource_id,
+        )
+        .await
+    }
+
+    async fn sandbox(&self) -> Result<Arc<dyn Sandbox>> {
+        BindingsProviderApi::load_sandbox(
+            &*self.provider(RequestedBindingKind::Sandbox).await?,
             &self.resource_id,
         )
         .await
@@ -911,7 +957,7 @@ impl RemoteStorageResolver {
         if expires_at <= now {
             return Err(AlienError::new(ErrorData::RemoteAccessFailed {
                 operation: format!(
-                    "manager returned an expired lease for Storage binding '{}'",
+                    "manager returned an expired lease for remote binding '{}'",
                     self.resource_id
                 ),
             }));
@@ -929,6 +975,9 @@ impl RemoteStorageResolver {
             }
             RequestedBindingKind::Key => {
                 BindingsProviderApi::load_key(&*provider, &self.resource_id).await?;
+            }
+            RequestedBindingKind::Sandbox => {
+                BindingsProviderApi::load_sandbox(&*provider, &self.resource_id).await?;
             }
         }
         let lifetime = expires_at - now;

--- a/crates/alien-bindings/src/remote/access.rs
+++ b/crates/alien-bindings/src/remote/access.rs
@@ -30,7 +30,7 @@ pub(crate) enum RemoteBindingCapability {
     /// naming the wrong capability at a call site is a compile error rather than a 4xx.
     #[expect(
         dead_code,
-        reason = "constructed by the follow-up that widens the wire enum"
+        reason = "constructed once the wire enum carries the sandbox capability"
     )]
     Sandbox,
 }

--- a/crates/alien-bindings/src/remote/access.rs
+++ b/crates/alien-bindings/src/remote/access.rs
@@ -19,6 +19,39 @@ pub(super) enum RemoteBindingSelector<'a> {
     Ai,
 }
 
+/// The capability an external-environment access request asks Platform for.
+///
+/// Platform selects the deployment by its purpose, so this decides which of a project's
+/// deployments the returned Manager capability addresses.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RemoteBindingCapability {
+    Storage,
+    /// Reachable once Platform's external-access schema accepts it; the variant exists so that
+    /// naming the wrong capability at a call site is a compile error rather than a 4xx.
+    #[expect(
+        dead_code,
+        reason = "constructed by the follow-up that widens the wire enum"
+    )]
+    Sandbox,
+}
+
+impl RemoteBindingCapability {
+    fn into_request_capability(
+        self,
+    ) -> Result<alien_platform_api::types::RemoteBindingsExternalAccessRequestCapability> {
+        match self {
+            Self::Storage => Ok(
+                alien_platform_api::types::RemoteBindingsExternalAccessRequestCapability::Storage,
+            ),
+            // Platform's external-access schema still accepts `storage` alone. Refusing beats
+            // asking for storage under a sandbox's name and reaching the wrong deployment.
+            Self::Sandbox => Err(remote_configuration_error(
+                "request external environment access for a Sandbox capability",
+            )),
+        }
+    }
+}
+
 const DEFAULT_PLATFORM_API_URL: &str = "https://api.alien.dev";
 const MANAGER_ACCESS_MAX_AGE_SECONDS: i64 = 300;
 const MANAGER_TOKEN_REFRESH_SKEW_SECONDS: i64 = 30;
@@ -42,6 +75,7 @@ enum PlatformAccessSelector {
     ExternalEnvironment {
         project: String,
         external_id: String,
+        capability: RemoteBindingCapability,
     },
 }
 
@@ -138,6 +172,7 @@ impl RemoteBindingSource {
     pub(super) async fn discover_external_environment(
         project: &str,
         external_id: &str,
+        capability: RemoteBindingCapability,
         platform_token: &str,
         api_base_url: Option<&str>,
         resolver_kind: ManagerResolverKind,
@@ -159,6 +194,7 @@ impl RemoteBindingSource {
             &platform,
             project,
             external_id,
+            capability,
             allow_insecure_manager_url,
             clock.as_ref(),
             0,
@@ -169,6 +205,7 @@ impl RemoteBindingSource {
             access_selector: PlatformAccessSelector::ExternalEnvironment {
                 project: project.to_string(),
                 external_id: external_id.to_string(),
+                capability,
             },
             platform: Some(platform),
             manager: RwLock::new(manager),
@@ -258,11 +295,13 @@ impl RemoteBindingSource {
             PlatformAccessSelector::ExternalEnvironment {
                 project,
                 external_id,
+                capability,
             } => {
                 discover_external_environment_manager_access(
                     platform,
                     project,
                     external_id,
+                    *capability,
                     self.allow_insecure_manager_url,
                     self.clock.as_ref(),
                     next_generation,
@@ -477,6 +516,7 @@ async fn discover_external_environment_manager_access(
     platform: &alien_platform_api::Client,
     project: &str,
     external_id: &str,
+    capability: RemoteBindingCapability,
     allow_insecure: bool,
     clock: &dyn Clock,
     generation: u64,
@@ -487,9 +527,7 @@ async fn discover_external_environment_manager_access(
         .id_or_name(project)
         .body(
             alien_platform_api::types::RemoteBindingsExternalAccessRequest::builder()
-                .capability(
-                    alien_platform_api::types::RemoteBindingsExternalAccessRequestCapability::Storage,
-                )
+                .capability(capability.into_request_capability()?)
                 .external_id(external_id),
         )
         .send()

--- a/crates/alien-bindings/src/remote/manager_conversion.rs
+++ b/crates/alien-bindings/src/remote/manager_conversion.rs
@@ -3,7 +3,7 @@
 //! Keep this boundary exhaustive: a manager schema change must fail compilation
 //! until every new response or credential variant has an intentional mapping.
 
-use alien_error::{Context, IntoAlienError};
+use alien_error::{AlienError, Context, IntoAlienError};
 use alien_manager_api::types as manager_types;
 use chrono::{DateTime, Utc};
 
@@ -244,9 +244,75 @@ impl ResolvedRemoteBinding {
                     expires_at,
                 }
             }
+            manager_types::ResolveBindingResponse::SandboxAws {
+                binding,
+                client_config,
+                expires_at,
+            } => {
+                let manager_types::RemoteAwsCredentials::SessionCredentials {
+                    access_key_id,
+                    secret_access_key,
+                    session_token,
+                    expires_at: credential_expires_at,
+                } = client_config.credentials;
+                let preview_ports = binding
+                    .preview_ports
+                    .into_iter()
+                    .map(|port| narrow_manager_number(port, "previewPorts", resource_id))
+                    .collect::<Result<Vec<u16>>>()?;
+                Self::SandboxAws {
+                    binding: Box::new(alien_core::AwsSandboxBinding {
+                        image_arn: alien_core::BindingValue::Value(binding.image_arn),
+                        image_version: alien_core::BindingValue::Value(binding.image_version),
+                        region: alien_core::BindingValue::Value(binding.region),
+                        // The remote contract carries neither: the provider refuses an execution
+                        // role outright, and reads egress from `allow_egress` against this list.
+                        execution_role_arn: None,
+                        egress_connector_arns: Vec::new(),
+                        preview_ports,
+                        idle_suspend_seconds: binding
+                            .idle_suspend_seconds
+                            .map(|seconds| {
+                                narrow_manager_number(seconds, "idleSuspendSeconds", resource_id)
+                            })
+                            .transpose()?,
+                        max_lifetime_seconds: binding
+                            .max_lifetime_seconds
+                            .map(|seconds| {
+                                narrow_manager_number(seconds, "maxLifetimeSeconds", resource_id)
+                            })
+                            .transpose()?,
+                        allow_egress: binding.allow_egress,
+                    }),
+                    client_config: Box::new(alien_core::AwsClientConfig {
+                        account_id: client_config.account_id,
+                        region: client_config.region,
+                        credentials: alien_core::AwsCredentials::SessionCredentials {
+                            access_key_id,
+                            secret_access_key,
+                            session_token,
+                            expires_at: credential_expires_at,
+                        },
+                        service_overrides: None,
+                    }),
+                    expires_at: parse_manager_expiry(expires_at, resource_id)?,
+                }
+            }
         };
         Ok(lease)
     }
+}
+
+/// Narrows one of the manager schema's `i32` fields, refusing the whole lease when it does not
+/// fit. A truncated preview port would mint ingress for a port the declaration never named.
+fn narrow_manager_number<T: TryFrom<i32>>(value: i32, field: &str, resource_id: &str) -> Result<T> {
+    T::try_from(value).map_err(|_| {
+        AlienError::new(ErrorData::RemoteAccessFailed {
+            operation: format!(
+                "read {field} value {value} for remote binding '{resource_id}': out of range"
+            ),
+        })
+    })
 }
 
 fn parse_manager_expiry(expires_at: String, resource_id: &str) -> Result<DateTime<Utc>> {

--- a/crates/alien-bindings/src/remote/tests.rs
+++ b/crates/alien-bindings/src/remote/tests.rs
@@ -178,6 +178,7 @@ impl Fixture {
                 RemoteBindingSource::discover_external_environment(
                     PROJECT_ID,
                     EXTERNAL_ID,
+                    RemoteBindingCapability::Storage,
                     PLATFORM_TOKEN,
                     Some(&self.api_url),
                     ManagerResolverKind::LocalFixture,

--- a/crates/alien-bindings/src/remote/tests/manager_contract.rs
+++ b/crates/alien-bindings/src/remote/tests/manager_contract.rs
@@ -385,3 +385,227 @@ async fn remote_ai_returns_a_typed_redacted_bedrock_lease() {
         assert!(!debug.contains(secret));
     }
 }
+
+const SANDBOX_IMAGE_ARN: &str =
+    "arn:aws:lambda:us-east-1:123456789012:microvm-image/alien-agent-image";
+
+/// One `sandbox-aws` resolve response, with the two fields whose handling the refusal tests
+/// vary left as parameters.
+fn sandbox_lease_body(
+    expires_at: DateTime<Utc>,
+    preview_ports: serde_json::Value,
+    allow_egress: bool,
+) -> serde_json::Value {
+    json!({
+        "service": "sandbox-aws",
+        "binding": {
+            "imageArn": SANDBOX_IMAGE_ARN,
+            "imageVersion": "7",
+            "region": "us-east-1",
+            "previewPorts": preview_ports,
+            "idleSuspendSeconds": 300,
+            "maxLifetimeSeconds": 3600,
+            "allowEgress": allow_egress,
+        },
+        "clientConfig": {
+            "accountId": "123456789012",
+            "region": "us-west-2",
+            "credentials": {
+                "type": "sessionCredentials",
+                "accessKeyId": "SENTINEL_ACCESS_KEY",
+                "secretAccessKey": "SENTINEL_SECRET_KEY",
+                "sessionToken": "SENTINEL_SESSION_TOKEN",
+                "expiresAt": expires_at.to_rfc3339(),
+            },
+        },
+        "expiresAt": expires_at.to_rfc3339(),
+    })
+}
+
+fn sandbox_resolve_request() -> RecordedRequest {
+    RecordedRequest {
+        method: "POST".to_string(),
+        path: "/v1/bindings/resolve".to_string(),
+        authorization: Some(format!("Bearer {GENERATED_MANAGER_TOKEN}")),
+        body: Some(json!({
+            "deploymentId": DEPLOYMENT_ID,
+            "resourceId": "agent",
+        })),
+    }
+}
+
+#[tokio::test]
+async fn remote_sandbox_decodes_every_declared_field_and_reaches_the_aws_provider() {
+    let expires_at = Utc::now() + ChronoDuration::minutes(5);
+    let response = Arc::new(StdRwLock::new((
+        StatusCode::OK,
+        sandbox_lease_body(expires_at, json!([8080, 3000]), true),
+    )));
+    let requests = Arc::new(StdMutex::new(Vec::new()));
+    let manager_url = spawn_generated_contract_server(GeneratedContractState {
+        response,
+        requests: requests.clone(),
+    })
+    .await;
+
+    let adapter = GeneratedManagerBindingResolver;
+    let manager = DiscoveredManager {
+        deployment_id: DEPLOYMENT_ID.to_string(),
+        url: reqwest::Url::parse(&manager_url).expect("valid manager URL"),
+        http: authenticated_http_client(GENERATED_MANAGER_TOKEN, "generated manager fixture")
+            .expect("build generated contract client"),
+        refresh_at: expires_at,
+        generation: 0,
+    };
+    let lease = adapter
+        .resolve(
+            &manager,
+            DEPLOYMENT_ID,
+            RemoteBindingSelector::Resource("agent"),
+        )
+        .await
+        .expect("generated client should decode a sandbox lease");
+    let ResolvedRemoteBinding::SandboxAws {
+        binding,
+        client_config,
+        expires_at: lease_expires_at,
+    } = lease
+    else {
+        panic!("generated client returned the wrong lease variant for a sandbox");
+    };
+    let value = |raw: &str| alien_core::BindingValue::Value(raw.to_string());
+    assert_eq!(binding.image_arn, value(SANDBOX_IMAGE_ARN));
+    assert_eq!(binding.image_version, value("7"));
+    assert_eq!(binding.region, value("us-east-1"));
+    assert_eq!(binding.preview_ports, vec![8080, 3000]);
+    assert_eq!(binding.idle_suspend_seconds, Some(300));
+    assert_eq!(binding.max_lifetime_seconds, Some(3600));
+    assert!(binding.allow_egress);
+    assert_eq!(binding.execution_role_arn, None);
+    assert!(binding.egress_connector_arns.is_empty());
+    assert_eq!(client_config.account_id, "123456789012");
+    assert_eq!(client_config.region, "us-west-2");
+    assert!(client_config.service_overrides.is_none());
+    let alien_core::AwsCredentials::SessionCredentials {
+        access_key_id,
+        secret_access_key,
+        session_token,
+        expires_at: credential_expires_at,
+    } = client_config.credentials
+    else {
+        panic!("generated client returned a non-session AWS credential for a sandbox");
+    };
+    assert_eq!(access_key_id, "SENTINEL_ACCESS_KEY");
+    assert_eq!(secret_access_key, "SENTINEL_SECRET_KEY");
+    assert_eq!(session_token, "SENTINEL_SESSION_TOKEN");
+    assert_eq!(credential_expires_at, expires_at.to_rfc3339());
+    assert_eq!(lease_expires_at.to_rfc3339(), expires_at.to_rfc3339());
+
+    let bindings = RemoteBindings::from_manager_access(
+        DEPLOYMENT_ID,
+        &manager_url,
+        GENERATED_MANAGER_TOKEN,
+        expires_at,
+    )
+    .expect("construct bindings from assigned Manager access");
+    let sandbox = bindings
+        .sandbox("agent")
+        .await
+        .expect("resolve the sandbox binding through Manager");
+    assert_eq!(
+        sandbox.capabilities(),
+        alien_core::SandboxCapabilities::for_platform(alien_core::Platform::Aws)
+            .expect("AWS has a sandbox backend"),
+        "a remote sandbox must expose the same surface as the in-cloud one"
+    );
+    let debug = format!("{sandbox:?}");
+    assert!(
+        debug.contains(SANDBOX_IMAGE_ARN) && debug.contains("8080"),
+        "the resolved topology should reach the provider: {debug}"
+    );
+    for secret in [
+        "SENTINEL_ACCESS_KEY",
+        "SENTINEL_SECRET_KEY",
+        "SENTINEL_SESSION_TOKEN",
+    ] {
+        assert!(
+            !debug.contains(secret),
+            "a sandbox handle must not render its credential lease"
+        );
+    }
+
+    assert_eq!(
+        requests
+            .lock()
+            .expect("generated contract requests lock")
+            .as_slice(),
+        &[sandbox_resolve_request(), sandbox_resolve_request()],
+        "a sandbox resolve is resource-scoped, with no selector of its own"
+    );
+}
+
+#[tokio::test]
+async fn remote_sandbox_lease_is_refused_when_it_declares_restricted_egress() {
+    let expires_at = Utc::now() + ChronoDuration::minutes(5);
+    let response = Arc::new(StdRwLock::new((
+        StatusCode::OK,
+        sandbox_lease_body(expires_at, json!([8080]), false),
+    )));
+    let manager_url = spawn_generated_contract_server(GeneratedContractState {
+        response,
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    })
+    .await;
+    let bindings = RemoteBindings::from_manager_access(
+        DEPLOYMENT_ID,
+        &manager_url,
+        GENERATED_MANAGER_TOKEN,
+        expires_at,
+    )
+    .expect("construct bindings from assigned Manager access");
+
+    // The remote contract carries no connectors, so `allowEgress: false` describes a sandbox
+    // whose sessions would start unrouted and reach the internet.
+    let error = bindings
+        .sandbox("agent")
+        .await
+        .expect_err("a sandbox declaring restricted egress must not be handed to a caller");
+    assert_eq!(error.code, "BINDING_CONFIG_INVALID");
+    assert!(
+        format!("{error}").contains("egressConnectorArns"),
+        "the refusal should name the field it read: {error}"
+    );
+}
+
+#[tokio::test]
+async fn remote_sandbox_lease_is_refused_when_a_preview_port_does_not_fit() {
+    let expires_at = Utc::now() + ChronoDuration::minutes(5);
+    let response = Arc::new(StdRwLock::new((
+        StatusCode::OK,
+        sandbox_lease_body(expires_at, json!([70000]), true),
+    )));
+    let manager_url = spawn_generated_contract_server(GeneratedContractState {
+        response,
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    })
+    .await;
+    let bindings = RemoteBindings::from_manager_access(
+        DEPLOYMENT_ID,
+        &manager_url,
+        GENERATED_MANAGER_TOKEN,
+        expires_at,
+    )
+    .expect("construct bindings from assigned Manager access");
+
+    // Narrowing 70000 into a port would mint ingress for 4464, which no declaration named.
+    let error = bindings
+        .sandbox("agent")
+        .await
+        .expect_err("an out-of-range preview port must refuse the whole lease");
+    assert_eq!(error.code, "REMOTE_ACCESS_FAILED");
+    let rendered = format!("{error}");
+    assert!(
+        rendered.contains("previewPorts") && rendered.contains("70000"),
+        "the refusal should name the field and the value it read: {rendered}"
+    );
+}

--- a/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
@@ -7,16 +7,19 @@
 use crate::{
     emitter::CfEmitter,
     emitters::aws::helpers::{
-        default_network, private_subnet_ids_expr, required_logical_id, resource_config,
-        service_trust_policy, subnet_refs, tags, vpc_id_expr, CONDITION_NETWORK_MODE_CREATE,
-        PARAM_PRIVATE_SUBNET_IDS,
+        cf_from_json, default_network, private_subnet_ids_expr, required_logical_id,
+        resource_config, service_trust_policy, subnet_refs, tags, vpc_id_expr,
+        CONDITION_NETWORK_MODE_CREATE, PARAM_PRIVATE_SUBNET_IDS,
     },
+    emitters::aws::service_account::permission_context,
     template::{CfExpression, CfResource},
 };
 use alien_core::{
-    import::EmitContext, ErrorData, NetworkSettings, Result, Sandbox, SandboxCode, SandboxEgress,
+    import::EmitContext, ErrorData, NetworkSettings, RemoteBindings, Result, Sandbox, SandboxCode,
+    SandboxEgress,
 };
-use alien_error::AlienError;
+use alien_error::{AlienError, Context, IntoAlienError};
+use alien_permissions::{generators::AwsCloudFormationPermissionsGenerator, BindingTarget};
 
 /// The only architecture MicroVM images accept — the schema's enum has one member, so the agent
 /// in the image has to be an aarch64 Linux binary.
@@ -234,6 +237,9 @@ impl CfEmitter for AwsSandboxEmitter {
         let mut resources = vec![role];
         resources.append(&mut egress_resources);
         resources.push(image);
+        if let Some(policy) = remote_access_policy(ctx)? {
+            resources.push(policy);
+        }
         Ok(resources)
     }
 
@@ -307,6 +313,67 @@ impl CfEmitter for AwsSandboxEmitter {
         }
         Ok(Some(CfExpression::object(fields)))
     }
+}
+
+/// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
+fn remote_access_policy(ctx: &EmitContext<'_>) -> Result<Option<CfResource>> {
+    let (Some(definition), Some(access_logical_id)) = (
+        alien_core::remote_bindings::remote_binding_for_entry(ctx.resource),
+        ctx.stack.resources().find_map(|(id, entry)| {
+            (entry.config.resource_type() == RemoteBindings::RESOURCE_TYPE)
+                .then(|| ctx.name_for(id))
+                .flatten()
+        }),
+    ) else {
+        return Ok(None);
+    };
+    let permission_set = alien_permissions::get_permission_set(definition.permission_set)
+        .ok_or_else(|| {
+            AlienError::new(ErrorData::GenericError {
+                message: format!(
+                    "permission set '{}' named by the sandbox Remote Bindings definition is missing",
+                    definition.permission_set
+                ),
+            })
+        })?;
+
+    // The bare resource id: the generator renders `${stackPrefix}` as `${AWS::StackName}`, which
+    // is how this template already names the image.
+    let context = permission_context().with_resource_name(ctx.resource_id.to_string());
+    let document = AwsCloudFormationPermissionsGenerator::new()
+        .generate_policy(permission_set, BindingTarget::Resource, &context)
+        .context(ErrorData::GenericError {
+            message: format!(
+                "could not generate the remote sandbox IAM policy for '{}'",
+                ctx.resource_id
+            ),
+        })?;
+    let document = cf_from_json(serde_json::to_value(document).into_alien_error().context(
+        ErrorData::TemplateSerializationFailed {
+            format: "CloudFormation IAM policy".to_string(),
+            reason: "Failed to serialize the remote sandbox IAM policy".to_string(),
+        },
+    )?)?;
+
+    let mut policy = CfResource::new(
+        format!("{}RemoteExecutePolicy", required_logical_id(ctx)?),
+        "AWS::IAM::Policy".to_string(),
+    );
+    policy.properties.insert(
+        "PolicyName".to_string(),
+        CfExpression::sub(format!(
+            "${{AWS::StackName}}-{}-sandbox-access",
+            ctx.resource_id
+        )),
+    );
+    policy.properties.insert(
+        "Roles".to_string(),
+        CfExpression::list([CfExpression::ref_(format!("{access_logical_id}Role"))]),
+    );
+    policy
+        .properties
+        .insert("PolicyDocument".to_string(), document);
+    Ok(Some(policy))
 }
 
 /// The ports a preview capability may be minted for.

--- a/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
@@ -318,7 +318,9 @@ impl CfEmitter for AwsSandboxEmitter {
 /// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
 fn remote_access_policy(ctx: &EmitContext<'_>) -> Result<Option<CfResource>> {
     let (Some(definition), Some(access_logical_id)) = (
-        alien_core::remote_bindings::remote_binding_for_entry(ctx.resource),
+        alien_core::remote_bindings::remote_binding_is_deliverable(ctx.resource)
+            .then(|| alien_core::remote_bindings::remote_binding_for_entry(ctx.resource))
+            .flatten(),
         ctx.stack.resources().find_map(|(id, entry)| {
             (entry.config.resource_type() == RemoteBindings::RESOURCE_TYPE)
                 .then(|| ctx.name_for(id))

--- a/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
@@ -485,3 +485,65 @@ fn aws_remote_sandbox_grants_the_access_identity_its_own_image_and_nothing_wider
         );
     }
 }
+
+/// A sandbox that routes egress through a connector is not remotely reachable, because
+/// `sandbox/remote-execute` withholds `lambda:PassNetworkConnector`. Preflight refuses such a
+/// stack; the emitter agrees, so a stack that reaches here another way installs no usable grant.
+#[test]
+fn aws_remote_sandbox_with_restricted_egress_carries_no_grant() {
+    let settings = StackSettings {
+        network: Some(NetworkSettings::Create {
+            cidr: None,
+            availability_zones: 2,
+        }),
+        ..StackSettings::default()
+    };
+    let stack = Stack::new("byo-sandbox-deny".to_string())
+        .add(
+            Network::new("default-network".to_string())
+                .settings(settings.network.clone().expect("network"))
+                .build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add_with_remote_access(
+            sandbox_fixture(SandboxEgress::Deny),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+    // Not `render_built_ins_template`: a bindings-only stack skips the standard conditions, which
+    // the created network's own resources reference, so cfn-lint refuses the template this shape
+    // produces. That is the pre-existing gap the refusal above closes, not the subject here.
+    let template = try_render_built_ins(
+        &stack,
+        settings,
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "remote sandbox deny",
+    )
+    .expect("the template renders");
+
+    let logical_ids = template.resources.keys().collect::<Vec<_>>();
+    assert!(
+        template.resources.contains_key("Agents")
+            && template.resources.contains_key("AgentsEgressConnector"),
+        "the sandbox and its deny connector must still render: {logical_ids:?}"
+    );
+    assert!(
+        template.resources.contains_key("AccessRole"),
+        "the Remote Bindings identity must still render: {logical_ids:?}"
+    );
+    assert!(
+        !template.resources.contains_key("AgentsRemoteExecutePolicy"),
+        "an egress-restricted sandbox must carry no remote execute grant: {logical_ids:?}"
+    );
+    let rendered = serde_json::to_string(&template.resources).expect("serializes");
+    assert!(
+        !rendered.contains("lambda:CreateMicrovmAuthToken"),
+        "no policy in the template may mint session credentials for this sandbox: {rendered}"
+    );
+}

--- a/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
@@ -5,8 +5,8 @@ use super::helpers::{
 };
 use alien_cloudformation::CloudFormationTarget;
 use alien_core::{
-    Network, NetworkSettings, ResourceLifecycle, Sandbox, SandboxCode, SandboxEgress,
-    SandboxSessionPolicy, Stack, StackSettings, Worker, WorkerCode,
+    Network, NetworkSettings, RemoteBindings, ResourceLifecycle, Sandbox, SandboxCode,
+    SandboxEgress, SandboxSessionPolicy, Stack, StackSettings, Worker, WorkerCode,
 };
 
 fn sandbox_fixture(egress: SandboxEgress) -> Sandbox {
@@ -412,5 +412,76 @@ fn the_sandbox_templates_render_whole() {
             name,
         );
         insta::assert_snapshot!(name, yaml);
+    }
+}
+
+/// The grant a remote caller's credentials are bounded by.
+///
+/// The setup package is where the Remote Bindings identity gets its policies, so without this the
+/// manager mints a session against a role that carries none.
+#[test]
+fn aws_remote_sandbox_grants_the_access_identity_its_own_image_and_nothing_wider() {
+    let stack = Stack::new("byo-sandbox".to_string())
+        .add_with_remote_access(
+            sandbox_fixture(SandboxEgress::Allow),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+    let (template, _yaml) = render_built_ins_template(
+        &stack,
+        StackSettings::default(),
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "remote sandbox",
+    );
+
+    let policy = template
+        .resources
+        .get("AgentsRemoteExecutePolicy")
+        .expect("the remote grant must attach to the Remote Bindings role");
+    assert_eq!(policy.resource_type, "AWS::IAM::Policy");
+    let roles =
+        serde_json::to_string(policy.properties.get("Roles").expect("Roles")).expect("serializes");
+    assert!(
+        roles.contains("AccessRole"),
+        "the grant belongs to the shared Remote Bindings identity: {roles}"
+    );
+
+    let document = serde_json::to_string(
+        policy
+            .properties
+            .get("PolicyDocument")
+            .expect("PolicyDocument"),
+    )
+    .expect("serializes");
+    for action in [
+        "lambda:RunMicrovm",
+        "lambda:SuspendMicrovm",
+        "lambda:ResumeMicrovm",
+        "lambda:TerminateMicrovm",
+        "lambda:CreateMicrovmAuthToken",
+        "lambda:GetMicrovm",
+    ] {
+        assert!(document.contains(action), "{action} is missing: {document}");
+    }
+    assert!(
+        document.contains("microvm-image:${AWS::StackName}-agents"),
+        "the grant must name this sandbox's own image: {document}"
+    );
+    for withheld in [
+        "lambda:PassNetworkConnector",
+        "iam:PassRole",
+        "lambda:CreateMicrovmShellAuthToken",
+        "microvm-image:${AWS::StackName}-*",
+    ] {
+        assert!(
+            !document.contains(withheld),
+            "{withheld} must stay out of the remote grant: {document}"
+        );
     }
 }

--- a/crates/alien-core/src/remote_bindings.rs
+++ b/crates/alien-core/src/remote_bindings.rs
@@ -5,6 +5,7 @@ pub enum RemoteBindingKind {
     Storage,
     Key,
     Ai,
+    Sandbox,
 }
 
 /// One resource type's provider-neutral Remote Bindings contract.
@@ -49,6 +50,17 @@ const DEFINITIONS: &[RemoteBindingDefinition] = &[
         kind: RemoteBindingKind::Ai,
         description: "Invoke models through this AI resource",
         setup_support_resource_types: &["azure_resource_group", "service_activation"],
+        revision: 1,
+    },
+    RemoteBindingDefinition {
+        resource_type: "sandbox",
+        permission_set: "sandbox/remote-execute",
+        kind: RemoteBindingKind::Sandbox,
+        description:
+            "Create and terminate sessions in this sandbox, and run arbitrary code inside them",
+        // A sandbox's parent is the MicroVM image its own emitter builds, and an open-egress
+        // sandbox attaches no VPC connector, so setup owes this binding no other resource.
+        setup_support_resource_types: &[],
         revision: 1,
     },
 ];

--- a/crates/alien-core/src/remote_bindings.rs
+++ b/crates/alien-core/src/remote_bindings.rs
@@ -1,4 +1,4 @@
-use crate::{ResourceEntry, ResourceLifecycle, ResourceType};
+use crate::{ResourceEntry, ResourceLifecycle, ResourceType, Sandbox, SandboxEgress};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteBindingKind {
@@ -77,6 +77,19 @@ pub fn remote_binding_for_entry(entry: &ResourceEntry) -> Option<&'static Remote
     (entry.remote_access && entry.lifecycle == ResourceLifecycle::Frozen)
         .then(|| remote_binding_definition(&entry.config.resource_type()))
         .flatten()
+}
+
+/// Whether a declaration's remote binding is one a deployment can actually deliver.
+///
+/// A sandbox reaches the network through an egress connector, and starting a session on one is
+/// additionally authorized as `lambda:PassNetworkConnector` — which AWS scopes to no resource and
+/// no condition key, so `sandbox/remote-execute` withholds it. Preflight refuses such a stack;
+/// emitters and generated docs read this so nothing advertises a grant that cannot be used.
+pub fn remote_binding_is_deliverable(entry: &ResourceEntry) -> bool {
+    entry
+        .config
+        .downcast_ref::<Sandbox>()
+        .is_none_or(|sandbox| matches!(sandbox.egress, SandboxEgress::Allow))
 }
 
 pub fn remote_binding_definitions() -> &'static [RemoteBindingDefinition] {

--- a/crates/alien-manager/openapi.json
+++ b/crates/alien-manager/openapi.json
@@ -14367,6 +14367,63 @@
         },
         "additionalProperties": false
       },
+      "RemoteAwsSandboxBinding": {
+        "type": "object",
+        "description": "Concrete MicroVM sandbox topology returned to remote clients.\n\nDeliberately without the execution role and the egress connectors of the in-cloud binding: the\nprovider passes no role, and a binding carrying connectors is refused before it reaches here.",
+        "required": [
+          "imageArn",
+          "imageVersion",
+          "region",
+          "previewPorts",
+          "allowEgress"
+        ],
+        "properties": {
+          "allowEgress": {
+            "type": "boolean",
+            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied so the client's own fail-open check on an empty connector list still has an answer."
+          },
+          "idleSuspendSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Idle seconds after which a session suspends, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "imageArn": {
+            "type": "string",
+            "description": "MicroVM image the credential lease authorizes sessions against."
+          },
+          "imageVersion": {
+            "type": "string",
+            "description": "Image version sessions are enumerated by together with the image."
+          },
+          "maxLifetimeSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Wall-clock ceiling on a session, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "previewPorts": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "description": "Ports a session capability may be minted for."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region the MicroVMs run in."
+          }
+        },
+        "additionalProperties": false
+      },
       "RemoteAzureClientConfig": {
         "type": "object",
         "description": "Response-safe Azure client configuration containing one storage-audience\naccess token for the stack's Remote Bindings identity.",
@@ -14990,6 +15047,33 @@
                 "type": "string",
                 "enum": [
                   "foundry"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "AWS Lambda MicroVM sandbox and an AWS session.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteAwsSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteAwsClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-aws"
                 ]
               }
             }

--- a/crates/alien-manager/src/credential_materialization.rs
+++ b/crates/alien-manager/src/credential_materialization.rs
@@ -45,6 +45,7 @@ pub(crate) enum RemoteBindingCredentialScope {
     AwsAi,
     GcpAi,
     AzureAi,
+    AwsSandbox,
 }
 
 impl std::fmt::Debug for MaterializedCredentialLease {
@@ -226,6 +227,7 @@ fn remote_binding_scope_platform(scope: &RemoteBindingCredentialScope) -> Platfo
         RemoteBindingCredentialScope::AwsS3 => Platform::Aws,
         RemoteBindingCredentialScope::AwsKms => Platform::Aws,
         RemoteBindingCredentialScope::AwsAi => Platform::Aws,
+        RemoteBindingCredentialScope::AwsSandbox => Platform::Aws,
         RemoteBindingCredentialScope::GcpGcs => Platform::Gcp,
         RemoteBindingCredentialScope::GcpCloudKms => Platform::Gcp,
         RemoteBindingCredentialScope::GcpAi => Platform::Gcp,

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -7,7 +7,7 @@
 use alien_core::{
     Ai, AiBinding, AwsClientConfig, AwsCredentials, AzureClientConfig, AzureCredentials,
     BindingValue, ClientConfig, DeploymentStatus, GcpClientConfig, GcpCredentials, Key, KeyBinding,
-    Platform, ResourceLifecycle, ResourceStatus, Storage, StorageBinding,
+    Platform, ResourceLifecycle, ResourceStatus, Sandbox, SandboxBinding, Storage, StorageBinding,
 };
 use alien_error::{Context, ContextError, IntoAlienError};
 use axum::{
@@ -138,6 +138,42 @@ pub enum ResolveBindingResponse {
         #[serde(rename = "expiresAt")]
         expires_at: String,
     },
+    /// AWS Lambda MicroVM sandbox and an AWS session.
+    #[serde(rename = "sandbox-aws")]
+    SandboxAws {
+        binding: RemoteAwsSandboxBinding,
+        #[serde(rename = "clientConfig")]
+        client_config: RemoteAwsClientConfig,
+        #[serde(rename = "expiresAt")]
+        expires_at: String,
+    },
+}
+
+/// Concrete MicroVM sandbox topology returned to remote clients.
+///
+/// Deliberately without the execution role and the egress connectors of the in-cloud binding: the
+/// provider passes no role, and a binding carrying connectors is refused before it reaches here.
+#[derive(Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RemoteAwsSandboxBinding {
+    /// MicroVM image the credential lease authorizes sessions against.
+    pub image_arn: String,
+    /// Image version sessions are enumerated by together with the image.
+    pub image_version: String,
+    /// Region the MicroVMs run in.
+    pub region: String,
+    /// Ports a session capability may be minted for.
+    pub preview_ports: Vec<u16>,
+    /// Idle seconds after which a session suspends, where the declaration asked for one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_suspend_seconds: Option<u32>,
+    /// Wall-clock ceiling on a session, where the declaration asked for one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_lifetime_seconds: Option<u32>,
+    /// Whether the declaration asked for open egress. Always true here, and sent rather than
+    /// implied so the client's own fail-open check on an empty connector list still has an answer.
+    pub allow_egress: bool,
 }
 
 #[derive(Serialize)]
@@ -337,10 +373,15 @@ enum RemoteAiBinding {
     Azure(RemoteAzureFoundryAiBinding),
 }
 
+enum RemoteSandboxBinding {
+    Aws(RemoteAwsSandboxBinding),
+}
+
 enum ResolvedRemoteBinding {
     Storage(RemoteStorageBinding),
     Key(RemoteKeyBinding),
     Ai(RemoteAiBinding),
+    Sandbox(RemoteSandboxBinding),
 }
 
 impl ResolvedRemoteBinding {
@@ -349,6 +390,15 @@ impl ResolvedRemoteBinding {
             Self::Storage(binding) => binding.credential_scope(),
             Self::Key(binding) => binding.credential_scope(),
             Self::Ai(binding) => binding.credential_scope(),
+            Self::Sandbox(binding) => binding.credential_scope(),
+        }
+    }
+}
+
+impl RemoteSandboxBinding {
+    fn credential_scope(&self) -> RemoteBindingCredentialScope {
+        match self {
+            Self::Aws(_) => RemoteBindingCredentialScope::AwsSandbox,
         }
     }
 }
@@ -584,6 +634,25 @@ impl ResolveBindingResponse {
             )),
         }
     }
+
+    fn from_sandbox_parts(
+        binding: RemoteSandboxBinding,
+        lease: MaterializedCredentialLease,
+        expires_at: String,
+    ) -> Result<Self, alien_error::AlienError<ErrorData>> {
+        match (binding, lease.client_config) {
+            (RemoteSandboxBinding::Aws(binding), ClientConfig::Aws(client_config)) => {
+                Ok(Self::SandboxAws {
+                    binding,
+                    client_config: (*client_config).try_into()?,
+                    expires_at,
+                })
+            }
+            _ => Err(ErrorData::internal(
+                "Remote Sandbox binding and materialized credential platforms do not match",
+            )),
+        }
+    }
 }
 
 pub fn router() -> Router<AppState> {
@@ -686,6 +755,9 @@ async fn resolve_binding(
         alien_core::remote_bindings::RemoteBindingKind::Ai => {
             remote_ai_binding(&deployment, &resource_id).map(ResolvedRemoteBinding::Ai)
         }
+        alien_core::remote_bindings::RemoteBindingKind::Sandbox => {
+            remote_sandbox_binding(&deployment, &resource_id).map(ResolvedRemoteBinding::Sandbox)
+        }
     };
     let binding = match binding {
         Ok(binding) => binding,
@@ -732,6 +804,9 @@ async fn resolve_binding(
             lease,
             expires_at.clone(),
         ),
+        ResolvedRemoteBinding::Sandbox(binding) => {
+            ResolveBindingResponse::from_sandbox_parts(binding, lease, expires_at.clone())
+        }
     };
     let response = match response {
         Ok(response) => response,
@@ -1155,6 +1230,81 @@ fn remote_ai_binding(
             deployment.platform
         ))),
     }
+}
+
+fn remote_sandbox_binding(
+    deployment: &DeploymentRecord,
+    resource_id: &str,
+) -> Result<RemoteSandboxBinding, alien_error::AlienError<ErrorData>> {
+    // AWS alone, unlike the other kinds. A GCP sandbox is a subprocess of the application's own
+    // Cloud Run instance, and an Azure sandbox group is created by the runtime controller, so
+    // neither has a durable parent a setup-owned identity could be scoped to.
+    if deployment.platform != Platform::Aws {
+        return Err(ErrorData::bad_request(format!(
+            "Remote Sandbox is only supported on AWS, not deployment platform '{}'",
+            deployment.platform
+        )));
+    }
+    let stack_state = deployment.stack_state.as_ref().ok_or_else(|| {
+        ErrorData::bad_request("Deployment has no stack state (not yet provisioned)")
+    })?;
+    let resource = stack_state.resource(resource_id).ok_or_else(|| {
+        ErrorData::bad_request(format!(
+            "Resource '{resource_id}' does not exist in stack state"
+        ))
+    })?;
+    if resource.resource_type != Sandbox::RESOURCE_TYPE.as_ref() {
+        return Err(ErrorData::bad_request(format!(
+            "Resource '{resource_id}' is not a sandbox"
+        )));
+    }
+    if resource.lifecycle != Some(ResourceLifecycle::Frozen) {
+        return Err(ErrorData::bad_request(format!(
+            "Sandbox resource '{resource_id}' is not Frozen"
+        )));
+    }
+    if resource.status != ResourceStatus::Running {
+        return Err(ErrorData::bad_request(format!(
+            "Sandbox resource '{resource_id}' is not running"
+        )));
+    }
+    let binding = resource.remote_binding_params.clone().ok_or_else(|| {
+        ErrorData::bad_request(format!(
+            "Sandbox resource '{resource_id}' is not enabled for remote access"
+        ))
+    })?;
+    let binding: SandboxBinding =
+        serde_json::from_value(binding)
+            .into_alien_error()
+            .context(ErrorData::BadRequest {
+                reason: format!("Sandbox resource '{resource_id}' has an invalid remote binding"),
+            })?;
+
+    let SandboxBinding::Aws(binding) = binding else {
+        return Err(ErrorData::bad_request(format!(
+            "Sandbox resource '{resource_id}' binding does not match deployment platform '{}'",
+            deployment.platform
+        )));
+    };
+    // Starting a session on a connector is a third authorization, `lambda:PassNetworkConnector`,
+    // which AWS scopes to no resource and no condition key. `sandbox/remote-execute` therefore
+    // withholds it, and a sandbox that restricts egress is refused here rather than reaching the
+    // caller as an AccessDenied from inside its own `create()`.
+    if !binding.egress_connector_arns.is_empty() {
+        return Err(ErrorData::bad_request(format!(
+            "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"
+        )));
+    }
+
+    Ok(RemoteSandboxBinding::Aws(RemoteAwsSandboxBinding {
+        image_arn: concrete_binding_value(&binding.image_arn, "AWS sandbox imageArn")?,
+        image_version: concrete_binding_value(&binding.image_version, "AWS sandbox imageVersion")?,
+        region: concrete_binding_value(&binding.region, "AWS sandbox region")?,
+        preview_ports: binding.preview_ports,
+        idle_suspend_seconds: binding.idle_suspend_seconds,
+        max_lifetime_seconds: binding.max_lifetime_seconds,
+        allow_egress: binding.allow_egress,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -278,6 +278,25 @@ fn remote_sandbox_validation_refuses_a_sandbox_that_restricts_egress() {
     );
 }
 
+/// Preflight refuses a remote binding by its permission set's platform coverage, while this route
+/// hardcodes AWS. Widening either alone brings back a deployment that installs a grant the other
+/// end will not honour.
+#[test]
+fn remote_sandbox_resolve_agrees_with_the_permission_set_platform_coverage() {
+    for platform in [Platform::Aws, Platform::Gcp, Platform::Azure] {
+        let deployment = deployment_on_platform(
+            sandbox_stack_state(open_sandbox_binding(), platform),
+            platform,
+        );
+
+        assert_eq!(
+            alien_permissions::permission_set_covers_platform("sandbox/remote-execute", platform),
+            remote_sandbox_binding(&deployment, "agents").is_ok(),
+            "{platform}"
+        );
+    }
+}
+
 #[test]
 fn remote_sandbox_validation_refuses_platforms_without_a_durable_parent() {
     for platform in [Platform::Gcp, Platform::Azure, Platform::Local] {

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use alien_core::{
-    Ai, ExternalBinding, ExternalBindings, Platform, Resource, Stack, StackResourceState,
-    StackSettings, StackState,
+    Ai, AwsSandboxBinding, BindingValue, ExternalBinding, ExternalBindings, Platform, Resource,
+    SandboxCode, SandboxEgress, SandboxSessionPolicy, Stack, StackResourceState, StackSettings,
+    StackState,
 };
 use alien_error::AlienError;
 use async_trait::async_trait;
@@ -180,6 +181,166 @@ fn lease(client_config: ClientConfig) -> MaterializedCredentialLease {
         client_config,
         expires_at: Utc::now() + chrono::Duration::minutes(15),
     }
+}
+
+fn sandbox_resource() -> Sandbox {
+    Sandbox::new("agents".to_string())
+        .code(SandboxCode::Image {
+            image: "ubuntu:24.04".to_string(),
+        })
+        .egress(SandboxEgress::Allow)
+        .session(SandboxSessionPolicy {
+            max_lifetime_seconds: None,
+            idle_suspend_seconds: None,
+        })
+        .build()
+}
+
+fn sandbox_stack_state(binding: SandboxBinding, platform: Platform) -> StackState {
+    let mut stack_state = StackState::new(platform);
+    stack_state.resources.insert(
+        "agents".to_string(),
+        StackResourceState::builder()
+            .resource_type(Sandbox::RESOURCE_TYPE.to_string())
+            .status(ResourceStatus::Running)
+            .config(Resource::new(sandbox_resource()))
+            .lifecycle(ResourceLifecycle::Frozen)
+            .remote_binding_params(serde_json::to_value(binding).unwrap())
+            .dependencies(Vec::new())
+            .build(),
+    );
+    stack_state
+}
+
+fn open_sandbox_binding() -> SandboxBinding {
+    let SandboxBinding::Aws(mut binding) = SandboxBinding::aws(
+        "arn:aws:lambda:us-east-1:123456789012:microvm-image:stack-agents",
+        "3",
+        "us-east-1",
+    ) else {
+        unreachable!("the AWS constructor returns the AWS variant")
+    };
+    binding.allow_egress = true;
+    binding.preview_ports = vec![8080];
+    binding.max_lifetime_seconds = Some(1800);
+    SandboxBinding::Aws(binding)
+}
+
+#[test]
+fn remote_sandbox_validation_returns_the_topology_a_session_is_started_from() {
+    let deployment = deployment(sandbox_stack_state(open_sandbox_binding(), Platform::Aws));
+
+    let Ok(RemoteSandboxBinding::Aws(binding)) = remote_sandbox_binding(&deployment, "agents")
+    else {
+        panic!("a running Frozen sandbox with an open-egress binding resolves")
+    };
+
+    assert_eq!(
+        binding.image_arn,
+        "arn:aws:lambda:us-east-1:123456789012:microvm-image:stack-agents"
+    );
+    assert_eq!(binding.image_version, "3");
+    assert_eq!(binding.region, "us-east-1");
+    assert_eq!(binding.preview_ports, vec![8080]);
+    assert_eq!(binding.max_lifetime_seconds, Some(1800));
+    assert_eq!(binding.idle_suspend_seconds, None);
+    assert!(
+        binding.allow_egress,
+        "an empty connector list means open egress, and the client re-checks the pair"
+    );
+}
+
+/// `sandbox/remote-execute` withholds `lambda:PassNetworkConnector`, so a session cannot be
+/// started on the connector a restricting sandbox declares. Refusing here names the reason
+/// instead of surfacing an AccessDenied from inside the caller's own `create()`.
+#[test]
+fn remote_sandbox_validation_refuses_a_sandbox_that_restricts_egress() {
+    let SandboxBinding::Aws(binding) = open_sandbox_binding() else {
+        unreachable!("the fixture is the AWS variant")
+    };
+    let restricted = SandboxBinding::Aws(AwsSandboxBinding {
+        allow_egress: false,
+        egress_connector_arns: vec![BindingValue::value(
+            "arn:aws:lambda:us-east-1:123456789012:network-connector:stack-agents".to_string(),
+        )],
+        ..binding
+    });
+    let deployment = deployment(sandbox_stack_state(restricted, Platform::Aws));
+
+    let Err(error) = remote_sandbox_binding(&deployment, "agents") else {
+        panic!("a connector cannot be passed with the remote grant")
+    };
+    assert_eq!(error.code, "BAD_REQUEST");
+    assert!(
+        error.message.contains("restricts egress"),
+        "{}",
+        error.message
+    );
+}
+
+#[test]
+fn remote_sandbox_validation_refuses_platforms_without_a_durable_parent() {
+    for platform in [Platform::Gcp, Platform::Azure, Platform::Local] {
+        let deployment = deployment_on_platform(
+            sandbox_stack_state(open_sandbox_binding(), platform),
+            platform,
+        );
+        let Err(error) = remote_sandbox_binding(&deployment, "agents") else {
+            panic!("only AWS provisions a sandbox parent a setup identity can be scoped to")
+        };
+        assert_eq!(error.code, "BAD_REQUEST");
+        assert!(
+            error.message.contains("only supported on AWS"),
+            "{platform}"
+        );
+    }
+}
+
+/// The wire contract slice D reads. `service` selects the variant, so a rename is a silent
+/// breakage for every remote client.
+#[test]
+fn remote_sandbox_response_carries_the_service_tag_and_no_extra_credentials() {
+    let response = ResolveBindingResponse::from_sandbox_parts(
+        match remote_sandbox_binding(
+            &deployment(sandbox_stack_state(open_sandbox_binding(), Platform::Aws)),
+            "agents",
+        ) {
+            Ok(binding) => binding,
+            Err(error) => panic!("fixture must resolve: {error}"),
+        },
+        lease(ClientConfig::Aws(Box::new(AwsClientConfig {
+            account_id: "123456789012".to_string(),
+            region: "us-east-1".to_string(),
+            credentials: AwsCredentials::SessionCredentials {
+                access_key_id: "AKIA".to_string(),
+                secret_access_key: "secret".to_string(),
+                session_token: "token".to_string(),
+                expires_at: "2026-01-01T00:00:00Z".to_string(),
+            },
+            service_overrides: None,
+        }))),
+        "2026-01-01T00:00:00Z".to_string(),
+    )
+    .expect("an AWS binding pairs with an AWS lease");
+
+    let json = serde_json::to_value(&response).expect("response serializes");
+    assert_eq!(json["service"], "sandbox-aws");
+    assert_eq!(json["binding"]["imageVersion"], "3");
+    assert_eq!(json["binding"]["allowEgress"], true);
+    assert_eq!(json["binding"]["previewPorts"], serde_json::json!([8080]));
+    assert!(
+        json["binding"].get("idleSuspendSeconds").is_none(),
+        "an absent ceiling is omitted rather than sent as null"
+    );
+    assert_eq!(
+        json["clientConfig"]["credentials"]["type"],
+        "sessionCredentials"
+    );
+    assert_eq!(json["expiresAt"], "2026-01-01T00:00:00Z");
+    assert_eq!(
+        format!("{response:?}"),
+        "ResolveBindingResponse { lease: \"<redacted>\" }"
+    );
 }
 
 #[test]

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -296,7 +296,7 @@ fn remote_sandbox_validation_refuses_platforms_without_a_durable_parent() {
     }
 }
 
-/// The wire contract slice D reads. `service` selects the variant, so a rename is a silent
+/// The wire contract remote clients decode. `service` selects the variant, so a rename is a silent
 /// breakage for every remote client.
 #[test]
 fn remote_sandbox_response_carries_the_service_tag_and_no_extra_credentials() {

--- a/crates/alien-permissions/permission-sets/sandbox/execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/execute.jsonc
@@ -5,10 +5,12 @@
     "aws": [
       {
         "grant": {
-          // Minting a MicroVM auth token is the action that grants access to session contents,
-          // so it belongs in this set alone — management, provision and heartbeat must never
-          // reach inside a session. CreateMicrovmShellAuthToken is deliberately excluded: an
-          // interactive shell is not part of the resource's surface.
+          // Minting a MicroVM auth token is the action that grants access to session contents, so
+          // it belongs here and in `sandbox/remote-execute` alone — management, provision and
+          // heartbeat must never reach inside a session, and
+          // `only_session_reaching_sandbox_sets_mint_microvm_auth_tokens` pins that list.
+          // CreateMicrovmShellAuthToken is deliberately excluded: an interactive shell is not
+          // part of the resource's surface.
           //
           // Authorized against the image the session was launched from, which is what bounds
           // it: a workload can only mint tokens for sessions of its own sandbox.

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -14,8 +14,11 @@
           // No `lambda:PassNetworkConnector`, which is the third action a RunMicrovm carrying an
           // egress connector is authorized as. It takes no resource type and no condition key, so
           // granting it would let the remote caller start the session on a connector the customer
-          // did not declare. A sandbox that denies egress therefore cannot start a session
-          // remotely; the manager refuses it at resolve time rather than at AccessDenied.
+          // did not declare.
+          //
+          // Only an open-egress sandbox is therefore remotely reachable. That is a deliberate
+          // product decision, not a gap: preflight refuses a `remoteAccess` sandbox that restricts
+          // egress, and both setup emitters withhold this set from one, so it never attaches.
           "actions": [
             "lambda:RunMicrovm",
             "lambda:SuspendMicrovm",

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -1,0 +1,57 @@
+{
+  "id": "sandbox/remote-execute",
+  "description": "Allows a remote caller to create sandbox sessions and run arbitrary code inside them",
+  "platforms": {
+    // AWS alone. A GCP sandbox is a launcher subprocess inside the app's own Cloud Run instance,
+    // so there is no parent a remote caller could address; on Azure the sandbox group is created
+    // by the runtime controller, and setup can scope no role assignment to a group that does not
+    // exist yet — see the same note in `sandbox/management`.
+    "aws": [
+      {
+        "label": "session-lifecycle",
+        "description": "Start, suspend, resume, and terminate sessions of the selected sandbox.",
+        "grant": {
+          // No `lambda:PassNetworkConnector`, which is the third action a RunMicrovm carrying an
+          // egress connector is authorized as. It takes no resource type and no condition key, so
+          // granting it would let the remote caller start the session on a connector the customer
+          // did not declare. A sandbox that denies egress therefore cannot start a session
+          // remotely; the manager refuses it at resolve time rather than at AccessDenied.
+          "actions": [
+            "lambda:RunMicrovm",
+            "lambda:SuspendMicrovm",
+            "lambda:ResumeMicrovm",
+            "lambda:TerminateMicrovm"
+          ]
+        },
+        // Resource-scoped only, unlike `sandbox/execute`, and this is the whole boundary. The
+        // manager hands a remote caller raw session credentials, so `owned_microvm`'s image check
+        // runs in code the caller can decline to call; a stack-wide pattern would match every
+        // sibling sandbox's image and let one deployment's caller address another's sessions.
+        "binding": {
+          "resource": {
+            "resources": [
+              "arn:aws:lambda:${awsRegion}:${awsAccountId}:microvm-image:${stackPrefix}-${resourceName}"
+            ]
+          }
+        }
+      },
+      {
+        "label": "reach-inside-a-session",
+        "description": "Read a session's state and mint the token the sandbox agent protocol travels on.",
+        "grant": {
+          // The same pair as `sandbox/execute`, and it carries the same weight: minting a MicroVM
+          // auth token is access to session contents. `CreateMicrovmShellAuthToken` stays out for
+          // the same reason it does there — an interactive shell is not part of this surface.
+          "actions": ["lambda:CreateMicrovmAuthToken", "lambda:GetMicrovm"]
+        },
+        "binding": {
+          "resource": {
+            "resources": [
+              "arn:aws:lambda:${awsRegion}:${awsAccountId}:microvm-image:${stackPrefix}-${resourceName}"
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -50,6 +50,9 @@
           // reaches every session of it, whoever started it. Preflight makes the sandbox
           // single-tenant to the remote caller by refusing one the deployment's own compute can
           // also reach, which is the only containment IAM cannot express.
+          //
+          // The mint also has no port condition key, so a declared `previewPorts` list bounds only
+          // callers going through the provider, not a holder of these credentials.
           "actions": ["lambda:CreateMicrovmAuthToken", "lambda:GetMicrovm"]
         },
         "binding": {

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -45,6 +45,11 @@
           // The same pair as `sandbox/execute`, and it carries the same weight: minting a MicroVM
           // auth token is access to session contents. `CreateMicrovmShellAuthToken` stays out for
           // the same reason it does there — an interactive shell is not part of this surface.
+          //
+          // One image serves every session of the sandbox and AWS has no finer ARN, so this pair
+          // reaches every session of it, whoever started it. Preflight makes the sandbox
+          // single-tenant to the remote caller by refusing one the deployment's own compute can
+          // also reach, which is the only containment IAM cannot express.
           "actions": ["lambda:CreateMicrovmAuthToken", "lambda:GetMicrovm"]
         },
         "binding": {

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -7,7 +7,11 @@ pub mod variables;
 use alien_core::{ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_TAG_KEY};
 
 pub use error::*;
-pub use registry::{get_permission_set, has_permission_set, list_permission_set_ids};
+pub use registry::{
+    get_permission_set, has_permission_set, list_permission_set_ids, permission_set_covers_platform,
+    permission_set_reaches_a_microvm_session, MICROVM_SESSION_LIFECYCLE_ACTIONS,
+    SENSITIVE_MICROVM_ACTIONS,
+};
 pub use variables::VariableInterpolator;
 
 // Core types are re-exported by the generators that need them

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -112,6 +112,93 @@
 // This includes the static PERMISSION_SETS_REGISTRY and the public API workers
 include!(concat!(env!("OUT_DIR"), "/permission_sets_registry.rs"));
 
+/// AWS actions that hand out a credential reaching inside a MicroVM session.
+///
+/// A MicroVM auth token is what the sandbox agent protocol travels on, and `ConnectMicrovm`
+/// attaches to a running session with no matching API operation to audit.
+pub const SENSITIVE_MICROVM_ACTIONS: &[&str] = &[
+    "lambda:CreateMicrovmAuthToken",
+    "lambda:CreateMicrovmShellAuthToken",
+    "lambda:ConnectMicrovm",
+];
+
+/// AWS actions that address an existing MicroVM session, or start one.
+///
+/// Starting counts: one image serves every session of a sandbox and AWS scopes a mint no finer,
+/// so whoever holds `sandbox/remote-execute` mints into whatever sessions exist.
+pub const MICROVM_SESSION_LIFECYCLE_ACTIONS: &[&str] = &[
+    "lambda:RunMicrovm",
+    "lambda:SuspendMicrovm",
+    "lambda:ResumeMicrovm",
+    "lambda:TerminateMicrovm",
+    "lambda:GetMicrovm",
+];
+
+/// Whether `permission_set` grants anything that addresses a MicroVM session.
+///
+/// Bindings are deliberately not consulted. `${stackPrefix}` is uninterpolated this early and an
+/// inline set's ARNs are free-form user strings, so any ARN comparison is either unsound or
+/// widened past by writing `*`. Carrying the verb at all is the answer.
+///
+/// AWS only: a GCP sandbox is a launcher subprocess that makes no GCP API call, and an Azure
+/// sandbox group is created by the runtime controller rather than reached through a stack grant.
+pub fn permission_set_reaches_a_microvm_session(
+    permission_set: &alien_core::permissions::PermissionSet,
+) -> bool {
+    permission_set
+        .platforms
+        .aws
+        .iter()
+        .flatten()
+        .filter(|entry| entry.effect.is_allow())
+        .flat_map(|entry| entry.grant.actions.iter().flatten())
+        .any(|action| action_reaches_a_microvm_session(action))
+}
+
+/// Whether one IAM action, possibly carrying a `*`, can authorize an operation on a session.
+///
+/// Three cases sit together here: a wildcard is cleared only against the known verbs, an exact
+/// action is matched on the `Microvm` namespace so a verb AWS adds later fails closed, and the
+/// `MicrovmImage` family is excluded because it addresses the image a session launches from —
+/// `sandbox/provision` and `sandbox/heartbeat` legitimately hold those.
+fn action_reaches_a_microvm_session(action: &str) -> bool {
+    if action.contains('*') {
+        let literal = action.split('*').next().unwrap_or_default();
+        return SENSITIVE_MICROVM_ACTIONS
+            .iter()
+            .chain(MICROVM_SESSION_LIFECYCLE_ACTIONS)
+            .any(|known| known.starts_with(literal));
+    }
+    action
+        .strip_prefix("lambda:")
+        .is_some_and(|verb| verb.contains("Microvm") && !verb.contains("MicrovmImage"))
+}
+
+/// Whether `permission_set_id` grants anything at all on `platform`.
+///
+/// An absent or empty block is a kind the platform does not support: emitters and the generated
+/// permission docs both iterate the block, so such a grant installs no role binding and prints a
+/// heading with no permissions under it.
+pub fn permission_set_covers_platform(
+    permission_set_id: &str,
+    platform: alien_core::Platform,
+) -> bool {
+    let Some(permission_set) = get_permission_set(permission_set_id) else {
+        return false;
+    };
+    let platforms = &permission_set.platforms;
+    let entries = match platform {
+        alien_core::Platform::Aws => platforms.aws.as_ref().map(Vec::len),
+        alien_core::Platform::Gcp => platforms.gcp.as_ref().map(Vec::len),
+        alien_core::Platform::Azure => platforms.azure.as_ref().map(Vec::len),
+        alien_core::Platform::Kubernetes
+        | alien_core::Platform::Machines
+        | alien_core::Platform::Local
+        | alien_core::Platform::Test => None,
+    };
+    entries.is_some_and(|count| count > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +257,44 @@ mod tests {
 
         // Should be sorted or at least consistent
         println!("Available permission sets: {:?}", ids);
+    }
+
+    /// The Remote Bindings platform gate refuses a kind whose set does not cover the deployment's
+    /// platform, so this data is what decides where each kind may be published. `sandbox/remote-execute`
+    /// is AWS-only, and `alien-manager`'s resolve route hardcodes the same answer.
+    #[test]
+    fn remote_binding_permission_sets_cover_the_platforms_that_support_them() {
+        use alien_core::Platform;
+
+        for id in [
+            "storage/remote-data-write",
+            "key/remote-cryptography",
+            "ai/invoke",
+        ] {
+            for platform in [Platform::Aws, Platform::Gcp, Platform::Azure] {
+                assert!(
+                    permission_set_covers_platform(id, platform),
+                    "{id} must grant something on {platform}"
+                );
+            }
+        }
+
+        assert!(permission_set_covers_platform(
+            "sandbox/remote-execute",
+            Platform::Aws
+        ));
+        for platform in [Platform::Gcp, Platform::Azure, Platform::Local] {
+            assert!(
+                !permission_set_covers_platform("sandbox/remote-execute", platform),
+                "widening sandbox/remote-execute to {platform} must be done together with \
+                 alien-manager's resolve route and alien-preflights' platform gate"
+            );
+        }
+
+        assert!(!permission_set_covers_platform(
+            "nonexistent/permission",
+            Platform::Aws
+        ));
     }
 
     #[test]

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -161,17 +161,21 @@ pub fn permission_set_reaches_a_microvm_session(
 /// action is matched on the `Microvm` namespace so a verb AWS adds later fails closed, and the
 /// `MicrovmImage` family is excluded because it addresses the image a session launches from —
 /// `sandbox/provision` and `sandbox/heartbeat` legitimately hold those.
+///
+/// Compared lowercased throughout, because AWS matches action names case-insensitively — a set
+/// granting `lambda:runmicrovm` reaches a session exactly as `lambda:RunMicrovm` does.
 fn action_reaches_a_microvm_session(action: &str) -> bool {
+    let action = action.to_ascii_lowercase();
     if action.contains('*') {
         let literal = action.split('*').next().unwrap_or_default();
         return SENSITIVE_MICROVM_ACTIONS
             .iter()
             .chain(MICROVM_SESSION_LIFECYCLE_ACTIONS)
-            .any(|known| known.starts_with(literal));
+            .any(|known| known.to_ascii_lowercase().starts_with(literal));
     }
     action
         .strip_prefix("lambda:")
-        .is_some_and(|verb| verb.contains("Microvm") && !verb.contains("MicrovmImage"))
+        .is_some_and(|verb| verb.contains("microvm") && !verb.contains("microvmimage"))
 }
 
 /// Whether `permission_set_id` grants anything at all on `platform`.

--- a/crates/alien-permissions/tests/aws_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/aws_sensitive_invariant.rs
@@ -1,4 +1,4 @@
-use alien_permissions::list_permission_set_ids;
+use alien_permissions::{list_permission_set_ids, SENSITIVE_MICROVM_ACTIONS};
 
 const SENSITIVE_IMPLICIT_ACTIONS: &[&str] = &[
     "s3:GetObject",

--- a/crates/alien-permissions/tests/aws_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/aws_sensitive_invariant.rs
@@ -15,13 +15,6 @@ const SENSITIVE_IMPLICIT_ACTIONS: &[&str] = &[
     "codebuild:BatchGetBuilds",
     "logs:GetLogEvents",
     "logs:FilterLogEvents",
-    // A MicroVM auth token is the credential the sandbox agent protocol travels on, so holding
-    // one is access to session contents.
-    "lambda:CreateMicrovmAuthToken",
-    "lambda:CreateMicrovmShellAuthToken",
-    // Grantable in IAM without a matching API operation, and it attaches to a running session
-    // directly. Listed so no later edit can put it in an implicit-management set.
-    "lambda:ConnectMicrovm",
 ];
 
 #[test]
@@ -40,8 +33,12 @@ fn aws_implicit_management_sets_do_not_grant_sensitive_content() {
         for (index, entry) in aws_entries.iter().enumerate() {
             if let Some(actions) = &entry.grant.actions {
                 for action in actions {
+                    // The MicroVM token/connect family is a session-content credential, held apart
+                    // in one constant so the single-tenancy classifier and this invariant agree on
+                    // what reaches a session.
                     assert!(
-                        !SENSITIVE_IMPLICIT_ACTIONS.contains(&action.as_str()),
+                        !SENSITIVE_IMPLICIT_ACTIONS.contains(&action.as_str())
+                            && !SENSITIVE_MICROVM_ACTIONS.contains(&action.as_str()),
                         "{permission_set_id} AWS entry {index} grants sensitive action {action}"
                     );
                 }

--- a/crates/alien-permissions/tests/aws_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/aws_sensitive_invariant.rs
@@ -16,7 +16,7 @@ const SENSITIVE_IMPLICIT_ACTIONS: &[&str] = &[
     "logs:GetLogEvents",
     "logs:FilterLogEvents",
     // A MicroVM auth token is the credential the sandbox agent protocol travels on, so holding
-    // one is access to session contents. Only sandbox/execute may mint them.
+    // one is access to session contents.
     "lambda:CreateMicrovmAuthToken",
     "lambda:CreateMicrovmShellAuthToken",
     // Grantable in IAM without a matching API operation, and it attaches to a running session
@@ -48,6 +48,41 @@ fn aws_implicit_management_sets_do_not_grant_sensitive_content() {
             }
         }
     }
+}
+
+/// The only permission sets that may mint a credential reaching inside a sandbox session.
+///
+/// `execute` serves a workload in the customer's own cloud; `remote-execute` serves a hosted
+/// caller across the Remote Bindings boundary, and is resource-scoped for that reason.
+const SESSION_REACHING_SANDBOX_SETS: &[&str] = &["sandbox/execute", "sandbox/remote-execute"];
+
+#[test]
+fn only_session_reaching_sandbox_sets_mint_microvm_auth_tokens() {
+    let mut minting_sets = Vec::new();
+
+    for permission_set_id in list_permission_set_ids() {
+        let permission_set = alien_permissions::get_permission_set(permission_set_id)
+            .expect("permission set exists");
+        let Some(aws_entries) = &permission_set.platforms.aws else {
+            continue;
+        };
+        let mints = aws_entries.iter().any(|entry| {
+            entry.grant.actions.iter().flatten().any(|action| {
+                action.starts_with("lambda:CreateMicrovm") && action.ends_with("AuthToken")
+            })
+        });
+        if mints {
+            minting_sets.push(permission_set_id);
+        }
+    }
+
+    minting_sets.sort_unstable();
+    let mut expected = SESSION_REACHING_SANDBOX_SETS.to_vec();
+    expected.sort_unstable();
+    assert_eq!(
+        minting_sets, expected,
+        "the sets that mint a MicroVM auth token changed; a new one reaches inside a session"
+    );
 }
 
 fn is_implicit_management_set(permission_set_id: &str) -> bool {

--- a/crates/alien-permissions/tests/operation_coverage.rs
+++ b/crates/alien-permissions/tests/operation_coverage.rs
@@ -291,8 +291,9 @@ fn critical_e2e_provider_operations_are_declared() {
             azure_predefined_roles: &[],
         },
         OperationCoverage {
-            // The auth token is the credential the agent protocol travels on, so it is the one
-            // grant that reaches inside a session and must stay in execute alone.
+            // The auth token is the credential the agent protocol travels on, so holding one is
+            // access to session contents. Which sets may mint it is pinned by
+            // `only_session_reaching_sandbox_sets_mint_microvm_auth_tokens`.
             permission_set_id: "sandbox/execute",
             aws_actions: &["lambda:CreateMicrovmAuthToken"],
             gcp_permissions: &[],

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -134,10 +134,11 @@ fn validate_isolated_remote_resource(stack: &Stack, mutation_name: &str) -> Resu
     }))
 }
 
-/// Refuses a remotely published sandbox whose binding a deployment cannot deliver.
+/// Refuses a remotely published sandbox that restricts egress.
 ///
 /// The declaration has to fail here rather than install a role carrying arbitrary code execution
-/// for a binding the manager will then refuse to resolve.
+/// for a binding the manager will then refuse to resolve. `remote_binding_is_deliverable` holds
+/// the reason and is the same predicate both setup emitters read.
 fn validate_remote_sandboxes_allow_egress(stack: &Stack, mutation_name: &str) -> Result<()> {
     for (resource_id, entry) in &stack.resources {
         if !entry.has_remote_bindings()

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -3,7 +3,7 @@
 use crate::{error::ErrorData, error::Result, StackMutation};
 use alien_core::{
     Ai, DeploymentConfig, Key, Platform, RemoteBindingGrant, RemoteBindings, ResourceEntry,
-    ResourceLifecycle, Stack, StackState,
+    ResourceLifecycle, Sandbox, Stack, StackState,
 };
 use alien_error::AlienError;
 use async_trait::async_trait;
@@ -90,6 +90,11 @@ impl StackMutation for RemoteBindingsMutation {
     }
 }
 
+/// Refuses a deployment that pairs an isolated remote kind with any other published resource.
+///
+/// Every kind's grants attach to the one shared `-access` role, and the credential lease is a
+/// plain AssumeRole with no session policy, so resolving any binding hands the caller the whole
+/// role's authority. Isolation is the only thing bounding what one resolve is worth.
 fn validate_isolated_remote_resource(stack: &Stack, mutation_name: &str) -> Result<()> {
     let remote_resources = stack
         .resources
@@ -101,7 +106,10 @@ fn validate_isolated_remote_resource(stack: &Stack, mutation_name: &str) -> Resu
         .filter(|(_, entry)| {
             matches!(
                 entry.config.resource_type(),
-                resource_type if resource_type == Key::RESOURCE_TYPE || resource_type == Ai::RESOURCE_TYPE
+                resource_type
+                    if resource_type == Key::RESOURCE_TYPE
+                        || resource_type == Ai::RESOURCE_TYPE
+                        || resource_type == Sandbox::RESOURCE_TYPE
             )
         })
         .collect::<Vec<_>>();
@@ -291,6 +299,57 @@ mod tests {
                 "the refusal must name the declaration to change, got: {error}"
             );
         }
+    }
+
+    /// Resolving any binding yields credentials for the whole shared `-access` role, so a vendor
+    /// granted bucket read on a stack like this would also receive arbitrary code execution.
+    #[tokio::test]
+    async fn a_remote_sandbox_rejects_another_published_resource() {
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .add_with_remote_access(
+                Storage::new("exports".to_string()).build(),
+                ResourceLifecycle::Frozen,
+            )
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect_err("a remote sandbox must reject another remotely published resource");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(
+            error.to_string().contains(
+                "a remotely published sandbox must be the deployment's only remoteAccess resource"
+            ),
+            "the sandbox must be named as the resource forcing isolation, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_remote_sandbox_allows_non_remote_application_resources() {
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .add(
+                Storage::new("internal".to_string()).build(),
+                ResourceLifecycle::Frozen,
+            )
+            .build();
+
+        let mutated = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect("non-remote application resources are allowed beside a remote sandbox");
+        let bindings = mutated
+            .resources
+            .get(REMOTE_BINDINGS_ID)
+            .and_then(|entry| entry.config.downcast_ref::<RemoteBindings>())
+            .expect("Remote Bindings config");
+
+        assert_eq!(bindings.grants.len(), 1);
+        assert_eq!(bindings.grants[0].resource_id, "agents");
+        assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -2,8 +2,9 @@
 
 use crate::{error::ErrorData, error::Result, StackMutation};
 use alien_core::{
-    Ai, DeploymentConfig, Key, Platform, RemoteBindingGrant, RemoteBindings, ResourceEntry,
-    ResourceLifecycle, Sandbox, Stack, StackState,
+    Ai, Build, Container, Daemon, DeploymentConfig, Key, Platform, RemoteBindingGrant,
+    RemoteBindings, ResourceEntry, ResourceLifecycle, ResourceRef, Sandbox, Stack, StackState,
+    Worker,
 };
 use alien_error::AlienError;
 use async_trait::async_trait;
@@ -46,6 +47,7 @@ impl StackMutation for RemoteBindingsMutation {
     ) -> Result<Stack> {
         validate_isolated_remote_resource(&stack, self.description())?;
         validate_remote_sandboxes_allow_egress(&stack, self.description())?;
+        validate_remote_sandboxes_are_single_tenant(&stack, self.description())?;
 
         if let Some(existing) = stack.resources.get(REMOTE_BINDINGS_ID) {
             return Err(AlienError::new(ErrorData::StackMutationFailed {
@@ -154,12 +156,84 @@ fn validate_remote_sandboxes_allow_egress(stack: &Stack, mutation_name: &str) ->
     Ok(())
 }
 
+/// Refuses a remotely published sandbox that the deployment's own workloads can also reach.
+///
+/// One MicroVM image serves every session of a sandbox and AWS scopes a token mint no finer than
+/// the image, so a remote caller holding raw credentials can read, suspend, terminate or mint into
+/// sessions the customer's own compute started. Single tenancy is the only containment available.
+fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &str) -> Result<()> {
+    for (resource_id, entry) in &stack.resources {
+        if !entry.has_remote_bindings() || entry.config.resource_type() != Sandbox::RESOURCE_TYPE {
+            continue;
+        }
+        let Some(reach) = in_cloud_reach_to(stack, resource_id) else {
+            continue;
+        };
+        return Err(AlienError::new(ErrorData::StackMutationFailed {
+            mutation_name: mutation_name.to_string(),
+            message: format!(
+                "a remotely published sandbox must be reachable by nobody else in the deployment, \
+                 but {reach}"
+            ),
+            resource_id: Some(resource_id.clone()),
+        }));
+    }
+    Ok(())
+}
+
+/// How the deployment's own workloads can reach `sandbox_id`, if any can.
+///
+/// Both routes matter: a link authors `sandbox/execute`, while `sandbox/management` — session
+/// lifecycle — only ever arrives as an explicit profile grant.
+fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
+    let linked_by = stack.resources().find(|(_, entry)| {
+        compute_links(entry).is_some_and(|links| links.iter().any(|link| link.id() == sandbox_id))
+    });
+    if let Some((consumer_id, _)) = linked_by {
+        return Some(format!("resource '{consumer_id}' links it"));
+    }
+
+    stack
+        .permissions
+        .profiles
+        .iter()
+        .find_map(|(profile_name, profile)| {
+            profile
+                .0
+                .iter()
+                .any(|(target, permission_sets)| {
+                    (target == sandbox_id || target == "*")
+                        && permission_sets
+                            .iter()
+                            .any(|permission_set| permission_set.id().starts_with("sandbox/"))
+                })
+                .then(|| format!("permission profile '{profile_name}' grants access to it"))
+        })
+}
+
+/// The resources this stack's own compute declares it reaches.
+fn compute_links(entry: &ResourceEntry) -> Option<&[ResourceRef]> {
+    if let Some(worker) = entry.config.downcast_ref::<Worker>() {
+        Some(&worker.links)
+    } else if let Some(container) = entry.config.downcast_ref::<Container>() {
+        Some(&container.links)
+    } else if let Some(daemon) = entry.config.downcast_ref::<Daemon>() {
+        Some(&daemon.links)
+    } else {
+        entry
+            .config
+            .downcast_ref::<Build>()
+            .map(|build| build.links.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alien_core::{
-        Ai, EnvironmentVariablesSnapshot, ExternalBindings, Key, ManagementConfig, Sandbox,
-        SandboxCode, SandboxEgress, SandboxSessionPolicy, StackSettings, Storage,
+        permissions::PermissionProfile, Ai, EnvironmentVariablesSnapshot, ExternalBindings, Key,
+        ManagementConfig, Sandbox, SandboxCode, SandboxEgress, SandboxSessionPolicy, StackSettings,
+        Storage, WorkerCode,
     };
 
     fn config() -> DeploymentConfig {
@@ -341,6 +415,93 @@ mod tests {
             .mutate(stack, &StackState::new(Platform::Test), &config())
             .await
             .expect("non-remote application resources are allowed beside a remote sandbox");
+        let bindings = mutated
+            .resources
+            .get(REMOTE_BINDINGS_ID)
+            .and_then(|entry| entry.config.downcast_ref::<RemoteBindings>())
+            .expect("Remote Bindings config");
+
+        assert_eq!(bindings.grants.len(), 1);
+        assert_eq!(bindings.grants[0].resource_id, "agents");
+        assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
+    }
+
+    /// A link authors `sandbox/execute` on the customer's own workload, which starts sessions in
+    /// the same MicroVM image the remote caller's credentials address.
+    #[tokio::test]
+    async fn a_remote_sandbox_linked_by_compute_is_refused() {
+        let sandbox = sandbox(SandboxEgress::Allow);
+        let worker = Worker::new("processor".to_string())
+            .permissions("execution".to_string())
+            .code(WorkerCode::Image {
+                image: "example.com/processor:latest".to_string(),
+            })
+            .link(&sandbox)
+            .build();
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+            .add(worker, ResourceLifecycle::Live)
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect_err("a linked sandbox is not single-tenant to the remote caller");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(
+            error.to_string().contains("resource 'processor' links it"),
+            "the refusal must name the workload that shares the sandbox, got: {error}"
+        );
+    }
+
+    /// `sandbox/management` never arrives through a link, so a profile-only grant is the case a
+    /// link scan misses — and it is session lifecycle over the remote caller's own sessions.
+    #[tokio::test]
+    async fn a_remote_sandbox_granted_to_a_profile_is_refused() {
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission(
+                "execution",
+                PermissionProfile::new().resource("agents", ["sandbox/management"]),
+            )
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect_err("an in-cloud management grant is not single-tenant to the remote caller");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(
+            error
+                .to_string()
+                .contains("permission profile 'execution' grants access to it"),
+            "the refusal must name the profile that shares the sandbox, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_remote_sandbox_allows_compute_that_does_not_reach_it() {
+        let worker = Worker::new("processor".to_string())
+            .permissions("execution".to_string())
+            .code(WorkerCode::Image {
+                image: "example.com/processor:latest".to_string(),
+            })
+            .build();
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .add(worker, ResourceLifecycle::Live)
+            .permission(
+                "execution",
+                PermissionProfile::new().resource("exports", ["storage/data-write"]),
+            )
+            .build();
+
+        let mutated = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect("compute that never reaches the sandbox leaves it single-tenant");
         let bindings = mutated
             .resources
             .get(REMOTE_BINDINGS_ID)

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -313,7 +313,7 @@ mod tests {
     }
 
     /// A Sandbox declared the way Remote Bindings requires — `Frozen` with `remoteAccess` — is
-    /// what every downstream slice assumes exists. Lifecycle is per declaration, so nothing about
+    /// what the remaining remote-binding paths assume exists. Lifecycle is per declaration, so nothing about
     /// the type blocks it; this pins that the grant actually reaches the shared identity.
     #[tokio::test]
     async fn a_frozen_remote_sandbox_is_granted_the_remote_execute_set() {

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -127,8 +127,8 @@ fn validate_isolated_remote_resource(stack: &Stack, mutation_name: &str) -> Resu
 mod tests {
     use super::*;
     use alien_core::{
-        Ai, EnvironmentVariablesSnapshot, ExternalBindings, Key, ManagementConfig, StackSettings,
-        Storage,
+        Ai, EnvironmentVariablesSnapshot, ExternalBindings, Key, ManagementConfig, Sandbox,
+        SandboxCode, SandboxEgress, SandboxSessionPolicy, StackSettings, Storage,
     };
 
     fn config() -> DeploymentConfig {
@@ -191,6 +191,52 @@ mod tests {
             bindings.grants[0].permission_set,
             "storage/remote-data-write"
         );
+    }
+
+    /// A Sandbox declared the way Remote Bindings requires — `Frozen` with `remoteAccess` — is
+    /// what every downstream slice assumes exists. Lifecycle is per declaration, so nothing about
+    /// the type blocks it; this pins that the grant actually reaches the shared identity.
+    #[tokio::test]
+    async fn a_frozen_remote_sandbox_is_granted_the_remote_execute_set() {
+        let sandbox = Sandbox::new("agents".to_string())
+            .code(SandboxCode::Image {
+                image: "ubuntu:24.04".to_string(),
+            })
+            .egress(SandboxEgress::Allow)
+            .session(SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build();
+        let stack = Stack::new("byo-sandbox".to_string())
+            .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+            .build();
+        let state = StackState::new(Platform::Test);
+
+        let entry = stack.resources.get("agents").expect("declared sandbox");
+        assert!(entry.remote_access, "the declaration opted in");
+        assert_eq!(entry.lifecycle, ResourceLifecycle::Frozen);
+        let definition = alien_core::remote_bindings::remote_binding_for_entry(entry)
+            .expect("a Frozen remoteAccess Sandbox is a Remote Bindings resource");
+        assert_eq!(
+            definition.kind,
+            alien_core::remote_bindings::RemoteBindingKind::Sandbox
+        );
+
+        assert!(RemoteBindingsMutation.should_run(&stack, &state, &config()));
+        let mutated = RemoteBindingsMutation
+            .mutate(stack, &state, &config())
+            .await
+            .expect("a sandbox is not an isolated remote kind, so the mutation runs");
+        let bindings = mutated
+            .resources
+            .get(REMOTE_BINDINGS_ID)
+            .and_then(|entry| entry.config.downcast_ref::<RemoteBindings>())
+            .expect("Remote Bindings config");
+        assert_eq!(bindings.grants.len(), 1);
+        assert_eq!(bindings.grants[0].resource_id, "agents");
+        assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
+        assert_eq!(bindings.grants[0].revision, definition.revision);
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -2,10 +2,12 @@
 
 use crate::{error::ErrorData, error::Result, StackMutation};
 use alien_core::{
-    links_of, Ai, DeploymentConfig, Key, Platform, RemoteBindingGrant, RemoteBindings,
-    ResourceEntry, ResourceLifecycle, Sandbox, Stack, StackState,
+    links_of, permissions::PermissionSetReference, Ai, DeploymentConfig, Key, Platform,
+    RemoteBindingGrant, RemoteBindings, ResourceEntry, ResourceLifecycle, Sandbox, ServiceAccount,
+    Stack, StackState,
 };
 use alien_error::AlienError;
+use alien_permissions::{get_permission_set, permission_set_reaches_a_microvm_session};
 use async_trait::async_trait;
 
 pub const REMOTE_BINDINGS_ID: &str = "access";
@@ -41,9 +43,11 @@ impl StackMutation for RemoteBindingsMutation {
     async fn mutate(
         &self,
         mut stack: Stack,
-        _stack_state: &StackState,
-        _config: &DeploymentConfig,
+        stack_state: &StackState,
+        config: &DeploymentConfig,
     ) -> Result<Stack> {
+        let platform = config.base_platform.unwrap_or(stack_state.platform);
+        validate_remote_bindings_cover_the_platform(&stack, platform, self.description())?;
         validate_isolated_remote_resource(&stack, self.description())?;
         validate_remote_sandboxes_allow_egress(&stack, self.description())?;
         validate_remote_sandboxes_are_single_tenant(&stack, self.description())?;
@@ -89,6 +93,41 @@ impl StackMutation for RemoteBindingsMutation {
         );
         Ok(stack)
     }
+}
+
+/// Refuses a remote binding whose permission set grants nothing on the deployment's platform.
+///
+/// The permission set is the whole grant, so an uncovered kind installs no role binding and its
+/// generated permission docs carry a heading with no permissions under it — while the manager
+/// still refuses to resolve it, days later and at the vendor rather than at deploy.
+fn validate_remote_bindings_cover_the_platform(
+    stack: &Stack,
+    platform: Platform,
+    mutation_name: &str,
+) -> Result<()> {
+    // `Platform::Test` is not deployable and no permission set describes it.
+    if platform == Platform::Test {
+        return Ok(());
+    }
+    for (resource_id, entry) in &stack.resources {
+        let Some(definition) = alien_core::remote_bindings::remote_binding_for_entry(entry) else {
+            continue;
+        };
+        if alien_permissions::permission_set_covers_platform(definition.permission_set, platform) {
+            continue;
+        }
+        return Err(AlienError::new(ErrorData::StackMutationFailed {
+            mutation_name: mutation_name.to_string(),
+            message: format!(
+                "a remotely published {} is not supported on {platform}: permission set '{}' \
+                 grants nothing there",
+                entry.config.resource_type(),
+                definition.permission_set
+            ),
+            resource_id: Some(resource_id.clone()),
+        }));
+    }
+    Ok(())
 }
 
 /// Refuses a deployment that pairs an isolated remote kind with any other published resource.
@@ -183,8 +222,12 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 
 /// How the deployment's own workloads can reach `sandbox_id`, if any can.
 ///
-/// Both routes matter: a link authors `sandbox/execute`, while `sandbox/management` — session
-/// lifecycle — only ever arrives as an explicit profile grant.
+/// Three routes, none of which the vendor's own `-access` grant travels: a compute link, a
+/// permission profile, and a stack permission set on a user-declared ServiceAccount. Reach is
+/// decided by the resolved set's session-reaching verbs, never by a set id — an inline set an
+/// author names anything defeats a prefix test. GCP's blanket `sandboxLauncher` is a fourth
+/// route no declaration shows, and only the platform gate refusing a GCP remote sandbox keeps
+/// this answer honest there.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
@@ -195,22 +238,46 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
         return Some(format!("resource '{consumer_id}' links it"));
     }
 
-    stack
-        .permissions
-        .profiles
-        .iter()
-        .find_map(|(profile_name, profile)| {
-            profile
-                .0
-                .iter()
-                .any(|(target, permission_sets)| {
-                    (target == sandbox_id || target == "*")
-                        && permission_sets
-                            .iter()
-                            .any(|permission_set| permission_set.id().starts_with("sandbox/"))
-                })
-                .then(|| format!("permission profile '{profile_name}' grants access to it"))
-        })
+    let by_profile = stack.permissions.profiles.iter().find_map(|(profile_name, profile)| {
+        profile
+            .0
+            .iter()
+            .any(|(target, permission_sets)| {
+                (target == sandbox_id || target == "*")
+                    && permission_sets.iter().any(reference_reaches_a_session)
+            })
+            .then(|| format!("permission profile '{profile_name}' grants access to it"))
+    });
+    if by_profile.is_some() {
+        return by_profile;
+    }
+
+    stack.resources().find_map(|(id, entry)| {
+        entry
+            .config
+            .downcast_ref::<ServiceAccount>()
+            .filter(|account| {
+                account
+                    .stack_permission_sets
+                    .iter()
+                    .any(permission_set_reaches_a_microvm_session)
+            })
+            .map(|_| format!("service account '{id}' can start sessions in it"))
+    })
+}
+
+/// Whether a profile's permission set, once resolved, reaches a session.
+///
+/// A named reference is looked up in the built-in registry rather than trusted by name; an
+/// inline set is inspected directly. An unresolvable name is treated as no reach — the manager
+/// rejects an unknown set before it grants anything.
+fn reference_reaches_a_session(reference: &PermissionSetReference) -> bool {
+    match reference {
+        PermissionSetReference::Inline(set) => permission_set_reaches_a_microvm_session(set),
+        PermissionSetReference::Name(name) => {
+            get_permission_set(name).is_some_and(permission_set_reaches_a_microvm_session)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -284,6 +351,12 @@ mod tests {
         );
     }
 
+    fn published(resource: impl alien_core::ResourceDefinition) -> Stack {
+        Stack::new("byo".to_string())
+            .add_with_remote_access(resource, ResourceLifecycle::Frozen)
+            .build()
+    }
+
     fn sandbox(egress: SandboxEgress) -> Sandbox {
         Sandbox::new("agents".to_string())
             .code(SandboxCode::Image {
@@ -305,7 +378,7 @@ mod tests {
         let stack = Stack::new("byo-sandbox".to_string())
             .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
             .build();
-        let state = StackState::new(Platform::Test);
+        let state = StackState::new(Platform::Aws);
 
         let entry = stack.resources.get("agents").expect("declared sandbox");
         assert!(entry.remote_access, "the declaration opted in");
@@ -331,6 +404,125 @@ mod tests {
         assert_eq!(bindings.grants[0].resource_id, "agents");
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
         assert_eq!(bindings.grants[0].revision, definition.revision);
+    }
+
+    /// `sandbox/remote-execute` has an AWS block alone. Without this gate the deployment installs
+    /// a GCP or Azure identity with no sandbox role binding, and the customer's security team
+    /// approves a PERMISSIONS.md heading promising arbitrary code execution and listing nothing.
+    #[tokio::test]
+    async fn a_remote_sandbox_is_refused_where_its_permission_set_grants_nothing() {
+        for platform in [Platform::Gcp, Platform::Azure] {
+            let stack = Stack::new("byo-sandbox".to_string())
+                .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+                .build();
+
+            let error = RemoteBindingsMutation
+                .mutate(stack, &StackState::new(platform), &config())
+                .await
+                .expect_err("a sandbox the permission set does not cover must not deploy");
+
+            assert_eq!(error.code, "STACK_MUTATION_FAILED");
+            let message = error.to_string();
+            assert!(
+                message.contains(&format!("is not supported on {platform}")),
+                "the refusal must name the platform, got: {message}"
+            );
+            assert!(
+                message.contains("sandbox/remote-execute"),
+                "the refusal must name the permission set that decides it, got: {message}"
+            );
+        }
+    }
+
+    /// The gate reads `base_platform` where a deployment sets one, exactly as `should_run` does.
+    #[tokio::test]
+    async fn a_remote_sandbox_is_refused_on_the_base_platform_the_config_selects() {
+        let stack = Stack::new("byo-sandbox".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .build();
+        let mut config = config();
+        config.base_platform = Some(Platform::Gcp);
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Kubernetes), &config)
+            .await
+            .expect_err("the base platform is the one the grants are emitted for");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(error.to_string().contains("is not supported on gcp"));
+    }
+
+    /// `GcpSandboxLauncherMutation` marks every Worker a session launcher, which
+    /// `in_cloud_reach_to` cannot see — so single tenancy would certify this stack. The platform
+    /// gate runs first and is what keeps that unreachable.
+    #[tokio::test]
+    async fn a_gcp_remote_sandbox_is_refused_before_single_tenancy_can_certify_it() {
+        let worker = Worker::new("processor".to_string())
+            .permissions("execution".to_string())
+            .code(WorkerCode::Image {
+                image: "example.com/processor:latest".to_string(),
+            })
+            .build();
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .add(worker, ResourceLifecycle::Live)
+            .build();
+
+        assert!(
+            in_cloud_reach_to(&stack, "agents").is_none(),
+            "no link and no profile grant, so the single-tenancy scan finds nobody"
+        );
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Gcp), &config())
+            .await
+            .expect_err("a GCP remote sandbox must be refused whatever the reach scan says");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(error.to_string().contains("is not supported on gcp"));
+    }
+
+    /// The gate is the permission set's own coverage, so the kinds that carry all three blocks
+    /// must be untouched by it on every cloud.
+    #[tokio::test]
+    async fn the_other_remote_kinds_deploy_on_every_cloud_platform() {
+        let cases: [(fn() -> Stack, &str, &str); 3] = [
+            (
+                || published(Storage::new("exports".to_string()).build()),
+                "exports",
+                "storage/remote-data-write",
+            ),
+            (
+                || published(Key::new("customer-key".to_string()).build()),
+                "customer-key",
+                "key/remote-cryptography",
+            ),
+            (
+                || published(Ai::new("models".to_string()).build()),
+                "models",
+                "ai/invoke",
+            ),
+        ];
+
+        for platform in [Platform::Aws, Platform::Gcp, Platform::Azure] {
+            for (build_stack, resource_id, permission_set) in cases {
+                let mutated = RemoteBindingsMutation
+                    .mutate(build_stack(), &StackState::new(platform), &config())
+                    .await
+                    .unwrap_or_else(|error| {
+                        panic!("{permission_set} covers {platform} and must deploy: {error}")
+                    });
+                let bindings = mutated
+                    .resources
+                    .get(REMOTE_BINDINGS_ID)
+                    .and_then(|entry| entry.config.downcast_ref::<RemoteBindings>())
+                    .expect("Remote Bindings config");
+
+                assert_eq!(bindings.grants.len(), 1);
+                assert_eq!(bindings.grants[0].resource_id, resource_id);
+                assert_eq!(bindings.grants[0].permission_set, permission_set);
+            }
+        }
     }
 
     /// `sandbox/remote-execute` withholds `lambda:PassNetworkConnector`, so a session on an egress
@@ -497,6 +689,69 @@ mod tests {
         assert_eq!(bindings.grants.len(), 1);
         assert_eq!(bindings.grants[0].resource_id, "agents");
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
+    }
+
+    /// An inline set that starts a session, named so it would clear an id-prefix test.
+    fn inline_run_microvm_set(id: &str) -> alien_core::permissions::PermissionSet {
+        serde_json::from_value(serde_json::json!({
+            "id": id,
+            "description": "custom",
+            "platforms": { "aws": [{
+                "grant": { "actions": ["lambda:RunMicrovm"] },
+                "binding": { "stack": { "resources": ["*"] } }
+            }]}
+        }))
+        .expect("valid inline permission set")
+    }
+
+    #[tokio::test]
+    async fn a_remote_sandbox_reached_by_an_inline_non_sandbox_set_is_refused() {
+        // Reach is the resolved verb, not the id: the vendor already holds the mint on the image,
+        // so a workload that can merely start a session hands it every session of the sandbox.
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission(
+                "execution",
+                PermissionProfile::new().global([inline_run_microvm_set("custom/telemetry")]),
+            )
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect_err("an inline set granting RunMicrovm is not single-tenant, whatever its id");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(
+            error
+                .to_string()
+                .contains("permission profile 'execution' grants access to it"),
+            "the refusal must name the profile, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_remote_sandbox_reached_by_a_service_account_set_is_refused() {
+        let account = ServiceAccount::new("runner".to_string())
+            .stack_permission_set(inline_run_microvm_set("custom/telemetry"))
+            .build();
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .add(account, ResourceLifecycle::Live)
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect_err("a service account that can start sessions is a second tenant");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(
+            error
+                .to_string()
+                .contains("service account 'runner' can start sessions in it"),
+            "the refusal must name the service account, got: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -731,6 +731,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_lowercase_run_microvm_grant_does_not_slip_the_reach_scan() {
+        // AWS matches action names case-insensitively, so a set the classifier read literally
+        // would be a bypass by casing alone.
+        let mut set = inline_run_microvm_set("custom/telemetry");
+        set.platforms.aws.as_mut().unwrap()[0].grant.actions =
+            Some(vec!["lambda:runmicrovm".to_string()]);
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission("execution", PermissionProfile::new().global([set]))
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Test), &config())
+            .await
+            .expect_err("a lowercase RunMicrovm still starts a session");
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+    }
+
+    #[tokio::test]
     async fn a_remote_sandbox_reached_by_a_service_account_set_is_refused() {
         let account = ServiceAccount::new("runner".to_string())
             .stack_permission_set(inline_run_microvm_set("custom/telemetry"))

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -2,9 +2,8 @@
 
 use crate::{error::ErrorData, error::Result, StackMutation};
 use alien_core::{
-    Ai, Build, Container, Daemon, DeploymentConfig, Key, Platform, RemoteBindingGrant,
-    RemoteBindings, ResourceEntry, ResourceLifecycle, ResourceRef, Sandbox, Stack, StackState,
-    Worker,
+    links_of, Ai, DeploymentConfig, Key, Platform, RemoteBindingGrant, RemoteBindings,
+    ResourceEntry, ResourceLifecycle, Sandbox, Stack, StackState,
 };
 use alien_error::AlienError;
 use async_trait::async_trait;
@@ -188,7 +187,9 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 /// lifecycle — only ever arrives as an explicit profile grant.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
-        compute_links(entry).is_some_and(|links| links.iter().any(|link| link.id() == sandbox_id))
+        links_of(&entry.config)
+            .iter()
+            .any(|link| link.id() == sandbox_id)
     });
     if let Some((consumer_id, _)) = linked_by {
         return Some(format!("resource '{consumer_id}' links it"));
@@ -212,29 +213,13 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
         })
 }
 
-/// The resources this stack's own compute declares it reaches.
-fn compute_links(entry: &ResourceEntry) -> Option<&[ResourceRef]> {
-    if let Some(worker) = entry.config.downcast_ref::<Worker>() {
-        Some(&worker.links)
-    } else if let Some(container) = entry.config.downcast_ref::<Container>() {
-        Some(&container.links)
-    } else if let Some(daemon) = entry.config.downcast_ref::<Daemon>() {
-        Some(&daemon.links)
-    } else {
-        entry
-            .config
-            .downcast_ref::<Build>()
-            .map(|build| build.links.as_slice())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use alien_core::{
         permissions::PermissionProfile, Ai, EnvironmentVariablesSnapshot, ExternalBindings, Key,
         ManagementConfig, Sandbox, SandboxCode, SandboxEgress, SandboxSessionPolicy, StackSettings,
-        Storage, WorkerCode,
+        Storage, Worker, WorkerCode,
     };
 
     fn config() -> DeploymentConfig {
@@ -313,8 +298,8 @@ mod tests {
     }
 
     /// A Sandbox declared the way Remote Bindings requires — `Frozen` with `remoteAccess` — is
-    /// what the remaining remote-binding paths assume exists. Lifecycle is per declaration, so nothing about
-    /// the type blocks it; this pins that the grant actually reaches the shared identity.
+    /// what the remaining remote-binding paths assume exists. Lifecycle is per declaration, so
+    /// nothing about the type blocks it; this pins that the grant reaches the shared identity.
     #[tokio::test]
     async fn a_frozen_remote_sandbox_is_granted_the_remote_execute_set() {
         let stack = Stack::new("byo-sandbox".to_string())

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -45,6 +45,7 @@ impl StackMutation for RemoteBindingsMutation {
         _config: &DeploymentConfig,
     ) -> Result<Stack> {
         validate_isolated_remote_resource(&stack, self.description())?;
+        validate_remote_sandboxes_allow_egress(&stack, self.description())?;
 
         if let Some(existing) = stack.resources.get(REMOTE_BINDINGS_ID) {
             return Err(AlienError::new(ErrorData::StackMutationFailed {
@@ -123,6 +124,28 @@ fn validate_isolated_remote_resource(stack: &Stack, mutation_name: &str) -> Resu
     }))
 }
 
+/// Refuses a remotely published sandbox whose binding a deployment cannot deliver.
+///
+/// The declaration has to fail here rather than install a role carrying arbitrary code execution
+/// for a binding the manager will then refuse to resolve.
+fn validate_remote_sandboxes_allow_egress(stack: &Stack, mutation_name: &str) -> Result<()> {
+    for (resource_id, entry) in &stack.resources {
+        if !entry.has_remote_bindings()
+            || alien_core::remote_bindings::remote_binding_is_deliverable(entry)
+        {
+            continue;
+        }
+        return Err(AlienError::new(ErrorData::StackMutationFailed {
+            mutation_name: mutation_name.to_string(),
+            message: "a remotely published sandbox must declare egress 'allow'; a sandbox that \
+                      routes its traffic through an egress connector cannot be reached remotely"
+                .to_string(),
+            resource_id: Some(resource_id.clone()),
+        }));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,23 +216,26 @@ mod tests {
         );
     }
 
+    fn sandbox(egress: SandboxEgress) -> Sandbox {
+        Sandbox::new("agents".to_string())
+            .code(SandboxCode::Image {
+                image: "ubuntu:24.04".to_string(),
+            })
+            .egress(egress)
+            .session(SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build()
+    }
+
     /// A Sandbox declared the way Remote Bindings requires — `Frozen` with `remoteAccess` — is
     /// what every downstream slice assumes exists. Lifecycle is per declaration, so nothing about
     /// the type blocks it; this pins that the grant actually reaches the shared identity.
     #[tokio::test]
     async fn a_frozen_remote_sandbox_is_granted_the_remote_execute_set() {
-        let sandbox = Sandbox::new("agents".to_string())
-            .code(SandboxCode::Image {
-                image: "ubuntu:24.04".to_string(),
-            })
-            .egress(SandboxEgress::Allow)
-            .session(SandboxSessionPolicy {
-                max_lifetime_seconds: None,
-                idle_suspend_seconds: None,
-            })
-            .build();
         let stack = Stack::new("byo-sandbox".to_string())
-            .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
             .build();
         let state = StackState::new(Platform::Test);
 
@@ -227,7 +253,7 @@ mod tests {
         let mutated = RemoteBindingsMutation
             .mutate(stack, &state, &config())
             .await
-            .expect("a sandbox is not an isolated remote kind, so the mutation runs");
+            .expect("an open-egress sandbox alone in its deployment is a valid remote binding");
         let bindings = mutated
             .resources
             .get(REMOTE_BINDINGS_ID)
@@ -237,6 +263,34 @@ mod tests {
         assert_eq!(bindings.grants[0].resource_id, "agents");
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
         assert_eq!(bindings.grants[0].revision, definition.revision);
+    }
+
+    /// `sandbox/remote-execute` withholds `lambda:PassNetworkConnector`, so a session on an egress
+    /// connector cannot be started remotely. The deployment has to fail here rather than install a
+    /// role carrying arbitrary code execution for a binding the manager will then refuse.
+    #[tokio::test]
+    async fn a_remote_sandbox_that_restricts_egress_is_refused() {
+        for egress in [
+            SandboxEgress::Deny,
+            SandboxEgress::AllowDomains {
+                domains: vec!["registry.npmjs.org".to_string()],
+            },
+        ] {
+            let stack = Stack::new("byo-sandbox".to_string())
+                .add_with_remote_access(sandbox(egress), ResourceLifecycle::Frozen)
+                .build();
+
+            let error = RemoteBindingsMutation
+                .mutate(stack, &StackState::new(Platform::Test), &config())
+                .await
+                .expect_err("a restricted-egress sandbox must not reach a deployed remote grant");
+
+            assert_eq!(error.code, "STACK_MUTATION_FAILED");
+            assert!(
+                error.to_string().contains("must declare egress 'allow'"),
+                "the refusal must name the declaration to change, got: {error}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/alien-terraform/src/emitters/aws/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/aws/sandbox.rs
@@ -8,17 +8,20 @@ use crate::{
     block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
     emitters::aws::helpers::{
-        default_network, downcast, iam_role_block, iam_role_name_template, iam_role_policy_block,
-        nested_block, private_subnet_ids_expr, required_label, resource_prefix_template,
-        service_assume_role_policy, tags, vpc_id_expr,
+        aws_terraform_permission_context, default_network, downcast,
+        emit_iam_role_policy_for_target_with_label, iam_policy_name_sanitize, iam_role_block,
+        iam_role_name_template, iam_role_policy_block, nested_block, private_subnet_ids_expr,
+        required_label, resource_prefix_template, service_assume_role_policy, tags, vpc_id_expr,
     },
     expr,
 };
 use alien_core::{
-    import::EmitContext, ErrorData, NetworkSettings, Result, Sandbox, SandboxCode, SandboxEgress,
-    ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_TAG_KEY,
+    import::EmitContext, permissions::PermissionSetReference, ErrorData, NetworkSettings,
+    RemoteBindings, Result, Sandbox, SandboxCode, SandboxEgress, ALIEN_MANAGED_BY_TAG_KEY,
+    ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_TAG_KEY,
 };
 use alien_error::AlienError;
+use alien_permissions::BindingTarget;
 use hcl::expr::Expression;
 
 /// Terraform resource type for a MicroVM image.
@@ -348,20 +351,20 @@ impl TfEmitter for AwsSandboxEmitter {
             ],
         );
 
-        let fragment = TfFragment::empty()
+        let mut fragment = TfFragment::empty()
             .with_resource(build_role)
             .with_resource(build_policy)
             .with_resource(iam_propagation)
             .with_resource(image);
-        Ok(if open {
-            fragment
-        } else {
-            fragment
+        if !open {
+            fragment = fragment
                 .with_resource(operator_role)
                 .with_resource(operator_policy)
                 .with_resource(security_group)
-                .with_resource(connector)
-        })
+                .with_resource(connector);
+        }
+        emit_remote_bindings_policy(ctx, &mut fragment)?;
+        Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
@@ -424,6 +427,50 @@ impl TfEmitter for AwsSandboxEmitter {
         }
         Ok(Some(expr::object(fields)))
     }
+}
+
+/// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
+///
+/// The grant is authorized against the image name rather than its ARN: the permission set builds
+/// the ARN itself from `${stackPrefix}-${resourceName}`, and the image is named from the same two
+/// parts here.
+fn emit_remote_bindings_policy(ctx: &EmitContext<'_>, fragment: &mut TfFragment) -> Result<()> {
+    let (Some(definition), Some(access_label)) = (
+        alien_core::remote_bindings::remote_binding_for_entry(ctx.resource),
+        remote_bindings_label(ctx),
+    ) else {
+        return Ok(());
+    };
+    let permission = PermissionSetReference::from_name(definition.permission_set);
+    let Some(permission_set) =
+        permission.resolve(|name| alien_permissions::get_permission_set(name).cloned())
+    else {
+        return Ok(());
+    };
+
+    let context =
+        aws_terraform_permission_context().with_resource_name(ctx.resource_id.to_string());
+    emit_iam_role_policy_for_target_with_label(
+        fragment,
+        access_label,
+        &permission_set,
+        &format!("{access_label}_{}_remote_execute", ctx.resource_id),
+        &format!(
+            "access-{}-{}",
+            ctx.resource_id,
+            iam_policy_name_sanitize(&permission_set.id)
+        ),
+        &context,
+        BindingTarget::Resource,
+    )
+}
+
+fn remote_bindings_label<'a>(ctx: &'a EmitContext<'_>) -> Option<&'a str> {
+    ctx.stack.resources().find_map(|(id, entry)| {
+        (entry.config.resource_type() == RemoteBindings::RESOURCE_TYPE)
+            .then(|| ctx.name_for(id))
+            .flatten()
+    })
 }
 
 /// The ports a preview capability may be minted for.

--- a/crates/alien-terraform/src/emitters/aws/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/aws/sandbox.rs
@@ -436,7 +436,9 @@ impl TfEmitter for AwsSandboxEmitter {
 /// parts here.
 fn emit_remote_bindings_policy(ctx: &EmitContext<'_>, fragment: &mut TfFragment) -> Result<()> {
     let (Some(definition), Some(access_label)) = (
-        alien_core::remote_bindings::remote_binding_for_entry(ctx.resource),
+        alien_core::remote_bindings::remote_binding_is_deliverable(ctx.resource)
+            .then(|| alien_core::remote_bindings::remote_binding_for_entry(ctx.resource))
+            .flatten(),
         remote_bindings_label(ctx),
     ) else {
         return Ok(());

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -574,7 +574,11 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
     let resources = stack
         .resources()
         .filter_map(|(resource_id, entry)| {
-            alien_core::remote_bindings::remote_binding_for_entry(entry)
+            // The document a security team approves the grant from, so it lists only bindings the
+            // module actually installs a policy for.
+            alien_core::remote_bindings::remote_binding_is_deliverable(entry)
+                .then(|| alien_core::remote_bindings::remote_binding_for_entry(entry))
+                .flatten()
                 .map(|definition| (resource_id, definition))
         })
         .collect::<Vec<_>>();

--- a/crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
@@ -7,9 +7,9 @@
 
 use super::helpers::{assert_terraform_valid, render, snapshot_module};
 use alien_core::{
-    Ai, Key, Kv, LifecycleRule, PermissionProfile, Queue, RemoteBindings, ResourceLifecycle,
-    ResourceRef, Sandbox, SandboxCode, SandboxEgress, SandboxSessionPolicy, ServiceAccount, Stack,
-    StackSettings, Storage, Vault,
+    Ai, Key, Kv, LifecycleRule, Network, NetworkSettings, PermissionProfile, Queue, RemoteBindings,
+    ResourceLifecycle, ResourceRef, Sandbox, SandboxCode, SandboxEgress, SandboxSessionPolicy,
+    ServiceAccount, Stack, StackSettings, Storage, Vault,
 };
 use alien_terraform::TerraformTarget;
 
@@ -458,4 +458,63 @@ fn aws_remote_sandbox_grants_the_access_identity_its_own_image_and_nothing_wider
     }
 
     assert_terraform_valid(&module, "aws_remote_sandbox");
+}
+
+/// A sandbox that routes egress through a connector is not remotely reachable, because
+/// `sandbox/remote-execute` withholds `lambda:PassNetworkConnector`. Preflight refuses such a
+/// stack; the emitter agrees, so a stack that reaches here another way installs no usable grant.
+#[test]
+fn aws_remote_sandbox_with_restricted_egress_carries_no_grant() {
+    let settings = StackSettings {
+        network: Some(NetworkSettings::Create {
+            cidr: None,
+            availability_zones: 2,
+        }),
+        ..StackSettings::default()
+    };
+    let sandbox = Sandbox::new("agents".to_string())
+        .code(SandboxCode::Image {
+            image: "s3://acme-artifacts/agents/bundle.zip".to_string(),
+        })
+        .egress(SandboxEgress::Deny)
+        .session(SandboxSessionPolicy {
+            max_lifetime_seconds: None,
+            idle_suspend_seconds: None,
+        })
+        .build();
+    let stack = Stack::new("byo-sandbox-deny".to_string())
+        .add(
+            Network::new("default-network".to_string())
+                .settings(settings.network.clone().expect("network"))
+                .build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Aws, settings);
+    let rendered = module
+        .files
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        rendered.contains("awscc_lambda_network_connector\" \"agents\"")
+            && rendered.contains("\"aws_iam_role\" \"access\""),
+        "the deny connector and the Remote Bindings identity must still render:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("access_agents_remote_execute"),
+        "an egress-restricted sandbox must carry no remote execute grant:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("lambda:CreateMicrovmAuthToken"),
+        "nothing in the module may mint session credentials for this sandbox:\n{rendered}"
+    );
 }

--- a/crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
@@ -8,7 +8,8 @@
 use super::helpers::{assert_terraform_valid, render, snapshot_module};
 use alien_core::{
     Ai, Key, Kv, LifecycleRule, PermissionProfile, Queue, RemoteBindings, ResourceLifecycle,
-    ResourceRef, ServiceAccount, Stack, StackSettings, Storage, Vault,
+    ResourceRef, Sandbox, SandboxCode, SandboxEgress, SandboxSessionPolicy, ServiceAccount, Stack,
+    StackSettings, Storage, Vault,
 };
 use alien_terraform::TerraformTarget;
 
@@ -384,4 +385,77 @@ fn aws_remote_ai_invoke_permissions_attach_to_access_role() {
     assert!(rendered.contains("bedrock:InvokeModel"));
     assert!(rendered.contains("aws_iam_role.access.name"));
     assert_terraform_valid(&module, "aws_remote_ai_invoke_permissions");
+}
+
+/// The grant a remote caller's credentials are bounded by.
+///
+/// Nothing else in the module attaches it: the setup package is where the Remote Bindings
+/// identity gets its policies, so without this the manager mints a session against a role that
+/// carries none and every call comes back AccessDenied.
+#[test]
+fn aws_remote_sandbox_grants_the_access_identity_its_own_image_and_nothing_wider() {
+    let sandbox = Sandbox::new("agents".to_string())
+        .code(SandboxCode::Image {
+            image: "s3://acme-artifacts/agents/bundle.zip".to_string(),
+        })
+        .egress(SandboxEgress::Allow)
+        .session(SandboxSessionPolicy {
+            max_lifetime_seconds: None,
+            idle_suspend_seconds: None,
+        })
+        .build();
+    let stack = Stack::new("byo-sandbox".to_string())
+        .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Aws, StackSettings::default());
+    let rendered = module
+        .files
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let policy = rendered
+        .split("resource \"aws_iam_role_policy\" \"access_agents_remote_execute\"")
+        .nth(1)
+        .expect("the remote grant attaches to the Remote Bindings role")
+        .split("\nresource ")
+        .next()
+        .expect("block ends");
+
+    for action in [
+        "lambda:RunMicrovm",
+        "lambda:SuspendMicrovm",
+        "lambda:ResumeMicrovm",
+        "lambda:TerminateMicrovm",
+        "lambda:CreateMicrovmAuthToken",
+        "lambda:GetMicrovm",
+    ] {
+        assert!(policy.contains(action), "{action} is missing:\n{policy}");
+    }
+    assert!(
+        policy.contains("microvm-image:${local.resource_prefix}-agents"),
+        "the grant must name this sandbox's image, not a stack-wide pattern:\n{policy}"
+    );
+    assert!(
+        !policy.contains("microvm-image:${local.resource_prefix}-*"),
+        "a stack-wide pattern would reach every sibling sandbox:\n{policy}"
+    );
+    for withheld in [
+        "lambda:PassNetworkConnector",
+        "iam:PassRole",
+        "lambda:CreateMicrovmShellAuthToken",
+    ] {
+        assert!(
+            !policy.contains(withheld),
+            "{withheld} must stay out of the remote grant:\n{policy}"
+        );
+    }
+
+    assert_terraform_valid(&module, "aws_remote_sandbox");
 }

--- a/packages/bindings/src/__tests__/remote.test.ts
+++ b/packages/bindings/src/__tests__/remote.test.ts
@@ -10,6 +10,7 @@ import type {
   RawQueueHandle,
   RawRemoteBindingsHandle,
   RawRemoteStorageHandle,
+  RawSandboxHandle,
   RawStorageHandle,
   RawVaultHandle,
 } from "../loader.js"
@@ -53,6 +54,29 @@ function fakeRemoteAddon() {
     decrypt: async ciphertext => ciphertext,
   }
   const resolveKey = vi.fn<(name: string) => Promise<RawKeyHandle>>(async () => key)
+  const session = (sessionId: string | null | undefined) => ({
+    sessionId: sessionId ?? "generated",
+    state: "running",
+    generation: 1,
+  })
+  const terminate = vi.fn<RawSandboxHandle["terminate"]>(async () => {})
+  const sandbox: RawSandboxHandle = {
+    capabilities: () => ["files", "reconnect"],
+    create: async sessionId => session(sessionId),
+    get: async () => null,
+    getOrCreate: async sessionId => session(sessionId),
+    list: async () => [],
+    runCommand: async () => {
+      throw new Error("unused")
+    },
+    readFile: async (_sessionId, path) => Buffer.from(path),
+    writeFile: async () => {},
+    mkdir: async () => {},
+    suspend: async () => {},
+    resume: async () => {},
+    terminate,
+  }
+  const resolveSandbox = vi.fn<(name: string) => Promise<RawSandboxHandle>>(async () => sandbox)
   const resolveAi = vi.fn<RawRemoteBindingsHandle["ai"]>(async () => ({
     resourceId: "models",
     bindingJson: JSON.stringify({ service: "bedrock", region: "us-east-1" }),
@@ -115,6 +139,8 @@ function fakeRemoteAddon() {
 
     key = resolveKey
 
+    sandbox = resolveSandbox
+
     ai = resolveAi
   }
 
@@ -144,6 +170,8 @@ function fakeRemoteAddon() {
     head,
     put,
     resolveKey,
+    resolveSandbox,
+    terminate,
     resolveAi,
   }
 }
@@ -232,6 +260,79 @@ describe("Bindings.forRemoteDeployment", () => {
     expect(lease.binding).toEqual({ service: "bedrock", region: "us-east-1" })
     expect(lease.clientConfig.platform).toBe("aws")
     expect(lease.expiresAt).toEqual(new Date("2026-08-05T08:00:00Z"))
+  })
+
+  it("mirrors the in-cloud Sandbox surface and resolves each name lazily once", async () => {
+    const fixture = fakeRemoteAddon()
+    loadAddon.mockReturnValue(fixture.addon)
+    const bindings = await Bindings.forRemoteDeployment({
+      deploymentId: "dep_123",
+      token: "token_123",
+    })
+
+    const agent = bindings.sandbox("agent")
+    const build = bindings.sandbox("build")
+
+    expect(fixture.resolveSandbox).not.toHaveBeenCalled()
+    expect(bindings.sandbox("agent")).toBe(agent)
+    // A remote Sandbox is the in-cloud one, so a method missing here is a caller writing
+    // against a surface the hosted path silently does not have.
+    expect(Object.keys(agent).sort()).toEqual(
+      [
+        "capabilities",
+        "create",
+        "get",
+        "getOrCreate",
+        "list",
+        "runCommand",
+        "readFile",
+        "writeFiles",
+        "mkdir",
+        "suspend",
+        "resume",
+        "terminate",
+      ].sort(),
+    )
+
+    await expect(agent.capabilities()).resolves.toEqual(["files", "reconnect"])
+    await agent.terminate("session_1")
+    await build.capabilities()
+
+    expect(fixture.forRemoteDeployment).toHaveBeenCalledOnce()
+    expect(fixture.resolveSandbox.mock.calls).toEqual([["agent"], ["build"]])
+    expect(fixture.terminate).toHaveBeenCalledWith("session_1")
+  })
+
+  it("unwraps napi errors from Sandbox resolution and operations", async () => {
+    const fixture = fakeRemoteAddon()
+    fixture.resolveSandbox.mockRejectedValueOnce(
+      new Error(
+        JSON.stringify({
+          code: "REMOTE_BINDING_DENIED",
+          message: "Remote binding access denied",
+          retryable: false,
+        }),
+      ),
+    )
+    loadAddon.mockReturnValue(fixture.addon)
+    const bindings = await Bindings.forRemoteDeployment({
+      deploymentId: "dep_123",
+      token: "token_123",
+    })
+
+    await expect(bindings.sandbox("agent").capabilities()).rejects.toMatchObject({
+      code: "REMOTE_BINDING_DENIED",
+      message: "Remote binding access denied",
+    })
+
+    fixture.terminate.mockRejectedValueOnce(new Error("native transport failed"))
+    const operation = bindings.sandbox("build").terminate("session_1")
+
+    await expect(operation).rejects.toBeInstanceOf(AlienError)
+    await expect(operation).rejects.toMatchObject({
+      code: "BINDINGS_ERROR",
+      message: "native transport failed",
+    })
   })
 
   it("reuses one native bindings handle and resolves each Storage handle lazily once", async () => {

--- a/packages/bindings/src/factories.ts
+++ b/packages/bindings/src/factories.ts
@@ -593,3 +593,16 @@ export function createRemoteKeyFactory(bindings: RawRemoteBindingsHandle) {
     return key
   }
 }
+
+/** Build the remote Sandbox factory around one native bindings handle. */
+export function createRemoteSandboxFactory(bindings: RawRemoteBindingsHandle) {
+  const sandboxes = new Map<string, Sandbox>()
+  return (name: string): Sandbox => {
+    let sandbox = sandboxes.get(name)
+    if (!sandbox) {
+      sandbox = makeSandbox(lazyHandle(() => bindings.sandbox(name)))
+      sandboxes.set(name, sandbox)
+    }
+    return sandbox
+  }
+}

--- a/packages/bindings/src/loader.ts
+++ b/packages/bindings/src/loader.ts
@@ -242,6 +242,7 @@ export interface RawBindingsHandle {
 export interface RawRemoteBindingsHandle {
   storage(name: string): Promise<RawRemoteStorageHandle>
   key(name: string): Promise<RawKeyHandle>
+  sandbox(name: string): Promise<RawSandboxHandle>
   ai(): Promise<RawRemoteAiLease>
 }
 

--- a/packages/bindings/src/remote.ts
+++ b/packages/bindings/src/remote.ts
@@ -1,8 +1,12 @@
 import { z } from "zod"
 import { unwrapNapiError } from "./errors.js"
-import { createRemoteKeyFactory, createRemoteStorageFactory } from "./factories.js"
+import {
+  createRemoteKeyFactory,
+  createRemoteSandboxFactory,
+  createRemoteStorageFactory,
+} from "./factories.js"
 import { loadAddon } from "./loader.js"
-import type { Key, RemoteStorage } from "./types.js"
+import type { Key, RemoteStorage, Sandbox } from "./types.js"
 
 const aiBindingSchema = z.discriminatedUnion("service", [
   z.object({ service: z.literal("bedrock"), region: z.string().min(1) }),
@@ -61,15 +65,18 @@ export class Bindings {
   readonly #storage: (name: string) => RemoteStorage
   readonly #key: (name: string) => Key
   readonly #ai: () => Promise<RemoteAiLease>
+  readonly #sandbox: (name: string) => Sandbox
 
   private constructor(
     storage: (name: string) => RemoteStorage,
     key: (name: string) => Key,
     ai: () => Promise<RemoteAiLease>,
+    sandbox: (name: string) => Sandbox,
   ) {
     this.#storage = storage
     this.#key = key
     this.#ai = ai
+    this.#sandbox = sandbox
   }
 
   /** Select a customer's Storage by Project and stable external ID. */
@@ -121,6 +128,7 @@ export class Bindings {
             .parse(lease.expiresAt),
         }
       },
+      createRemoteSandboxFactory(bindings),
     )
   }
 
@@ -137,5 +145,10 @@ export class Bindings {
   /** Resolve the deployment's unique managed AI binding. */
   ai(): Promise<RemoteAiLease> {
     return this.#ai()
+  }
+
+  /** Resolve a remote Sandbox binding by resource name. */
+  sandbox(name: string): Sandbox {
+    return this.#sandbox(name)
   }
 }

--- a/packages/bindings/tests/remote.test.ts
+++ b/packages/bindings/tests/remote.test.ts
@@ -8,6 +8,12 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { Bindings } from "../src/index.js"
+import {
+  loadAddon,
+  type RawRemoteBindingsHandle,
+  type RawRemoteBindingsHandleConstructor,
+  type RawSandboxHandle,
+} from "../src/loader.js"
 
 const deploymentId = "dep_aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 const managerId = "mgr_bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -337,5 +343,78 @@ describe("Bindings.sandbox (real addon)", () => {
     expect(capabilities).toContain("files")
     expect(sandboxBindingTokenBodies).toEqual([{ deploymentId }])
     expect(sandboxResolveBodies).toEqual([{ deploymentId, resourceId: "agent" }])
+  })
+})
+
+/** Own properties of any JS function, so never an addon-emitted static. */
+const functionOwnProperties = new Set(["arguments", "caller", "length", "name", "prototype"])
+
+/** The addon exports every handle class; `NativeAddon` types only the ones the wrapper calls. */
+function nativeClass(name: string): { prototype: object } {
+  const addon = loadAddon() as unknown as Record<string, { prototype: object } | undefined>
+  const exported = addon[name]
+  if (!exported) throw new Error(`the addon exports no class named '${name}'`)
+  return exported
+}
+
+function instanceMethodsOf(name: string): string[] {
+  return Object.getOwnPropertyNames(nativeClass(name).prototype)
+    .filter(member => member !== "constructor")
+    .sort()
+}
+
+function staticMethodsOf(name: string): string[] {
+  return Object.getOwnPropertyNames(nativeClass(name))
+    .filter(member => !functionOwnProperties.has(member))
+    .sort()
+}
+
+const remoteBindingsMembers: Record<keyof RawRemoteBindingsHandle, true> = {
+  ai: true,
+  key: true,
+  sandbox: true,
+  storage: true,
+}
+
+const remoteBindingsFactories: Record<keyof RawRemoteBindingsHandleConstructor, true> = {
+  forCustomer: true,
+  forDeployment: true,
+}
+
+const sandboxMembers: Record<keyof RawSandboxHandle, true> = {
+  capabilities: true,
+  create: true,
+  get: true,
+  getOrCreate: true,
+  list: true,
+  mkdir: true,
+  readFile: true,
+  resume: true,
+  runCommand: true,
+  suspend: true,
+  terminate: true,
+  writeFile: true,
+}
+
+/**
+ * `Record<keyof Raw*, true>` pins each expected list to its interface at compile time, and the
+ * comparisons pin the interfaces to Rust at run time. Neither half alone catches a rename, and
+ * the generated `.d.ts` that would catch both is gitignored.
+ */
+describe("napi surface parity (real addon)", () => {
+  it("emits exactly the RemoteBindingsHandle members the loader declares", () => {
+    expect(instanceMethodsOf("RemoteBindingsHandle")).toEqual(
+      Object.keys(remoteBindingsMembers).sort(),
+    )
+  })
+
+  it("emits exactly the RemoteBindingsHandle factories the loader declares", () => {
+    expect(staticMethodsOf("RemoteBindingsHandle")).toEqual(
+      Object.keys(remoteBindingsFactories).sort(),
+    )
+  })
+
+  it("emits exactly the SandboxHandle members the loader declares", () => {
+    expect(instanceMethodsOf("SandboxHandle")).toEqual(Object.keys(sandboxMembers).sort())
   })
 })

--- a/packages/bindings/tests/remote.test.ts
+++ b/packages/bindings/tests/remote.test.ts
@@ -143,3 +143,90 @@ describe("Bindings.forRemoteDeployment (real addon)", () => {
     expect(managerAuthorizations).toEqual(Array(2).fill(`Bearer ${bindingToken}`))
   })
 })
+
+const externalId = "ext_customer_01"
+const customerToken = "remote-customer-token"
+const customerBindingToken = "customer-binding-token"
+
+let customerManagerServer: Server | undefined
+let customerPlatformServer: Server | undefined
+let customerManagerOrigin: string
+let customerPlatformOrigin: string
+const customerPlatformAuthorizations: Array<string | undefined> = []
+const customerManagerAuthorizations: Array<string | undefined> = []
+const externalAccessBodies: unknown[] = []
+const customerResolveBodies: unknown[] = []
+
+describe("Bindings.forRemoteCustomer (real addon)", () => {
+  beforeAll(async () => {
+    customerManagerServer = createServer(async (request, response) => {
+      customerManagerAuthorizations.push(request.headers.authorization)
+      if (request.method !== "POST" || request.url !== "/v1/bindings/resolve") {
+        json(response, 404, { message: "not found" })
+        return
+      }
+      customerResolveBodies.push(await bodyOf(request))
+      json(response, 403, {
+        code: "FORBIDDEN",
+        message: "Remote access was revoked",
+        retryable: false,
+        internal: false,
+        httpStatusCode: 403,
+      })
+    })
+    customerManagerOrigin = await listen(customerManagerServer)
+
+    customerPlatformServer = createServer(async (request, response) => {
+      customerPlatformAuthorizations.push(request.headers.authorization)
+      if (
+        request.method === "POST" &&
+        request.url === `/v1/projects/${projectId}/remote-bindings/access`
+      ) {
+        externalAccessBodies.push(await bodyOf(request))
+        json(response, 200, {
+          deploymentId,
+          resourceId: "uploads",
+          accessToken: customerBindingToken,
+          expiresIn: 300,
+          tokenType: "Bearer",
+          managerUrl: customerManagerOrigin,
+        })
+        return
+      }
+      json(response, 404, { message: "not found" })
+    })
+    customerPlatformOrigin = await listen(customerPlatformServer)
+  })
+
+  afterAll(async () => {
+    await Promise.all([close(customerPlatformServer), close(customerManagerServer)])
+  })
+
+  it("selects the customer's deployment by external ID and preserves the manager's denial", async () => {
+    const bindings = await Bindings.forRemoteCustomer({
+      project: projectId,
+      externalId,
+      token: customerToken,
+      apiBaseUrl: customerPlatformOrigin,
+    })
+    await expect(bindings.storage("uploads").head("missing.txt")).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Remote access was revoked",
+      retryable: false,
+    })
+    // The rejection reselects by external ID rather than by deployment id, so the
+    // second access request is the same one.
+    expect(externalAccessBodies).toEqual([
+      { externalId, capability: "storage" },
+      { externalId, capability: "storage" },
+    ])
+    // The caller never supplies a deployment id on this path, so its presence in
+    // the resolve body proves the manager was reached through the selection response.
+    expect(customerResolveBodies).toEqual([
+      { deploymentId, resourceId: "uploads" },
+      { deploymentId, resourceId: "uploads" },
+    ])
+    expect(customerPlatformAuthorizations).toEqual(Array(2).fill(`Bearer ${customerToken}`))
+    expect(customerManagerAuthorizations).toEqual(Array(2).fill(`Bearer ${customerBindingToken}`))
+  })
+})

--- a/packages/bindings/tests/remote.test.ts
+++ b/packages/bindings/tests/remote.test.ts
@@ -230,3 +230,112 @@ describe("Bindings.forRemoteCustomer (real addon)", () => {
     expect(customerManagerAuthorizations).toEqual(Array(2).fill(`Bearer ${customerBindingToken}`))
   })
 })
+
+const sandboxBindingToken = "sandbox-binding-token"
+
+let sandboxManagerServer: Server | undefined
+let sandboxPlatformServer: Server | undefined
+let sandboxManagerOrigin: string
+let sandboxPlatformOrigin: string
+const sandboxResolveBodies: unknown[] = []
+const sandboxBindingTokenBodies: unknown[] = []
+
+/**
+ * The napi surface is declared in a generated `index.d.ts` that is gitignored, so
+ * `RawRemoteBindingsHandle` is hand-written and nothing type-checks it against Rust. Only a
+ * call through the real addon catches a renamed or missing method.
+ */
+describe("Bindings.sandbox (real addon)", () => {
+  beforeAll(async () => {
+    sandboxManagerServer = createServer(async (request, response) => {
+      if (request.method !== "POST" || request.url !== "/v1/bindings/resolve") {
+        json(response, 404, { message: "not found" })
+        return
+      }
+      sandboxResolveBodies.push(await bodyOf(request))
+      const expiresAt = new Date(Date.now() + 5 * 60_000).toISOString()
+      json(response, 200, {
+        service: "sandbox-aws",
+        binding: {
+          imageArn: "arn:aws:lambda:us-east-1:123456789012:microvm-image/alien-agent-image",
+          imageVersion: "7",
+          region: "us-east-1",
+          previewPorts: [8080],
+          idleSuspendSeconds: 300,
+          maxLifetimeSeconds: 3600,
+          allowEgress: true,
+        },
+        clientConfig: {
+          accountId: "123456789012",
+          region: "us-east-1",
+          credentials: {
+            type: "sessionCredentials",
+            accessKeyId: "AKIAFIXTURE",
+            secretAccessKey: "fixture-secret",
+            sessionToken: "fixture-session",
+            expiresAt,
+          },
+        },
+        expiresAt,
+      })
+    })
+    sandboxManagerOrigin = await listen(sandboxManagerServer)
+
+    sandboxPlatformServer = createServer(async (request, response) => {
+      if (request.method === "GET" && request.url === `/v1/deployments/${deploymentId}`) {
+        json(response, 200, {
+          id: deploymentId,
+          name: "remote-sandbox-test",
+          status: "running",
+          projectId,
+          platform: "aws",
+          deploymentProtocolVersion: 1,
+          deploymentGroupId,
+          purpose: "application",
+          releaseChannel: "production",
+          stackSettings: {},
+          retryRequested: false,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          managerId,
+          workspaceId,
+        })
+        return
+      }
+      if (request.method === "POST" && request.url === `/v1/managers/${managerId}/binding-token`) {
+        sandboxBindingTokenBodies.push(await bodyOf(request))
+        json(response, 200, {
+          accessToken: sandboxBindingToken,
+          expiresIn: 300,
+          tokenType: "Bearer",
+          managerUrl: sandboxManagerOrigin,
+          databaseId: null,
+          controlPlaneUrl: null,
+        })
+        return
+      }
+      json(response, 404, { message: "not found" })
+    })
+    sandboxPlatformOrigin = await listen(sandboxPlatformServer)
+  })
+
+  afterAll(async () => {
+    await Promise.all([close(sandboxPlatformServer), close(sandboxManagerServer)])
+  })
+
+  it("resolves a sandbox lease through the manager and hands back a usable handle", async () => {
+    const bindings = await Bindings.forRemoteDeployment({
+      deploymentId,
+      token,
+      apiBaseUrl: sandboxPlatformOrigin,
+    })
+    const sandbox = bindings.sandbox("agent")
+
+    // Nothing is resolved until an operation runs, so this is the call that reaches the addon.
+    const capabilities = await sandbox.capabilities()
+
+    expect(capabilities).toContain("files")
+    expect(sandboxBindingTokenBodies).toEqual([{ deploymentId }])
+    expect(sandboxResolveBodies).toEqual([{ deploymentId, resourceId: "agent" }])
+  })
+})


### PR DESCRIPTION
## Summary

Remote Bindings could hand a hosted caller storage, key, and AI access, but not a sandbox — so a caller running in our cloud had no way to execute code inside a customer's sandbox. This adds a `sandbox` binding kind end to end: a new AWS-only permission set, the manager resolve route, the preflight guards that keep it single-tenant, and the `.sandbox()` accessor in Rust and TypeScript.

When a hosted caller resolves a sandbox binding, this is what runs:

1. The caller asks for the `sandbox` kind on a customer deployment, and the SDK reaches the native factory through `forRemoteCustomer`.
2. **[the heart]** The manager refuses the binding unless the deployment is on AWS and the grant reaches nothing but a sandbox session, then returns a short-lived handle scoped to that one customer's cloud.
3. The caller drives the sandbox — run a command, read and write files — over that handle.

This turns Remote Bindings from a three-kind surface (storage, key, AI) into one that also mints a sandbox handle.

### What was broken

- `RemoteBindings` had no `sandbox()` accessor; the closed `RemoteBindingKind` enum had no sandbox variant.
- `forRemoteCustomer` never reached the native binding factory — a hand-written interface in the loader had drifted from the Rust surface and was never type-checked against it, so the call silently no-op'd.

### What I did

- Added the `sandbox` binding kind through core, the manager resolve route, and the SDK.
- Added the `sandbox/remote-execute` permission set (AWS only) and attached its grant in both setup packages.
- Guarded it in preflight: a remote sandbox is refused on an egress-restricted sandbox, refused when the deployment carries other bindings, and refused when the deployment's own compute could reach the same session. The reach check classifies by IAM verb (case-insensitive, since AWS matches action names that way), not by matching a user-controllable id.
- Refused the kind on any platform whose permission set covers nothing there, so a GCP or Azure deployment fails at preflight with a clear reason instead of at resolve.
- Added a parity test that fails when the addon and loader surfaces drift apart, closing the class of bug behind the `forRemoteCustomer` no-op.

### Files touched

- `crates/alien-bindings/` — `RemoteBindings::sandbox`, the remote access + manager-conversion path, contract tests.
- `crates/alien-manager/src/routes/bindings.rs` — resolve route for the sandbox kind.
- `crates/alien-permissions/` — `sandbox/remote-execute` set, the verb reach-scan, platform-coverage check, sensitive-action invariant.
- `crates/alien-preflights/src/mutations/remote_bindings.rs` — the single-tenancy and platform guards.
- `crates/alien-terraform/`, `crates/alien-cloudformation/` — the grant emitter in both setup packages.
- `packages/bindings/` — the `.sandbox()` accessor, the `forRemoteCustomer` fix, the parity test.

### How I tested

- `cargo test -p alien-permissions -p alien-preflights -p alien-bindings -p alien-manager` — full crate suites green, including the new reach-scan, platform-coverage, and contract tests.
- Mutation-checked each new guard: flipped the verb match, the id check, and the platform gate one at a time and confirmed a test fails for each.
- `pnpm test` in `packages/bindings` — the `forRemoteCustomer` path and the addon/loader parity test pass.
- Security review of the grant surface:
  - Cross-tenant reach — a customer's own in-cloud compute cannot use a sandbox it also exposes remotely; the reach-scan walks inline sets, named sets, and ServiceAccount grants (`remote_bindings.rs`, three refusal tests).
  - Id-spoofing — the single-tenancy gate classifies by IAM verb, not by a `sandbox/`-prefixed id a user controls; the lowercase-verb test pins it.
  - Wrong-platform escalation — GCP/Azure remote sandbox is refused at preflight, not silently shipped in an approval doc with no permissions behind it (`registry.rs` coverage test).
  - Token blast radius — `sandbox/remote-execute` mints only into sessions of the one image it scopes; the sensitive-action invariant test fails if a new set gains the mint.
  - Nothing turned up.
