### PR TITLE
fix: retry resources for corrective updates

### DIFF
--- a/crates/alien-deployment/src/updating.rs
+++ b/crates/alien-deployment/src/updating.rs
@@ -6,7 +6,7 @@ use alien_core::{
     StackStatus,
 };
 use alien_error::{AlienError, Context};
-use alien_infra::{RunningResourcePolicy, StackExecutor};
+use alien_infra::{state_utils::StackStateExt, RunningResourcePolicy, StackExecutor};
 use std::collections::HashSet;
 use tracing::{debug, info};
 
@@ -102,11 +102,27 @@ pub async fn handle_update_pending(
     let mut next = current.clone();
 
     // Stack state is required
-    let stack_state = current.stack_state.clone().ok_or_else(|| {
+    let mut stack_state = current.stack_state.clone().ok_or_else(|| {
         AlienError::new(ErrorData::MissingConfiguration {
             message: "Stack state required for update".to_string(),
         })
     })?;
+
+    // UpdatePending is also the entry point for a corrective release selected
+    // after an update failed. Normalize terminal resource failures here so an
+    // externally selected release cannot bypass the ordinary UpdateFailed retry
+    // handler and leave the executor polling a superseded controller state.
+    let retried = stack_state
+        .retry_failed()
+        .context(ErrorData::StackExecutionFailed {
+            message: "Failed to prepare resources for update".to_string(),
+        })?;
+    if !retried.is_empty() {
+        info!(
+            resource_ids = ?retried,
+            "Reset failed resource state before preparing update"
+        );
+    }
 
     // A frozen gate is answered once: the answers recorded at creation are
     // what every later input value is held against. A gate with no recorded
@@ -483,7 +499,6 @@ pub async fn handle_update_failed(
     // retry/backoff budget before re-running preflights. Stack preparation will
     // still replace this state when the desired resource config changed; when
     // it did not, execution resumes without losing durable provider IDs.
-    use alien_infra::state_utils::StackStateExt;
     let retried = stack_state
         .retry_failed()
         .context(ErrorData::StackExecutionFailed {

--- a/crates/alien-deployment/tests/test_platform.rs
+++ b/crates/alien-deployment/tests/test_platform.rs
@@ -999,6 +999,10 @@ async fn test_update_failed_retry_gate_returns_to_update_pending() {
         .expect("Step should succeed");
     assert_eq!(result.state.status, DeploymentStatus::UpdateFailed);
 
+    // Keep the persisted failed state to reproduce a corrective release being
+    // selected directly by the release controller.
+    let mut corrective_state = state.clone();
+
     // With retry_requested, should transition to UpdatePending (not Updating)
     request_retry(&mut state);
     let result = alien_deployment::step(state, config.clone(), ClientConfig::Test, None)
@@ -1045,6 +1049,47 @@ async fn test_update_failed_retry_gate_returns_to_update_pending() {
             .is_some(),
         "retry preparation must not consume setup authorization"
     );
+
+    // A newly selected corrective release enters UpdatePending directly rather
+    // than passing through the manual UpdateFailed retry handler. It must still
+    // reset the failed controller before reconciling the corrected config.
+    corrective_state.status = DeploymentStatus::UpdatePending;
+    corrective_state.retry_requested = false;
+    corrective_state.target_release = Some(ReleaseInfo {
+        release_id: Some("rel_v3".to_string()),
+        version: Some("3.0.0".to_string()),
+        description: None,
+        stack: create_test_stack("test-stack", "test-function-v2"),
+    });
+    corrective_state
+        .runtime_metadata
+        .as_mut()
+        .unwrap()
+        .setup_update_authorization = None;
+
+    let corrected = run_to_completion(corrective_state, config).await;
+    assert_eq!(corrected.status, DeploymentStatus::Running);
+    assert_eq!(
+        corrected
+            .current_release
+            .as_ref()
+            .and_then(|release| release.release_id.as_deref()),
+        Some("rel_v3")
+    );
+    let corrected_resource = corrected
+        .stack_state
+        .as_ref()
+        .unwrap()
+        .resources
+        .get("test-function-v2")
+        .expect("corrected resource should remain in stack state");
+    assert_eq!(
+        corrected_resource.status,
+        alien_core::ResourceStatus::Running
+    );
+    assert_eq!(corrected_resource.retry_attempt, 0);
+    assert!(corrected_resource.error.is_none());
+    assert!(corrected_resource.last_failed_state.is_none());
 }
 
 async fn assert_failed_retry_transition(


### PR DESCRIPTION
## Summary

- reset terminal resource failures whenever a deployment enters `UpdatePending`
- preserve ordinary release-update behavior while covering corrective releases that bypass the manual retry handler
- add a persisted-state regression proving the corrected release reaches `Running`

Closes ALIEN-604.