### PR TITLE
docs(sandbox): drop the stale Cloud Run launcher rationale from GCP comments

### DIFF
--- a/crates/alien-helm/src/emitters/sandbox.rs
+++ b/crates/alien-helm/src/emitters/sandbox.rs
@@ -23,7 +23,8 @@ const LABEL_SANDBOX: &str = "alien.dev/sandbox";
 ///
 /// The metadata server is the one that matters. gVisor is a kernel boundary, not a network
 /// boundary, so it does nothing about routing and link-local has to be denied explicitly rather
-/// than assumed unreachable. Cloud Run and Azure block it at the platform; Kubernetes does not.
+/// than assumed unreachable. The managed sandbox runtimes block it at the platform; Kubernetes,
+/// this emitter's target, does not.
 ///
 /// **The metadata entry is a `/32`, not the `169.254.0.0/16` it sits in.** GKE puts NodeLocal
 /// DNSCache at `169.254.20.10`, so denying the whole range takes DNS out and with it every

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -1236,9 +1236,9 @@ fn remote_sandbox_binding(
     deployment: &DeploymentRecord,
     resource_id: &str,
 ) -> Result<RemoteSandboxBinding, alien_error::AlienError<ErrorData>> {
-    // AWS alone, unlike the other kinds. A GCP sandbox is a subprocess of the application's own
-    // Cloud Run instance, and an Azure sandbox group is created by the runtime controller, so
-    // neither has a durable parent a setup-owned identity could be scoped to.
+    // AWS alone: it is the only sandbox with a RemoteSandboxBinding, and the connector
+    // authorization below (`lambda:PassNetworkConnector`) is AWS-specific. Remote access to a
+    // GCP or Azure sandbox is not wired yet.
     if deployment.platform != Platform::Aws {
         return Err(ErrorData::bad_request(format!(
             "Remote Sandbox is only supported on AWS, not deployment platform '{}'",

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -140,8 +140,8 @@ pub const MICROVM_SESSION_LIFECYCLE_ACTIONS: &[&str] = &[
 /// inline set's ARNs are free-form user strings, so any ARN comparison is either unsound or
 /// widened past by writing `*`. Carrying the verb at all is the answer.
 ///
-/// AWS only: a GCP sandbox is a launcher subprocess that makes no GCP API call, and an Azure
-/// sandbox group is created by the runtime controller rather than reached through a stack grant.
+/// AWS only: it scans for the verbs that reach an AWS MicroVM session. The other clouds do not
+/// expose a session through the stack grants this inspects.
 pub fn permission_set_reaches_a_microvm_session(
     permission_set: &alien_core::permissions::PermissionSet,
 ) -> bool {

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -225,9 +225,9 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 /// Three routes, none of which the vendor's own `-access` grant travels: a compute link, a
 /// permission profile, and a stack permission set on a user-declared ServiceAccount. Reach is
 /// decided by the resolved set's session-reaching verbs, never by a set id — an inline set an
-/// author names anything defeats a prefix test. GCP's blanket `sandboxLauncher` is a fourth
-/// route no declaration shows, and only the platform gate refusing a GCP remote sandbox keeps
-/// this answer honest there.
+/// author names anything defeats a prefix test. This scan is shaped for the AWS routes; what
+/// keeps it honest for GCP is the platform gate refusing a GCP remote sandbox before this answer
+/// is used, not anything this function checks.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
@@ -452,9 +452,9 @@ mod tests {
         assert!(error.to_string().contains("is not supported on gcp"));
     }
 
-    /// `GcpSandboxLauncherMutation` marks every Worker a session launcher, which
-    /// `in_cloud_reach_to` cannot see — so single tenancy would certify this stack. The platform
-    /// gate runs first and is what keeps that unreachable.
+    /// A GCP remote sandbox's in-cloud reach is not something `in_cloud_reach_to` can see, so
+    /// single tenancy would certify this stack. The platform gate runs first and is what keeps
+    /// that unreachable.
     #[tokio::test]
     async fn a_gcp_remote_sandbox_is_refused_before_single_tenancy_can_certify_it() {
         let worker = Worker::new("processor".to_string())


### PR DESCRIPTION
## Summary

The GCP sandbox is an Agent Platform engine and template, but several comments still
explained the AWS-only remote-sandbox and permission-reach rules as if GCP were a Cloud Run
launcher subprocess. This rewords them to state the real reason — remote sandbox has only an
AWS binding and the platform gate refuses GCP — without the obsolete mechanism.

## What I did

- Reworded five comments across four files, keeping the invariant each protects (remote
  sandbox is AWS-only; the platform gate refuses GCP; a Kubernetes sandbox must deny the
  metadata server itself) and dropping the Cloud Run launcher description.
- No code changed — the `GcpSandboxLauncherMutation` and blanket `sandboxLauncher` grant the
  old comments named no longer exist.

## Files touched

- `alien-manager/src/routes/bindings.rs` — the remote-sandbox AWS-only rationale.
- `alien-permissions/src/registry.rs` — the MicroVM-session permission-reach scan.
- `alien-preflights/src/mutations/remote_bindings.rs` — a reachability note and a test's doc.
- `alien-helm/src/emitters/sandbox.rs` — the metadata-server block, named as the managed
  runtime rather than a cloud (which kept it consistent with the GKE note below it).

## How I tested

- **Manually:** comment-only; confirmed the wording matches current behavior — the AWS-only
  gate and the GCP refusal are unchanged.
- Ran the OSS-boundary scrub over the diff and commit message — clean.
