### PR TITLE
fix(aws): allow compute role policy reconciliation

### DIFF
--- a/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
@@ -420,10 +420,10 @@
         },
         "binding": {
           "stack": {
-            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*"]
+            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*-role"]
           },
           "resource": {
-            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*"]
+            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*-role"]
           }
         }
       },

--- a/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
@@ -410,6 +410,23 @@
           }
         }
       },
+      // The runtime controller keeps the setup-created compute role, but owns
+      // the generated execute policy attached to it. Capacity reconciliation
+      // must therefore be able to refresh that policy and remove its legacy
+      // predecessor without gaining authority over unrelated IAM roles.
+      {
+        "grant": {
+          "actions": ["iam:PutRolePolicy", "iam:DeleteRolePolicy"]
+        },
+        "binding": {
+          "stack": {
+            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*"]
+          },
+          "resource": {
+            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*"]
+          }
+        }
+      },
       // Read-only inspection. AWS requires Resource: "*" for these Describe APIs.
       {
         "grant": {

--- a/crates/alien-permissions/tests/aws_cloudformation.rs
+++ b/crates/alien-permissions/tests/aws_cloudformation.rs
@@ -227,7 +227,7 @@ fn test_aws_cloudformation_compute_management_can_reconcile_instance_role_policy
     assert_eq!(
         statement.resource,
         [json!({
-            "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-*"
+            "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-*-role"
         })]
     );
 }

--- a/crates/alien-permissions/tests/aws_cloudformation.rs
+++ b/crates/alien-permissions/tests/aws_cloudformation.rs
@@ -204,6 +204,35 @@ fn test_aws_cloudformation_compute_management_can_use_setup_security_group() {
 }
 
 #[test]
+fn test_aws_cloudformation_compute_management_can_reconcile_instance_role_policy() {
+    let generator = AwsCloudFormationPermissionsGenerator::new();
+    let permission_set =
+        get_permission_set("compute-cluster/management").expect("permission set exists");
+    let context = PermissionContext::new()
+        .with_stack_prefix("")
+        .with_aws_region("${AWS::Region}")
+        .with_aws_account_id("${AWS::AccountId}");
+
+    let result = generator
+        .generate_policy(permission_set, BindingTarget::Stack, &context)
+        .expect("Should generate AWS CloudFormation policy successfully");
+
+    let statement = result
+        .statement
+        .iter()
+        .find(|statement| statement.action.contains(&json!("iam:PutRolePolicy")))
+        .expect("compute-cluster management should grant inline role policy reconciliation");
+
+    assert!(statement.action.contains(&json!("iam:DeleteRolePolicy")));
+    assert_eq!(
+        statement.resource,
+        [json!({
+            "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-*"
+        })]
+    );
+}
+
+#[test]
 fn test_aws_cloudformation_compute_management_can_terminate_only_tagged_stack_instances() {
     let generator = AwsCloudFormationPermissionsGenerator::new();
     let permission_set =

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -630,7 +630,7 @@ fn test_compute_cluster_management_can_reconcile_stack_prefixed_instance_role_po
         .contains(&"iam:DeleteRolePolicy".to_string()));
     assert_eq!(
         role_policy_statement.resource,
-        vec!["arn:aws:iam::123456789012:role/my-stack-*".to_string()]
+        vec!["arn:aws:iam::123456789012:role/my-stack-*-role".to_string()]
     );
 }
 

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -609,6 +609,32 @@ fn test_compute_cluster_management_can_pass_stack_prefixed_instance_roles() {
 }
 
 #[test]
+fn test_compute_cluster_management_can_reconcile_stack_prefixed_instance_role_policy() {
+    let generator = AwsRuntimePermissionsGenerator::new();
+    let permission_set =
+        get_permission_set("compute-cluster/management").expect("permission set exists");
+    let context = create_test_context();
+
+    let result = generator
+        .generate_policy(permission_set, BindingTarget::Stack, &context)
+        .expect("Should generate AWS policy successfully");
+
+    let role_policy_statement = result
+        .statement
+        .iter()
+        .find(|statement| statement.action.contains(&"iam:PutRolePolicy".to_string()))
+        .expect("compute-cluster management should grant inline role policy reconciliation");
+
+    assert!(role_policy_statement
+        .action
+        .contains(&"iam:DeleteRolePolicy".to_string()));
+    assert_eq!(
+        role_policy_statement.resource,
+        vec!["arn:aws:iam::123456789012:role/my-stack-*".to_string()]
+    );
+}
+
+#[test]
 fn test_aws_statement_id_generation() {
     let generator = AwsRuntimePermissionsGenerator::new();
 


### PR DESCRIPTION
## Summary

- let the compute-cluster management controller refresh the generated execute policy on setup-created runtime roles
- let it remove the legacy inline policy during reconciliation
- keep both actions scoped to roles under the deployment stack prefix

## Why

Capacity updates reconcile the node execution policy before changing the fleet. The generated management role already owns fleet reconciliation, but lacked the IAM actions required for this narrow step, causing AWS updates to fail before reaching the ASG.

## Verification

- runtime AWS permission generation
- CloudFormation permission generation
- permission operation coverage