### PR TITLE
fix(cli): refresh setup before failed retries

### DIFF
--- a/crates/alien-core/src/stack_settings.rs
+++ b/crates/alien-core/src/stack_settings.rs
@@ -904,9 +904,9 @@ mod failure_domain_tests {
         let settings: StackSettings = serde_json::from_value(serde_json::json!({
             "publicEndpoints": {
                 "loader": {
-                    "api": "https://10m5el.compute.islo.ai",
-                    "shares": "https://shares.10m5el.compute.islo.ai",
-                    "webhooks": "https://webhooks.10m5el.compute.islo.ai"
+                    "api": "https://loader.compute.example.com",
+                    "shares": "https://shares.compute.example.com",
+                    "webhooks": "https://webhooks.compute.example.com"
                 }
             }
         }))
@@ -915,7 +915,7 @@ mod failure_domain_tests {
         assert_eq!(
             serde_json::to_value(settings).expect("stack settings should serialize")
                 ["publicEndpoints"]["loader"]["shares"],
-            "https://shares.10m5el.compute.islo.ai"
+            "https://shares.compute.example.com"
         );
     }
 }

--- a/crates/alien-deploy-cli/src/commands/up.rs
+++ b/crates/alien-deploy-cli/src/commands/up.rs
@@ -415,7 +415,13 @@ mod tests {
 
     #[test]
     fn hosted_setup_reconciles_each_packaged_revision_once() {
-        for status in ["running", "update-failed", "refresh-failed"] {
+        for status in [
+            "running",
+            "update-failed",
+            "refresh-failed",
+            "initial-setup-failed",
+            "provisioning-failed",
+        ] {
             assert!(hosted_setup_reconcile_required(
                 status,
                 Some("package-b"),
@@ -699,7 +705,7 @@ mod tests {
                 "loader".to_string(),
                 std::collections::HashMap::from([(
                     "api".to_string(),
-                    "https://10m5el.compute.islo.ai".to_string(),
+                    "https://loader.compute.example.com".to_string(),
                 )]),
             )])),
             ..StackSettings::default()
@@ -712,7 +718,7 @@ mod tests {
 
         assert_eq!(
             wire["publicEndpoints"]["loader"]["api"],
-            "https://10m5el.compute.islo.ai"
+            "https://loader.compute.example.com"
         );
     }
 
@@ -2913,7 +2919,14 @@ fn hosted_setup_reconcile_required(
     packaged_revision: Option<&str>,
     applied_revision: Option<&str>,
 ) -> bool {
-    matches!(status, "running" | "update-failed" | "refresh-failed")
+    matches!(
+        status,
+        "running"
+            | "update-failed"
+            | "refresh-failed"
+            | "initial-setup-failed"
+            | "provisioning-failed"
+    )
         && packaged_revision.is_some()
         && packaged_revision != applied_revision
 }

--- a/crates/alien-deployment/src/manager_api_transport.rs
+++ b/crates/alien-deployment/src/manager_api_transport.rs
@@ -308,18 +308,26 @@ pub async fn acquire_setup_run_deployment(
         deployment_model,
         Some("setup-run".to_string()),
         Some("cli".to_string()),
-        Some(vec![
-            "pending".to_string(),
-            "preflights-failed".to_string(),
-            "initial-setup".to_string(),
-            "initial-setup-failed".to_string(),
-            "waiting-for-machines".to_string(),
-            "running".to_string(),
-            "update-failed".to_string(),
-            "refresh-failed".to_string(),
-        ]),
+        Some(setup_run_acquire_statuses()),
     )
     .await
+}
+
+fn setup_run_acquire_statuses() -> Vec<String> {
+    [
+        "pending",
+        "preflights-failed",
+        "initial-setup",
+        "initial-setup-failed",
+        "waiting-for-machines",
+        "running",
+        "update-failed",
+        "refresh-failed",
+        "provisioning-failed",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 /// Acquire a deployment lock for a caller that owns setup-time teardown.
@@ -532,6 +540,18 @@ mod tests {
 
         error.http_status_code = Some(409);
         assert!(!is_missing_deployment_response(&error));
+    }
+
+    #[test]
+    fn setup_run_can_recover_failed_setup_and_provisioning_states() {
+        let statuses = setup_run_acquire_statuses();
+
+        assert!(statuses
+            .iter()
+            .any(|status| status == "initial-setup-failed"));
+        assert!(statuses
+            .iter()
+            .any(|status| status == "provisioning-failed"));
     }
 
     fn sample_heartbeat() -> ResourceHeartbeat {


### PR DESCRIPTION
## Summary

- reconcile a newer generated setup revision before retrying deployments in initial-setup-failed or provisioning-failed
- keep the existing once-per-package-revision behavior
- replace customer-specific endpoint fixtures with neutral example domains

## Tests

- `cargo test -p alien-deploy-cli commands::up::tests::hosted_setup_reconciles_each_packaged_revision_once -- --exact`
- `cargo test -p alien-core machine_public_endpoints_round_trip_without_rewriting_urls`