### PR TITLE
ci: run CodeQL nightly instead of on pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,8 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
-    - cron: "17 3 * * 1"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- stop running CodeQL on every push and pull request
- run CodeQL nightly at 03:17 UTC on the default branch
- retain manual workflow dispatch

The Rust CodeQL job on PR #551 took 48m39s, making it unsuitable as a pull-request check.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `git diff --check`