### PR TITLE
feat: show operation parameters in access requests

### DIFF
--- a/crates/alien-helm/src/generator.rs
+++ b/crates/alien-helm/src/generator.rs
@@ -790,6 +790,10 @@ spec:
                       summary:
                         type: string
                         description: One-line human summary for display.
+                      params:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        description: Exact operation parameters covered by the grant.
                 approvedForMinutes:
                   type: integer
                   minimum: 1
@@ -4403,6 +4407,14 @@ mod tests {
         assert_eq!(
             yaml_path(&crd, &["spec", "names", "plural"]).and_then(YamlValue::as_str),
             Some("acmeaccessrequests")
+        );
+        assert_eq!(
+            crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+                ["properties"]["commands"]["items"]["properties"]["params"]
+                ["x-kubernetes-preserve-unknown-fields"]
+                .as_bool(),
+            Some(true),
+            "the CRD must retain exact operation parameters for customer review"
         );
         // Not the Alien defaults.
         let text = &manifest;

--- a/crates/alien-operator/src/loops/access_requests.rs
+++ b/crates/alien-operator/src/loops/access_requests.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use serde_json::{Map, Value};
 use tracing::debug;
 
 use crate::OperatorState;
@@ -36,6 +37,8 @@ pub struct AccessRequestCommand {
     pub command: String,
     /// One-line human summary for display.
     pub summary: String,
+    /// Exact operation parameters the customer is being asked to authorize.
+    pub params: Map<String, Value>,
 }
 
 /// A control-plane access request: a grant the customer must approve before its


### PR DESCRIPTION
## Summary

- preserve exact operation parameters in access-request plans
- allow the Kubernetes resource schema to retain nested parameter values
- verify the rendered customer-facing schema

## Test plan

- `cargo test -p alien-operator loops::access_requests`
- `cargo test -p alien-helm access_request_crd_is_white_labeled_from_the_brand_domain -- --nocapture`
- `cargo fmt -p alien-operator -p alien-helm -- --check`