### PR TITLE
fix(aws): keep compute role policy setup-owned

### DIFF
--- a/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
@@ -410,23 +410,6 @@
           }
         }
       },
-      // The runtime controller keeps the setup-created compute role, but owns
-      // the generated execute policy attached to it. Capacity reconciliation
-      // must therefore be able to refresh that policy and remove its legacy
-      // predecessor without gaining authority over unrelated IAM roles.
-      {
-        "grant": {
-          "actions": ["iam:PutRolePolicy", "iam:DeleteRolePolicy"]
-        },
-        "binding": {
-          "stack": {
-            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*-role"]
-          },
-          "resource": {
-            "resources": ["arn:aws:iam::${awsAccountId}:role/${stackPrefix}-*-role"]
-          }
-        }
-      },
       // Read-only inspection. AWS requires Resource: "*" for these Describe APIs.
       {
         "grant": {

--- a/crates/alien-permissions/tests/aws_cloudformation.rs
+++ b/crates/alien-permissions/tests/aws_cloudformation.rs
@@ -204,7 +204,7 @@ fn test_aws_cloudformation_compute_management_can_use_setup_security_group() {
 }
 
 #[test]
-fn test_aws_cloudformation_compute_management_can_reconcile_instance_role_policy() {
+fn test_aws_cloudformation_compute_management_cannot_mutate_instance_role_policy() {
     let generator = AwsCloudFormationPermissionsGenerator::new();
     let permission_set =
         get_permission_set("compute-cluster/management").expect("permission set exists");
@@ -217,19 +217,10 @@ fn test_aws_cloudformation_compute_management_can_reconcile_instance_role_policy
         .generate_policy(permission_set, BindingTarget::Stack, &context)
         .expect("Should generate AWS CloudFormation policy successfully");
 
-    let statement = result
-        .statement
-        .iter()
-        .find(|statement| statement.action.contains(&json!("iam:PutRolePolicy")))
-        .expect("compute-cluster management should grant inline role policy reconciliation");
-
-    assert!(statement.action.contains(&json!("iam:DeleteRolePolicy")));
-    assert_eq!(
-        statement.resource,
-        [json!({
-            "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-*-role"
-        })]
-    );
+    assert!(result.statement.iter().all(|statement| {
+        !statement.action.contains(&json!("iam:PutRolePolicy"))
+            && !statement.action.contains(&json!("iam:DeleteRolePolicy"))
+    }));
 }
 
 #[test]

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -609,7 +609,7 @@ fn test_compute_cluster_management_can_pass_stack_prefixed_instance_roles() {
 }
 
 #[test]
-fn test_compute_cluster_management_can_reconcile_stack_prefixed_instance_role_policy() {
+fn test_compute_cluster_management_cannot_mutate_instance_role_policy() {
     let generator = AwsRuntimePermissionsGenerator::new();
     let permission_set =
         get_permission_set("compute-cluster/management").expect("permission set exists");
@@ -619,19 +619,12 @@ fn test_compute_cluster_management_can_reconcile_stack_prefixed_instance_role_po
         .generate_policy(permission_set, BindingTarget::Stack, &context)
         .expect("Should generate AWS policy successfully");
 
-    let role_policy_statement = result
-        .statement
-        .iter()
-        .find(|statement| statement.action.contains(&"iam:PutRolePolicy".to_string()))
-        .expect("compute-cluster management should grant inline role policy reconciliation");
-
-    assert!(role_policy_statement
-        .action
-        .contains(&"iam:DeleteRolePolicy".to_string()));
-    assert_eq!(
-        role_policy_statement.resource,
-        vec!["arn:aws:iam::123456789012:role/my-stack-*-role".to_string()]
-    );
+    assert!(result.statement.iter().all(|statement| {
+        !statement.action.contains(&"iam:PutRolePolicy".to_string())
+            && !statement
+                .action
+                .contains(&"iam:DeleteRolePolicy".to_string())
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- remove inline role-policy mutation from ComputeCluster management permissions
- keep the setup-created VM role policy under setup ownership
- add runtime and CloudFormation regressions proving management cannot mutate role policies

## Verification

- `cargo nextest run -p alien-permissions --test aws_runtime --test aws_cloudformation`