### PR TITLE
chore: release v3.3.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "alien-ai-gateway"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "base64 0.23.1",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "aegis",
  "alien-aws-clients",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error",
  "chrono",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error",
  "chrono",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sandbox-agent"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-ai-gateway",
  "alien-aws-clients",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.3.17"
+version = "3.3.18"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.3.17"
+version = "3.3.18"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -64,39 +64,39 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.3.17", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.3.18", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.3.17", default-features = false }
-alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.17" }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.17" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.3.17", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.17" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.3.18", default-features = false }
+alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.18" }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.18" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.3.18", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.18" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.3.17" }
-alien-infra = { path = "crates/alien-infra", version = "3.3.17" }
-alien-build = { path = "crates/alien-build", version = "3.3.17" }
-alien-macros = { path = "crates/alien-macros", version = "3.3.17" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.3.17" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.3.17" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.17" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.17" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.17" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.17" }
-alien-error = { path = "crates/alien-error", version = "3.3.17", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.17" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.3.17" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.3.17" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.3.17" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.17" }
-alien-local = { path = "crates/alien-local", version = "3.3.17" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.17" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.3.17" }
-alien-helm = { path = "crates/alien-helm", version = "3.3.17" }
-alien-manager = { path = "crates/alien-manager", version = "3.3.17" }
-alien-observer = { path = "crates/alien-observer", version = "3.3.17" }
+alien-core = { path = "crates/alien-core", version = "3.3.18" }
+alien-infra = { path = "crates/alien-infra", version = "3.3.18" }
+alien-build = { path = "crates/alien-build", version = "3.3.18" }
+alien-macros = { path = "crates/alien-macros", version = "3.3.18" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.3.18" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.3.18" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.18" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.18" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.18" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.18" }
+alien-error = { path = "crates/alien-error", version = "3.3.18", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.18" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.3.18" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.3.18" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.3.18" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.18" }
+alien-local = { path = "crates/alien-local", version = "3.3.18" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.18" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.3.18" }
+alien-helm = { path = "crates/alien-helm", version = "3.3.18" }
+alien-manager = { path = "crates/alien-manager", version = "3.3.18" }
+alien-observer = { path = "crates/alien-observer", version = "3.3.18" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.17", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.17", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.18", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.18", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/.speakeasy/gen.lock
+++ b/client-sdks/manager/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.17
+  releaseVersion: 3.3.18
   configChecksum: 44d827c044b50072551da66b6620ad00
   repoURL: https://github.com/alienplatform/alien.git
   repoSubDirectory: client-sdks/manager/typescript

--- a/client-sdks/manager/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/manager/typescript/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: automatic
 typescript:
-  version: 3.3.17
+  version: 3.3.18
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/manager/typescript/jsr.json
+++ b/client-sdks/manager/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/.speakeasy/gen.lock
+++ b/client-sdks/platform/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.17
+  releaseVersion: 3.3.18
   configChecksum: 0019d133e3b38468a7601b56fd8346bb
 persistentEdits:
   generation_id: db6ac3e5-6bcc-4de5-a81f-eb659048385d

--- a/client-sdks/platform/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/platform/typescript/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.17
+  version: 3.3.18
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/platform/typescript/jsr.json
+++ b/client-sdks/platform/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/platform/typescript/package-lock.json
+++ b/client-sdks/platform/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alienplatform/platform-api",
-      "version": "3.3.17",
+      "version": "3.3.18",
       "license": "FSL-1.1-Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/ai-gateway",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "type": "module",
   "files": [
     "dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "type": "module",
   "files": [
     "dist"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Version-only release PR generated by the stable release workflow. The **Release qualification** check builds and records the exact artifact set. After every required check passes and this merges, run the stable **publish** action from `main` to promote those qualified artifacts.