### PR TITLE
chore: release v3.3.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "alien-ai-gateway"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "base64 0.23.1",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "aegis",
  "alien-aws-clients",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error",
  "chrono",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sandbox-agent"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-ai-gateway",
  "alien-aws-clients",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.3.19"
+version = "3.3.20"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.3.19"
+version = "3.3.20"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -65,39 +65,39 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.3.19", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.3.20", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.3.19", default-features = false }
-alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.19" }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.19" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.3.19", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.19" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.3.20", default-features = false }
+alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.20" }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.20" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.3.20", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.20" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.3.19" }
-alien-infra = { path = "crates/alien-infra", version = "3.3.19" }
-alien-build = { path = "crates/alien-build", version = "3.3.19" }
-alien-macros = { path = "crates/alien-macros", version = "3.3.19" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.3.19" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.3.19" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.19" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.19" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.19" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.19" }
-alien-error = { path = "crates/alien-error", version = "3.3.19", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.19" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.3.19" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.3.19" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.3.19" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.19" }
-alien-local = { path = "crates/alien-local", version = "3.3.19" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.19" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.3.19" }
-alien-helm = { path = "crates/alien-helm", version = "3.3.19" }
-alien-manager = { path = "crates/alien-manager", version = "3.3.19" }
-alien-observer = { path = "crates/alien-observer", version = "3.3.19" }
+alien-core = { path = "crates/alien-core", version = "3.3.20" }
+alien-infra = { path = "crates/alien-infra", version = "3.3.20" }
+alien-build = { path = "crates/alien-build", version = "3.3.20" }
+alien-macros = { path = "crates/alien-macros", version = "3.3.20" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.3.20" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.3.20" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.20" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.20" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.20" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.20" }
+alien-error = { path = "crates/alien-error", version = "3.3.20", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.20" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.3.20" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.3.20" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.3.20" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.20" }
+alien-local = { path = "crates/alien-local", version = "3.3.20" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.20" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.3.20" }
+alien-helm = { path = "crates/alien-helm", version = "3.3.20" }
+alien-manager = { path = "crates/alien-manager", version = "3.3.20" }
+alien-observer = { path = "crates/alien-observer", version = "3.3.20" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.19", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.19", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.20", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.20", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/.speakeasy/gen.lock
+++ b/client-sdks/manager/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.19
+  releaseVersion: 3.3.20
   configChecksum: e4b2d88985ffb955cd697b9adc28ca69
   repoURL: https://github.com/alienplatform/alien.git
   repoSubDirectory: client-sdks/manager/typescript

--- a/client-sdks/manager/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/manager/typescript/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.19
+  version: 3.3.20
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/manager/typescript/jsr.json
+++ b/client-sdks/manager/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/.speakeasy/gen.lock
+++ b/client-sdks/platform/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.19
+  releaseVersion: 3.3.20
   configChecksum: 96f8df7a303072e120ab4adfd2e3ad4a
 persistentEdits:
   generation_id: db6ac3e5-6bcc-4de5-a81f-eb659048385d

--- a/client-sdks/platform/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/platform/typescript/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.19
+  version: 3.3.20
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/platform/typescript/jsr.json
+++ b/client-sdks/platform/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/platform/typescript/package-lock.json
+++ b/client-sdks/platform/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alienplatform/platform-api",
-      "version": "3.3.19",
+      "version": "3.3.20",
       "license": "FSL-1.1-Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/ai-gateway",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "type": "module",
   "files": [
     "dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "type": "module",
   "files": [
     "dist"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Release Alien v3.3.20 from current main, including remote sandbox capability support in the CLI (#573) and the SDK runtime metadata release fix (#577).

Rust, npm, JSR, generator manifests, and both SDK runtime versions/default user-agents are synchronized to 3.3.20. The diff against main contains only release-version changes. SDK runtime metadata was generated with `node scripts/sdk-release-metadata.mjs`.

Validation: eight release metadata/routing tests pass. Both TypeScript SDK builds pass, and Request objects from both built SDKs identify version 3.3.20. Refreshed CI and release qualification are running; publication follows successful qualification and merge.
