### PR TITLE
feat(bindings): tell an unreported sandbox outcome apart from an answered one

### DIFF
--- a/crates/alien-bindings-node/src/error.rs
+++ b/crates/alien-bindings-node/src/error.rs
@@ -241,6 +241,22 @@ mod tests {
         }
     }
 
+    /// The code and `retryable` flag have to survive the napi boundary, and neither side's tests
+    /// can see that alone: the Rust tests stop at the error, the TypeScript tests start at the
+    /// envelope.
+    #[test]
+    fn an_unknown_outcome_reaches_typescript_as_a_code_and_a_retry_flag() {
+        let napi_err = map_alien_error(AlienError::new(ErrorData::SandboxOutcomeUnknown {
+            operation: "sandbox.runCommand".to_string(),
+            reason: "the request never reached the agent".to_string(),
+        }));
+
+        let env = envelope_of(&napi_err);
+        assert_eq!(env["code"], "SANDBOX_OUTCOME_UNKNOWN");
+        assert_eq!(env["retryable"], false);
+        assert_eq!(env["context"]["operation"], "sandbox.runCommand");
+    }
+
     /// `retryable` must survive translation (STORAGE_OPERATION_FAILED is
     /// retryable, BINDING_NOT_CONFIGURED is not).
     #[test]

--- a/crates/alien-bindings/src/error.rs
+++ b/crates/alien-bindings/src/error.rs
@@ -325,11 +325,15 @@ pub enum ErrorData {
     /// The counterpart to `SandboxUnreachable`: there the call did not take effect and repeating it
     /// is safe, here it may already have taken effect, so a repeat can run the same command twice.
     /// Visibility is inherited for the reason `SandboxUnreachable` gives below.
+    ///
+    /// 502 rather than the 503 its neighbour carries: the exchange with the sandbox broke down,
+    /// which is not the same invitation to try again later.
     #[error(
         code = "SANDBOX_OUTCOME_UNKNOWN",
         message = "Sandbox operation '{operation}' did not report its outcome and may have taken effect: {reason}",
         retryable = "false",
-        internal = "inherit"
+        internal = "inherit",
+        http_status_code = 502
     )]
     SandboxOutcomeUnknown {
         /// Operation that was in flight

--- a/crates/alien-bindings/src/error.rs
+++ b/crates/alien-bindings/src/error.rs
@@ -313,9 +313,28 @@ pub enum ErrorData {
         http_status_code = 400
     )]
     SandboxCommandFailed {
-        /// The agent's own cause, kept as a field so a caller can branch on it
+        /// Diagnostic label from the provider or agent, for logs and support; callers branch on
+        /// the error code
         failure: String,
         /// Human-readable detail from the agent
+        reason: String,
+    },
+
+    /// A sandbox operation was dispatched and never reported its outcome.
+    ///
+    /// The counterpart to `SandboxUnreachable`: there the call did not take effect and repeating it
+    /// is safe, here it may already have taken effect, so a repeat can run the same command twice.
+    /// Visibility is inherited for the reason `SandboxUnreachable` gives below.
+    #[error(
+        code = "SANDBOX_OUTCOME_UNKNOWN",
+        message = "Sandbox operation '{operation}' did not report its outcome and may have taken effect: {reason}",
+        retryable = "false",
+        internal = "inherit"
+    )]
+    SandboxOutcomeUnknown {
+        /// Operation that was in flight
+        operation: String,
+        /// What went wrong on the wire
         reason: String,
     },
 

--- a/crates/alien-bindings/src/providers/sandbox/agent_protocol.rs
+++ b/crates/alien-bindings/src/providers/sandbox/agent_protocol.rs
@@ -214,9 +214,9 @@ fn deadline_millis(deadline: Duration) -> u64 {
 /// twice, and the refusal must not carry the retry signal.
 fn unanswered(operation: &str, reason: &str) -> ErrorData {
     if operation == RUN_COMMAND {
-        return ErrorData::SandboxCommandFailed {
-            failure: "outcomeUnknown".to_string(),
-            reason: format!("{reason}; the command may have started, its outcome is unknown"),
+        return ErrorData::SandboxOutcomeUnknown {
+            operation: operation.to_string(),
+            reason: reason.to_string(),
         };
     }
     ErrorData::SandboxUnreachable {
@@ -256,49 +256,22 @@ pub async fn send(request: reqwest::RequestBuilder, operation: &str) -> Result<r
     // two would let a dropped connection claim the request never arrived.
     let body = match response.text().await {
         Ok(body) => body,
-        // Unknown, and said so: for `run_command` a repeat could run it twice, so it is marked
-        // non-retryable; the file operations are idempotent and keep the retryable classification
-        // they had before the read failed.
-        Err(error) if operation == RUN_COMMAND => {
-            return Err(error)
-                .into_alien_error()
-                .context(ErrorData::SandboxCommandFailed {
-                    failure: "outcomeUnknown".to_string(),
-                    reason: format!(
-                        "{operation} returned {status} and its body could not be read, so whether \
-                         it ran is unknown"
-                    ),
-                })
-        }
         Err(error) => {
-            return Err(error)
-                .into_alien_error()
-                .context(ErrorData::SandboxUnreachable {
-                    operation: operation.to_string(),
-                    reason: format!("{operation} returned {status} and its body could not be read"),
-                })
+            return Err(error).into_alien_error().context(unanswered(
+                operation,
+                &format!("{operation} returned {status} and its body could not be read"),
+            ))
         }
     };
 
     // A 5xx with no body is the cloud's proxy, not the agent — it answers 502/503/504 that way
-    // when it cannot reach the guest, but can also synthesize one after delivering the request,
-    // so `run_command` reports an unknown outcome rather than never-delivered.
+    // when it cannot reach the guest, but can also synthesize one after delivering the request, so
+    // this cannot claim the request never arrived.
     if status.is_server_error() && body.trim().is_empty() {
-        if operation == RUN_COMMAND {
-            return Err(AlienError::new(ErrorData::SandboxCommandFailed {
-                failure: "outcomeUnknown".to_string(),
-                reason: format!(
-                    "the sandbox host returned {status} with no response from the agent, so \
-                     whether the command ran is unknown"
-                ),
-            }));
-        }
-        return Err(AlienError::new(ErrorData::SandboxUnreachable {
-            operation: operation.to_string(),
-            reason: format!(
-                "the sandbox host returned {status} before the request reached the agent"
-            ),
-        }));
+        return Err(AlienError::new(unanswered(
+            operation,
+            &format!("the sandbox host returned {status} with no response from the agent"),
+        )));
     }
 
     // A 5xx is the agent failing to complete a request it accepted, which is worth another
@@ -353,7 +326,11 @@ fn frame_stream(
                     Ok(frame) => frame,
                     Err(error) => {
                         state.finished = true;
-                        let failure = malformed(&error.to_string(), state.provider);
+                        // Classified like the decode arms in `into_output`, and for the same
+                        // reason: the frame arrived, so the command ran.
+                        let failure = Err::<(), _>(malformed(&error.to_string(), state.provider))
+                            .context(unanswered(RUN_COMMAND, "an output frame did not parse"))
+                            .expect_err("the Err arm is constructed on the line above");
                         return Some((Err(failure), state));
                     }
                 };
@@ -407,13 +384,18 @@ fn frame_stream(
 impl AgentFrame {
     fn into_output(self, provider: &'static str) -> Result<CommandOutput> {
         match self {
+            // A frame that arrived is proof the command ran, so a payload that will not decode
+            // leaves the outcome unestablished rather than merely malformed — reading it as a
+            // format problem would let a caller repeat a command that already executed.
             Self::Stdout { seq, data } => Ok(CommandOutput::Stdout {
                 seq,
-                data: decode(&data, provider, RUN_COMMAND, "data")?,
+                data: decode(&data, provider, RUN_COMMAND, "data")
+                    .context(unanswered(RUN_COMMAND, "an output frame did not decode"))?,
             }),
             Self::Stderr { seq, data } => Ok(CommandOutput::Stderr {
                 seq,
-                data: decode(&data, provider, RUN_COMMAND, "data")?,
+                data: decode(&data, provider, RUN_COMMAND, "data")
+                    .context(unanswered(RUN_COMMAND, "an output frame did not decode"))?,
             }),
             Self::Exit { code, truncated } => Ok(CommandOutput::Exit { code, truncated }),
             // An error frame is the command's outcome, so it surfaces as an error rather than
@@ -530,8 +512,8 @@ mod tests {
             !rendered.contains("agentRefused"),
             "a proxy 502 is not the agent refusing: {rendered}"
         );
-        assert!(
-            rendered.contains("outcomeUnknown"),
+        assert_eq!(
+            error.code, "SANDBOX_OUTCOME_UNKNOWN",
             "a proxy can synthesize a 502 after the agent accepted the request, so the caller has \
              to be told the outcome is unknown rather than that it is safe to repeat: {rendered}"
         );
@@ -548,8 +530,8 @@ mod tests {
             rendered.contains("spawn failed: ENOMEM"),
             "the agent's cause has to survive: {rendered}"
         );
-        assert!(
-            !rendered.contains("outcomeUnknown"),
+        assert_ne!(
+            error.code, "SANDBOX_OUTCOME_UNKNOWN",
             "the agent answered with its own cause, so the outcome is not unknown: {rendered}"
         );
     }
@@ -686,13 +668,13 @@ mod tests {
         .await
         .expect_err("a dropped connection is a refusal, not a response");
 
-        assert_eq!(error.code, "SANDBOX_COMMAND_FAILED", "got: {error}");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
         assert!(
             !error.retryable,
             "a command that may have started must not be retried: {error}"
         );
         assert!(
-            error.to_string().contains("may have started"),
+            error.to_string().contains("may have taken effect"),
             "the refusal says the outcome is unknown: {error}"
         );
     }
@@ -710,14 +692,14 @@ mod tests {
         .await
         .expect_err("a stalled agent must be refused, not waited on");
 
-        assert_eq!(error.code, "SANDBOX_COMMAND_FAILED", "got: {error}");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
         assert!(
             !error.retryable,
             "a command with an unknown outcome must not be retried: {error}"
         );
         assert!(
             error.to_string().contains("did not answer")
-                && error.to_string().contains("may have started"),
+                && error.to_string().contains("may have taken effect"),
             "the refusal says the agent stalled and the outcome is unknown: {error}"
         );
     }
@@ -811,6 +793,43 @@ mod tests {
         );
     }
 
+    /// A frame that arrived is proof the command ran, so a payload that will not decode leaves the
+    /// outcome unestablished. Reported as a format problem it would read as safe to repeat, and the
+    /// repeat would be a second execution.
+    #[tokio::test]
+    async fn a_frame_that_arrives_but_does_not_decode_leaves_the_outcome_unknown() {
+        let outputs = frames_from(vec!["{\"t\":\"stdout\",\"seq\":0,\"data\":\"!!not base64!!\"}\n"]).await;
+
+        let error = outputs[0]
+            .as_ref()
+            .expect_err("a payload that does not decode is not output");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
+        assert!(
+            !error.retryable,
+            "the command ran; a repeat would run it twice: {error}"
+        );
+        // The cause survives, so the reader still learns what was wrong with the frame.
+        assert!(
+            error.to_string().contains("base64"),
+            "the decode failure must stay in the chain: {error}"
+        );
+    }
+
+    /// A line that does not parse arrives the same way a decodable one does, so it carries the same
+    /// proof that the command ran.
+    #[tokio::test]
+    async fn a_frame_that_does_not_parse_leaves_the_outcome_unknown() {
+        let outputs = frames_from(vec!["{not json at all}\n"]).await;
+
+        let error = outputs[0].as_ref().expect_err("a malformed frame is not output");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
+        assert!(!error.retryable, "the command ran: {error}");
+        assert!(
+            error.to_string().contains("did not parse"),
+            "the parse failure must stay in the chain: {error}"
+        );
+    }
+
     /// A body that stops early looks exactly like a command that produced less output — the
     /// difference is only visible in the missing terminal frame. The command had started, so
     /// its end is unknown, and a retry could run it twice: the refusal must not invite one.
@@ -827,7 +846,7 @@ mod tests {
             error.to_string().contains("without a terminal frame"),
             "the failure must name the cause: {error}"
         );
-        assert_eq!(error.code, "SANDBOX_COMMAND_FAILED", "got: {error}");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
         assert!(
             !error.retryable,
             "a command that started and whose end was lost must not be retried: {error}"

--- a/crates/alien-bindings/src/providers/sandbox/agent_protocol.rs
+++ b/crates/alien-bindings/src/providers/sandbox/agent_protocol.rs
@@ -22,7 +22,7 @@ use serde_json::json;
 
 use crate::error::{ErrorData, Result};
 use crate::traits::{CommandOutput, RunCommandRequest};
-use alien_error::{AlienError, Context, IntoAlienError};
+use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 
 pub use alien_core::sandbox_process::AGENT_PORT;
 
@@ -264,24 +264,16 @@ pub async fn send(request: reqwest::RequestBuilder, operation: &str) -> Result<r
         }
     };
 
-    // A 5xx with no body is the cloud's proxy, not the agent — it answers 502/503/504 that way
-    // when it cannot reach the guest, but can also synthesize one after delivering the request, so
-    // this cannot claim the request never arrived.
-    if status.is_server_error() && body.trim().is_empty() {
+    // A 5xx never proves the agent answered, with or without a body: the cloud's proxy emits them
+    // too, and a 504 means the request reached the guest and no answer came back in time. A body
+    // is no evidence either way — a proxy's error page is a body. So a 5xx is the unanswered case,
+    // which for the idempotent file operations is still safe to repeat and for `run_command` is
+    // not. A 4xx is the agent refusing before it does anything, which is an answer.
+    if status.is_server_error() {
         return Err(AlienError::new(unanswered(
             operation,
-            &format!("the sandbox host returned {status} with no response from the agent"),
+            &format!("the sandbox host returned {status}: {body}"),
         )));
-    }
-
-    // A 5xx is the agent failing to complete a request it accepted, which is worth another
-    // attempt — except for `run_command`, where the command may already be running and a retry
-    // would run it twice. A 4xx is a refusal: repeating it repeats the refusal.
-    if status.is_server_error() && operation != RUN_COMMAND {
-        return Err(AlienError::new(ErrorData::SandboxUnreachable {
-            operation: operation.to_string(),
-            reason: format!("the agent returned {status}: {body}"),
-        }));
     }
 
     Err(AlienError::new(ErrorData::SandboxCommandFailed {
@@ -326,11 +318,11 @@ fn frame_stream(
                     Ok(frame) => frame,
                     Err(error) => {
                         state.finished = true;
+                        state.buffer.clear();
                         // Classified like the decode arms in `into_output`, and for the same
                         // reason: the frame arrived, so the command ran.
-                        let failure = Err::<(), _>(malformed(&error.to_string(), state.provider))
-                            .context(unanswered(RUN_COMMAND, "an output frame did not parse"))
-                            .expect_err("the Err arm is constructed on the line above");
+                        let failure = malformed(&error.to_string(), state.provider)
+                            .context(unanswered(RUN_COMMAND, "an output frame did not parse"));
                         return Some((Err(failure), state));
                     }
                 };
@@ -340,6 +332,14 @@ fn frame_stream(
                 }
 
                 let output = frame.into_output(state.provider);
+                // A failure here ends the stream. Yielding whatever the buffer still holds would
+                // let a later exit frame answer the question this item just reported as
+                // unanswerable, and which of the two a caller believes would depend only on
+                // whether it stopped at the first error.
+                if output.is_err() {
+                    state.finished = true;
+                    state.buffer.clear();
+                }
                 return Some((output, state));
             }
 
@@ -519,20 +519,46 @@ mod tests {
         );
     }
 
-    /// The counterpart: the agent puts its cause in the body, and that is a real refusal which
-    /// must stay distinguishable from the transport failing to deliver the request.
+    /// A body is not evidence of who sent it: a proxy's error page is a body too, and a 504 in
+    /// particular means the request reached the guest. The cause still has to survive for whoever
+    /// reads the failure.
     #[tokio::test]
-    async fn a_server_error_carrying_the_agents_own_cause_stays_a_refusal() {
+    async fn a_server_error_is_unknown_however_much_body_it_carries() {
         let error = send_status(StatusCode::INTERNAL_SERVER_ERROR, "spawn failed: ENOMEM").await;
         let rendered = error.to_string();
 
         assert!(
             rendered.contains("spawn failed: ENOMEM"),
-            "the agent's cause has to survive: {rendered}"
+            "the cause has to survive: {rendered}"
         );
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {rendered}");
+    }
+
+    /// The scenario the rule above exists for: a gateway timing out on a command that is still
+    /// running, and answering with its own HTML.
+    #[tokio::test]
+    async fn a_gateway_timeout_with_an_error_page_does_not_read_as_the_agent_refusing() {
+        let error = send_status(
+            StatusCode::GATEWAY_TIMEOUT,
+            "<html><body>504 Gateway Time-out</body></html>",
+        )
+        .await;
+
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
+        assert!(
+            !error.retryable,
+            "the command may still be running behind the gateway: {error}"
+        );
+    }
+
+    /// A 4xx is the agent refusing before it does anything, which is an answer.
+    #[tokio::test]
+    async fn a_client_error_is_the_agent_answering() {
+        let error = send_status(StatusCode::BAD_REQUEST, "the command was empty").await;
+
         assert_ne!(
             error.code, "SANDBOX_OUTCOME_UNKNOWN",
-            "the agent answered with its own cause, so the outcome is not unknown: {rendered}"
+            "a refusal before dispatch establishes that nothing ran: {error}"
         );
     }
 
@@ -808,7 +834,6 @@ mod tests {
             !error.retryable,
             "the command ran; a repeat would run it twice: {error}"
         );
-        // The cause survives, so the reader still learns what was wrong with the frame.
         assert!(
             error.to_string().contains("base64"),
             "the decode failure must stay in the chain: {error}"
@@ -827,6 +852,37 @@ mod tests {
         assert!(
             error.to_string().contains("did not parse"),
             "the parse failure must stay in the chain: {error}"
+        );
+    }
+
+    /// One chunk can hold both a frame that will not parse and the exit frame after it. The stream
+    /// has to stop at the first: yielding the exit as well would answer the question the failure
+    /// just reported as unanswerable, and a caller that reads to the end would believe the wrong
+    /// one of the two.
+    #[tokio::test]
+    async fn an_unestablished_outcome_ends_the_stream_mid_chunk() {
+        let outputs = frames_from(vec![
+            "{not json at all}\n{\"t\":\"exit\",\"code\":0,\"truncated\":false}\n",
+        ])
+        .await;
+
+        assert_eq!(outputs.len(), 1, "the exit frame must not follow the failure");
+        let error = outputs[0].as_ref().expect_err("a malformed frame is not output");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "got: {error}");
+    }
+
+    /// The same rule for a payload that arrives whole and will not decode.
+    #[tokio::test]
+    async fn a_decode_failure_ends_the_stream_mid_chunk() {
+        let outputs = frames_from(vec![
+            "{\"t\":\"stdout\",\"seq\":0,\"data\":\"!!\"}\n{\"t\":\"exit\",\"code\":0,\"truncated\":false}\n",
+        ])
+        .await;
+
+        assert_eq!(outputs.len(), 1, "the exit frame must not follow the failure");
+        assert_eq!(
+            outputs[0].as_ref().expect_err("a bad payload is not output").code,
+            "SANDBOX_OUTCOME_UNKNOWN"
         );
     }
 

--- a/crates/alien-bindings/src/providers/sandbox/azure.rs
+++ b/crates/alien-bindings/src/providers/sandbox/azure.rs
@@ -118,12 +118,9 @@ impl AzureSandbox {
         }
 
         if operation == RUN_COMMAND || operation == CREATE {
-            return error.context(ErrorData::SandboxCommandFailed {
-                failure: "outcomeUnknown".to_string(),
-                reason: format!(
-                    "{operation} did not complete against the Azure sandbox data plane, so \
-                     whether it took effect is unknown"
-                ),
+            return error.context(ErrorData::SandboxOutcomeUnknown {
+                operation: operation.to_string(),
+                reason: "the Azure sandbox data plane did not complete the call".to_string(),
             });
         }
 
@@ -2164,7 +2161,7 @@ mod tests {
             Ok(_) => panic!("an unavailable data plane is an error"),
             Err(error) => error,
         };
-        assert_eq!(command.code, "SANDBOX_COMMAND_FAILED", "{command}");
+        assert_eq!(command.code, "SANDBOX_OUTCOME_UNKNOWN", "{command}");
         assert!(
             !command.retryable,
             "the command may already be running, so a retry would run it twice: {command}"

--- a/crates/alien-bindings/src/providers/sandbox/azure.rs
+++ b/crates/alien-bindings/src/providers/sandbox/azure.rs
@@ -359,12 +359,18 @@ impl Sandbox for AzureSandbox {
                 ),
             })));
         } else {
-            frames.push(Ok(CommandOutput::Exit {
-                // A missing exit code is not success. Azure did not report one, so the command's
-                // outcome is unknown, and -1 says that rather than claiming zero.
-                code: result.exit_code.unwrap_or(-1),
-                truncated: false,
-            }));
+            match result.exit_code {
+                Some(code) => frames.push(Ok(CommandOutput::Exit {
+                    code,
+                    truncated: false,
+                })),
+                // Azure reported no exit code, so the command's outcome was never established.
+                // Any invented code is indistinguishable from one the command really exited with.
+                None => frames.push(Err(AlienError::new(ErrorData::SandboxOutcomeUnknown {
+                    operation: RUN_COMMAND.to_string(),
+                    reason: "the data plane returned no exit code for the command".to_string(),
+                }))),
+            }
         }
 
         Ok(Box::pin(stream::iter(frames)))

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -904,10 +904,22 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
                     &cancel_body(&state.job_id),
                 )
                 .await;
+            // A reply arriving is not the cancel succeeding: the agent answers `{}` when it
+            // cancelled the job and its own error text when it did not — `JobNotFound`, say — and
+            // both come back through a successful `:execute`. Only the first proves the command
+            // was stopped, so only the first may name an established outcome.
+            let confirmed = cancelled.as_ref().is_ok_and(|body| {
+                serde_json::from_slice::<serde_json::Value>(body).is_ok_and(|value| value.is_object())
+            });
             state.pending.push_back(Err(match cancelled {
-                Ok(_) => AlienError::new(ErrorData::SandboxCommandFailed {
+                Ok(_) if confirmed => AlienError::new(ErrorData::SandboxCommandFailed {
                     failure: "deadlineExceeded".to_string(),
                     reason: "the command's deadline elapsed before its job reported an outcome"
+                        .to_string(),
+                }),
+                Ok(_) => AlienError::new(ErrorData::SandboxOutcomeUnknown {
+                    operation: RUN_COMMAND.to_string(),
+                    reason: "the command's deadline elapsed and its job did not confirm the cancel"
                         .to_string(),
                 }),
                 Err(error) => error.context(ErrorData::SandboxOutcomeUnknown {
@@ -970,7 +982,15 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
             // highest seq seen and the loop never waits for a "missing" one; `max` rather than the
             // last frame's seq so an out-of-order frame cannot walk the cursor backwards.
             state.since_seq = state.since_seq.max(frame.seq());
-            state.pending.push_back(frame.into_output());
+            let output = frame.into_output();
+            // As in the synchronous path: a frame that will not convert ends the poll rather than
+            // being queued ahead of a terminal result that would contradict it.
+            let failed = output.is_err();
+            state.pending.push_back(output);
+            if failed {
+                state.finished = true;
+                break;
+            }
         }
 
         if !poll.running {
@@ -1133,7 +1153,16 @@ fn parse_exec_frames(body: &[u8]) -> Result<Vec<Result<CommandOutput>>> {
             Ok(frame) => {
                 saw_any = true;
                 saw_terminal |= frame.is_terminal();
-                frames.push(frame.into_output());
+                let output = frame.into_output();
+                // A frame that will not convert ends the body: letting a later exit follow would
+                // answer the question this item just reported as unanswerable. `saw_terminal`
+                // stops the trailing item below from saying the same thing twice.
+                let failed = output.is_err();
+                frames.push(output);
+                if failed {
+                    saw_terminal = true;
+                    break;
+                }
             }
             Err(error) => {
                 if !saw_any {

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -274,10 +274,16 @@ impl GcpAgentPlatformSandbox {
                 reason: format!("{operation}: the session does not exist"),
             });
         }
-        // Non-retryable across the board: a `:execute` is single-attempt because it may already
-        // have started the command, and the client does not tell a delivered-but-failed call apart
-        // from an undelivered one. The cause stays on the chain rather than in `reason`, keeping a
-        // redacted request body out of an externally visible message.
+        // The client does not tell a delivered-but-failed call apart from an undelivered one, so
+        // a `:execute` carrying a command leaves its outcome unestablished. The cause stays on the
+        // chain rather than in `reason`, keeping a redacted request body out of an externally
+        // visible message.
+        if operation == RUN_COMMAND {
+            return error.context(ErrorData::SandboxOutcomeUnknown {
+                operation: operation.to_string(),
+                reason: "the session did not complete the call".to_string(),
+            });
+        }
         error.context(ErrorData::SandboxCommandFailed {
             failure: "executeFailed".to_string(),
             reason: format!("{operation} could not be completed against the session"),
@@ -452,12 +458,20 @@ impl GcpAgentPlatformSandbox {
         struct JobStart {
             job_id: String,
         }
+        // The `:execute` succeeded, so the job was accepted and is running; only its id could not
+        // be read. Nothing can poll or cancel it after this, and the command's own deadline is what
+        // bounds it — so the outcome is unestablished rather than a bad response shape.
         let started: JobStart = serde_json::from_slice(&body).map_err(|_| {
             AlienError::new(ErrorData::UnexpectedResponseFormat {
                 provider: "gcp-agent-platform".to_string(),
                 binding_name: RUN_COMMAND.to_string(),
                 field: "jobId".to_string(),
                 response_json: truncated(&body),
+            })
+            .context(ErrorData::SandboxOutcomeUnknown {
+                operation: RUN_COMMAND.to_string(),
+                reason: "the job started and its id could not be read, so it cannot be polled"
+                    .to_string(),
             })
         })?;
 
@@ -879,9 +893,10 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
         }
 
         if tokio::time::Instant::now() >= state.deadline_at {
-            // Best-effort: the job is cancelled so its process group is killed, and the caller is
-            // told the deadline was exceeded rather than left reading a stream that never ends.
-            let _ = state
+            // The deadline is this client's decision, so it only names an outcome once the cancel
+            // that makes it true has landed. A cancel that fails leaves the job running, and the
+            // caller has to be told that rather than that the command was stopped.
+            let cancelled = state
                 .client
                 .execute(
                     &state.engine,
@@ -889,13 +904,18 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
                     &cancel_body(&state.job_id),
                 )
                 .await;
-            state
-                .pending
-                .push_back(Err(AlienError::new(ErrorData::SandboxCommandFailed {
+            state.pending.push_back(Err(match cancelled {
+                Ok(_) => AlienError::new(ErrorData::SandboxCommandFailed {
                     failure: "deadlineExceeded".to_string(),
                     reason: "the command's deadline elapsed before its job reported an outcome"
                         .to_string(),
-                })));
+                }),
+                Err(error) => error.context(ErrorData::SandboxOutcomeUnknown {
+                    operation: RUN_COMMAND.to_string(),
+                    reason: "the command's deadline elapsed and its job could not be cancelled"
+                        .to_string(),
+                }),
+            }));
             state.finished = true;
             continue;
         }
@@ -925,6 +945,8 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
         let poll: JobPoll = match serde_json::from_slice(&body) {
             Ok(poll) => poll,
             Err(_) => {
+                // The job is still running and this stops watching it, so its outcome is
+                // unestablished — not merely a reply this could not read.
                 state.pending.push_back(Err(AlienError::new(
                     ErrorData::UnexpectedResponseFormat {
                         provider: "gcp-agent-platform".to_string(),
@@ -932,7 +954,12 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
                         field: "jobPoll".to_string(),
                         response_json: truncated(&body),
                     },
-                )));
+                )
+                .context(ErrorData::SandboxOutcomeUnknown {
+                    operation: RUN_COMMAND.to_string(),
+                    reason: "the job's reply could not be read, so it is no longer watched"
+                        .to_string(),
+                })));
                 state.finished = true;
                 continue;
             }
@@ -954,10 +981,18 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
                     failure: error.code,
                     reason: error.message,
                 })),
-                None => Ok(CommandOutput::Exit {
-                    code: poll.exit_code.unwrap_or(-1),
-                    truncated: poll.truncated.unwrap_or(false),
-                }),
+                // A job that finished without an exit code never established its outcome; an
+                // invented code is indistinguishable from one the command really exited with.
+                None => match poll.exit_code {
+                    Some(code) => Ok(CommandOutput::Exit {
+                        code,
+                        truncated: poll.truncated.unwrap_or(false),
+                    }),
+                    None => Err(AlienError::new(ErrorData::SandboxOutcomeUnknown {
+                        operation: RUN_COMMAND.to_string(),
+                        reason: "the job finished without reporting an exit code".to_string(),
+                    })),
+                },
             };
             state.pending.push_back(terminal);
             state.finished = true;
@@ -1062,6 +1097,8 @@ impl WireFrame {
     }
 }
 
+/// A frame that arrived is proof the command ran, so a payload that will not decode leaves the
+/// outcome unestablished rather than merely malformed.
 fn decode_frame_data(data: &str) -> Result<Vec<u8>> {
     BASE64.decode(data).map_err(|error| {
         AlienError::new(ErrorData::UnexpectedResponseFormat {
@@ -1069,6 +1106,10 @@ fn decode_frame_data(data: &str) -> Result<Vec<u8>> {
             binding_name: RUN_COMMAND.to_string(),
             field: "data".to_string(),
             response_json: format!("an output frame's data is not base64: {error}"),
+        })
+        .context(ErrorData::SandboxOutcomeUnknown {
+            operation: RUN_COMMAND.to_string(),
+            reason: "an output frame did not decode".to_string(),
         })
     })
 }
@@ -1101,11 +1142,17 @@ fn parse_exec_frames(body: &[u8]) -> Result<Vec<Result<CommandOutput>>> {
                         reason: format!("run_command was refused: {}", truncated(body)),
                     }));
                 }
+                // Frames already arrived, so the command ran and this leaves its end unknown.
+                // `saw_terminal` stops the trailing item below from saying the same thing twice.
                 frames.push(Err(AlienError::new(ErrorData::UnexpectedResponseFormat {
                     provider: "gcp-agent-platform".to_string(),
                     binding_name: RUN_COMMAND.to_string(),
                     field: "frame".to_string(),
                     response_json: format!("an output frame did not parse: {error}"),
+                })
+                .context(ErrorData::SandboxOutcomeUnknown {
+                    operation: RUN_COMMAND.to_string(),
+                    reason: "an output frame did not parse".to_string(),
                 })));
                 saw_terminal = true;
                 break;

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -1120,11 +1120,9 @@ fn parse_exec_frames(body: &[u8]) -> Result<Vec<Result<CommandOutput>>> {
         }));
     }
     if !saw_terminal {
-        frames.push(Err(AlienError::new(ErrorData::SandboxCommandFailed {
-            failure: "outcomeUnknown".to_string(),
-            reason: "the command's output ended without a terminal frame, so whether it finished \
-                     is unknown"
-                .to_string(),
+        frames.push(Err(AlienError::new(ErrorData::SandboxOutcomeUnknown {
+            operation: RUN_COMMAND.to_string(),
+            reason: "the command's output ended without a terminal frame".to_string(),
         })));
     }
     Ok(frames)

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -691,8 +691,8 @@ async fn a_job_error_object_becomes_a_stream_error() {
 
 /// The write-once / read-retries split, pinned in one test so neither half can pass on the
 /// absence of the other. A mutating `:execute` that fails is delivered exactly once — it may have
-/// already run, and re-sending it could double a side effect — while a read is polled until the
-/// session settles. Mutation check: give `execute_op` a retry loop and `execute`'s `.times(1)`
+/// already run, so its outcome is unestablished and re-sending it could double a side effect —
+/// while a read is polled until the session settles. Mutation check: give `execute_op` a retry loop and `execute`'s `.times(1)`
 /// fails; remove `terminate`'s poll and the read count collapses to one.
 #[tokio::test(start_paused = true)]
 async fn a_failed_command_is_delivered_once_where_a_read_still_retries() {
@@ -733,7 +733,11 @@ async fn a_failed_command_is_delivered_once_where_a_read_still_retries() {
     else {
         panic!("a mutating command whose execute fails is refused, not retried into success");
     };
-    assert_eq!(command.code, "SANDBOX_COMMAND_FAILED", "{command}");
+    assert_eq!(command.code, "SANDBOX_OUTCOME_UNKNOWN", "{command}");
+    assert!(
+        !command.retryable,
+        "the call may have started the command, so it is delivered once: {command}"
+    );
 
     sut.terminate("s1")
         .await
@@ -1024,6 +1028,47 @@ fn an_output_without_a_terminal_frame_is_an_unknown_outcome() {
         error.to_string().contains("without a terminal frame"),
         "{error}"
     );
+    assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "{error}");
+    assert!(
+        !error.retryable,
+        "the command started and its end was lost, so a repeat would run it twice: {error}"
+    );
+}
+
+/// A frame that arrived is proof the command ran, so a payload that will not decode leaves the
+/// outcome unestablished. Reported as a response-format problem it would read as safe to repeat.
+#[test]
+fn a_frame_that_does_not_decode_leaves_the_outcome_unknown() {
+    let frames = parse_exec_frames(&ndjson(&[serde_json::json!({
+        "t": "stdout",
+        "seq": 0,
+        "data": "!!not base64!!",
+    })]))
+    .expect("frames parse");
+
+    let error = frames[0]
+        .as_ref()
+        .expect_err("a payload that does not decode is not output");
+    assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "{error}");
+    assert!(
+        error.to_string().contains("base64"),
+        "the decode failure must stay in the chain: {error}"
+    );
+}
+
+/// The same rule for a line that does not parse once frames have already arrived.
+#[test]
+fn a_frame_that_does_not_parse_after_output_leaves_the_outcome_unknown() {
+    let mut body = ndjson(&[stdout_frame(0, b"partial")]);
+    body.extend_from_slice(b"{not json at all}\n");
+
+    let frames = parse_exec_frames(&body).expect("frames parse");
+    let error = frames
+        .last()
+        .expect("a trailing item")
+        .as_ref()
+        .expect_err("a malformed frame is not output");
+    assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "{error}");
 }
 
 /// A body that is not frames at all is the agent's refusal, not a command's output.

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -1071,6 +1071,26 @@ fn a_frame_that_does_not_parse_after_output_leaves_the_outcome_unknown() {
     assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "{error}");
 }
 
+/// A frame that will not convert ends the body. Letting the exit frame after it through would
+/// answer the question the failure just reported as unanswerable, and a caller reading to the end
+/// would believe the wrong one of the two.
+#[test]
+fn a_frame_that_does_not_convert_ends_the_body() {
+    let mut body = ndjson(&[serde_json::json!({
+        "t": "stdout",
+        "seq": 0,
+        "data": "!!not base64!!",
+    })]);
+    body.extend_from_slice(&ndjson(&[exit_frame(0)]));
+
+    let frames = parse_exec_frames(&body).expect("frames parse");
+    assert_eq!(frames.len(), 1, "the exit frame must not follow the failure");
+    assert_eq!(
+        frames[0].as_ref().expect_err("a bad payload is not output").code,
+        "SANDBOX_OUTCOME_UNKNOWN"
+    );
+}
+
 /// A body that is not frames at all is the agent's refusal, not a command's output.
 #[test]
 fn a_non_frame_body_is_reported_as_a_refusal() {

--- a/crates/alien-bindings/src/providers/sandbox/local.rs
+++ b/crates/alien-bindings/src/providers/sandbox/local.rs
@@ -202,9 +202,12 @@ impl LocalSandbox {
         {
             Ok(inner) => inner,
             Err(_) => {
+                // Terminating ends the session, not whatever the command already did before the
+                // kill landed, so this is an outcome that was never reported rather than one the
+                // sandbox established.
                 self.terminate(session_id).await?;
-                Err(AlienError::new(ErrorData::SandboxCommandFailed {
-                    failure: "deadlineExceeded".to_string(),
+                Err(AlienError::new(ErrorData::SandboxOutcomeUnknown {
+                    operation: "sandbox.runCommand".to_string(),
                     reason: format!(
                         "the command exceeded its {}s deadline and the session could not end it, so the session was terminated",
                         request.deadline.as_secs()
@@ -702,7 +705,8 @@ mod tests {
     }
 
     /// When the session cannot end the command — the route never answers — the guard ends the
-    /// session and reports the deadline. Time is paused, so the guard fires instantly.
+    /// session. Ending it does not undo whatever the command did first, so the outcome is
+    /// unreported rather than established. Time is paused, so the guard fires instantly.
     #[tokio::test(start_paused = true)]
     async fn a_command_the_session_cannot_end_takes_the_session_with_it() {
         let route = Arc::new(Route::default());
@@ -714,7 +718,11 @@ mod tests {
             .err()
             .expect("a command that outran its deadline has not succeeded");
 
-        assert!(error.to_string().contains("deadlineExceeded"), "{error}");
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "{error}");
+        assert!(
+            !error.retryable,
+            "the command may have run before the kill landed: {error}"
+        );
         assert_eq!(
             route.deleted.lock().expect("deleted").clone(),
             vec!["s1".to_string()],

--- a/crates/alien-bindings/src/providers/sandbox/local.rs
+++ b/crates/alien-bindings/src/providers/sandbox/local.rs
@@ -23,7 +23,7 @@ use crate::traits::{
 };
 use alien_core::bindings::LocalSandboxBinding;
 use alien_core::{Platform, SandboxCapabilities};
-use alien_error::{AlienError, Context, IntoAlienError};
+use alien_error::{AlienError, Context, ContextError, IntoAlienError};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -204,15 +204,20 @@ impl LocalSandbox {
             Err(_) => {
                 // Terminating ends the session, not whatever the command already did before the
                 // kill landed, so this is an outcome that was never reported rather than one the
-                // sandbox established.
-                self.terminate(session_id).await?;
-                Err(AlienError::new(ErrorData::SandboxOutcomeUnknown {
+                // sandbox established. A terminate that itself fails is chained rather than
+                // returned: it leaves the command even more likely to be running, so replacing the
+                // outcome with it would drop the one thing the caller has to know.
+                let outcome = ErrorData::SandboxOutcomeUnknown {
                     operation: "sandbox.runCommand".to_string(),
                     reason: format!(
-                        "the command exceeded its {}s deadline and the session could not end it, so the session was terminated",
+                        "the command exceeded its {}s deadline and the session could not end it",
                         request.deadline.as_secs()
                     ),
-                }))
+                };
+                Err(match self.terminate(session_id).await {
+                    Ok(()) => AlienError::new(outcome),
+                    Err(error) => error.context(outcome),
+                })
             }
         }
     }
@@ -507,6 +512,9 @@ mod tests {
         execs: Mutex<std::collections::VecDeque<serde_json::Value>>,
         commands: Mutex<Vec<Vec<String>>>,
         deleted: Mutex<Vec<String>>,
+        /// Set to make the session refuse to be deleted, which is the case where the command is
+        /// even more likely to still be running.
+        delete_refuses: std::sync::atomic::AtomicBool,
     }
 
     /// Stands in for the wrapper's kill in a scripted response.
@@ -556,9 +564,15 @@ mod tests {
         async fn delete(
             State(route): State<Arc<Route>>,
             Path(session): Path<String>,
-        ) -> Json<serde_json::Value> {
+        ) -> std::result::Result<Json<serde_json::Value>, axum::http::StatusCode> {
+            if route
+                .delete_refuses
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+            }
             route.deleted.lock().expect("deleted").push(session);
-            Json(json!({}))
+            Ok(Json(json!({})))
         }
 
         let router = Router::new()
@@ -702,6 +716,30 @@ mod tests {
             frames.last().expect("frames"),
             Ok(CommandOutput::Exit { code: 124, .. })
         ));
+    }
+
+    /// A terminate that itself fails leaves the command even more likely to be running, so the
+    /// unknown outcome has to survive it. Returning the terminate's own error instead would tell a
+    /// caller the session could not be deleted and say nothing about the command.
+    #[tokio::test(start_paused = true)]
+    async fn a_terminate_that_fails_does_not_hide_the_unknown_outcome() {
+        let route = Arc::new(Route::default());
+        route
+            .delete_refuses
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let sandbox = serve(route.clone()).await;
+
+        let error = sandbox
+            .run_command("s1", command(30))
+            .await
+            .err()
+            .expect("a command that outran its deadline has not succeeded");
+
+        assert_eq!(error.code, "SANDBOX_OUTCOME_UNKNOWN", "{error}");
+        assert!(
+            error.to_string().contains("could not end it"),
+            "the deadline stays the headline: {error}"
+        );
     }
 
     /// When the session cannot end the command — the route never answers — the guard ends the

--- a/packages/bindings/src/__tests__/errors.test.ts
+++ b/packages/bindings/src/__tests__/errors.test.ts
@@ -1,10 +1,6 @@
 import { AlienError } from "@alienplatform/core"
 import { describe, expect, it } from "vitest"
-import {
-  BindingNotConfiguredError,
-  isSandboxOutcomeUnknown,
-  unwrapNapiError,
-} from "../errors.js"
+import { BindingNotConfiguredError, isSandboxOutcomeUnknown, unwrapNapiError } from "../errors.js"
 
 /** Build a napi-style error whose message carries the addon envelope. */
 function napiError(envelope: unknown): Error {
@@ -85,18 +81,27 @@ describe("unwrapNapiError", () => {
 describe("isSandboxOutcomeUnknown", () => {
   // Asserted against the envelope the addon actually emits rather than a hand-built AlienError:
   // the envelope shape is the contract, and a hand-built object cannot break when it changes.
-  const napiError = (code: string) =>
-    new Error(JSON.stringify({ code, message: "m", retryable: false, internal: false }))
+  const decoded = (code: string) =>
+    unwrapNapiError(napiError({ code, message: "m", retryable: false, internal: false }))
 
   it("recognizes an operation the sandbox never reported the outcome of", () => {
-    expect(isSandboxOutcomeUnknown(unwrapNapiError(napiError("SANDBOX_OUTCOME_UNKNOWN")))).toBe(true)
+    expect(isSandboxOutcomeUnknown(decoded("SANDBOX_OUTCOME_UNKNOWN"))).toBe(true)
   })
 
   it("does not recognize a failure the sandbox answered", () => {
-    expect(isSandboxOutcomeUnknown(unwrapNapiError(napiError("SANDBOX_COMMAND_FAILED")))).toBe(false)
+    expect(isSandboxOutcomeUnknown(decoded("SANDBOX_COMMAND_FAILED"))).toBe(false)
   })
 
   it("does not recognize a value that is not an alien error", () => {
     expect(isSandboxOutcomeUnknown(new Error("SANDBOX_OUTCOME_UNKNOWN"))).toBe(false)
+  })
+
+  // A caller that adds its own context before checking must still see the signal; reading only the
+  // outermost code would answer "safe to repeat" and run the command a second time.
+  it("still recognizes it after a caller has wrapped it with context", () => {
+    const wrapped = decoded("SANDBOX_OUTCOME_UNKNOWN").withContext(
+      BindingNotConfiguredError.create({ binding: "files", envVar: "ALIEN_FILES_BINDING" }),
+    )
+    expect(isSandboxOutcomeUnknown(wrapped)).toBe(true)
   })
 })

--- a/packages/bindings/src/__tests__/errors.test.ts
+++ b/packages/bindings/src/__tests__/errors.test.ts
@@ -1,6 +1,10 @@
 import { AlienError } from "@alienplatform/core"
 import { describe, expect, it } from "vitest"
-import { BindingNotConfiguredError, unwrapNapiError } from "../errors.js"
+import {
+  BindingNotConfiguredError,
+  isSandboxOutcomeUnknown,
+  unwrapNapiError,
+} from "../errors.js"
 
 /** Build a napi-style error whose message carries the addon envelope. */
 function napiError(envelope: unknown): Error {
@@ -75,5 +79,24 @@ describe("unwrapNapiError", () => {
     const err = unwrapNapiError("boom")
     expect(err.code).toBe("BINDINGS_ERROR")
     expect(err.message).toBe("boom")
+  })
+})
+
+describe("isSandboxOutcomeUnknown", () => {
+  // Asserted against the envelope the addon actually emits rather than a hand-built AlienError:
+  // the envelope shape is the contract, and a hand-built object cannot break when it changes.
+  const napiError = (code: string) =>
+    new Error(JSON.stringify({ code, message: "m", retryable: false, internal: false }))
+
+  it("recognizes an operation the sandbox never reported the outcome of", () => {
+    expect(isSandboxOutcomeUnknown(unwrapNapiError(napiError("SANDBOX_OUTCOME_UNKNOWN")))).toBe(true)
+  })
+
+  it("does not recognize a failure the sandbox answered", () => {
+    expect(isSandboxOutcomeUnknown(unwrapNapiError(napiError("SANDBOX_COMMAND_FAILED")))).toBe(false)
+  })
+
+  it("does not recognize a value that is not an alien error", () => {
+    expect(isSandboxOutcomeUnknown(new Error("SANDBOX_OUTCOME_UNKNOWN"))).toBe(false)
   })
 })

--- a/packages/bindings/src/errors.ts
+++ b/packages/bindings/src/errors.ts
@@ -107,6 +107,9 @@ const GENERIC_BINDINGS_CODE = "BINDINGS_ERROR"
 /** Envelope codes the wrapper maps to a dedicated typed error. */
 const BINDING_NOT_CONFIGURED = "BINDING_NOT_CONFIGURED"
 
+/** Envelope code for an operation the sandbox never reported the outcome of. */
+const SANDBOX_OUTCOME_UNKNOWN = "SANDBOX_OUTCOME_UNKNOWN"
+
 /** The structured payload the addon serializes into `err.message`. */
 interface NapiErrorEnvelope {
   code: string
@@ -194,6 +197,17 @@ export function unwrapNapiError(err: unknown): AlienError {
     hint: envelope.hint,
     context,
   })
+}
+
+/**
+ * Whether a sandbox operation was dispatched without reporting what it did.
+ *
+ * Callers branch on the envelope's code rather than on the message, which is prose and free to
+ * change. A caller that must not run an operation twice reads this: anything else either reached
+ * the sandbox and was answered, or never left.
+ */
+export function isSandboxOutcomeUnknown(error: unknown): error is AlienError {
+  return error instanceof AlienError && error.code === SANDBOX_OUTCOME_UNKNOWN
 }
 
 // Shared with the AI binding surface in @alienplatform/ai-gateway.

--- a/packages/bindings/src/errors.ts
+++ b/packages/bindings/src/errors.ts
@@ -205,9 +205,13 @@ export function unwrapNapiError(err: unknown): AlienError {
  * Callers branch on the envelope's code rather than on the message, which is prose and free to
  * change. A caller that must not run an operation twice reads this: anything else either reached
  * the sandbox and was answered, or never left.
+ *
+ * The whole chain is searched, not just the outermost code, so a caller that adds its own context
+ * before checking still sees the signal. Reading only the outermost would answer "safe to repeat"
+ * for a wrapped error, which is the one wrong answer that runs a command a second time.
  */
 export function isSandboxOutcomeUnknown(error: unknown): error is AlienError {
-  return error instanceof AlienError && error.code === SANDBOX_OUTCOME_UNKNOWN
+  return error instanceof AlienError && error.hasErrorCode(SANDBOX_OUTCOME_UNKNOWN)
 }
 
 // Shared with the AI binding surface in @alienplatform/ai-gateway.

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -46,6 +46,7 @@ export {
   BindingNotFoundError,
   defineError,
   InvalidPostgresTlsConfigError,
+  isSandboxOutcomeUnknown,
   UnknownPostgresSslModeError,
   UnknownSandboxValueError,
 } from "./errors.js"


### PR DESCRIPTION
## Summary

A sandbox command that failed did not tell its caller whether it had run — an operation the
sandbox never reported and one it answered arrived as the same error code, separated only by a
free-text label. This adds `SANDBOX_OUTCOME_UNKNOWN` for the first case and classifies every
path that cannot establish an outcome, on all four backends.

When a command fails, the caller now finds out which of three things happened:

1. The call did not reach the sandbox, or names a file operation, which is idempotent —
   `SANDBOX_UNREACHABLE`, and repeating it is safe.
2. **The sandbox never reported the outcome — `SANDBOX_OUTCOME_UNKNOWN`. The command may have
   run, so repeating it can run it a second time.** This is the case that had no code of its own.
3. The sandbox answered — `SANDBOX_COMMAND_FAILED`. The outcome is established, and the answer
   may itself be a failure.

This changes a caller's question from "what does this free-text label say" to "which of three
codes is it".

## What was broken

The `failure` field carried 18 different strings across five backends with no closed set, and its
doc invited callers to branch on it. Nothing could: one of those strings meant "we never found
out" and the rest meant "we did", and both arrived as `SANDBOX_COMMAND_FAILED`.

Several paths were also mis-stating what they knew:

- A 5xx carrying any body was read as the agent answering. A proxy's error page is a body, and a
  504 means the request reached the guest and no answer came back — the command most likely
  running right then.
- A stream that reported an unestablished outcome kept going. One chunk holding a bad frame and
  the exit frame after it produced "the outcome is unknown" followed by "it exited 0"; which one
  a caller believed depended only on whether it stopped at the first error.
- A missing exit code was reported as `-1`, indistinguishable from a command that really exited
  `-1`.
- A deadline reported that it had stopped a command while discarding the cancel that would have
  made that true.
- A job whose id or reply could not be read is running and no longer watched; both were reported
  as a bad response shape.

## What I did

Added the variant, and made `unanswered` the single place that decides. A 5xx is now unanswered
whatever body it carries — the agent's own refusals are 4xx, so requiring more than bytes as
evidence loses nothing. An item reporting an unestablished outcome ends the stream. A missing
exit code, a deadline whose cancel failed, an unreadable job id or poll reply, and frames that
arrive and will not decode or parse all say so now.

File operations are untouched: reading or writing a whole file at a fixed path is idempotent, so
an unanswered one stays retryable.

`failure` stays, documented as what it is — a diagnostic label for logs and support. TypeScript
gets `isSandboxOutcomeUnknown`, which searches the whole error chain so a caller that adds its own
context before checking still sees the signal.

A "did the command start" axis was considered and rejected: Azure runs no in-guest agent, so a
missing binary is exit 127 and that signal would be permanently unreachable there. Its absence
would then be misread as "may have run" on every Azure failure. Whether an answer arrived is a
property of the transport, and every backend has one.

## Files touched

- `crates/alien-bindings/src/error.rs` — the new variant; the `failure` field's doc corrected
- `crates/alien-bindings/src/providers/sandbox/agent_protocol.rs` — `unanswered` as the single
  producer, the 5xx rule, stream termination, the decode and parse arms
- `crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs` — the same decisions on the
  job path, plus the deadline cancel and the two unreadable-reply cases
- `crates/alien-bindings/src/providers/sandbox/azure.rs`, `local.rs` — the data-plane call and the
  client-side deadline
- `crates/alien-bindings-node/src/error.rs` — a test that the code and retry flag survive the
  boundary
- `packages/bindings/src/errors.ts`, `index.ts` — the predicate

## How I tested

- `cargo test -p alien-bindings --all-features` — 308 pass.
- `cargo test -p alien-bindings-node` — 29 pass, including the envelope test. Neither language's
  tests can see that boundary alone: the Rust ones stop at the error, the TypeScript ones start at
  the envelope.
- `pnpm --filter @alienplatform/bindings test` — 125 pass.
- `cargo check -p alien-bindings --no-default-features --features <aws|gcp|azure|kubernetes>` —
  each compiles alone.
- Every behavioural change is pinned by a test that fails without it. I reverted each fix in turn
  and confirmed the matching test goes red: the 504-with-a-body case, the two mid-stream arms on
  both agent paths, the stream ending mid-chunk, the chain search in the predicate, and the GCP
  terminal-frame case.
- Four existing tests asserted the old code for cases this reclassifies. Their assertions moved;
  what each was pinning — not retryable, outcome unknown — is unchanged. One asserted that a 500
  carrying the agent's own text was a refusal, and that premise is what this PR disproves, so it
  was replaced by the gateway-timeout case it could not distinguish.
