### PR TITLE
fix(sandbox): close the lifecycle gaps in remote bindings, build-role trust, and re-import

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
@@ -69,7 +69,7 @@ impl CfEmitter for AwsSandboxEmitter {
         );
         role.properties.insert(
             "AssumeRolePolicyDocument".to_string(),
-            service_trust_policy(["lambda.amazonaws.com"]),
+            build_role_trust_policy(),
         );
         role.properties.insert(
             "Policies".to_string(),
@@ -421,6 +421,35 @@ fn runtime_import_ref(sandbox: &Sandbox, image_id: &str) -> Result<CfExpression>
         ("buildRoleArn", CfExpression::get_att(&role_id, "Arn")),
         ("bundleUri", code_artifact_uri(artifact_uri(sandbox)?)),
     ]))
+}
+
+/// Lambda assumes the build role on the stack's own behalf; without the account condition any
+/// account's MicroVM build could name this role and run under it.
+fn build_role_trust_policy() -> CfExpression {
+    CfExpression::object([
+        ("Version", CfExpression::from("2012-10-17")),
+        (
+            "Statement",
+            CfExpression::list([CfExpression::object([
+                ("Effect", CfExpression::from("Allow")),
+                (
+                    "Principal",
+                    CfExpression::object([("Service", CfExpression::from("lambda.amazonaws.com"))]),
+                ),
+                ("Action", CfExpression::from("sts:AssumeRole")),
+                (
+                    "Condition",
+                    CfExpression::object([(
+                        "StringEquals",
+                        CfExpression::object([(
+                            "aws:SourceAccount",
+                            CfExpression::ref_("AWS::AccountId"),
+                        )]),
+                    )]),
+                ),
+            ])]),
+        ),
+    ])
 }
 
 /// The ports a preview capability may be minted for.

--- a/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
@@ -423,8 +423,8 @@ fn runtime_import_ref(sandbox: &Sandbox, image_id: &str) -> Result<CfExpression>
     ]))
 }
 
-/// Lambda assumes the build role on the stack's own behalf; without the account condition any
-/// account's MicroVM build could name this role and run under it.
+/// AWS's MicroVM build-role guidance prescribes this `aws:SourceAccount` condition on the trust
+/// policy as confused-deputy prevention.
 fn build_role_trust_policy() -> CfExpression {
     CfExpression::object([
         ("Version", CfExpression::from("2012-10-17")),

--- a/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
@@ -310,8 +310,7 @@ fn a_frozen_sandbox_still_bakes_its_image_into_the_setup_stack() {
         "a Frozen build role must carry no ECR action: {statements:#?}"
     );
 
-    // Lambda assumes the role on the stack's behalf; without the account condition any account's
-    // MicroVM build could name this role and run under it.
+    // See `build_role_trust_policy` for why the condition belongs on this statement.
     let role = serde_json::to_value(
         template
             .resources

--- a/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
@@ -309,6 +309,21 @@ fn a_frozen_sandbox_still_bakes_its_image_into_the_setup_stack() {
         !statements.iter().any(grants_ecr),
         "a Frozen build role must carry no ECR action: {statements:#?}"
     );
+
+    // Lambda assumes the role on the stack's behalf; without the account condition any account's
+    // MicroVM build could name this role and run under it.
+    let role = serde_json::to_value(
+        template
+            .resources
+            .get("AgentsBuildRole")
+            .expect("the build role must render"),
+    )
+    .expect("serializes");
+    assert_eq!(
+        role["Properties"]["AssumeRolePolicyDocument"]["Statement"][0]["Condition"],
+        serde_json::json!({ "StringEquals": { "aws:SourceAccount": { "Ref": "AWS::AccountId" } } }),
+        "the trust policy must be conditioned on the stack's own account: {role:#}"
+    );
 }
 
 /// Open + Live is the leanest emitted combination — no image (built at runtime) and no egress

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_open_aws.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_open_aws.snap
@@ -548,6 +548,10 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            StringEquals:
+              aws:SourceAccount:
+                Ref: AWS::AccountId
       Policies:
       - PolicyName: sandbox-image-build
         PolicyDocument:

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_restricted_aws.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_restricted_aws.snap
@@ -543,6 +543,10 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Action: sts:AssumeRole
+          Condition:
+            StringEquals:
+              aws:SourceAccount:
+                Ref: AWS::AccountId
       Policies:
       - PolicyName: sandbox-image-build
         PolicyDocument:

--- a/crates/alien-core/src/remote_bindings.rs
+++ b/crates/alien-core/src/remote_bindings.rs
@@ -1,4 +1,4 @@
-use crate::{ResourceEntry, ResourceLifecycle, ResourceType, Sandbox, SandboxEgress};
+use crate::{ResourceEntry, ResourceType, Sandbox, SandboxEgress};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteBindingKind {
@@ -73,10 +73,15 @@ pub fn remote_binding_definition(
         .find(|definition| definition.resource_type == resource_type.as_ref())
 }
 
+/// A grant is attached by the setup artifact, so only a resource it renders something for can
+/// be published: every Frozen one, and the Live sandbox through its scaffolding.
 pub fn remote_binding_for_entry(entry: &ResourceEntry) -> Option<&'static RemoteBindingDefinition> {
-    (entry.remote_access && entry.lifecycle == ResourceLifecycle::Frozen)
-        .then(|| remote_binding_definition(&entry.config.resource_type()))
-        .flatten()
+    let resource_type = entry.config.resource_type();
+    (entry.remote_access
+        && crate::ownership_policy_for_resource_type(resource_type.as_ref())
+            .emits_setup_scaffolding(entry.lifecycle))
+    .then(|| remote_binding_definition(&resource_type))
+    .flatten()
 }
 
 /// Why a declaration's remote binding is one a deployment cannot deliver, if it cannot.
@@ -141,7 +146,7 @@ pub fn remote_binding_definitions() -> &'static [RemoteBindingDefinition] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Sandbox, SandboxCode, SandboxLimits, SandboxSessionPolicy};
+    use crate::{ResourceLifecycle, Sandbox, SandboxCode, SandboxLimits, SandboxSessionPolicy};
 
     fn remote_sandbox(egress: SandboxEgress, preview_ports: Vec<u16>) -> ResourceEntry {
         let sandbox = Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-core/src/remote_bindings.rs
+++ b/crates/alien-core/src/remote_bindings.rs
@@ -1,4 +1,6 @@
-use crate::{ResourceEntry, ResourceType, Sandbox, SandboxEgress};
+use crate::{
+    ownership_policy_for_resource_type, ResourceEntry, ResourceType, Sandbox, SandboxEgress,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteBindingKind {
@@ -78,7 +80,7 @@ pub fn remote_binding_definition(
 pub fn remote_binding_for_entry(entry: &ResourceEntry) -> Option<&'static RemoteBindingDefinition> {
     let resource_type = entry.config.resource_type();
     (entry.remote_access
-        && crate::ownership_policy_for_resource_type(resource_type.as_ref())
+        && ownership_policy_for_resource_type(resource_type.as_ref())
             .emits_setup_scaffolding(entry.lifecycle))
     .then(|| remote_binding_definition(&resource_type))
     .flatten()

--- a/crates/alien-core/src/stack.rs
+++ b/crates/alien-core/src/stack.rs
@@ -370,8 +370,10 @@ mod tests {
         }
     }
 
+    /// The grant is rendered by setup, so a resource setup renders nothing for — a Live bucket —
+    /// cannot be published, while a Live sandbox can: setup still installs its scaffolding.
     #[test]
-    fn remote_bindings_require_a_registered_frozen_resource_and_opt_in() {
+    fn remote_bindings_require_a_setup_rendered_resource_and_opt_in() {
         assert!(resource_entry(
             Storage::new("archive".to_string()).build(),
             ResourceLifecycle::Frozen,
@@ -390,6 +392,17 @@ mod tests {
             true,
         )
         .has_remote_bindings());
+        let sandbox = crate::Sandbox::new("agents".to_string())
+            .code(crate::SandboxCode::Image {
+                image: "s3://alien-bundles/sandbox/bundle.zip".to_string(),
+            })
+            .egress(crate::SandboxEgress::Allow)
+            .session(crate::SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build();
+        assert!(resource_entry(sandbox, ResourceLifecycle::Live, true).has_remote_bindings());
         assert!(!resource_entry(
             Worker::new("worker".to_string())
                 .code(WorkerCode::Image {

--- a/crates/alien-infra/src/sandbox/aws_import.rs
+++ b/crates/alien-infra/src/sandbox/aws_import.rs
@@ -2,7 +2,8 @@
 
 use alien_core::{
     import::{data::AwsSandboxImportData, ImportContext},
-    ErrorData as CoreErrorData, Platform, ResourceStatus, Result, Sandbox, StackResourceState,
+    ErrorData as CoreErrorData, Platform, ResourceLifecycle, ResourceStatus, Result, Sandbox,
+    StackResourceState,
 };
 use alien_error::AlienError;
 
@@ -111,13 +112,19 @@ impl ResourceImporter for AwsSandboxImporter {
     /// sandbox that is serving — and re-run the create flow against an image that exists.
     ///
     /// Only the setup-owned facts cross over. The bundle deliberately does not: a new release's
-    /// bundle is a desired-config change and reaches the image through the update flow.
+    /// bundle is a desired-config change and reaches the image through the update flow. A Frozen
+    /// sandbox is replaced outright.
     fn merge_reimport(
         &self,
         existing: StackResourceState,
         imported: StackResourceState,
         ctx: &ImportContext<'_>,
     ) -> Result<StackResourceState> {
+        // Frozen is setup-authoritative: stack creation built the image, so its registration
+        // replaces whatever state the manager held, whatever the payload names.
+        if ctx.resource.lifecycle == ResourceLifecycle::Frozen {
+            return Ok(imported);
+        }
         let (Some(existing_state), Some(imported_state)) = (
             existing.internal_state.clone(),
             imported.internal_state.clone(),
@@ -143,12 +150,6 @@ impl ResourceImporter for AwsSandboxImporter {
                     ),
                 })
             })?;
-
-        // A Frozen registration names no build role. Its image is setup-owned and stack creation
-        // is authoritative about it, so replacement is right there.
-        if imported_controller.build_role_arn.is_none() {
-            return Ok(imported);
-        }
 
         let merged = AwsSandboxController {
             build_role_arn: imported_controller.build_role_arn,

--- a/crates/alien-infra/src/sandbox/aws_import.rs
+++ b/crates/alien-infra/src/sandbox/aws_import.rs
@@ -152,7 +152,9 @@ impl ResourceImporter for AwsSandboxImporter {
             })?;
 
         let merged = AwsSandboxController {
-            build_role_arn: imported_controller.build_role_arn,
+            build_role_arn: imported_controller
+                .build_role_arn
+                .or(existing_controller.build_role_arn.clone()),
             egress_connector_arns: imported_controller.egress_connector_arns,
             allow_egress: imported_controller.allow_egress,
             preview_ports: imported_controller.preview_ports,
@@ -190,6 +192,7 @@ impl ResourceImporter for AwsSandboxImporter {
             internal_state: Some(internal_state),
             outputs,
             remote_binding_params,
+            lifecycle: Some(ctx.resource.lifecycle),
             ..existing
         })
     }

--- a/crates/alien-infra/tests/importers.rs
+++ b/crates/alien-infra/tests/importers.rs
@@ -1483,10 +1483,98 @@ fn aws_sandbox_frozen_reimport_replaces() {
             &ctx,
         )
         .expect("merge should succeed");
-    assert_eq!(replaced.status, imported.status);
+    assert_eq!(replaced.status, ResourceStatus::Provisioning);
     assert_eq!(
-        replaced.internal_state, imported.internal_state,
+        internal_state(&replaced)["state"],
+        "creatingImage",
         "a Frozen sandbox takes the registration as it is"
+    );
+    assert!(
+        replaced.remote_binding_params.is_none(),
+        "the payload carried no image, so nothing publishes a binding"
+    );
+}
+
+/// A declaration that flips a sandbox from Frozen to Live re-registers with build inputs; the
+/// merged state must carry the new lifecycle, or the controller keeps treating the image as
+/// setup-owned and never rolls it.
+#[test]
+fn aws_sandbox_reimport_carries_the_declared_lifecycle_through_a_merge() {
+    let settings = settings();
+    let management = aws_management_config();
+    let registry = ImporterRegistry::built_in();
+    let frozen_entry = sandbox_entry(ResourceLifecycle::Frozen, true);
+    let frozen_ctx = ImportContext {
+        resource_id: "agents",
+        platform: Platform::Aws,
+        region: "us-east-2",
+        stack_settings: &settings,
+        management_config: Some(&management),
+        resource: &frozen_entry,
+    };
+    let existing = registry
+        .run(
+            &Sandbox::RESOURCE_TYPE,
+            Platform::Aws,
+            serde_json::to_value(AwsSandboxImportData {
+                image_identifier: Some(
+                    "arn:aws:lambda:us-east-2:123456789012:microvm-image:stack-agents".to_string(),
+                ),
+                image_arn: Some(
+                    "arn:aws:lambda:us-east-2:123456789012:microvm-image:stack-agents".to_string(),
+                ),
+                image_version: Some("1.0".to_string()),
+                build_role_arn: None,
+                bundle_uri: None,
+                egress_connector_arns: Vec::new(),
+                allow_egress: true,
+                preview_ports: Vec::new(),
+            })
+            .unwrap(),
+            &frozen_ctx,
+        )
+        .expect("first import");
+    assert_eq!(existing.lifecycle, Some(ResourceLifecycle::Frozen));
+
+    let live_entry = sandbox_entry(ResourceLifecycle::Live, true);
+    let live_ctx = ImportContext {
+        resource: &live_entry,
+        ..frozen_ctx
+    };
+    let imported = registry
+        .run(
+            &Sandbox::RESOURCE_TYPE,
+            Platform::Aws,
+            serde_json::to_value(AwsSandboxImportData {
+                image_identifier: None,
+                image_arn: None,
+                image_version: None,
+                build_role_arn: Some(
+                    "arn:aws:iam::123456789012:role/stack-agents-build".to_string(),
+                ),
+                bundle_uri: Some("s3://alien-bundles/sandbox/bundle.zip".to_string()),
+                egress_connector_arns: Vec::new(),
+                allow_egress: true,
+                preview_ports: Vec::new(),
+            })
+            .unwrap(),
+            &live_ctx,
+        )
+        .expect("re-import");
+    let merged = registry
+        .merge_reimport(
+            &Sandbox::RESOURCE_TYPE,
+            Platform::Aws,
+            existing,
+            imported,
+            &live_ctx,
+        )
+        .expect("merge should succeed");
+
+    assert_eq!(merged.lifecycle, Some(ResourceLifecycle::Live));
+    assert_eq!(
+        internal_state(&merged)["buildRoleArn"],
+        "arn:aws:iam::123456789012:role/stack-agents-build"
     );
 }
 

--- a/crates/alien-infra/tests/importers.rs
+++ b/crates/alien-infra/tests/importers.rs
@@ -1448,6 +1448,46 @@ fn aws_sandbox_frozen_reimport_replaces() {
         "2.0",
         "stack creation is authoritative about a setup-owned image"
     );
+
+    // Replacement is decided by the lifecycle, not by what the payload names: a Frozen
+    // registration carrying build inputs still replaces rather than merging onto the image.
+    let existing = registry
+        .run(&Sandbox::RESOURCE_TYPE, Platform::Aws, frozen("2.0"), &ctx)
+        .expect("existing");
+    let imported = registry
+        .run(
+            &Sandbox::RESOURCE_TYPE,
+            Platform::Aws,
+            serde_json::to_value(AwsSandboxImportData {
+                image_identifier: None,
+                image_arn: None,
+                image_version: None,
+                build_role_arn: Some(
+                    "arn:aws:iam::123456789012:role/stack-agents-build".to_string(),
+                ),
+                bundle_uri: Some("s3://alien-bundles/sandbox/bundle.zip".to_string()),
+                egress_connector_arns: Vec::new(),
+                allow_egress: true,
+                preview_ports: Vec::new(),
+            })
+            .unwrap(),
+            &ctx,
+        )
+        .expect("re-import");
+    let replaced = registry
+        .merge_reimport(
+            &Sandbox::RESOURCE_TYPE,
+            Platform::Aws,
+            existing,
+            imported.clone(),
+            &ctx,
+        )
+        .expect("merge should succeed");
+    assert_eq!(replaced.status, imported.status);
+    assert_eq!(
+        replaced.internal_state, imported.internal_state,
+        "a Frozen sandbox takes the registration as it is"
+    );
 }
 
 /// A Live sandbox registers its build inputs instead of an image, and imports Provisioning at

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -975,14 +975,16 @@ async fn require_current_release_remote_access(
                     "Resource '{resource_id}' does not support Remote Bindings"
                 ))
             })?;
-    if resource.lifecycle != ResourceLifecycle::Frozen {
-        return Err(ErrorData::bad_request(format!(
-            "Remote resource '{resource_id}' is not Frozen in the deployment's current release"
-        )));
-    }
     if !resource.remote_access {
         return Err(ErrorData::bad_request(format!(
             "Resource '{resource_id}' is not enabled for remote access in the deployment's current release"
+        )));
+    }
+    // The same rule the preflight grants by: setup must render something for the resource.
+    if alien_core::remote_bindings::remote_binding_for_entry(resource).is_none() {
+        return Err(ErrorData::bad_request(format!(
+            "Remote resource '{resource_id}' is {:?} and setup renders nothing for it in the deployment's current release",
+            resource.lifecycle
         )));
     }
     if definition.kind == alien_core::remote_bindings::RemoteBindingKind::Key

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -635,6 +635,52 @@ async fn legacy_binding_params_cannot_bypass_a_disabled_current_release() {
     assert!(error.message.contains("not enabled for remote access"));
 }
 
+/// The resolve gate follows the preflight's rule, not the lifecycle alone: setup renders a Live
+/// sandbox's scaffolding, so its grant exists; it renders nothing for a Live bucket.
+#[tokio::test]
+async fn remote_access_accepts_a_live_sandbox_and_refuses_a_live_bucket() {
+    let mut live_sandbox = deployment(sandbox_stack_state_with_lifecycle(
+        open_sandbox_binding(),
+        Platform::Aws,
+        ResourceLifecycle::Live,
+    ));
+    live_sandbox.current_release_id = Some("current".to_string());
+    let sandbox_stack = Stack::new("stack".to_string())
+        .add_with_remote_access(sandbox_resource(), ResourceLifecycle::Live)
+        .build();
+    let store = StubReleaseStore {
+        releases: HashMap::from([(
+            "current".to_string(),
+            release("current", Platform::Aws, sandbox_stack),
+        )]),
+    };
+    require_current_release_remote_access(&store, &live_sandbox, "agents")
+        .await
+        .expect("a Live sandbox is scaffolded by setup and resolves");
+
+    let mut live_bucket = deployment(stack_state_with_resource(
+        Storage::RESOURCE_TYPE.as_ref(),
+        Some(ResourceLifecycle::Live),
+        ResourceStatus::Running,
+        Some(serde_json::to_value(StorageBinding::s3("files")).unwrap()),
+    ));
+    live_bucket.current_release_id = Some("current".to_string());
+    let bucket_stack = Stack::new("stack".to_string())
+        .add_with_remote_access(storage(), ResourceLifecycle::Live)
+        .build();
+    let store = StubReleaseStore {
+        releases: HashMap::from([(
+            "current".to_string(),
+            release("current", Platform::Aws, bucket_stack),
+        )]),
+    };
+    let error = require_current_release_remote_access(&store, &live_bucket, "files")
+        .await
+        .expect_err("setup renders nothing for a Live bucket, so no grant exists");
+    assert_eq!(error.code, "BAD_REQUEST");
+    assert!(error.message.contains("renders nothing"), "{}", error.message);
+}
+
 #[tokio::test]
 async fn remote_access_fails_closed_when_current_release_context_is_missing() {
     let stack_state = stack_state_with_resource(

--- a/crates/alien-permissions/permission-sets/sandbox/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/provision.jsonc
@@ -5,12 +5,13 @@
     "aws": [
       {
         "grant": {
-          // The Frozen parent on AWS is a MicroVM image and its versions. run-microvm rejects
-          // the AWS-managed base image, so every AWS sandbox builds one — provision therefore
-          // covers the build and its status reads, not just create and delete.
+          // The parent on AWS is a MicroVM image and its versions. run-microvm rejects the
+          // AWS-managed base image, so every AWS sandbox builds one — provision therefore covers
+          // the build and its status reads, not just create and delete, whether the installer
+          // runs it for a Frozen sandbox or the runtime controller for a Live one.
           //
           // UpdateMicrovmImage is the roll a new release's bundle takes onto an image that
-          // already exists. It accepts no request tags, so unlike the create below it can only
+          // already exists. It accepts no request tags, so unlike the creates below it can only
           // be authorized here, against the image ARN pattern the stack binding compiles.
           "actions": [
             "lambda:UpdateMicrovmImage",
@@ -39,7 +40,8 @@
       {
         "grant": {
           // AWS authorizes creation against no resource type, so an ARN here would deny rather
-          // than narrow. The boundary tags are what bound it instead.
+          // than narrow. The boundary tags are what bound it instead: this statement is the
+          // runtime controller's build.
           "actions": ["lambda:CreateMicrovmImage"]
         },
         "binding": {
@@ -58,6 +60,32 @@
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
                 "aws:RequestTag/${managedByTag}": "runtime"
+              }
+            }
+          }
+        }
+      },
+      {
+        "grant": {
+          // The same build under the tag CloudFormation and Terraform put on a Frozen image.
+          "actions": ["lambda:CreateMicrovmImage"]
+        },
+        "binding": {
+          "stack": {
+            "resources": ["*"],
+            "condition": {
+              "StringEquals": {
+                "aws:RequestTag/${stackTag}": "${stackPrefix}",
+                "aws:RequestTag/${managedByTag}": "setup"
+              }
+            }
+          },
+          "resource": {
+            "resources": ["*"],
+            "condition": {
+              "StringEquals": {
+                "aws:RequestTag/${stackTag}": "${stackPrefix}",
+                "aws:RequestTag/${managedByTag}": "setup"
               }
             }
           }
@@ -85,6 +113,7 @@
       {
         // The build runs under a role the call names, so CreateMicrovmImage — and the
         // UpdateMicrovmImage roll, which restates it — are authorized as a pass of it too.
+        // Setup installs the role; neither the installer nor the controller creates it here.
         // Name-scoped, like the session-time pass in sandbox/management:
         // PassRole is evaluated against the role being passed, which carries no tag to bound it.
         "label": "pass-sandbox-build-role",

--- a/crates/alien-permissions/permission-sets/sandbox/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/provision.jsonc
@@ -59,6 +59,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
+                "aws:RequestTag/${resourceTag}": "${resourceName}",
                 "aws:RequestTag/${managedByTag}": "runtime"
               }
             }
@@ -85,6 +86,7 @@
             "condition": {
               "StringEquals": {
                 "aws:RequestTag/${stackTag}": "${stackPrefix}",
+                "aws:RequestTag/${resourceTag}": "${resourceName}",
                 "aws:RequestTag/${managedByTag}": "setup"
               }
             }

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -239,16 +239,20 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
         return Some(format!("resource '{consumer_id}' links it"));
     }
 
-    let by_profile = stack.permissions.profiles.iter().find_map(|(profile_name, profile)| {
-        profile
-            .0
-            .iter()
-            .any(|(target, permission_sets)| {
-                (target == sandbox_id || target == "*")
-                    && permission_sets.iter().any(reference_reaches_a_session)
-            })
-            .then(|| format!("permission profile '{profile_name}' grants access to it"))
-    });
+    let by_profile = stack
+        .permissions
+        .profiles
+        .iter()
+        .find_map(|(profile_name, profile)| {
+            profile
+                .0
+                .iter()
+                .any(|(target, permission_sets)| {
+                    (target == sandbox_id || target == "*")
+                        && permission_sets.iter().any(reference_reaches_a_session)
+                })
+                .then(|| format!("permission profile '{profile_name}' grants access to it"))
+        });
     if by_profile.is_some() {
         return by_profile;
     }
@@ -405,6 +409,31 @@ mod tests {
         assert_eq!(bindings.grants[0].resource_id, "agents");
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
         assert_eq!(bindings.grants[0].revision, definition.revision);
+    }
+
+    /// A Live sandbox is scaffolded by setup — its build role and connector — and its binding is
+    /// published by the runtime controller once the image is active, so the remote grant attaches
+    /// exactly as it does for a Frozen one.
+    #[tokio::test]
+    async fn a_live_remote_sandbox_is_granted_the_remote_execute_set() {
+        let stack = Stack::new("byo-sandbox".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Live)
+            .build();
+        let state = StackState::new(Platform::Aws);
+
+        assert!(RemoteBindingsMutation.should_run(&stack, &state, &config()));
+        let mutated = RemoteBindingsMutation
+            .mutate(stack, &state, &config())
+            .await
+            .expect("a Live open-egress sandbox is a valid remote binding");
+        let bindings = mutated
+            .resources
+            .get(REMOTE_BINDINGS_ID)
+            .and_then(|entry| entry.config.downcast_ref::<RemoteBindings>())
+            .expect("Remote Bindings config");
+        assert_eq!(bindings.grants.len(), 1);
+        assert_eq!(bindings.grants[0].resource_id, "agents");
+        assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
     }
 
     /// `sandbox/remote-execute` has an AWS block alone. Without this gate the deployment installs

--- a/crates/alien-terraform/src/emitters/aws/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/aws/sandbox.rs
@@ -10,8 +10,9 @@ use crate::{
     emitters::aws::helpers::{
         aws_terraform_permission_context, default_network, downcast,
         emit_iam_role_policy_for_target_with_label, iam_policy_name_sanitize, iam_role_block,
-        iam_role_name_template, iam_role_policy_block, nested_block, private_subnet_ids_expr,
-        required_label, resource_prefix_template, service_assume_role_policy, tags, vpc_id_expr,
+        iam_role_name_template, iam_role_policy_block, jsonencode, nested_block,
+        private_subnet_ids_expr, required_label, resource_prefix_template,
+        service_assume_role_policy, tags, vpc_id_expr,
     },
     expr,
 };
@@ -91,7 +92,7 @@ impl TfEmitter for AwsSandboxEmitter {
         let build_role = iam_role_block(
             label,
             iam_role_name_template(&format!("{}-build", sandbox.id())),
-            service_assume_role_policy(&["lambda.amazonaws.com"]),
+            build_role_trust_policy(),
             tags(ctx, "sandbox"),
         );
 
@@ -516,6 +517,43 @@ fn runtime_import_ref(sandbox: &Sandbox, label: &str) -> Result<Expression> {
             expr::traversal(["aws_iam_role", label, "arn"]),
         ),
         ("bundleUri", code_artifact_uri(artifact_uri(sandbox)?)),
+    ]))
+}
+
+/// The build role's trust policy, conditioned on the stack's own account. See the CloudFormation
+/// emitter's `build_role_trust_policy`.
+fn build_role_trust_policy() -> Expression {
+    jsonencode(expr::object([
+        ("Version", Expression::String("2012-10-17".to_string())),
+        (
+            "Statement",
+            Expression::Array(vec![expr::object([
+                ("Effect", Expression::String("Allow".to_string())),
+                (
+                    "Principal",
+                    expr::object([(
+                        "Service",
+                        Expression::String("lambda.amazonaws.com".to_string()),
+                    )]),
+                ),
+                ("Action", Expression::String("sts:AssumeRole".to_string())),
+                (
+                    "Condition",
+                    expr::object([(
+                        "StringEquals",
+                        expr::object([(
+                            "aws:SourceAccount",
+                            expr::traversal([
+                                "data",
+                                "aws_caller_identity",
+                                "current",
+                                "account_id",
+                            ]),
+                        )]),
+                    )]),
+                ),
+            ])]),
+        ),
     ]))
 }
 

--- a/crates/alien-terraform/tests/generator/aws_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_identity_tests.rs
@@ -305,6 +305,10 @@ fn aws_sandbox_build_policy_is_a_well_formed_scoped_document() {
         !rendered.contains("ecr:"),
         "a Frozen build role must carry no ECR action:\n{rendered}"
     );
+    assert!(
+        rendered.contains("\"aws:SourceAccount\" = data.aws_caller_identity.current.account_id"),
+        "the build role's trust policy must be conditioned on the stack's account:\n{rendered}"
+    );
 }
 
 /// A module that declares `awscc` must configure it, or the customer cannot plan.

--- a/crates/alien-terraform/tests/generator/aws_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_identity_tests.rs
@@ -305,10 +305,6 @@ fn aws_sandbox_build_policy_is_a_well_formed_scoped_document() {
         !rendered.contains("ecr:"),
         "a Frozen build role must carry no ECR action:\n{rendered}"
     );
-    assert!(
-        rendered.contains("\"aws:SourceAccount\" = data.aws_caller_identity.current.account_id"),
-        "the build role's trust policy must be conditioned on the stack's account:\n{rendered}"
-    );
 }
 
 /// A module that declares `awscc` must configure it, or the customer cannot plan.

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_sandbox_restricted.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_sandbox_restricted.snap
@@ -405,7 +405,7 @@ resource "aws_security_group" "default_network_workload" {
 === agents.tf ===
 resource "aws_iam_role" "agents" {
   name               = length(format("%s-%s", local.resource_prefix, "agents-build")) <= 64 ? format("%s-%s", local.resource_prefix, "agents-build") : format("%s-%s", substr(format("%s-%s", local.resource_prefix, "agents-build"), 0, 55), substr(sha1(format("%s-%s", local.resource_prefix, "agents-build")), 0, 8))
-  assume_role_policy = jsonencode({ Version = "2012-10-17", Statement = [{ Effect = "Allow", Principal = { Service = "lambda.amazonaws.com" }, Action = "sts:AssumeRole" }] })
+  assume_role_policy = jsonencode({ Version = "2012-10-17", Statement = [{ Effect = "Allow", Principal = { Service = "lambda.amazonaws.com" }, Action = "sts:AssumeRole", Condition = { StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id } } }] })
   tags = {
     "managed-by"    = "setup"
     deployment      = local.resource_prefix


### PR DESCRIPTION
## Summary

Four fixes to how an AWS sandbox is granted, trusted, and re-registered. None of them changes what a sandbox does; each closes a gap between two parts of the codebase that answered the same question differently.

Step-by-step flow when a Live sandbox with `remoteAccess` is deployed and a session is requested:

1. The preflight decides which resources get a remote grant. It now grants for every resource setup renders something for — a Live sandbox's build role counts — instead of only Frozen resources.
2. Setup renders the sandbox build role with its trust policy conditioned on the deploying account, the condition AWS prescribes for MicroVM build roles.
3. The manager's resolve route asks the same question as the preflight before handing out session credentials.  ← this is where the bug lived: it refused every non-Frozen resource, so a Live sandbox the preflight had granted could never be reached.
4. A later re-registration replaces a Frozen sandbox's state outright and merges a Live one's, keeping its build role and the lifecycle the release declares.

This PR changes "remote bindings and re-imports decide by lifecycle name or by which fields the payload happens to carry" to "they decide by what setup renders and what the release declares".

## What was broken

- A Live sandbox with `remoteAccess` got session credentials from the manager but no grant behind them, and then the resolve route refused it anyway.
- The installer policy compiled from `sandbox/provision` could not create the Frozen image: the grant required the `runtime` tag while CloudFormation and Terraform tag a setup-built image `setup`.
- The build role could be assumed by Lambda from any account.
- A Frozen re-import was recognised by "the payload names no build role", and a merge kept the lifecycle the record had before the release changed it.

## What I did

- `remote_binding_for_entry` keys on `remoteAccess` plus whether setup renders scaffolding for the resource; the manager's resolve gate calls the same function.
- Added an `aws:SourceAccount` condition to the sandbox build-role trust policy in both emitters; snapshots re-accepted with exactly that diff.
- Added a second `CreateMicrovmImage` grant under `managedBy = setup`, and the resource-tag condition on both, matching every other provision set.
- `merge_reimport` branches on the declared lifecycle, carries the build role through a merge when the payload names none, and writes the declared lifecycle into the merged state.

## Files touched

- `crates/alien-core/src/remote_bindings.rs`, `crates/alien-manager/src/routes/bindings.rs` — one grant rule, used by preflight and resolve.
- `crates/alien-cloudformation/src/emitters/aws/sandbox.rs`, `crates/alien-terraform/src/emitters/aws/sandbox.rs` — build-role trust condition.
- `crates/alien-permissions/permission-sets/sandbox/provision.jsonc` — setup grant and resource-tag condition.
- `crates/alien-infra/src/sandbox/aws_import.rs` — lifecycle-keyed re-import.
- Tests: preflight (Live sandbox granted, Live bucket not), manager resolve (Live sandbox accepted, Live bucket refused), importer (Frozen replaces, Live merge keeps the serving version, lifecycle flip carried), emitter snapshots, permission-set coverage.

## How I tested

- **Manually:** rendered the Frozen sandbox CloudFormation template and ran `cfn-lint` on it inside the generator test; read the two accepted snapshots to confirm the only diff is the trust condition; ran `cargo test -p alien-permissions` to confirm the operation-coverage and ABAC suites accept the second grant.
- **Unit tests:** `cargo test -p alien-core -p alien-infra --features all-platforms,test-utils -p alien-permissions -p alien-preflights -p alien-manager -p alien-cloudformation -p alien-terraform -p alien-helm` — 43 suites, 0 failures.
- **Anything I couldn't test:** a live MicroVM image build under the conditioned trust policy; the condition is the one AWS documents for this role, and the e2e sandbox proof runs on staging.

I also ran a security review on the diff. What it checked:
- Cross-account assumption of the build role — blocked by the new `aws:SourceAccount` condition (`emitters/aws/sandbox.rs`, `build_role_trust_policy`).
- A Live bucket declared with `remoteAccess` obtaining credentials — refused at resolve and never granted by the preflight (`routes/bindings/tests.rs`, `remote_access_accepts_a_live_sandbox_and_refuses_a_live_bucket`).
- One sandbox's provision grant creating an image under a sibling's name — the resource-tag condition now binds both `CreateMicrovmImage` grants.
Nothing turned up.
