### PR TITLE
fix: preserve heartbeat deployment claims

### DIFF
--- a/crates/alien-manager/src/loops/deployment.rs
+++ b/crates/alien-manager/src/loops/deployment.rs
@@ -359,10 +359,16 @@ impl DeploymentLoop {
     pub(crate) async fn process_heartbeat_deployment(
         &self,
         deployment: DeploymentRecord,
+        execution_claim: Option<crate::traits::deployment_store::ExecutionClaim>,
         session: &str,
     ) {
-        self.process_deployment(deployment, None, session, ProcessOptions::heartbeat_tick())
-            .await;
+        self.process_deployment(
+            deployment,
+            execution_claim,
+            session,
+            ProcessOptions::heartbeat_tick(),
+        )
+        .await;
     }
 
     /// Process a single deployment: step until stable, reconcile, release.

--- a/crates/alien-manager/src/loops/heartbeat.rs
+++ b/crates/alien-manager/src/loops/heartbeat.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use futures::{stream, StreamExt};
 use tracing::{debug, error};
 
@@ -11,7 +12,7 @@ use alien_core::DeploymentModel;
 use crate::auth::Subject;
 use crate::config::ManagerConfig;
 use crate::loops::deployment::{DeploymentLoop, MAX_CONCURRENT_DEPLOYMENTS};
-use crate::traits::deployment_store::DeploymentFilter;
+use crate::traits::deployment_store::{AcquiredDeployment, DeploymentFilter};
 use crate::traits::DeploymentStore;
 
 /// Maximum deployments to health-check per tick, across all batches.
@@ -20,19 +21,32 @@ const HEARTBEAT_DEPLOYMENTS_PER_TICK: usize = 100;
 pub struct HeartbeatLoop {
     config: Arc<ManagerConfig>,
     deployment_store: Arc<dyn DeploymentStore>,
-    deployment_loop: Arc<DeploymentLoop>,
+    deployment_processor: Arc<dyn HeartbeatDeploymentProcessor>,
+}
+
+#[async_trait]
+pub(crate) trait HeartbeatDeploymentProcessor: Send + Sync {
+    async fn process_heartbeat_deployment(&self, item: AcquiredDeployment, session: &str);
+}
+
+#[async_trait]
+impl HeartbeatDeploymentProcessor for DeploymentLoop {
+    async fn process_heartbeat_deployment(&self, item: AcquiredDeployment, session: &str) {
+        self.process_heartbeat_deployment(item.deployment, item.execution_claim, session)
+            .await;
+    }
 }
 
 impl HeartbeatLoop {
-    pub fn new(
+    pub(crate) fn new(
         config: Arc<ManagerConfig>,
         deployment_store: Arc<dyn DeploymentStore>,
-        deployment_loop: Arc<DeploymentLoop>,
+        deployment_processor: Arc<dyn HeartbeatDeploymentProcessor>,
     ) -> Self {
         Self {
             config,
             deployment_store,
-            deployment_loop,
+            deployment_processor,
         }
     }
 
@@ -94,8 +108,8 @@ impl HeartbeatLoop {
                     );
                     stream::iter(acquired)
                         .for_each_concurrent(MAX_CONCURRENT_DEPLOYMENTS, |item| async {
-                            self.deployment_loop
-                                .process_heartbeat_deployment(item.deployment, &session)
+                            self.deployment_processor
+                                .process_heartbeat_deployment(item, &session)
                                 .await;
                         })
                         .await;
@@ -106,5 +120,122 @@ impl HeartbeatLoop {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    use alien_core::{DeploymentModel, Platform, StackSettings};
+    use chrono::Utc;
+
+    use super::*;
+    use crate::traits::deployment_store::{DeploymentRecord, ExecutionClaim, MockDeploymentStore};
+
+    struct RecordingProcessor {
+        processed: Mutex<Vec<(AcquiredDeployment, String)>>,
+    }
+
+    #[async_trait]
+    impl HeartbeatDeploymentProcessor for RecordingProcessor {
+        async fn process_heartbeat_deployment(&self, item: AcquiredDeployment, session: &str) {
+            self.processed
+                .lock()
+                .expect("recording processor mutex poisoned")
+                .push((item, session.to_string()));
+        }
+    }
+
+    fn running_deployment() -> DeploymentRecord {
+        let mut stack_settings = StackSettings::default();
+        stack_settings.deployment_model = DeploymentModel::Push;
+        DeploymentRecord {
+            id: "dep_heartbeat_claim".to_string(),
+            workspace_id: "default".to_string(),
+            project_id: "default".to_string(),
+            name: "heartbeat-claim".to_string(),
+            deployment_group_id: "dg_test".to_string(),
+            platform: Platform::Machines,
+            deployment_protocol_version: alien_core::DEPLOYMENT_PROTOCOL_VERSION,
+            base_platform: None,
+            status: "running".to_string(),
+            stack_settings: Some(stack_settings),
+            stack_state: None,
+            environment_info: None,
+            runtime_metadata: None,
+            current_release_id: Some("rel_test".to_string()),
+            desired_release_id: Some("rel_test".to_string()),
+            import_source: None,
+            setup_method: None,
+            setup_metadata: None,
+            setup_target: None,
+            setup_fingerprint: None,
+            setup_fingerprint_version: None,
+            user_environment_variables: None,
+            management_config: None,
+            deployment_config: None,
+            deployment_token: None,
+            input_values: Default::default(),
+            retry_requested: false,
+            locked_by: None,
+            locked_at: None,
+            created_at: Utc::now(),
+            updated_at: None,
+            error: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn acquired_execution_claim_reaches_heartbeat_processor_unchanged() {
+        let expected_claim = ExecutionClaim {
+            operation_id: "op_123".to_string(),
+            attempt_id: "attempt_456".to_string(),
+        };
+        let acquired = AcquiredDeployment {
+            deployment: running_deployment(),
+            execution_claim: Some(expected_claim.clone()),
+        };
+        let acquire_calls = Arc::new(AtomicUsize::new(0));
+        let mut store = MockDeploymentStore::new();
+        store.expect_acquire().times(2).returning({
+            let acquire_calls = acquire_calls.clone();
+            let acquired = acquired.clone();
+            move |_, _, filter, limit| {
+                assert_eq!(
+                    filter.statuses.as_deref(),
+                    Some(["running".to_string()].as_slice())
+                );
+                assert_eq!(filter.deployment_model, Some(DeploymentModel::Push));
+                assert_eq!(limit, MAX_CONCURRENT_DEPLOYMENTS as u32);
+                let result = if acquire_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    vec![acquired.clone()]
+                } else {
+                    Vec::new()
+                };
+                Ok(result)
+            }
+        });
+
+        let processor = Arc::new(RecordingProcessor {
+            processed: Mutex::new(Vec::new()),
+        });
+        let heartbeat = HeartbeatLoop::new(
+            Arc::new(ManagerConfig::default()),
+            Arc::new(store),
+            processor.clone(),
+        );
+
+        heartbeat.tick().await;
+
+        let processed = processor
+            .processed
+            .lock()
+            .expect("recording processor mutex poisoned");
+        assert_eq!(processed.len(), 1);
+        assert_eq!(processed[0].0.deployment.id, "dep_heartbeat_claim");
+        assert_eq!(processed[0].0.execution_claim, Some(expected_claim));
+        assert!(!processed[0].1.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- preserve the execution claim acquired by the heartbeat loop
- pass the claim through heartbeat reconciliation and release
- add a regression test that verifies operation and attempt IDs reach the processor unchanged

## Testing

- `cargo test -p alien-manager --lib loops::heartbeat::tests::acquired_execution_claim_reaches_heartbeat_processor_unchanged`
- `rustfmt --edition 2021 --check crates/alien-manager/src/loops/heartbeat.rs crates/alien-manager/src/loops/deployment.rs`

Closes ALIEN-661.