### PR TITLE
feat(cli): support ALIEN_PROJECT env var for --project

### DIFF
--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Cli {
     pub dir: Option<String>,
 
     /// Project to manage (defaults to linked project or interactive bootstrap)
-    #[arg(long, global = true)]
+    #[arg(long, env = "ALIEN_PROJECT", global = true)]
     pub project: Option<String>,
 
     /// Platform base URL (defaults to https://api.alien.dev)

--- a/crates/alien-cli/src/lib.rs
+++ b/crates/alien-cli/src/lib.rs
@@ -93,6 +93,19 @@ pub struct Cli {
     pub workspace: Option<String>,
 }
 
+/// Treats a blank (empty or whitespace-only) string as unset, so
+/// `ALIEN_PROJECT=""` behaves the same as the variable not being set at
+/// all — falling back to the linked project or interactive bootstrap —
+/// instead of being treated as an explicit override for a blank project.
+fn non_blank(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 impl Cli {
     pub fn wants_json_output(&self) -> bool {
         match &self.command {
@@ -466,6 +479,17 @@ pub(crate) fn cli_env_vars_to_core(
 mod tests {
     use super::*;
     use alien_core::EnvironmentVariableType;
+
+    #[test]
+    fn non_blank_treats_empty_and_whitespace_as_unset() {
+        assert_eq!(non_blank("".to_string()), None);
+        assert_eq!(non_blank("   ".to_string()), None);
+    }
+
+    #[test]
+    fn non_blank_trims_non_blank_values() {
+        assert_eq!(non_blank("  my-project  ".to_string()), Some("my-project".to_string()));
+    }
 
     #[test]
     fn parse_single_env_var_supports_plain_value() {
@@ -1547,7 +1571,7 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
                 api_key: cli.api_key.clone(),
                 no_browser: cli.no_browser,
                 workspace: cli.workspace.clone().and_then(normalize_workspace_name),
-                project: cli.project.clone(),
+                project: cli.project.clone().and_then(non_blank),
             }
         }
         #[cfg(not(feature = "platform"))]


### PR DESCRIPTION
## Summary
- Adds `env = "ALIEN_PROJECT"` to the CLI's global `--project` flag, matching the existing `ALIEN_API_KEY`/`ALIEN_WORKSPACE` pattern.
- Lets callers that prefer environment variables (e.g. the ai-agent sandbox, which already resolves and passes `--project` explicitly per invocation) set the project once via env instead of a flag on every call.

## Test plan
- [x] Additive change to an existing `Option<String>` field's input sources — no behavior change when the env var is unset.
- [ ] `cargo build -p alien-cli` / relevant CLI tests pass in CI.