### PR TITLE
chore: add CLAUDE.md symlinks for nested AGENTS.md

### DIFF
--- a/client-sdks/CLAUDE.md
+++ b/client-sdks/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/client-sdks/manager/CLAUDE.md
+++ b/client-sdks/manager/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/client-sdks/platform/rust/CLAUDE.md
+++ b/client-sdks/platform/rust/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-aws-clients/src/aws/CLAUDE.md
+++ b/crates/alien-aws-clients/src/aws/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-azure-clients/src/azure/CLAUDE.md
+++ b/crates/alien-azure-clients/src/azure/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-bindings/CLAUDE.md
+++ b/crates/alien-bindings/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-bindings/tests/CLAUDE.md
+++ b/crates/alien-bindings/tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-cli/src/CLAUDE.md
+++ b/crates/alien-cli/src/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-commands/CLAUDE.md
+++ b/crates/alien-commands/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-core/CLAUDE.md
+++ b/crates/alien-core/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-core/src/bindings/CLAUDE.md
+++ b/crates/alien-core/src/bindings/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-deploy-cli/CLAUDE.md
+++ b/crates/alien-deploy-cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-deployment/CLAUDE.md
+++ b/crates/alien-deployment/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-gcp-clients/src/gcp/CLAUDE.md
+++ b/crates/alien-gcp-clients/src/gcp/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-infra/CLAUDE.md
+++ b/crates/alien-infra/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-k8s-clients/src/kubernetes/CLAUDE.md
+++ b/crates/alien-k8s-clients/src/kubernetes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-manager/CLAUDE.md
+++ b/crates/alien-manager/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-permissions/permission-sets/CLAUDE.md
+++ b/crates/alien-permissions/permission-sets/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-preflights/CLAUDE.md
+++ b/crates/alien-preflights/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-test/CLAUDE.md
+++ b/crates/alien-test/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/alien-worker-runtime/CLAUDE.md
+++ b/crates/alien-worker-runtime/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/examples/basic-worker-ts/CLAUDE.md
+++ b/examples/basic-worker-ts/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/examples/enabled-demo/CLAUDE.md
+++ b/examples/enabled-demo/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/examples/github-agent/CLAUDE.md
+++ b/examples/github-agent/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/sdk/CLAUDE.md
+++ b/packages/sdk/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Claude Code reads `CLAUDE.md`, not `AGENTS.md`. Only the repo root had one, so
the 28 nested `AGENTS.md` files below it never entered its context.

This change:
- adds a relative `CLAUDE.md -> AGENTS.md` symlink beside each nested `AGENTS.md`
- matches the symlink form already used at the repo root
- changes no file content

## Validation

- `readlink` on all 28 returns the relative target `AGENTS.md`
- `cat crates/alien-core/CLAUDE.md` returns the `AGENTS.md` text
- `git ls-files -s` reports mode `120000` for all 28

Linear: ALIEN-633
