### PR TITLE
fix: synchronize generated SDK runtime release versions

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -55,15 +55,16 @@ jobs:
               echo "::error::Release qualification requires a Linear-derived branch"
               exit 1
             fi
-            allowed='^(Cargo.toml|Cargo.lock|packages/(core|commands|sdk|testing|bindings|ai-gateway)/package.json|crates/alien-bindings-node/package.json|client-sdks/(platform|manager)/typescript/(package.json|jsr.json|package-lock.json|\.speakeasy/(gen.yaml|gen.lock))|packages/bindings/npm/(darwin-arm64|darwin-x64|linux-x64-gnu|linux-arm64-gnu)/package.json)$'
+            allowed='^(Cargo.toml|Cargo.lock|packages/(core|commands|sdk|testing|bindings|ai-gateway)/package.json|crates/alien-bindings-node/package.json|client-sdks/(platform|manager)/typescript/(package.json|jsr.json|package-lock.json|src/lib/config.ts|\.speakeasy/(gen.yaml|gen.lock))|packages/bindings/npm/(darwin-arm64|darwin-x64|linux-x64-gnu|linux-arm64-gnu)/package.json)$'
             unexpected=$(git diff --name-only "$BASE_SHA" "$SOURCE_REF" | grep -Ev "$allowed" || true)
             if [ -n "$unexpected" ]; then
               echo "::error::Release PR contains non-version files:"
               echo "$unexpected"
               exit 1
             fi
-            BASE_SHA="$BASE_SHA" SOURCE_REF="$SOURCE_REF" node <<'NODE'
-            const { execFileSync } = require('child_process');
+            BASE_SHA="$BASE_SHA" SOURCE_REF="$SOURCE_REF" node --input-type=module <<'NODE'
+            import { execFileSync } from 'node:child_process';
+            import { withSDKReleaseVersion } from './scripts/sdk-release-metadata.mjs';
 
             const changed = execFileSync(
               'git',
@@ -107,6 +108,9 @@ jobs:
                          path.endsWith('/.speakeasy/gen.lock')) {
                 base = normalizeSpeakeasy(path, fromRef(process.env.BASE_SHA, path));
                 head = normalizeSpeakeasy(path, fromRef(process.env.SOURCE_REF, path));
+              } else if (path.endsWith('/src/lib/config.ts')) {
+                base = withSDKReleaseVersion(fromRef(process.env.BASE_SHA, path), '0.0.0');
+                head = withSDKReleaseVersion(fromRef(process.env.SOURCE_REF, path), '0.0.0');
               } else {
                 continue;
               }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           fetch-depth: 0
 
+      - name: Test release metadata and routing
+        run: node --test scripts/sdk-release-metadata.test.mjs scripts/release-routing.test.mjs
+
       - name: Compute next version
         id: bump
         if: ${{ inputs.stable_action == 'prepare' || inputs.dry_run }}
@@ -272,6 +275,10 @@ jobs:
             }
           "
 
+      - name: Generate SDK release metadata
+        if: ${{ inputs.stable_action == 'prepare' || inputs.dry_run }}
+        run: node scripts/sdk-release-metadata.mjs
+
       - name: Regenerate Cargo lockfile
         if: ${{ inputs.stable_action == 'prepare' || inputs.dry_run }}
         run: cargo metadata --format-version 1 >/dev/null
@@ -298,12 +305,14 @@ jobs:
             client-sdks/platform/typescript/package-lock.json
             client-sdks/platform/typescript/.speakeasy/gen.yaml
             client-sdks/platform/typescript/.speakeasy/gen.lock
+            client-sdks/platform/typescript/src/lib/config.ts
             client-sdks/manager/typescript/package.json
             client-sdks/manager/typescript/jsr.json
             client-sdks/manager/typescript/package-lock.json
             client-sdks/manager/typescript/examples/package-lock.json
             client-sdks/manager/typescript/.speakeasy/gen.yaml
             client-sdks/manager/typescript/.speakeasy/gen.lock
+            client-sdks/manager/typescript/src/lib/config.ts
             packages/bindings/package.json
             crates/alien-bindings-node/package.json
             packages/bindings/npm/darwin-arm64/package.json
@@ -363,6 +372,10 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Verify SDK release metadata
+        if: ${{ inputs.stable_action == 'qualification' || inputs.stable_action == 'publish' }}
+        run: node scripts/sdk-release-metadata.mjs --check
 
       - name: Select same-run qualification artifacts
         id: qualification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.stable_action == 'qualification' && inputs.source_ref || github.ref }}
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           fetch-depth: 0
+
+      - name: Verify qualification source commit
+        if: ${{ inputs.stable_action == 'qualification' }}
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          if ! grep -qE '^[0-9a-f]{40}$' <<< "$SOURCE_REF" || \
+             [ "$(git rev-parse HEAD)" != "$SOURCE_REF" ]; then
+            echo "::error::Qualification must validate its exact source commit"
+            exit 1
+          fi
 
       - name: Test release metadata and routing
         run: node --test scripts/sdk-release-metadata.test.mjs scripts/release-routing.test.mjs

--- a/scripts/release-routing.test.mjs
+++ b/scripts/release-routing.test.mjs
@@ -28,26 +28,6 @@ function parseJobs(source) {
   return jobs
 }
 
-const stableJobs = [
-  "prepare",
-  "generate-changelog",
-  "publish-crates",
-  "publish-npm",
-  "publish-client-sdks",
-  "build-addon",
-  "smoke-addon",
-  "publish-bindings",
-  "build-binaries-linux-x86_64",
-  "build-binaries-linux-aarch64",
-  "build-binaries-darwin",
-  "build-binaries-windows",
-  "upload-binaries",
-  "create-github-release",
-  "publish-images",
-  "publish-homebrew-tap",
-  "publish-npm-cli-wrapper",
-]
-
 test("stable remains the default release mode", () => {
   assert.match(
     workflow,
@@ -75,15 +55,11 @@ test("dev publication passes npm an unambiguous local tarball path", () => {
 
 test("dev mode can reach only the reusable npm dev workflow", () => {
   const jobs = parseJobs(workflow)
-  assert.deepEqual([...jobs.keys()].sort(), ["publish-npm-dev", ...stableJobs].sort())
   assert.equal(jobs.get("publish-npm-dev").if, "inputs.mode == 'dev'")
   assert.equal(jobs.get("publish-npm-dev").uses, "./.github/workflows/publish-npm-dev.yml")
 
-  for (const name of stableJobs) {
-    assert.match(
-      jobs.get(name).if,
-      /inputs\.mode == 'stable'/,
-      `${name} must be unreachable in dev mode`,
-    )
+  for (const [name, job] of jobs) {
+    if (name === "publish-npm-dev") continue
+    assert.match(job.if, /inputs\.mode == 'stable'/, `${name} must be unreachable in dev mode`)
   }
 })

--- a/scripts/sdk-release-metadata.mjs
+++ b/scripts/sdk-release-metadata.mjs
@@ -1,0 +1,36 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+// Release preparation must version runtime metadata as well as manifests.
+// Keep the API and generator versions supplied by Speakeasy unchanged.
+export function withSDKReleaseVersion(source, version) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid SDK release version: ${version}`)
+  }
+  const patterns = [/(\bsdkVersion: ")[^"]+("[,]?)/g, /("speakeasy-sdk\/typescript )\S+( )/g]
+  let result = source
+  for (const pattern of patterns) {
+    if ([...result.matchAll(pattern)].length !== 1) {
+      throw new Error("Expected exactly one SDK version and default user-agent in generated config")
+    }
+    result = result.replace(pattern, (_, prefix, suffix) => prefix + version + suffix)
+  }
+  return result
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  for (const sdk of ["platform", "manager"]) {
+    const root = `client-sdks/${sdk}/typescript`
+    const { version } = JSON.parse(readFileSync(`${root}/package.json`, "utf8"))
+    const path = `${root}/src/lib/config.ts`
+    const source = readFileSync(path, "utf8")
+    const generated = withSDKReleaseVersion(source, version)
+    if (process.argv.includes("--check")) {
+      if (source !== generated)
+        throw new Error(`${sdk} SDK runtime metadata does not match package version ${version}`)
+    } else {
+      writeFileSync(path, generated)
+    }
+  }
+}

--- a/scripts/sdk-release-metadata.test.mjs
+++ b/scripts/sdk-release-metadata.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import { withSDKReleaseVersion } from "./sdk-release-metadata.mjs"
+
+for (const sdk of ["platform", "manager"]) {
+  const path = `client-sdks/${sdk}/typescript/src/lib/config.ts`
+  const source = readFileSync(path, "utf8")
+  test(`${sdk} release metadata advances without changing the API or generator`, () => {
+    const generated = withSDKReleaseVersion(source, "9.8.7")
+    const metadata = text =>
+      JSON.parse(
+        text
+          .slice(
+            text.indexOf("export const SDK_METADATA = ") + "export const SDK_METADATA = ".length,
+          )
+          .replace(/ as const;\s*$/, "")
+          .replace(/(\w+):/g, '"$1":')
+          .replace(/,\s*}/, "}"),
+      )
+    const before = metadata(source)
+    const after = metadata(generated)
+    assert.deepEqual(after, {
+      ...before,
+      sdkVersion: "9.8.7",
+      userAgent: before.userAgent.replace(/^(speakeasy-sdk\/typescript )\S+/, "$19.8.7"),
+    })
+    assert.equal(withSDKReleaseVersion(generated, before.sdkVersion), source)
+    assert.equal(withSDKReleaseVersion(generated, "9.8.7"), generated)
+  })
+  test(`${sdk} rejects missing or duplicate runtime version fields`, () => {
+    assert.throws(() => withSDKReleaseVersion(source.replace("sdkVersion:", "version:"), "9.8.7"))
+    assert.throws(() => withSDKReleaseVersion(source + source, "9.8.7"))
+    assert.throws(() =>
+      withSDKReleaseVersion(
+        source.replace("speakeasy-sdk/typescript", "other-sdk/typescript"),
+        "9.8.7",
+      ),
+    )
+    assert.throws(() => withSDKReleaseVersion(source, "invalid"))
+  })
+}


### PR DESCRIPTION
Release preparation previously advanced SDK manifests to 3.3.20 while leaving the runtime SDK version and default user-agent at 3.3.19. Generate both runtime version fields from each SDK package version during release preparation, carry the generated configs into dry runs, and reject mismatches during qualification and publication.

Qualification checks out and verifies the exact source commit used by the artifact builds.

Release qualification permits only the two version fields to change in generated configs; server URLs, API versions, generator versions, and other code must remain identical. Update the release-routing test to check every stable job, including the qualification jobs added since its original fixed list.

Validation: eight metadata/routing tests, formatting/lint, and actionlint passed. Generated 3.3.20 metadata for both SDKs in temporary copies and verified the exact default user-agent on actual SDK Request objects. No network requests were sent by that test.
