### PR TITLE
fix(sandbox): grant a runtime-built sandbox the bundle prefix it rebuilds from

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/sandbox.rs
@@ -73,7 +73,7 @@ impl CfEmitter for AwsSandboxEmitter {
         );
         role.properties.insert(
             "Policies".to_string(),
-            build_policies(artifact_uri, provisioned_at_runtime(ctx)),
+            build_policies(sandbox, artifact_uri, provisioned_at_runtime(ctx))?,
         );
         role.properties.insert("Tags".to_string(), tags(ctx));
 
@@ -469,14 +469,26 @@ fn preview_ports(sandbox: &Sandbox) -> CfExpression {
 /// What the build role may do: read the bundle, write its own build logs, and — only when the
 /// image is built at runtime — authenticate to ECR for its base image.
 ///
-/// Scoped to the one object it reads. The bundle URI is known when the template is generated, so
-/// there is no reason for the role a customer installs to carry account-wide object read.
+/// A setup-baked image is built once, from the bundle the template names, so its role reads that
+/// one object; a runtime-built image reads the prefix instead — see `artifact_prefix_arn`.
 ///
 /// A setup-baked image builds from a public base and pulls it anonymously, so the Frozen role
 /// carries no ECR grant; a runtime-built image's base is a private registry image.
-fn build_policies(artifact_uri: BundleUri<'_>, runtime_built: bool) -> CfExpression {
+fn build_policies(
+    sandbox: &Sandbox,
+    artifact_uri: BundleUri<'_>,
+    runtime_built: bool,
+) -> Result<CfExpression> {
     let mut statements = vec![
         CfExpression::object([
+            (
+                "Sid",
+                CfExpression::from(if runtime_built {
+                    "ReadSandboxBundlePrefix"
+                } else {
+                    "ReadSandboxBundle"
+                }),
+            ),
             ("Effect", CfExpression::from("Allow")),
             (
                 "Action",
@@ -484,10 +496,11 @@ fn build_policies(artifact_uri: BundleUri<'_>, runtime_built: bool) -> CfExpress
             ),
             (
                 "Resource",
-                // Partition-qualified like every other ARN here: a hardcoded
-                // `aws` never matches in GovCloud or China, and the build fails
-                // on the bundle it was granted.
-                artifact_object_arn(artifact_uri),
+                if runtime_built {
+                    artifact_prefix_arn(sandbox, artifact_uri)?
+                } else {
+                    artifact_object_arn(artifact_uri)
+                },
             ),
         ]),
         CfExpression::object([
@@ -544,7 +557,7 @@ fn build_policies(artifact_uri: BundleUri<'_>, runtime_built: bool) -> CfExpress
             ),
         ]));
     }
-    CfExpression::list([CfExpression::object([
+    Ok(CfExpression::list([CfExpression::object([
         ("PolicyName", CfExpression::from("sandbox-image-build")),
         (
             "PolicyDocument",
@@ -553,7 +566,7 @@ fn build_policies(artifact_uri: BundleUri<'_>, runtime_built: bool) -> CfExpress
                 ("Statement", CfExpression::list(statements)),
             ]),
         ),
-    ])])
+    ])]))
 }
 
 /// Lifecycle hooks, served by the agent on its own port.
@@ -826,14 +839,48 @@ fn code_artifact_uri(uri: BundleUri<'_>) -> CfExpression {
 /// The bundle object's ARN. Partition-qualified like every other ARN here — a hardcoded `aws`
 /// never matches in GovCloud — and region-qualified for the same reason one region out.
 fn artifact_object_arn(uri: BundleUri<'_>) -> CfExpression {
-    let path = match uri {
+    CfExpression::sub(format!(
+        "arn:${{AWS::Partition}}:s3:::{}",
+        bundle_object_path(uri)
+    ))
+}
+
+/// The bucket-and-key path a bundle URI addresses, with the region token resolved.
+fn bundle_object_path(uri: BundleUri<'_>) -> String {
+    match uri {
         BundleUri::Literal(uri) => uri.trim_start_matches("s3://").to_string(),
         BundleUri::Regional { before, after } => format!(
             "{}${{AWS::Region}}{after}",
             before.trim_start_matches("s3://")
         ),
+    }
+}
+
+/// The prefix a runtime-built image's build role reads bundles under — `stable_bundle_key_prefix`
+/// says which part of the key that is, and the Terraform module grants through the same rule.
+/// Refused, not narrowly granted, when absent: the alternative denies partway through a build.
+fn artifact_prefix_arn(sandbox: &Sandbox, uri: BundleUri<'_>) -> Result<CfExpression> {
+    let path = bundle_object_path(uri);
+    let (bucket, key) = path
+        .split_once('/')
+        .unwrap_or_else(|| unreachable!("artifact_uri refuses a URI with no object key"));
+
+    let Some(prefix) = alien_core::stable_bundle_key_prefix(key) else {
+        return Err(AlienError::new(ErrorData::OperationNotSupported {
+            operation: format!("cloudformation emit sandbox '{}'", sandbox.id()),
+            reason: format!(
+                "code.image key '{key}' cannot be granted to a sandbox built at runtime: each \
+                 rebuild reads a new key, so the grant has to name a prefix the new key still \
+                 sits under, and this one has nothing above its version segment. Publish the \
+                 bundle under a stable prefix, for example \
+                 s3://bucket/sandbox-bundle/<version>/bundle.zip"
+            ),
+        }));
     };
-    CfExpression::sub(format!("arn:${{AWS::Partition}}:s3:::{path}"))
+
+    Ok(CfExpression::sub(format!(
+        "arn:${{AWS::Partition}}:s3:::{bucket}/{prefix}/*"
+    )))
 }
 
 #[cfg(test)]
@@ -892,6 +939,75 @@ mod tests {
             uri_text.contains("${AWS::Region}") && !uri_text.contains("{region}"),
             "the token must be consumed, not emitted verbatim: {uri_text}"
         );
+    }
+
+    /// A sandbox carrying one bundle URI, for the prefix-grant cases.
+    fn sandbox_with(image: &str) -> Sandbox {
+        Sandbox::new("sbx".to_string())
+            .code(SandboxCode::Image {
+                image: image.to_string(),
+            })
+            .limits(alien_core::SandboxLimits {
+                cpu: "1".to_string(),
+                memory: "2Gi".to_string(),
+                disk: "20Gi".to_string(),
+                max_processes: None,
+            })
+            .egress(SandboxEgress::Allow)
+            .session(alien_core::SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build()
+    }
+
+    fn prefix_grant(image: &str) -> Result<String> {
+        let sandbox = sandbox_with(image);
+        artifact_prefix_arn(&sandbox, parsed(image)).map(|arn| sub_text(&arn).to_string())
+    }
+
+    /// A deep key separates the true prefix from both near-misses: the key's first segment would
+    /// hand the role every team's objects under `artifacts/`, and the object's own directory
+    /// would pin the version segment that moves.
+    #[test]
+    fn the_prefix_grant_stops_above_the_segment_that_moves() {
+        assert_eq!(
+            prefix_grant("s3://acme-artifacts/sandbox-bundle/f00dcafe/bundle.zip")
+                .expect("the store layout is grantable"),
+            "arn:${AWS::Partition}:s3:::acme-artifacts/sandbox-bundle/*"
+        );
+        assert_eq!(
+            prefix_grant("s3://acme-releases/artifacts/team-a/sandbox/f00dcafe/bundle.zip")
+                .expect("a deeper layout is grantable too"),
+            "arn:${AWS::Partition}:s3:::acme-releases/artifacts/team-a/sandbox/*",
+            "a deeper key must narrow the grant, never widen it to its first segment"
+        );
+    }
+
+    /// The prefix grant is derived from the same path the URI is, so the region token has to
+    /// survive into it. A grant naming a literal region denies the build in every other one.
+    #[test]
+    fn the_prefix_grant_carries_the_region_the_uri_resolves_to() {
+        assert_eq!(
+            prefix_grant("s3://acme-artifacts-{region}/sandbox-bundle/f00dcafe/bundle.zip")
+                .expect("a regional store is grantable"),
+            "arn:${AWS::Partition}:s3:::acme-artifacts-${AWS::Region}/sandbox-bundle/*"
+        );
+    }
+
+    /// A key with nothing above its version segment cannot express a prefix a moved bundle would
+    /// still sit under. Emitting the object grant instead would install a role that denies the
+    /// first rebuild, so the refusal has to land at plan time.
+    #[test]
+    fn a_key_with_no_stable_prefix_is_refused_rather_than_granted_narrowly() {
+        for image in [
+            "s3://acme-artifacts/bundle.zip",
+            "s3://acme-artifacts/agents/bundle.zip",
+        ] {
+            let error = prefix_grant(image)
+                .expect_err("a key with no stable prefix must be refused, not silently granted");
+            assert_eq!(error.code, "OPERATION_NOT_SUPPORTED", "for {image}");
+        }
     }
 
     /// The refusal has to land at plan time. A brace reaching S3 verbatim dies ~160s into the

--- a/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
+++ b/crates/alien-cloudformation/tests/generator/aws_sandbox_tests.rs
@@ -10,10 +10,19 @@ use alien_core::{
     StackSettings, Worker, WorkerCode,
 };
 
+/// A bundle key a runtime rebuild can be granted: the version segment moves, the prefix does not.
+/// A Frozen sandbox is built once and needs no such shape, so it keeps the flat key its snapshots
+/// were taken with.
+const LIVE_BUNDLE: &str = "s3://acme-artifacts/sandbox-bundle/f00dcafe/bundle.zip";
+
 fn sandbox_fixture(egress: SandboxEgress) -> Sandbox {
+    sandbox_fixture_with(egress, "s3://acme-artifacts/agents/bundle.zip")
+}
+
+fn sandbox_fixture_with(egress: SandboxEgress, image: &str) -> Sandbox {
     Sandbox::new("agents".to_string())
         .code(SandboxCode::Image {
-            image: "s3://acme-artifacts/agents/bundle.zip".to_string(),
+            image: image.to_string(),
         })
         .egress(egress)
         .session(SandboxSessionPolicy {
@@ -47,7 +56,13 @@ fn sandbox_stack_with_lifecycle(
                 .build(),
             ResourceLifecycle::Frozen,
         )
-        .add(sandbox_fixture(egress), lifecycle)
+        .add(
+            match lifecycle {
+                ResourceLifecycle::Live => sandbox_fixture_with(egress, LIVE_BUNDLE),
+                _ => sandbox_fixture(egress),
+            },
+            lifecycle,
+        )
         .build();
     (stack, settings)
 }
@@ -67,6 +82,19 @@ fn build_role_statements(template: &alien_cloudformation::CfTemplate) -> Vec<ser
         .as_array()
         .unwrap_or_else(|| panic!("the build policy statements must be a list: {role:#}"))
         .clone()
+}
+
+/// The `Fn::Sub` text of the statement granting `s3:GetObject`, which is the bundle grant.
+fn bundle_grant(template: &alien_cloudformation::CfTemplate) -> String {
+    let statements = build_role_statements(template);
+    let grant = statements
+        .iter()
+        .find(|statement| statement["Action"] == serde_json::json!(["s3:GetObject"]))
+        .unwrap_or_else(|| panic!("the build role must read its bundle: {statements:#?}"));
+    grant["Resource"]["Fn::Sub"]
+        .as_str()
+        .unwrap_or_else(|| panic!("the grant must be partition-qualified through Sub: {grant:#}"))
+        .to_string()
 }
 
 /// Whether a parsed IAM statement carries any `ecr:` action.
@@ -265,6 +293,46 @@ fn a_live_sandbox_ships_its_build_role_but_not_its_image() {
     );
 }
 
+/// A grant naming the one object the template was generated with denies the build the first
+/// time the base image changes its key — exactly the update Live exists to avoid. The Frozen
+/// case here is the mutation guard: the same code path must not widen its grant too.
+#[test]
+fn only_a_live_build_role_reads_the_bundle_prefix() {
+    let (live, live_settings) = sandbox_stack_with_lifecycle(
+        "acme-sandbox-live-grant",
+        SandboxEgress::Deny,
+        ResourceLifecycle::Live,
+    );
+    let (live_template, _yaml) = render_built_ins_template(
+        &live,
+        live_settings,
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "live sandbox",
+    );
+    let (frozen, frozen_settings) = sandbox_stack("acme-sandbox-frozen-grant", SandboxEgress::Deny);
+    let (frozen_template, _yaml) = render_built_ins_template(
+        &frozen,
+        frozen_settings,
+        custom_resource_registration(),
+        CloudFormationTarget::Aws,
+        "aws",
+        "frozen sandbox",
+    );
+
+    assert_eq!(
+        bundle_grant(&frozen_template),
+        "arn:${AWS::Partition}:s3:::acme-artifacts/agents/bundle.zip",
+        "a Frozen role reads the one object its template names, and nothing else"
+    );
+    assert_eq!(
+        bundle_grant(&live_template),
+        "arn:${AWS::Partition}:s3:::acme-artifacts/sandbox-bundle/*",
+        "a Live role reads the prefix the moving key stays inside"
+    );
+}
+
 /// The Frozen path is the one every installed stack is on.
 #[test]
 fn a_frozen_sandbox_still_bakes_its_image_into_the_setup_stack() {
@@ -331,7 +399,7 @@ fn a_frozen_sandbox_still_bakes_its_image_into_the_setup_stack() {
 fn an_open_live_sandbox_ships_only_the_build_role() {
     let stack = Stack::new("acme-sandbox-open-live".to_string())
         .add(
-            sandbox_fixture(SandboxEgress::Allow),
+            sandbox_fixture_with(SandboxEgress::Allow, LIVE_BUNDLE),
             ResourceLifecycle::Live,
         )
         .build();

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_open_aws.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_open_aws.snap
@@ -557,7 +557,8 @@ Resources:
         PolicyDocument:
           Version: 2012-10-17
           Statement:
-          - Effect: Allow
+          - Sid: ReadSandboxBundle
+            Effect: Allow
             Action:
             - s3:GetObject
             Resource:

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_restricted_aws.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_restricted_aws.snap
@@ -552,7 +552,8 @@ Resources:
         PolicyDocument:
           Version: 2012-10-17
           Statement:
-          - Effect: Allow
+          - Sid: ReadSandboxBundle
+            Effect: Allow
             Action:
             - s3:GetObject
             Resource:

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -996,6 +996,16 @@ pub fn parse_bundle_uri(uri: &str) -> std::result::Result<BundleUri<'_>, String>
         .split_once('/')
         .ok_or_else(|| format!("'{uri}' names a bucket with no object key"))?;
 
+    // Both emitters interpolate this path into the build role's resource ARN, where `*` and `?`
+    // are IAM wildcards rather than literal characters. S3 accepts them in a key, so a bundle
+    // published under one would silently widen the grant past the bundle it names.
+    if path.contains('*') || path.contains('?') {
+        return Err(format!(
+            "'{uri}' carries an IAM wildcard; the bundle's path is interpolated into the build \
+             role's grant, so '*' and '?' would widen it past the bundle"
+        ));
+    }
+
     if key.contains('{') || key.contains('}') {
         return Err(format!(
             "'{uri}' places a token in the object key; {BUNDLE_REGION_TOKEN} is accepted in the \
@@ -1031,6 +1041,23 @@ pub fn parse_bundle_uri(uri: &str) -> std::result::Result<BundleUri<'_>, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A wildcard reaching the grant would widen it past the bundle, and it widens the Frozen
+    /// object grant as readily as the Live prefix — both interpolate the path into the ARN.
+    #[test]
+    fn a_uri_carrying_an_iam_wildcard_is_refused() {
+        for uri in [
+            "s3://acme/team-*/v1/bundle.zip",
+            "s3://acme/sandbox-bundle/f00d/bundle?.zip",
+            "s3://acme-*/sandbox-bundle/f00d/bundle.zip",
+        ] {
+            let error = parse_bundle_uri(uri).expect_err("a wildcard must be refused");
+            assert!(error.contains("IAM wildcard"), "for {uri}: {error}");
+        }
+
+        parse_bundle_uri("s3://acme/sandbox-bundle/f00d/bundle.zip")
+            .expect("an ordinary key still parses");
+    }
 
     /// The rule both package formats grant by, pinned here rather than in either. The
     /// near-misses the cases separate: the key's first segment grants objects a rebuild never

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -974,6 +974,15 @@ pub enum BundleUri<'a> {
     Regional { before: &'a str, after: &'a str },
 }
 
+/// The prefix a rebuild's new key still sits under: everything above the file name and the
+/// version segment beneath it. `None` when nothing sits there, meaning no prefix can be granted
+/// without also granting objects a rebuild never reads. Shared so both emitters agree on it.
+pub fn stable_bundle_key_prefix(key: &str) -> Option<&str> {
+    let (above_file, _) = key.rsplit_once('/')?;
+    let (above_version, _) = above_file.rsplit_once('/')?;
+    Some(above_version)
+}
+
 /// Reads a sandbox bundle URI, refusing anything an image build would only reject later.
 ///
 /// The token is accepted in the bucket alone. A key-position token would name an object that does
@@ -1022,6 +1031,27 @@ pub fn parse_bundle_uri(uri: &str) -> std::result::Result<BundleUri<'_>, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The rule both package formats grant by, pinned here rather than in either. The
+    /// near-misses the cases separate: the key's first segment grants objects a rebuild never
+    /// reads, and the object's own directory pins the version segment that moves.
+    #[test]
+    fn a_grantable_prefix_stops_above_the_segment_that_moves() {
+        assert_eq!(
+            stable_bundle_key_prefix("sandbox-bundle/f00dcafe/bundle.zip"),
+            Some("sandbox-bundle")
+        );
+        assert_eq!(
+            stable_bundle_key_prefix("artifacts/team-a/sandbox/f00dcafe/bundle.zip"),
+            Some("artifacts/team-a/sandbox"),
+            "a deeper key narrows the prefix, it never widens to the first segment"
+        );
+
+        // Nothing sits above the version segment, so no prefix a moved bundle stays inside
+        // exists. Emitting the object grant instead installs a role that denies the next rebuild.
+        assert_eq!(stable_bundle_key_prefix("agents/bundle.zip"), None);
+        assert_eq!(stable_bundle_key_prefix("bundle.zip"), None);
+    }
 
     fn sandbox_with(egress: SandboxEgress, preview_ports: Vec<u16>) -> Sandbox {
         Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-terraform/src/emitters/aws/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/aws/sandbox.rs
@@ -100,8 +100,20 @@ impl TfEmitter for AwsSandboxEmitter {
         // document, and encoding them again renders each one as a JSON *string*, which IAM
         // rejects with MalformedPolicyDocument. `terraform validate` cannot see it — the HCL
         // and the string are both well-formed — so it only shows up at apply.
+        let runtime_built = provisioned_at_runtime(ctx);
         let mut build_statements = vec![
             Expression::from_iter([
+                (
+                    "Sid",
+                    Expression::String(
+                        if runtime_built {
+                            "ReadSandboxBundlePrefix"
+                        } else {
+                            "ReadSandboxBundle"
+                        }
+                        .to_string(),
+                    ),
+                ),
                 ("Effect", Expression::String("Allow".to_string())),
                 (
                     "Action",
@@ -112,7 +124,11 @@ impl TfEmitter for AwsSandboxEmitter {
                     // A template for the same reason the operator policy's ARNs are: a plain
                     // string literal has its `${` escaped, so the partition would reach IAM as
                     // literal text and the grant would match nothing.
-                    expr::template(artifact_object_arn(artifact_uri)),
+                    expr::template(if runtime_built {
+                        artifact_prefix_arn(sandbox, artifact_uri)?
+                    } else {
+                        artifact_object_arn(artifact_uri)
+                    }),
                 ),
             ]),
             Expression::from_iter([
@@ -133,7 +149,7 @@ impl TfEmitter for AwsSandboxEmitter {
         ];
         // A setup-baked image builds from a public base and pulls it anonymously, so the Frozen
         // role carries no ECR grant; a runtime-built image's base is a private registry image.
-        if provisioned_at_runtime(ctx) {
+        if runtime_built {
             build_statements.push(Expression::from_iter([
                 (
                     "Sid",
@@ -672,20 +688,54 @@ fn base_image_arn() -> Expression {
     ))
 }
 
-/// The one object the build reads, as an ARN.
+/// The one object a setup-baked build reads, as an ARN.
 ///
 /// The bundle URI is known when the module is emitted, so the build role is scoped to it rather
 /// than to every object in the account. `s3://bucket/key` maps to `arn:<partition>:s3:::bucket/key`; a
 /// URI without a key would be a bucket ARN, which `artifact_uri` has already refused.
 fn artifact_object_arn(uri: BundleUri<'_>) -> String {
-    let path = match uri {
+    format!(
+        "arn:${{data.aws_partition.current.partition}}:s3:::{}",
+        bundle_object_path(uri)
+    )
+}
+
+/// The bucket-and-key path a bundle URI addresses, with the region token resolved.
+fn bundle_object_path(uri: BundleUri<'_>) -> String {
+    match uri {
         BundleUri::Literal(uri) => uri.trim_start_matches("s3://").to_string(),
         BundleUri::Regional { before, after } => format!(
             "{}${{data.aws_region.current.region}}{after}",
             before.trim_start_matches("s3://")
         ),
+    }
+}
+
+/// The prefix a runtime-built image's build role reads bundles under — `stable_bundle_key_prefix`
+/// says which part of the key that is, and the CloudFormation template grants through the same
+/// rule, so one declaration installs one grant whichever package format a customer chose.
+fn artifact_prefix_arn(sandbox: &Sandbox, uri: BundleUri<'_>) -> Result<String> {
+    let path = bundle_object_path(uri);
+    let (bucket, key) = path
+        .split_once('/')
+        .unwrap_or_else(|| unreachable!("artifact_uri refuses a URI with no object key"));
+
+    let Some(prefix) = alien_core::stable_bundle_key_prefix(key) else {
+        return Err(AlienError::new(ErrorData::OperationNotSupported {
+            operation: format!("terraform emit sandbox '{}'", sandbox.id()),
+            reason: format!(
+                "code.image key '{key}' cannot be granted to a sandbox built at runtime: each \
+                 rebuild reads a new key, so the grant has to name a prefix the new key still \
+                 sits under, and this one has nothing above its version segment. Publish the \
+                 bundle under a stable prefix, for example \
+                 s3://bucket/sandbox-bundle/<version>/bundle.zip"
+            ),
+        }));
     };
-    format!("arn:${{data.aws_partition.current.partition}}:s3:::{path}")
+
+    Ok(format!(
+        "arn:${{data.aws_partition.current.partition}}:s3:::{bucket}/{prefix}/*"
+    ))
 }
 
 /// The `CodeArtifact.Uri`, with the region resolved where the vendor asked for one.

--- a/crates/alien-terraform/tests/generator/aws_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_identity_tests.rs
@@ -392,10 +392,19 @@ fn aws_sandbox_refuses_an_egress_mode_it_cannot_deliver() {
     }
 }
 
+/// A bundle key a runtime rebuild can be granted: the version segment moves, the prefix does not.
+/// A Frozen sandbox is built once and needs no such shape, so it keeps the flat key its snapshots
+/// were taken with.
+const LIVE_BUNDLE: &str = "s3://acme-artifacts/sandbox-bundle/f00dcafe/bundle.zip";
+
 fn sandbox_fixture(egress: SandboxEgress) -> Sandbox {
+    sandbox_fixture_with(egress, "s3://acme-artifacts/agents/bundle.zip")
+}
+
+fn sandbox_fixture_with(egress: SandboxEgress, image: &str) -> Sandbox {
     Sandbox::new("agents".to_string())
         .code(SandboxCode::Image {
-            image: "s3://acme-artifacts/agents/bundle.zip".to_string(),
+            image: image.to_string(),
         })
         .egress(egress)
         .session(SandboxSessionPolicy {
@@ -451,7 +460,10 @@ fn live_sandbox_stack(name: &str, egress: SandboxEgress) -> (Stack, StackSetting
                 .build(),
             ResourceLifecycle::Frozen,
         )
-        .add(sandbox_fixture(egress), ResourceLifecycle::Live)
+        .add(
+            sandbox_fixture_with(egress, LIVE_BUNDLE),
+            ResourceLifecycle::Live,
+        )
         .build();
     (stack, settings)
 }
@@ -487,9 +499,23 @@ fn a_live_sandbox_module_keeps_the_build_role_and_drops_the_image() {
         "the connector the build and the session are passed must still be installed:\n{rendered}"
     );
 
+    let statements = build_policy_statements(&rendered);
+
+    // The grant a runtime rebuild needs, and the assertion that keeps this module and the
+    // CloudFormation one from installing different roles for one declaration: both derive the
+    // prefix through `alien_core::stable_bundle_key_prefix`, and both must render it.
+    let bundle = statements
+        .iter()
+        .find(|statement| statement["Sid"] == "ReadSandboxBundlePrefix")
+        .unwrap_or_else(|| panic!("a Live build role must read its bundle: {statements:#?}"));
+    assert_eq!(
+        bundle["Resource"],
+        "arn:${data.aws_partition.current.partition}:s3:::acme-artifacts/sandbox-bundle/*",
+        "a Live role reads the prefix the moving key stays inside, not the one object"
+    );
+
     // The runtime build's base image comes from a private registry, and the identity itself
     // needs all three actions — a repository policy on the registry side is not enough.
-    let statements = build_policy_statements(&rendered);
     let allow = statements
         .iter()
         .find(|statement| statement["Sid"] == "PullSandboxBaseImage")

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_sandbox_restricted.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_sandbox_restricted.snap
@@ -417,7 +417,7 @@ resource "aws_iam_role" "agents" {
 resource "aws_iam_role_policy" "agents" {
   name   = "sandbox-image-build"
   role   = aws_iam_role.agents.id
-  policy = jsonencode({ Version = "2012-10-17", Statement = [{ "Effect" = "Allow", "Action" = ["s3:GetObject"], "Resource" = "arn:${data.aws_partition.current.partition}:s3:::acme-artifacts/agents/bundle.zip" }, { "Effect" = "Allow", "Action" = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"], "Resource" = "*" }] })
+  policy = jsonencode({ Version = "2012-10-17", Statement = [{ "Sid" = "ReadSandboxBundle", "Effect" = "Allow", "Action" = ["s3:GetObject"], "Resource" = "arn:${data.aws_partition.current.partition}:s3:::acme-artifacts/agents/bundle.zip" }, { "Effect" = "Allow", "Action" = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"], "Resource" = "*" }] })
 }
 
 resource "time_sleep" "agents_iam_propagation" {


### PR DESCRIPTION
## Summary

A Live sandbox's image is rebuilt whenever its bundle key moves, but the build role we install was granted the one object the template happened to be generated with, so the first rebuild is denied. The grant now names the part of the key a rebuild keeps.

When a Live sandbox's image is rebuilt:

1. The controller reads whichever bundle the declaration names — a key that has moved since the customer installed their stack.
2. **The build role's `s3:GetObject` decides whether that read is allowed. It now names everything above the file name and the version segment beneath it, so a moved key is still inside it.** ← the heart
3. The image builds, and the customer never has to update their stack for it.

This changes a Live sandbox's bundle grant from one object to the prefix that object sits under.

## What was broken

The bundle key moves on every rebuild. A grant on one object stops authorizing the build the first time it moves, and the only way a customer clears that is by updating their setup stack — the update Live exists to avoid.

Terraform had the same problem and was not covered: it already knew Live from Frozen (it branches there for the registry grants) but emitted the object grant for both.

## What I did

Both package formats now derive the prefix through one rule, `stable_bundle_key_prefix` in `alien-core`. Two emitters deriving it apart is how one ends up installing a grant the other's customer would not recognise.

The rule takes everything above the file name and the version segment beneath it:

| declared `code.image` (Live) | grant |
|---|---|
| `s3://acme/sandbox-bundle/f00dcafe/bundle.zip` | `acme/sandbox-bundle/*` |
| `s3://acme/artifacts/team-a/sandbox/f00dcafe/bundle.zip` | `acme/artifacts/team-a/sandbox/*` |
| `s3://acme/agents/bundle.zip` | refused at plan time |

Taking the key's *first* segment instead would hand the role every object under `artifacts/`; taking the object's own directory would pin the version segment that moves, denying the rebuild the widening exists for. Assuming the version sits higher widens the grant on a guess; assuming it sits lower only ever denies.

A key with nothing above its version segment cannot express a prefix a moved bundle stays under, so it is refused at plan time — the same call `artifact_uri` already makes one level up, where it refuses a bucket with no key "rather than silently widening the grant". The alternative is a role that denies partway through a ~160s image build.

Frozen is unchanged: its image is built once, from the object the template names.

**Behaviour change:** a Live sandbox whose key has nothing above its version segment — `s3://bucket/agents/bundle.zip` — now fails at plan time instead of installing a role that denies at build time. Every bundle published under a `<prefix>/<version>/<file>` layout is unaffected.

## Files touched

- `alien-core/src/resources/sandbox.rs` — the shared rule
- `alien-cloudformation/src/emitters/aws/sandbox.rs` — branch the grant, refuse at plan time
- `alien-terraform/src/emitters/aws/sandbox.rs` — same, brought to parity
- tests and three snapshots (the snapshot diff is one `Sid:` line each)

## How I tested

- `cargo test -p alien-core -p alien-permissions -p alien-cloudformation -p alien-terraform -p alien-helm` — 554 / 21 / 122 / 213 / 16, all green.
- Rendered the Live AWS template and read the policy: the `s3:GetObject` statement is `arn:${AWS::Partition}:s3:::acme-artifacts/sandbox-bundle/*` and carries `Sid: ReadSandboxBundlePrefix`. The Frozen template still names the single object under `Sid: ReadSandboxBundle`.
- Mutation-checked the shared rule against both near-misses: the first-segment rule returns `Some("artifacts")` where the test expects `Some("artifacts/team-a/sandbox")`, and the containing-directory rule returns `Some("sandbox-bundle/f00dcafe")` where it expects `Some("sandbox-bundle")`. Both fail the test.
- A cross-format assertion pins that one declaration renders the same Live grant scope in the CloudFormation template and the Terraform module.

Walked the permission change for:

- **A Live role reading another tenant's bundles.** The prefix is bounded by what the declaration states, and every wildcard the customer installs is anchored to a name the stack composes — the same shape as `repository/${AWS::StackName}-<id>-*`. A deeper key now narrows the grant rather than widening it.
- **A customer-declared key silently widening the grant.** This is what the plan-time refusal exists for: a key whose moving segment cannot be identified is refused instead of being given the widest guess. `artifact_prefix_arn` returns `Result`, so there is no path that emits a grant for one.
- **Frozen quietly inheriting the widening.** `build_policies` branches on `provisioned_at_runtime`, and the Frozen half of `only_a_live_build_role_reads_the_bundle_prefix` fails if the same code path widens it.
- **The region token being dropped into a literal.** The prefix is derived from the same resolved path the URI is, and a test asserts `acme-artifacts-${AWS::Region}/sandbox-bundle/*`.

Nothing turned up.
