### PR TITLE
feat: create workspaces from the CLI

### DIFF
--- a/crates/alien-cli/src/commands/platform/login.rs
+++ b/crates/alien-cli/src/commands/platform/login.rs
@@ -1,5 +1,7 @@
 use crate::auth::{force_login, save_workspace};
-use crate::commands::platform::workspace::{prompt_workspace, validate_workspace_name};
+use crate::commands::platform::workspace::{
+    list_workspace_names, prompt_workspace, validate_workspace_name,
+};
 use crate::error::Result;
 use crate::execution_context::ExecutionMode;
 use crate::ui::{command, contextual_heading, dim_label, success_line};
@@ -18,6 +20,23 @@ pub struct LoginArgs {}
 pub async fn login_task(_args: LoginArgs, ctx: ExecutionMode) -> Result<()> {
     let auth_opts = ctx.auth_opts();
     let http = force_login(&auth_opts).await?;
+
+    if !matches!(
+        ctx,
+        ExecutionMode::Platform {
+            workspace: Some(_),
+            ..
+        }
+    ) && list_workspace_names(&http).await?.is_empty()
+    {
+        println!("{}", success_line("Logged in."));
+        println!("{}", dim_label("Next"));
+        println!(
+            "  {}  Create a workspace (its name is permanent)",
+            command("alien workspaces create <name>")
+        );
+        return Ok(());
+    }
 
     let workspace = if let ExecutionMode::Platform {
         workspace: Some(ref workspace),

--- a/crates/alien-cli/src/commands/platform/workspace.rs
+++ b/crates/alien-cli/src/commands/platform/workspace.rs
@@ -103,7 +103,9 @@ pub async fn workspace_task(args: WorkspaceArgs, ctx: ExecutionMode) -> Result<(
                 })?
                 .into_inner();
             let workspace = (*response.name).clone();
-            save_workspace(&workspace)?;
+            save_workspace(&workspace).context(ErrorData::WorkspaceCreatedSelectionFailed {
+                workspace: workspace.clone(),
+            })?;
 
             if args.json {
                 print_json(&WorkspaceCreateOutput {

--- a/crates/alien-cli/src/commands/platform/workspace.rs
+++ b/crates/alien-cli/src/commands/platform/workspace.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
     long_about = "Manage workspaces in the Alien platform.",
     after_help = "EXAMPLES:
     alien workspaces current
+    alien workspaces create my-workspace
     alien workspaces ls
     alien workspaces set my-workspace
     alien workspaces set --json"
@@ -32,6 +33,11 @@ pub struct WorkspaceArgs {
 pub enum WorkspaceCmd {
     /// Print the effective current workspace
     Current,
+    /// Create a workspace and select it as the default
+    Create {
+        /// Permanent workspace name used in URLs and CLI commands.
+        name: String,
+    },
     /// Set the default workspace
     Set {
         /// Workspace name. If omitted in a real TTY, prompts for selection.
@@ -55,6 +61,15 @@ struct WorkspaceSetOutput {
     saved: bool,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceCreateOutput {
+    id: String,
+    workspace: String,
+    role: String,
+    selected: bool,
+}
+
 pub async fn workspace_task(args: WorkspaceArgs, ctx: ExecutionMode) -> Result<()> {
     match args.cmd {
         WorkspaceCmd::Current => {
@@ -71,6 +86,38 @@ pub async fn workspace_task(args: WorkspaceArgs, ctx: ExecutionMode) -> Result<(
                     command("alien workspaces set <name>"),
                     command("alien login")
                 );
+            }
+        }
+        WorkspaceCmd::Create { name } => {
+            let http = ctx.auth_http().await?;
+            let response = http
+                .sdk_client()
+                .create_workspace()
+                .body_map(|body| body.name(name.as_str()))
+                .send()
+                .await
+                .into_sdk_error()
+                .context(ErrorData::ApiRequestFailed {
+                    message: "Failed to create workspace".to_string(),
+                    url: None,
+                })?
+                .into_inner();
+            let workspace = (*response.name).clone();
+            save_workspace(&workspace)?;
+
+            if args.json {
+                print_json(&WorkspaceCreateOutput {
+                    id: response.id.to_string(),
+                    workspace,
+                    role: response.role.to_string(),
+                    selected: true,
+                })?;
+            } else {
+                println!(
+                    "{}",
+                    success_line(&format!("Created workspace {workspace} and selected it."))
+                );
+                println!("{}", dim_label("Workspace names are permanent."));
             }
         }
         WorkspaceCmd::Set { name } => {
@@ -159,7 +206,8 @@ pub async fn prompt_workspace(http: &crate::auth::AuthHttp, json_mode: bool) -> 
     let workspaces = list_workspace_names(http).await?;
     if workspaces.is_empty() {
         return Err(AlienError::new(ErrorData::ConfigurationError {
-            message: "No workspaces found for this account.".to_string(),
+            message: "No workspaces found for this account. Run `alien workspaces create <name>`."
+                .to_string(),
         }));
     }
 
@@ -174,4 +222,21 @@ pub async fn prompt_workspace(http: &crate::auth::AuthHttp, json_mode: bool) -> 
     }
 
     prompt_select("Select a workspace:", &workspaces)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WorkspaceArgs, WorkspaceCmd};
+    use clap::Parser;
+
+    #[test]
+    fn parses_workspace_create_name() {
+        let args = WorkspaceArgs::try_parse_from(["workspaces", "create", "acme-prod"])
+            .expect("create command should parse");
+
+        assert!(matches!(
+            args.cmd,
+            WorkspaceCmd::Create { name } if name == "acme-prod"
+        ));
+    }
 }

--- a/crates/alien-cli/src/error.rs
+++ b/crates/alien-cli/src/error.rs
@@ -204,6 +204,19 @@ pub enum ErrorData {
         workspaces: Vec<String>,
     },
 
+    /// A workspace was created remotely but could not be selected locally.
+    #[error(
+        code = "WORKSPACE_CREATED_SELECTION_FAILED",
+        message = "Workspace '{workspace}' was created, but could not be selected locally",
+        hint = "Do not create it again. Fix the local profile error, then run `alien workspaces set {workspace}`.",
+        retryable = "false",
+        internal = "false"
+    )]
+    WorkspaceCreatedSelectionFailed {
+        /// Name of the workspace that was successfully created.
+        workspace: String,
+    },
+
     /// Invalid project name specified.
     #[error(
         code = "INVALID_PROJECT_NAME",


### PR DESCRIPTION
## Summary
- add `alien workspaces create <name>`
- select newly created workspaces automatically
- guide zero-workspace logins to the create command

## Validation
- `cargo check -p alien-cli`
- targeted rustfmt check

Linear: ALIEN-582
Companion PRs: alienplatform/platform#480, alienplatform/alien.dev#65