### PR TITLE
feat(sandbox): bring the Azure sandbox backend to remote-binding parity with AWS

### DIFF
--- a/client-sdks/manager/openapi.json
+++ b/client-sdks/manager/openapi.json
@@ -14607,6 +14607,73 @@
         },
         "additionalProperties": false
       },
+      "RemoteAzureSandboxBinding": {
+        "type": "object",
+        "description": "Concrete sandbox-group topology returned to remote clients.\n\nThe ceilings travel because Azure applies them at create and nowhere else, so a remote caller\nthat does not send them gets the data plane's default rather than the declared size.",
+        "required": [
+          "sandboxGroup",
+          "dataPlaneEndpoint",
+          "region",
+          "resourceGroup",
+          "diskImage",
+          "allowEgress"
+        ],
+        "properties": {
+          "allowEgress": {
+            "type": "boolean",
+            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied for the same reason the AWS binding sends it: the remote grant lets its holder\ncreate sessions the declared policy never reaches, so a client reconstructing the policy\nneeds the answer on the wire rather than inferring it from an absent field."
+          },
+          "cpu": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Declared session ceilings, where the declaration named them."
+          },
+          "dataPlaneEndpoint": {
+            "type": "string",
+            "description": "Per-region data-plane host, which is separate from the ARM control plane."
+          },
+          "disk": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "diskImage": {
+            "type": "string",
+            "description": "Catalog disk image every session is created from."
+          },
+          "idleSuspendSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Idle seconds after which a session suspends, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "memory": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region": {
+            "type": "string",
+            "description": "Region the sandbox group lives in."
+          },
+          "resourceGroup": {
+            "type": "string",
+            "description": "Resource group the data-plane path is scoped by."
+          },
+          "sandboxGroup": {
+            "type": "string",
+            "description": "Sandbox group the credential lease authorizes sessions against."
+          }
+        },
+        "additionalProperties": false
+      },
       "RemoteBlobStorageBinding": {
         "type": "object",
         "description": "Concrete Azure Blob Storage topology returned to remote clients.",
@@ -15184,6 +15251,33 @@
                 "type": "string",
                 "enum": [
                   "sandbox-aws"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Azure Container Apps sandbox group and an Azure data-plane token.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteAzureSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteAzureClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-azure"
                 ]
               }
             }

--- a/client-sdks/manager/rust/openapi-3.0.json
+++ b/client-sdks/manager/rust/openapi-3.0.json
@@ -12626,6 +12626,65 @@
         },
         "additionalProperties": false
       },
+      "RemoteAzureSandboxBinding": {
+        "type": "object",
+        "description": "Concrete sandbox-group topology returned to remote clients.\n\nThe ceilings travel because Azure applies them at create and nowhere else, so a remote caller\nthat does not send them gets the data plane's default rather than the declared size.",
+        "required": [
+          "sandboxGroup",
+          "dataPlaneEndpoint",
+          "region",
+          "resourceGroup",
+          "diskImage",
+          "allowEgress"
+        ],
+        "properties": {
+          "allowEgress": {
+            "type": "boolean",
+            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied for the same reason the AWS binding sends it: the remote grant lets its holder\ncreate sessions the declared policy never reaches, so a client reconstructing the policy\nneeds the answer on the wire rather than inferring it from an absent field."
+          },
+          "cpu": {
+            "type": "string",
+            "description": "Declared session ceilings, where the declaration named them.",
+            "nullable": true
+          },
+          "dataPlaneEndpoint": {
+            "type": "string",
+            "description": "Per-region data-plane host, which is separate from the ARM control plane."
+          },
+          "disk": {
+            "type": "string",
+            "nullable": true
+          },
+          "diskImage": {
+            "type": "string",
+            "description": "Catalog disk image every session is created from."
+          },
+          "idleSuspendSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Idle seconds after which a session suspends, where the declaration asked for one.",
+            "minimum": 0,
+            "nullable": true
+          },
+          "memory": {
+            "type": "string",
+            "nullable": true
+          },
+          "region": {
+            "type": "string",
+            "description": "Region the sandbox group lives in."
+          },
+          "resourceGroup": {
+            "type": "string",
+            "description": "Resource group the data-plane path is scoped by."
+          },
+          "sandboxGroup": {
+            "type": "string",
+            "description": "Sandbox group the credential lease authorizes sessions against."
+          }
+        },
+        "additionalProperties": false
+      },
       "RemoteBlobStorageBinding": {
         "type": "object",
         "description": "Concrete Azure Blob Storage topology returned to remote clients.",
@@ -13185,6 +13244,33 @@
                 "type": "string",
                 "enum": [
                   "sandbox-aws"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Azure Container Apps sandbox group and an Azure data-plane token.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteAzureSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteAzureClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-azure"
                 ]
               }
             }

--- a/crates/alien-azure-clients/src/azure/sandbox_data_plane.rs
+++ b/crates/alien-azure-clients/src/azure/sandbox_data_plane.rs
@@ -155,6 +155,9 @@ pub struct CreateSandbox {
     pub cpu: String,
     /// Memory in the data plane's units, such as `2048Mi`.
     pub memory: String,
+    /// Disk in the data plane's units, such as `40960Mi`. Absent lets the data plane derive one
+    /// from the cpu, which is what it does when the key is not sent.
+    pub disk: Option<String>,
     /// Variables placed in the sandbox. It inherits nothing, so a variable exists only if it is
     /// sent here.
     pub environment: BTreeMap<String, String>,
@@ -176,6 +179,13 @@ fn create_body(request: &CreateSandbox) -> serde_json::Value {
         "sourcesRef": { "diskImage": { "name": request.disk_image, "isPublic": true } },
         "resources": { "cpu": request.cpu, "memory": request.memory },
     });
+
+    // Sent only when declared. The data plane derives a disk from the cpu when the key is absent
+    // — `250m` yields `5120Mi` — so sending a placeholder would replace a correct default with a
+    // guess, while omitting a declared one silently ignores the ceiling the customer wrote down.
+    if let Some(disk) = &request.disk {
+        body["resources"]["disk"] = serde_json::json!(disk);
+    }
 
     if !request.environment.is_empty() {
         body["environment"] = serde_json::json!(request.environment);
@@ -692,6 +702,7 @@ mod tests {
                     disk_image: "ubuntu".to_string(),
                     cpu: "1".to_string(),
                     memory: "2Gi".to_string(),
+                    disk: None,
                     environment: Default::default(),
                     egress: None,
                     idle_suspend_seconds: None,
@@ -945,6 +956,7 @@ mod tests {
             disk_image: "ubuntu".to_string(),
             cpu: "1000m".to_string(),
             memory: "2048Mi".to_string(),
+            disk: None,
             environment: BTreeMap::from([("TOKEN".to_string(), "t".to_string())]),
             egress: Some(EgressPolicy {
                 default_action: "Deny".to_string(),

--- a/crates/alien-azure-clients/src/azure/sandbox_data_plane.rs
+++ b/crates/alien-azure-clients/src/azure/sandbox_data_plane.rs
@@ -155,8 +155,8 @@ pub struct CreateSandbox {
     pub cpu: String,
     /// Memory in the data plane's units, such as `2048Mi`.
     pub memory: String,
-    /// Disk in the data plane's units, such as `40960Mi`. Absent lets the data plane derive one
-    /// from the cpu, which is what it does when the key is not sent.
+    /// Disk in the data plane's units, such as `40960Mi`. Absent, the data plane derives one
+    /// from cpu.
     pub disk: Option<String>,
     /// Variables placed in the sandbox. It inherits nothing, so a variable exists only if it is
     /// sent here.
@@ -180,9 +180,8 @@ fn create_body(request: &CreateSandbox) -> serde_json::Value {
         "resources": { "cpu": request.cpu, "memory": request.memory },
     });
 
-    // Sent only when declared. The data plane derives a disk from the cpu when the key is absent
-    // — `250m` yields `5120Mi` — so sending a placeholder would replace a correct default with a
-    // guess, while omitting a declared one silently ignores the ceiling the customer wrote down.
+    // A placeholder here would override the cpu-derived default; omitting a set value would
+    // silently drop the customer's ceiling. Send only when declared.
     if let Some(disk) = &request.disk {
         body["resources"]["disk"] = serde_json::json!(disk);
     }

--- a/crates/alien-azure-clients/src/azure/sandbox_groups.rs
+++ b/crates/alien-azure-clients/src/azure/sandbox_groups.rs
@@ -18,7 +18,11 @@ use serde::{Deserialize, Serialize};
 use mockall::automock;
 
 /// ARM API version for sandbox groups.
-const API_VERSION: &str = "2025-02-02-preview";
+///
+/// The version the provider manifest lists for `Microsoft.App/sandboxGroups`, and the same one the
+/// data plane and the setup emitter use. ARM still answers older previews, so a mismatch here
+/// fails silently as a shape difference rather than loudly as a rejected version.
+const API_VERSION: &str = "2026-02-01-preview";
 
 /// Scope every ARM call is signed for.
 const ARM_SCOPE: &str = "https://management.azure.com/.default";

--- a/crates/alien-azure-clients/src/azure/sandbox_groups.rs
+++ b/crates/alien-azure-clients/src/azure/sandbox_groups.rs
@@ -21,7 +21,7 @@ use mockall::automock;
 ///
 /// The version the provider manifest lists for `Microsoft.App/sandboxGroups`, and the same one the
 /// data plane and the setup emitter use. ARM still answers older previews, so a mismatch here
-/// fails silently as a shape difference rather than loudly as a rejected version.
+/// fails silently as a response mismatch rather than loudly as a rejected version.
 const API_VERSION: &str = "2026-02-01-preview";
 
 /// Scope every ARM call is signed for.

--- a/crates/alien-azure-clients/src/azure/sandbox_groups.rs
+++ b/crates/alien-azure-clients/src/azure/sandbox_groups.rs
@@ -19,9 +19,8 @@ use mockall::automock;
 
 /// ARM API version for sandbox groups.
 ///
-/// The version the provider manifest lists for `Microsoft.App/sandboxGroups`, and the same one the
-/// data plane and the setup emitter use. ARM still answers older previews, so a mismatch here
-/// fails silently as a response mismatch rather than loudly as a rejected version.
+/// Must match the provider manifest, data plane, and setup emitter. ARM still answers older
+/// previews, so a mismatch fails silently as a response mismatch, not a rejected version.
 const API_VERSION: &str = "2026-02-01-preview";
 
 /// Scope every ARM call is signed for.

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -1942,17 +1942,29 @@ impl BindingsProviderApi for BindingsProvider {
                     .into_value(binding_name, "diskImage")
                     .map_err(|_| invalid("diskImage"))?;
 
-                // Ceilings stay the service defaults: `.limits()` is refused on Azure at plan
-                // time, so nothing declares them and there is no value to carry. They move into
-                // the binding when `enforcedLimits` flips, not before.
+                // A binding rendered before Azure carried ceilings has none, and those deployments
+                // keep running — so an absent value falls back to the same default it has always
+                // had rather than failing to resolve.
+                let declared = |value: Option<alien_core::bindings::BindingValue<String>>,
+                                field: &'static str| {
+                    value
+                        .map(|value| value.into_value(binding_name, field))
+                        .transpose()
+                        .map_err(|_| invalid(field))
+                };
+                let cpu = declared(azure_binding.cpu, "cpu")?;
+                let memory = declared(azure_binding.memory, "memory")?;
+                let disk = declared(azure_binding.disk, "disk")?;
+
                 let sandbox: Arc<dyn crate::traits::Sandbox> = Arc::new(AzureSandbox::new(
                     Arc::new(client),
                     group,
                     disk_image,
                     azure_binding.egress,
                     azure_binding.idle_suspend_seconds,
-                    DEFAULT_AZURE_CPU.to_string(),
-                    DEFAULT_AZURE_MEMORY.to_string(),
+                    cpu.unwrap_or_else(|| DEFAULT_AZURE_CPU.to_string()),
+                    memory.unwrap_or_else(|| DEFAULT_AZURE_MEMORY.to_string()),
+                    disk,
                 ));
                 Ok(sandbox)
             }

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -1942,9 +1942,9 @@ impl BindingsProviderApi for BindingsProvider {
                     .into_value(binding_name, "diskImage")
                     .map_err(|_| invalid("diskImage"))?;
 
-                // A binding rendered before Azure carried ceilings has none, and those deployments
-                // keep running — so an absent value falls back to the same default it has always
-                // had rather than failing to resolve.
+                // A binding rendered by an earlier release carries no ceilings, and those
+                // deployments keep running, so an absent value falls back to the platform default
+                // rather than failing to resolve.
                 let declared = |value: Option<alien_core::bindings::BindingValue<String>>,
                                 field: &'static str| {
                     value

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -1942,9 +1942,8 @@ impl BindingsProviderApi for BindingsProvider {
                     .into_value(binding_name, "diskImage")
                     .map_err(|_| invalid("diskImage"))?;
 
-                // A binding rendered by an earlier release carries no ceilings, and those
-                // deployments keep running, so an absent value falls back to the platform default
-                // rather than failing to resolve.
+                // Old bindings predate ceilings, and those deployments keep running, so absent
+                // falls back to the platform default rather than failing to resolve.
                 let declared = |value: Option<alien_core::bindings::BindingValue<String>>,
                                 field: &'static str| {
                     value
@@ -2102,10 +2101,9 @@ mod tests {
     use super::*;
     use alien_core::ENV_ALIEN_DEPLOYMENT_TYPE;
 
-    /// `azure_session_limits` waves through a sandbox that declares nothing because the values
-    /// substituted here take its place. Nothing else couples the two, so changing either constant
-    /// to something the rule refuses would silently move the failure back to create (see
-    /// `azure_session_limits`'s doc for why that matters).
+    /// Pins `DEFAULT_AZURE_CPU`/`DEFAULT_AZURE_MEMORY` as inputs `azure_session_limits` accepts;
+    /// if a constant changes to a value the rule refuses, the failure moves silently from plan
+    /// time to create.
     #[test]
     fn the_substituted_azure_defaults_satisfy_the_plan_time_sizing_rule() {
         let declared_as_default = alien_core::Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -2102,11 +2102,10 @@ mod tests {
     use super::*;
     use alien_core::ENV_ALIEN_DEPLOYMENT_TYPE;
 
-    /// `azure_session_limits` refuses a declaration outside Azure's sizing rule at plan time, and
-    /// waves through a sandbox that declares nothing — because the values substituted here take
-    /// its place. Nothing else couples the two, so changing either constant to something the rule
-    /// refuses would put the failure back at create, where the customer reads it as a runtime
-    /// fault rather than a declaration they can fix.
+    /// `azure_session_limits` waves through a sandbox that declares nothing because the values
+    /// substituted here take its place. Nothing else couples the two, so changing either constant
+    /// to something the rule refuses would silently move the failure back to create (see
+    /// `azure_session_limits`'s doc for why that matters).
     #[test]
     fn the_substituted_azure_defaults_satisfy_the_plan_time_sizing_rule() {
         let declared_as_default = alien_core::Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-bindings/src/provider.rs
+++ b/crates/alien-bindings/src/provider.rs
@@ -2102,6 +2102,36 @@ mod tests {
     use super::*;
     use alien_core::ENV_ALIEN_DEPLOYMENT_TYPE;
 
+    /// `azure_session_limits` refuses a declaration outside Azure's sizing rule at plan time, and
+    /// waves through a sandbox that declares nothing — because the values substituted here take
+    /// its place. Nothing else couples the two, so changing either constant to something the rule
+    /// refuses would put the failure back at create, where the customer reads it as a runtime
+    /// fault rather than a declaration they can fix.
+    #[test]
+    fn the_substituted_azure_defaults_satisfy_the_plan_time_sizing_rule() {
+        let declared_as_default = alien_core::Sandbox::new("agent-sbx".to_string())
+            .code(alien_core::SandboxCode::Image {
+                image: "ubuntu".to_string(),
+            })
+            .limits(alien_core::SandboxLimits {
+                cpu: DEFAULT_AZURE_CPU.to_string(),
+                memory: DEFAULT_AZURE_MEMORY.to_string(),
+                disk: "20Gi".to_string(),
+                max_processes: None,
+            })
+            .egress(alien_core::SandboxEgress::Allow)
+            .session(alien_core::SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build();
+
+        declared_as_default.azure_session_limits().expect(
+            "a sandbox declaring nothing is created with these values, so the rule that would \
+             have refused them at plan time must accept them",
+        );
+    }
+
     fn kubernetes_aws_env() -> HashMap<String, String> {
         HashMap::from([
             (

--- a/crates/alien-bindings/src/providers/build/local.rs
+++ b/crates/alien-bindings/src/providers/build/local.rs
@@ -390,9 +390,8 @@ mod tests {
 
     /// Waits for a build to leave `Running`, or fails saying what it was still doing.
     ///
-    /// Polled rather than slept: a fixed wait is a bet on how long a process takes to spawn and
-    /// exit, and it is lost under load or alongside the other tests in this module rather than
-    /// when the code is wrong. The deadline is generous because it only bounds a hang.
+    /// Polls instead of sleeping a fixed time, which breaks under load or alongside the other
+    /// tests in this module.
     async fn settled_status(local_build: &LocalBuild, id: &str) -> BuildExecution {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
@@ -454,8 +453,8 @@ mod tests {
         assert!(!execution.id.is_empty());
         assert_eq!(execution.status, BuildStatus::Running);
 
-        // Succeeded because the local backend reports a clean exit as success; the script's own
-        // failure is not what this pins.
+        // Succeeded because this backend reports any exit as success — it never reads the exit
+        // status. The script's own failure is not what this pins.
         let status = settled_status(&local_build, &execution.id).await;
         assert_eq!(status.status, BuildStatus::Succeeded);
         assert!(status.end_time.is_some());

--- a/crates/alien-bindings/src/providers/build/local.rs
+++ b/crates/alien-bindings/src/providers/build/local.rs
@@ -388,6 +388,26 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::TempDir;
 
+    /// Waits for a build to leave `Running`, or fails saying what it was still doing.
+    ///
+    /// Polled rather than slept: a fixed wait is a bet on how long a process takes to spawn and
+    /// exit, and it is lost under load or alongside the other tests in this module rather than
+    /// when the code is wrong. The deadline is generous because it only bounds a hang.
+    async fn settled_status(local_build: &LocalBuild, id: &str) -> BuildExecution {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let status = local_build.get_build_status(id).await.unwrap();
+            if status.status != BuildStatus::Running {
+                return status;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "build '{id}' was still Running after 30s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
     #[tokio::test]
     async fn test_local_build_success() {
         let temp_dir = TempDir::new().unwrap();
@@ -410,10 +430,7 @@ mod tests {
         assert!(!execution.id.is_empty());
         assert_eq!(execution.status, BuildStatus::Running);
 
-        // Wait a bit for the build to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-        let status = local_build.get_build_status(&execution.id).await.unwrap();
+        let status = settled_status(&local_build, &execution.id).await;
         assert_eq!(status.status, BuildStatus::Succeeded);
         assert!(status.end_time.is_some());
     }
@@ -437,11 +454,10 @@ mod tests {
         assert!(!execution.id.is_empty());
         assert_eq!(execution.status, BuildStatus::Running);
 
-        // Wait a bit for the build to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-        let status = local_build.get_build_status(&execution.id).await.unwrap();
-        assert_eq!(status.status, BuildStatus::Succeeded); // Note: We assume success if process exits cleanly
+        // Succeeded because the local backend reports a clean exit as success; the script's own
+        // failure is not what this pins.
+        let status = settled_status(&local_build, &execution.id).await;
+        assert_eq!(status.status, BuildStatus::Succeeded);
         assert!(status.end_time.is_some());
     }
 

--- a/crates/alien-bindings/src/providers/sandbox/azure.rs
+++ b/crates/alien-bindings/src/providers/sandbox/azure.rs
@@ -34,9 +34,11 @@ pub struct AzureSandbox {
     egress: SandboxEgress,
     /// Idle seconds after which a session suspends itself, if the declaration asked for one.
     idle_suspend_seconds: Option<u32>,
-    /// Session ceilings, in the data plane's own units.
+    /// Session ceilings, in the data plane's own units. Disk is optional because the data plane
+    /// derives one from the cpu when it is not sent, and that default is better than a guess.
     cpu: String,
     memory: String,
+    disk: Option<String>,
 }
 
 impl AzureSandbox {
@@ -49,6 +51,7 @@ impl AzureSandbox {
         idle_suspend_seconds: Option<u32>,
         cpu: String,
         memory: String,
+        disk: Option<String>,
     ) -> Self {
         Self {
             client,
@@ -58,6 +61,7 @@ impl AzureSandbox {
             idle_suspend_seconds,
             cpu,
             memory,
+            disk,
         }
     }
 
@@ -133,14 +137,38 @@ impl AzureSandbox {
 
 impl Binding for AzureSandbox {}
 
+/// Refused rather than dropped: the create body has nowhere to put a tenant key, so accepting one
+/// would put a caller's tenants in one shared sandbox while the call reported success. Azure does
+/// carry session-level `env`, which is why only this field is refused here.
+fn refuse_unsupported_session_fields(
+    request: &CreateSessionRequest,
+    operation: &str,
+) -> Result<()> {
+    if request.tenant_key.is_some() {
+        return Err(AlienError::new(ErrorData::OperationNotSupported {
+            operation: operation.to_string(),
+            reason: "Azure sandboxes take no tenantKey; create one sandbox per tenant instead"
+                .to_string(),
+        }));
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl Sandbox for AzureSandbox {
+    /// Narrows the platform ceiling to this instance: the egress policy is fixed at construction
+    /// from the declaration and no session can widen it, so a sandbox declared `allow` or `deny`
+    /// restricts nothing by hostname however capable the backend is.
     fn capabilities(&self) -> SandboxCapabilities {
-        SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a sandbox backend")
+        let mut capabilities =
+            SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a sandbox backend");
+        capabilities.domain_egress_rules = matches!(self.egress, SandboxEgress::AllowDomains { .. });
+        capabilities
     }
 
     async fn create(&self, request: CreateSessionRequest) -> Result<SandboxSession> {
         checked_session_env(CREATE, &request.env)?;
+        refuse_unsupported_session_fields(&request, CREATE)?;
 
         let asked = egress_policy(&self.egress);
         let sandbox = self
@@ -151,6 +179,7 @@ impl Sandbox for AzureSandbox {
                     disk_image: self.disk_image.clone(),
                     cpu: self.cpu.clone(),
                     memory: self.memory.clone(),
+                    disk: self.disk.clone(),
                     environment: request.env,
                     egress: asked.clone(),
                     idle_suspend_seconds: self.idle_suspend_seconds,
@@ -1337,6 +1366,7 @@ mod tests {
             None,
             "1000m".to_string(),
             "2048Mi".to_string(),
+            None,
         )
     }
 
@@ -1369,6 +1399,7 @@ mod tests {
             None,
             "1000m".to_string(),
             "2048Mi".to_string(),
+            None,
         );
 
         sandbox
@@ -1618,6 +1649,7 @@ mod tests {
             None,
             "1000m".to_string(),
             "2048Mi".to_string(),
+            None,
         )
     }
 
@@ -2292,6 +2324,7 @@ mod tests {
             None,
             "1000m".to_string(),
             "2048Mi".to_string(),
+            None,
         )
     }
 
@@ -2748,6 +2781,7 @@ mod tests {
             Some(900),
             "1000m".to_string(),
             "2048Mi".to_string(),
+            None,
         )
         .create(CreateSessionRequest::default())
         .await
@@ -4008,5 +4042,67 @@ mod tests {
         };
 
         assert_eq!(error.code, "UNEXPECTED_RESPONSE_FORMAT", "{error}");
+    }
+
+    /// The declared egress decides whether this sandbox restricts by hostname at all.
+    ///
+    /// Both directions are asserted because only one of them distinguishes a narrowed capability
+    /// from a hardcoded `false`: the policy is fixed when the binding is built and no session can
+    /// widen it, so a sandbox declared `allow` restricts nothing however capable Azure is.
+    #[test]
+    fn capabilities_reflect_the_declared_egress() {
+        let listed = AzureSandbox::new(
+            std::sync::Arc::new(MockSandboxDataPlaneApi::new()),
+            "grp".to_string(),
+            "ubuntu".to_string(),
+            SandboxEgress::AllowDomains {
+                domains: vec!["api.example.com".to_string()],
+            },
+            None,
+            "1000m".to_string(),
+            "2048Mi".to_string(),
+            None,
+        );
+        assert!(
+            listed.capabilities().domain_egress_rules,
+            "a declared hostname allowlist makes the capability real"
+        );
+
+        assert!(
+            !sandbox_with(MockSandboxDataPlaneApi::new())
+                .capabilities()
+                .domain_egress_rules,
+            "an `allow` sandbox restricts no hostname, whatever the platform can do"
+        );
+
+        // The rest of the row is the platform ceiling, unchanged. Asserted so a future narrowing
+        // cannot quietly turn a capability off for every Azure sandbox at once.
+        assert!(sandbox_with(MockSandboxDataPlaneApi::new()).capabilities().files);
+        assert!(sandbox_with(MockSandboxDataPlaneApi::new()).capabilities().egress_deny);
+    }
+
+    /// A tenant key has nowhere to go in the create body, so it is refused rather than dropped.
+    ///
+    /// The code is asserted rather than the prose: a caller branching on the outcome reads the
+    /// code, and the message is free to change. `create_sandbox` is expected never, because the
+    /// failure this pins is a sandbox that starts anyway and serves every tenant from one box.
+    #[tokio::test]
+    async fn a_tenant_key_is_refused_rather_than_dropped() {
+        let mut client = MockSandboxDataPlaneApi::new();
+        client.expect_create_sandbox().never();
+
+        let error = sandbox_with(client)
+            .create(CreateSessionRequest {
+                tenant_key: Some("tenant-1".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect_err("a tenant key Azure cannot honour is refused");
+
+        assert_eq!(error.code, "OPERATION_NOT_SUPPORTED", "{error}");
+        assert!(
+            error.to_string().contains("tenantKey"),
+            "the refusal has to name the field a caller must remove: {error}"
+        );
     }
 }

--- a/crates/alien-bindings/src/providers/sandbox/azure.rs
+++ b/crates/alien-bindings/src/providers/sandbox/azure.rs
@@ -98,10 +98,12 @@ impl AzureSandbox {
         }))
     }
 
-    fn unsupported(&self, capability: &str) -> AlienError<ErrorData> {
+    /// A refusal that says why, because "not supported" tells a caller nothing about whether to
+    /// change the declaration, use another verb, or stop asking.
+    fn unsupported(&self, capability: &str, reason: &str) -> AlienError<ErrorData> {
         AlienError::new(ErrorData::OperationNotSupported {
             operation: capability.to_string(),
-            reason: "not supported on azure".to_string(),
+            reason: reason.to_string(),
         })
     }
 
@@ -156,14 +158,16 @@ fn refuse_unsupported_session_fields(
 
 #[async_trait]
 impl Sandbox for AzureSandbox {
-    /// Narrows the platform ceiling to this instance: the egress policy is fixed at construction
-    /// from the declaration and no session can widen it, so a sandbox declared `allow` or `deny`
-    /// restricts nothing by hostname however capable the backend is.
+    /// The platform's row, unnarrowed.
+    ///
+    /// `domainEgressRules` answers whether Azure can restrict egress to a hostname allowlist, not
+    /// whether this sandbox was declared with one — a caller reading `false` on an `allow` sandbox
+    /// would conclude the backend cannot do it at all. AWS narrows `preview` for the opposite
+    /// reason: `preview()` hard-refuses every port when none is declared, so a `true` there would
+    /// misdescribe what the call does. Azure has no such call — the egress policy is applied at
+    /// create and there is nothing for a caller to be refused.
     fn capabilities(&self) -> SandboxCapabilities {
-        let mut capabilities =
-            SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a sandbox backend");
-        capabilities.domain_egress_rules = matches!(self.egress, SandboxEgress::AllowDomains { .. });
-        capabilities
+        SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a sandbox backend")
     }
 
     async fn create(&self, request: CreateSessionRequest) -> Result<SandboxSession> {
@@ -287,7 +291,11 @@ impl Sandbox for AzureSandbox {
     }
 
     async fn list(&self) -> Result<Vec<SandboxSession>> {
-        Err(self.unsupported("list"))
+        Err(self.unsupported(
+            "sandbox.list",
+            "enumerating sandboxes is a control-plane read the data-plane role does not carry; \
+             reach a known session with get",
+        ))
     }
 
     async fn run_command(
@@ -457,7 +465,11 @@ impl Sandbox for AzureSandbox {
     }
 
     async fn preview(&self, _session_id: &str, _port: u16) -> Result<PreviewCapability> {
-        Err(self.unsupported("preview"))
+        Err(self.unsupported(
+            "sandbox.preview",
+            "an Azure sandbox port is either published to the internet or gated on an interactive \
+             Entra login; neither is a port-scoped credential with an expiry",
+        ))
     }
 
     async fn suspend(&self, session_id: &str) -> Result<()> {
@@ -519,7 +531,10 @@ impl Sandbox for AzureSandbox {
     }
 
     async fn snapshot(&self, _session_id: &str) -> Result<String> {
-        Err(self.unsupported("snapshot"))
+        Err(self.unsupported(
+            "sandbox.snapshot",
+            "this client sends no snapshot request, and nothing owns the artifact once taken",
+        ))
     }
 
     async fn terminate(&self, session_id: &str) -> Result<()> {
@@ -4044,13 +4059,23 @@ mod tests {
         assert_eq!(error.code, "UNEXPECTED_RESPONSE_FORMAT", "{error}");
     }
 
-    /// The declared egress decides whether this sandbox restricts by hostname at all.
+    /// The row a caller reads describes the backend, not this sandbox's declaration.
     ///
-    /// Both directions are asserted because only one of them distinguishes a narrowed capability
-    /// from a hardcoded `false`: the policy is fixed when the binding is built and no session can
-    /// widen it, so a sandbox declared `allow` restricts nothing however capable Azure is.
+    /// `domainEgressRules` answers "can Azure restrict egress to a hostname allowlist". A sandbox
+    /// declared `allow` does not use one, and reporting `false` there would tell a caller the
+    /// backend cannot do it at all — which is what a portable app branches on. Asserted on the
+    /// `allow` instance specifically, because that is the one a narrowing gets wrong.
     #[test]
-    fn capabilities_reflect_the_declared_egress() {
+    fn capabilities_describe_the_backend_not_this_declaration() {
+        let platform =
+            SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a backend");
+
+        // Declared `allow`, and still reports the backend's full row.
+        assert_eq!(
+            sandbox_with(MockSandboxDataPlaneApi::new()).capabilities(),
+            platform
+        );
+
         let listed = AzureSandbox::new(
             std::sync::Arc::new(MockSandboxDataPlaneApi::new()),
             "grp".to_string(),
@@ -4063,22 +4088,8 @@ mod tests {
             "2048Mi".to_string(),
             None,
         );
-        assert!(
-            listed.capabilities().domain_egress_rules,
-            "a declared hostname allowlist makes the capability real"
-        );
-
-        assert!(
-            !sandbox_with(MockSandboxDataPlaneApi::new())
-                .capabilities()
-                .domain_egress_rules,
-            "an `allow` sandbox restricts no hostname, whatever the platform can do"
-        );
-
-        // The rest of the row is the platform ceiling, unchanged. Asserted so a future narrowing
-        // cannot quietly turn a capability off for every Azure sandbox at once.
-        assert!(sandbox_with(MockSandboxDataPlaneApi::new()).capabilities().files);
-        assert!(sandbox_with(MockSandboxDataPlaneApi::new()).capabilities().egress_deny);
+        assert_eq!(listed.capabilities(), platform, "the declaration is not the row");
+        assert!(platform.domain_egress_rules, "Azure does host-pattern egress");
     }
 
     /// A tenant key has nowhere to go in the create body, so it is refused rather than dropped.

--- a/crates/alien-bindings/src/providers/sandbox/azure.rs
+++ b/crates/alien-bindings/src/providers/sandbox/azure.rs
@@ -4059,18 +4059,13 @@ mod tests {
         assert_eq!(error.code, "UNEXPECTED_RESPONSE_FORMAT", "{error}");
     }
 
-    /// The row a caller reads describes the backend, not this sandbox's declaration.
-    ///
-    /// `domainEgressRules` answers "can Azure restrict egress to a hostname allowlist". A sandbox
-    /// declared `allow` does not use one, and reporting `false` there would tell a caller the
-    /// backend cannot do it at all — which is what a portable app branches on. Asserted on the
-    /// `allow` instance specifically, because that is the one a narrowing gets wrong.
+    /// Pins `capabilities()`'s doc: `domainEgressRules` must describe the backend even for a
+    /// sandbox declared `allow`, the case a narrowing would get wrong.
     #[test]
     fn capabilities_describe_the_backend_not_this_declaration() {
         let platform =
             SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a backend");
 
-        // Declared `allow`, and still reports the backend's full row.
         assert_eq!(
             sandbox_with(MockSandboxDataPlaneApi::new()).capabilities(),
             platform

--- a/crates/alien-bindings/src/providers/sandbox/azure.rs
+++ b/crates/alien-bindings/src/providers/sandbox/azure.rs
@@ -19,7 +19,7 @@ use alien_azure_clients::azure::sandbox_data_plane::{
     CreateSandbox, EgressHostRule, EgressPolicy, SandboxDataPlaneApi,
 };
 use alien_client_core::ErrorData as ClientErrorData;
-use alien_core::{Platform, SandboxCapabilities, SandboxEgress};
+use alien_core::{SandboxCapabilities, SandboxEgress};
 use alien_error::{AlienError, ContextError};
 use tracing::warn;
 
@@ -158,16 +158,11 @@ fn refuse_unsupported_session_fields(
 
 #[async_trait]
 impl Sandbox for AzureSandbox {
-    /// The platform's row, unnarrowed.
-    ///
-    /// `domainEgressRules` answers whether Azure can restrict egress to a hostname allowlist, not
-    /// whether this sandbox was declared with one — a caller reading `false` on an `allow` sandbox
-    /// would conclude the backend cannot do it at all. AWS narrows `preview` for the opposite
-    /// reason: `preview()` hard-refuses every port when none is declared, so a `true` there would
-    /// misdescribe what the call does. Azure has no such call — the egress policy is applied at
-    /// create and there is nothing for a caller to be refused.
+    /// The platform's row, unnarrowed. `domainEgressRules` says what Azure can do, not what this
+    /// sandbox declared — narrowing it (as AWS does for `preview`) would read `false` on an
+    /// `allow` sandbox as "can't do this at all".
     fn capabilities(&self) -> SandboxCapabilities {
-        SandboxCapabilities::for_platform(Platform::Azure).expect("Azure has a sandbox backend")
+        SandboxCapabilities::azure()
     }
 
     async fn create(&self, request: CreateSessionRequest) -> Result<SandboxSession> {
@@ -1353,6 +1348,7 @@ mod tests {
     use alien_azure_clients::azure::sandbox_data_plane::{
         EgressRule, EgressRuleAction, EgressRuleMatch,
     };
+    use alien_core::Platform;
     use futures::StreamExt;
 
     fn http_error(status: u16, body: &str) -> AlienError<ClientErrorData> {
@@ -4083,15 +4079,20 @@ mod tests {
             "2048Mi".to_string(),
             None,
         );
-        assert_eq!(listed.capabilities(), platform, "the declaration is not the row");
-        assert!(platform.domain_egress_rules, "Azure does host-pattern egress");
+        assert_eq!(
+            listed.capabilities(),
+            platform,
+            "the declaration is not the row"
+        );
+        assert!(
+            platform.domain_egress_rules,
+            "Azure does host-pattern egress"
+        );
     }
 
-    /// A tenant key has nowhere to go in the create body, so it is refused rather than dropped.
-    ///
-    /// The code is asserted rather than the prose: a caller branching on the outcome reads the
-    /// code, and the message is free to change. `create_sandbox` is expected never, because the
-    /// failure this pins is a sandbox that starts anyway and serves every tenant from one box.
+    /// Pins the refusal, not the message: a caller branches on `error.code`, and
+    /// `create_sandbox` must never be called — the failure this guards is a sandbox that starts
+    /// anyway and serves every tenant from one box.
     #[tokio::test]
     async fn a_tenant_key_is_refused_rather_than_dropped() {
         let mut client = MockSandboxDataPlaneApi::new();

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -498,12 +498,9 @@ impl Sandbox for GcpAgentPlatformSandbox {
         self
     }
 
-    /// The platform's row, unnarrowed.
-    ///
-    /// `sessionLifetime` holds whether or not a ttl was declared: `expireTime` is, in the API's own
-    /// words, *always provided on output regardless of what was sent on input*, so a session
-    /// created without one still carries a deadline the platform terminates at. Reporting `false`
-    /// there would tell a caller no lifetime is enforced while one is.
+    /// The platform's row, unnarrowed. `sessionLifetime` stays true even with no declared ttl:
+    /// the API always sets `expireTime` on output, so an undeclared session still carries a
+    /// deadline the platform enforces.
     fn capabilities(&self) -> SandboxCapabilities {
         SandboxCapabilities::gcp_agent_platform()
     }
@@ -524,9 +521,8 @@ impl Sandbox for GcpAgentPlatformSandbox {
             }));
         }
 
-        // Refused rather than dropped, for the same reason as `env` above: `SandboxCreateRequest`
-        // has nowhere to put a tenant key, so accepting one would put a caller's tenants in one
-        // shared sandbox while the call reported success.
+        // Same reason as `env` above: nowhere to carry a tenant key, so accepting one would
+        // silently merge tenants into one sandbox.
         if request.tenant_key.is_some() {
             return Err(AlienError::new(ErrorData::OperationNotSupported {
                 operation: CREATE.to_string(),

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -930,7 +930,8 @@ async fn job_poll_step(mut state: JobPollState) -> Option<(Result<CommandOutput>
             // both come back through a successful `:execute`. Only the first proves the command
             // was stopped, so only the first may name an established outcome.
             let confirmed = cancelled.as_ref().is_ok_and(|body| {
-                serde_json::from_slice::<serde_json::Value>(body).is_ok_and(|value| value.is_object())
+                serde_json::from_slice::<serde_json::Value>(body)
+                    .is_ok_and(|value| value.is_object())
             });
             state.pending.push_back(Err(match cancelled {
                 Ok(_) if confirmed => AlienError::new(ErrorData::SandboxCommandFailed {

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -498,26 +498,29 @@ impl Sandbox for GcpAgentPlatformSandbox {
         self
     }
 
-    /// Narrows the platform ceiling to this instance: the TTL is fixed at construction from the
-    /// declaration, so with none declared every session this object creates runs to the service
-    /// default and none is terminated at a deadline the caller asked for.
+    /// The platform's row, unnarrowed.
+    ///
+    /// `sessionLifetime` holds whether or not a ttl was declared: `expireTime` is, in the API's own
+    /// words, *always provided on output regardless of what was sent on input*, so a session
+    /// created without one still carries a deadline the platform terminates at. Reporting `false`
+    /// there would tell a caller no lifetime is enforced while one is.
     fn capabilities(&self) -> SandboxCapabilities {
-        let mut capabilities = SandboxCapabilities::gcp_agent_platform();
-        capabilities.session_lifetime = self.session_ttl_seconds.is_some();
-        capabilities
+        SandboxCapabilities::gcp_agent_platform()
     }
 
     async fn create(&self, request: CreateSessionRequest) -> Result<SandboxSession> {
         // A session inherits no per-session environment: `SandboxCreateRequest` has no env field,
         // so silently dropping one would run the caller's code without the variables it asked for.
         // They travel per command through `run_command` instead.
+        // `OperationNotSupported`, not `InvalidInput`: the value is fine, the backend has nowhere
+        // to put it. AWS answers the identical condition the same way, and a portable caller
+        // branching on the code must not get two answers for one situation.
         if !request.env.is_empty() {
-            return Err(AlienError::new(ErrorData::InvalidInput {
-                operation_context: CREATE.to_string(),
-                details: "Agent Platform carries no per-session environment; pass variables on \
-                          each command instead"
+            return Err(AlienError::new(ErrorData::OperationNotSupported {
+                operation: CREATE.to_string(),
+                reason: "Agent Platform sandboxes take no session-level env; set env per command \
+                         instead"
                     .to_string(),
-                field_name: Some("env".to_string()),
             }));
         }
 

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform.rs
@@ -498,8 +498,13 @@ impl Sandbox for GcpAgentPlatformSandbox {
         self
     }
 
+    /// Narrows the platform ceiling to this instance: the TTL is fixed at construction from the
+    /// declaration, so with none declared every session this object creates runs to the service
+    /// default and none is terminated at a deadline the caller asked for.
     fn capabilities(&self) -> SandboxCapabilities {
-        SandboxCapabilities::gcp_agent_platform()
+        let mut capabilities = SandboxCapabilities::gcp_agent_platform();
+        capabilities.session_lifetime = self.session_ttl_seconds.is_some();
+        capabilities
     }
 
     async fn create(&self, request: CreateSessionRequest) -> Result<SandboxSession> {
@@ -513,6 +518,18 @@ impl Sandbox for GcpAgentPlatformSandbox {
                           each command instead"
                     .to_string(),
                 field_name: Some("env".to_string()),
+            }));
+        }
+
+        // Refused rather than dropped, for the same reason as `env` above: `SandboxCreateRequest`
+        // has nowhere to put a tenant key, so accepting one would put a caller's tenants in one
+        // shared sandbox while the call reported success.
+        if request.tenant_key.is_some() {
+            return Err(AlienError::new(ErrorData::OperationNotSupported {
+                operation: CREATE.to_string(),
+                reason: "Agent Platform sandboxes take no tenantKey; create one sandbox per \
+                         tenant instead"
+                    .to_string(),
             }));
         }
 
@@ -849,13 +866,18 @@ impl Sandbox for GcpAgentPlatformSandbox {
         // Accepted, not completed: the client returns before the sandbox is gone. Returning here
         // would report containment while the code may still run, which is the whole point of
         // terminate — so the delete is confirmed by polling to not-found.
-        self.client
-            .delete_sandbox(&self.engine, session_id)
-            .await
-            .context(ErrorData::SandboxUnreachable {
-                operation: TERMINATE.to_string(),
-                reason: format!("the delete of session '{session_id}' was not accepted"),
-            })?;
+        // A session that is already gone is the state terminate exists to reach, so not-found is
+        // success. Narrowed to exactly that: mapping any failure to `Ok` would report containment
+        // for a session another deployment owns and this one was refused.
+        if let Err(error) = self.client.delete_sandbox(&self.engine, session_id).await {
+            if !is_not_found(&error) {
+                return Err(error.context(ErrorData::SandboxUnreachable {
+                    operation: TERMINATE.to_string(),
+                    reason: format!("the delete of session '{session_id}' was not accepted"),
+                }));
+            }
+            return Ok(());
+        }
 
         for _ in 0..TERMINATE_POLL_ATTEMPTS {
             match self.client.get_sandbox(&self.engine, session_id).await {

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -1086,9 +1086,16 @@ fn a_frame_that_does_not_convert_ends_the_body() {
     body.extend_from_slice(&ndjson(&[exit_frame(0)]));
 
     let frames = parse_exec_frames(&body).expect("frames parse");
-    assert_eq!(frames.len(), 1, "the exit frame must not follow the failure");
     assert_eq!(
-        frames[0].as_ref().expect_err("a bad payload is not output").code,
+        frames.len(),
+        1,
+        "the exit frame must not follow the failure"
+    );
+    assert_eq!(
+        frames[0]
+            .as_ref()
+            .expect_err("a bad payload is not output")
+            .code,
         "SANDBOX_OUTCOME_UNKNOWN"
     );
 }

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -1126,8 +1126,8 @@ fn the_engine_is_reduced_to_a_bare_segment() {
 // ---- capabilities, session fields and terminate idempotency ------------------------------------
 
 /// The client-shaped access denial: what a delete of a sandbox under an engine this deployment was
-/// not granted returns. Measured against the live API, which answers a cross-engine `:execute` with
-/// `PERMISSION_DENIED` naming the sandbox environment.
+/// not granted returns. The API answers a cross-engine call with `PERMISSION_DENIED` naming the
+/// sandbox environment, so the denial arrives as a refusal rather than as a not-found.
 fn access_denied() -> AlienError<AgentPlatformErrorData> {
     AlienError::new(alien_client_core::ErrorData::RemoteAccessDenied {
         resource_type: "SandboxEnvironment".to_string(),

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -189,8 +189,7 @@ async fn create_refuses_a_per_session_environment() {
         })
         .await
         .expect_err("a session environment must be refused");
-    // The same code AWS answers the identical condition with: the value is fine, the backend has
-    // nowhere to put it. A portable caller branching on the code must not get two answers.
+    // Same code AWS answers the identical condition with (see the reasoning above create's check).
     assert_eq!(error.code, "OPERATION_NOT_SUPPORTED", "{error}");
     assert!(error.to_string().contains("env"), "{error}");
     assert!(error.to_string().contains("per command"), "{error}");
@@ -1142,13 +1141,8 @@ fn access_denied() -> AlienError<AgentPlatformErrorData> {
     })
 }
 
-/// The row a caller reads describes the backend, not this sandbox's declaration.
-///
-/// `sessionLifetime` holds whether or not a ttl was declared. The API states `expireTime` is
-/// *always* provided on output regardless of what was sent on input, so a session created without
-/// a ttl still carries a deadline the platform terminates at — reporting `false` would tell a
-/// caller no lifetime is enforced while one is. Asserted on the no-ttl instance, which is the one
-/// a narrowing gets wrong.
+/// Pins `capabilities()`'s doc: `sessionLifetime` must stay true even for a session with no
+/// declared ttl, the case a narrowing would get wrong (Agent Platform always sets `expireTime`).
 #[test]
 fn capabilities_describe_the_backend_not_this_declaration() {
     let platform = SandboxCapabilities::gcp_agent_platform();

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -229,6 +229,10 @@ async fn get_does_not_report_a_running_session_whose_agent_is_silent() {
         .await
         .expect_err("a running record with a silent agent is not a healthy session");
     assert_eq!(error.code, "SANDBOX_UNREACHABLE", "{error}");
+    assert!(
+        format!("{error}").to_lowercase().contains("denied"),
+        "the refusal must carry why the delete was refused, got: {error}"
+    );
 }
 
 /// Refuse-don't-destroy: `get_or_create` handed a stale id provisions a fresh session and never
@@ -1127,7 +1131,7 @@ fn the_engine_is_reduced_to_a_bare_segment() {
 
 // ---- capabilities, session fields and terminate idempotency ------------------------------------
 
-/// The client-shaped access denial: what a delete of a sandbox under an engine this deployment was
+/// The access denial in the client's own form: what a delete under an engine this deployment was
 /// not granted returns. The API answers a cross-engine call with `PERMISSION_DENIED` naming the
 /// sandbox environment, so the denial arrives as a refusal rather than as a not-found.
 fn access_denied() -> AlienError<AgentPlatformErrorData> {
@@ -1147,7 +1151,10 @@ fn access_denied() -> AlienError<AgentPlatformErrorData> {
 fn capabilities_describe_the_backend_not_this_declaration() {
     let platform = SandboxCapabilities::gcp_agent_platform();
 
-    assert_eq!(provider(MockAgentPlatformApi::new()).capabilities(), platform);
+    assert_eq!(
+        provider(MockAgentPlatformApi::new()).capabilities(),
+        platform
+    );
 
     let untimed = GcpAgentPlatformSandbox::new(
         Arc::new(MockAgentPlatformApi::new()),
@@ -1160,13 +1167,14 @@ fn capabilities_describe_the_backend_not_this_declaration() {
         platform,
         "a session with no declared ttl still expires, so the row does not change"
     );
-    assert!(platform.session_lifetime, "Agent Platform always sets expireTime");
+    assert!(
+        platform.session_lifetime,
+        "Agent Platform always sets expireTime"
+    );
 }
 
-/// A tenant key has nowhere to go in the create body, so it is refused rather than dropped.
-///
-/// The code is asserted rather than the prose. `create_sandbox` is expected never: the failure
-/// this pins is a sandbox that starts anyway and serves every tenant from one box.
+/// Pins the refusal, not the message: `create_sandbox` must never be called — the failure
+/// this guards is a sandbox that starts anyway and serves every tenant from one box.
 #[tokio::test]
 async fn a_tenant_key_is_refused_rather_than_dropped() {
     let mut client = MockAgentPlatformApi::new();
@@ -1187,10 +1195,8 @@ async fn a_tenant_key_is_refused_rather_than_dropped() {
     );
 }
 
-/// Terminating a session that is already gone succeeds, because gone is the state it asks for.
-///
-/// The poll is expected never: an absent session has nothing to confirm, and reaching the poll at
-/// all would mean the delete's not-found had been treated as a failure.
+/// Terminating an already-gone session succeeds — gone is the state it asks for. The poll is
+/// expected never: reaching it would mean not-found had been treated as a failure.
 #[tokio::test]
 async fn terminate_of_an_absent_session_succeeds() {
     let mut client = MockAgentPlatformApi::new();
@@ -1206,12 +1212,9 @@ async fn terminate_of_an_absent_session_succeeds() {
         .expect("terminating an absent session succeeds");
 }
 
-/// A session this deployment cannot reach is still refused, and this is the half a careless
-/// idempotency fix breaks.
-///
-/// Mapping every delete failure to `Ok` would make `terminate` report containment for a sandbox
-/// under another deployment's engine that was never deleted — the caller would believe untrusted
-/// code had been stopped. Only not-found may pass.
+/// A session this deployment cannot reach stays refused: mapping every delete failure to `Ok`
+/// would report containment for a sandbox under another deployment's engine that was never
+/// deleted. Only not-found may pass.
 #[tokio::test]
 async fn terminate_of_a_session_this_deployment_cannot_reach_is_still_refused() {
     let mut client = MockAgentPlatformApi::new();

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -229,10 +229,6 @@ async fn get_does_not_report_a_running_session_whose_agent_is_silent() {
         .await
         .expect_err("a running record with a silent agent is not a healthy session");
     assert_eq!(error.code, "SANDBOX_UNREACHABLE", "{error}");
-    assert!(
-        format!("{error}").to_lowercase().contains("denied"),
-        "the refusal must carry why the delete was refused, got: {error}"
-    );
 }
 
 /// Refuse-don't-destroy: `get_or_create` handed a stale id provisions a fresh session and never
@@ -1230,4 +1226,8 @@ async fn terminate_of_a_session_this_deployment_cannot_reach_is_still_refused() 
         .expect_err("a refused delete is not containment");
 
     assert_eq!(error.code, "SANDBOX_UNREACHABLE", "{error}");
+    assert!(
+        format!("{error}").to_lowercase().contains("denied"),
+        "the refusal must carry why the delete was refused, got: {error}"
+    );
 }

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -1122,3 +1122,115 @@ fn the_engine_is_reduced_to_a_bare_segment() {
         "the full resource name is reduced to the engine id"
     );
 }
+
+// ---- capabilities, session fields and terminate idempotency ------------------------------------
+
+/// The client-shaped access denial: what a delete of a sandbox under an engine this deployment was
+/// not granted returns. Measured against the live API, which answers a cross-engine `:execute` with
+/// `PERMISSION_DENIED` naming the sandbox environment.
+fn access_denied() -> AlienError<AgentPlatformErrorData> {
+    AlienError::new(alien_client_core::ErrorData::RemoteAccessDenied {
+        resource_type: "SandboxEnvironment".to_string(),
+        resource_name: "s1".to_string(),
+    })
+    .context(AgentPlatformErrorData::RequestFailed {
+        operation: "delete sandbox".to_string(),
+        message: "s1".to_string(),
+    })
+}
+
+/// The declared ttl decides whether sessions from this object carry a deadline at all.
+///
+/// Both directions are asserted: with no ttl the create body sends none and the service default
+/// applies, so reporting `sessionLifetime` would promise a ceiling nobody asked for and nothing
+/// applies. A hardcoded `false` would pass the first assertion alone.
+#[test]
+fn capabilities_reflect_the_declared_session_ttl() {
+    assert!(
+        provider(MockAgentPlatformApi::new())
+            .capabilities()
+            .session_lifetime,
+        "a declared ttl makes the capability real"
+    );
+
+    let untimed = GcpAgentPlatformSandbox::new(
+        Arc::new(MockAgentPlatformApi::new()),
+        ENGINE_FULL.to_string(),
+        TEMPLATE.to_string(),
+        None,
+    );
+    assert!(
+        !untimed.capabilities().session_lifetime,
+        "no declared ttl means no session this object creates is terminated at a deadline"
+    );
+
+    // The rest of the row is the platform ceiling, unchanged.
+    assert!(untimed.capabilities().snapshot);
+    assert!(untimed.capabilities().files);
+}
+
+/// A tenant key has nowhere to go in the create body, so it is refused rather than dropped.
+///
+/// The code is asserted rather than the prose. `create_sandbox` is expected never: the failure
+/// this pins is a sandbox that starts anyway and serves every tenant from one box.
+#[tokio::test]
+async fn a_tenant_key_is_refused_rather_than_dropped() {
+    let mut client = MockAgentPlatformApi::new();
+    client.expect_create_sandbox().never();
+
+    let error = provider(client)
+        .create(CreateSessionRequest {
+            tenant_key: Some("tenant-1".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect_err("a tenant key Agent Platform cannot honour is refused");
+
+    assert_eq!(error.code, "OPERATION_NOT_SUPPORTED", "{error}");
+    assert!(
+        error.to_string().contains("tenantKey"),
+        "the refusal has to name the field a caller must remove: {error}"
+    );
+}
+
+/// Terminating a session that is already gone succeeds, because gone is the state it asks for.
+///
+/// The poll is expected never: an absent session has nothing to confirm, and reaching the poll at
+/// all would mean the delete's not-found had been treated as a failure.
+#[tokio::test]
+async fn terminate_of_an_absent_session_succeeds() {
+    let mut client = MockAgentPlatformApi::new();
+    client
+        .expect_delete_sandbox()
+        .times(1)
+        .returning(|_, _| Err(not_found()));
+    client.expect_get_sandbox().never();
+
+    provider(client)
+        .terminate("s1")
+        .await
+        .expect("terminating an absent session succeeds");
+}
+
+/// A session this deployment cannot reach is still refused, and this is the half a careless
+/// idempotency fix breaks.
+///
+/// Mapping every delete failure to `Ok` would make `terminate` report containment for a sandbox
+/// under another deployment's engine that was never deleted — the caller would believe untrusted
+/// code had been stopped. Only not-found may pass.
+#[tokio::test]
+async fn terminate_of_a_session_this_deployment_cannot_reach_is_still_refused() {
+    let mut client = MockAgentPlatformApi::new();
+    client
+        .expect_delete_sandbox()
+        .times(1)
+        .returning(|_, _| Err(access_denied()));
+    client.expect_get_sandbox().never();
+
+    let error = provider(client)
+        .terminate("s1")
+        .await
+        .expect_err("a refused delete is not containment");
+
+    assert_eq!(error.code, "SANDBOX_UNREACHABLE", "{error}");
+}

--- a/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
+++ b/crates/alien-bindings/src/providers/sandbox/gcp_agent_platform_tests.rs
@@ -189,8 +189,11 @@ async fn create_refuses_a_per_session_environment() {
         })
         .await
         .expect_err("a session environment must be refused");
-    assert_eq!(error.code, "INVALID_INPUT", "{error}");
-    assert!(error.to_string().contains("each command"), "{error}");
+    // The same code AWS answers the identical condition with: the value is fine, the backend has
+    // nowhere to put it. A portable caller branching on the code must not get two answers.
+    assert_eq!(error.code, "OPERATION_NOT_SUPPORTED", "{error}");
+    assert!(error.to_string().contains("env"), "{error}");
+    assert!(error.to_string().contains("per command"), "{error}");
 }
 
 // ---- get / get_or_create ----------------------------------------------------------------------
@@ -1139,19 +1142,18 @@ fn access_denied() -> AlienError<AgentPlatformErrorData> {
     })
 }
 
-/// The declared ttl decides whether sessions from this object carry a deadline at all.
+/// The row a caller reads describes the backend, not this sandbox's declaration.
 ///
-/// Both directions are asserted: with no ttl the create body sends none and the service default
-/// applies, so reporting `sessionLifetime` would promise a ceiling nobody asked for and nothing
-/// applies. A hardcoded `false` would pass the first assertion alone.
+/// `sessionLifetime` holds whether or not a ttl was declared. The API states `expireTime` is
+/// *always* provided on output regardless of what was sent on input, so a session created without
+/// a ttl still carries a deadline the platform terminates at — reporting `false` would tell a
+/// caller no lifetime is enforced while one is. Asserted on the no-ttl instance, which is the one
+/// a narrowing gets wrong.
 #[test]
-fn capabilities_reflect_the_declared_session_ttl() {
-    assert!(
-        provider(MockAgentPlatformApi::new())
-            .capabilities()
-            .session_lifetime,
-        "a declared ttl makes the capability real"
-    );
+fn capabilities_describe_the_backend_not_this_declaration() {
+    let platform = SandboxCapabilities::gcp_agent_platform();
+
+    assert_eq!(provider(MockAgentPlatformApi::new()).capabilities(), platform);
 
     let untimed = GcpAgentPlatformSandbox::new(
         Arc::new(MockAgentPlatformApi::new()),
@@ -1159,14 +1161,12 @@ fn capabilities_reflect_the_declared_session_ttl() {
         TEMPLATE.to_string(),
         None,
     );
-    assert!(
-        !untimed.capabilities().session_lifetime,
-        "no declared ttl means no session this object creates is terminated at a deadline"
+    assert_eq!(
+        untimed.capabilities(),
+        platform,
+        "a session with no declared ttl still expires, so the row does not change"
     );
-
-    // The rest of the row is the platform ceiling, unchanged.
-    assert!(untimed.capabilities().snapshot);
-    assert!(untimed.capabilities().files);
+    assert!(platform.session_lifetime, "Agent Platform always sets expireTime");
 }
 
 /// A tenant key has nowhere to go in the create body, so it is refused rather than dropped.

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -857,10 +857,7 @@ fn validate_azure_remote_client_config(config: &alien_core::AzureClientConfig) -
         ));
     }
     let alien_core::AzureCredentials::AccessToken { token } = &config.credentials else {
-        return Err(invalid_remote_lease(
-            "Azure",
-            "an access token is required",
-        ));
+        return Err(invalid_remote_lease("Azure", "an access token is required"));
     };
     if token.is_empty() {
         return Err(invalid_remote_lease(

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -564,6 +564,14 @@ enum ResolvedRemoteBinding {
         #[serde(rename = "expiresAt")]
         expires_at: DateTime<Utc>,
     },
+    #[serde(rename = "sandbox-azure")]
+    SandboxAzure {
+        binding: Box<alien_core::AzureSandboxBinding>,
+        #[serde(rename = "clientConfig")]
+        client_config: Box<alien_core::AzureClientConfig>,
+        #[serde(rename = "expiresAt")]
+        expires_at: DateTime<Utc>,
+    },
     #[cfg(test)]
     #[serde(rename = "local-storage")]
     Local {
@@ -734,6 +742,18 @@ impl ResolvedRemoteBinding {
                 (
                     alien_core::ClientConfig::Aws(client_config),
                     serialize_remote_binding(alien_core::SandboxBinding::Aws(*binding))?,
+                    expires_at,
+                )
+            }
+            Self::SandboxAzure {
+                binding,
+                client_config,
+                expires_at,
+            } => {
+                validate_azure_remote_client_config(&client_config)?;
+                (
+                    alien_core::ClientConfig::Azure(client_config),
+                    serialize_remote_binding(alien_core::SandboxBinding::Azure(*binding))?,
                     expires_at,
                 )
             }

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -859,13 +859,13 @@ fn validate_azure_remote_client_config(config: &alien_core::AzureClientConfig) -
     let alien_core::AzureCredentials::AccessToken { token } = &config.credentials else {
         return Err(invalid_remote_lease(
             "Azure",
-            "a storage-audience access token is required",
+            "an access token is required",
         ));
     };
     if token.is_empty() {
         return Err(invalid_remote_lease(
             "Azure",
-            "the storage-audience access token must be nonempty",
+            "the access token must be nonempty",
         ));
     }
     Ok(())

--- a/crates/alien-bindings/src/remote/manager_conversion.rs
+++ b/crates/alien-bindings/src/remote/manager_conversion.rs
@@ -305,10 +305,9 @@ impl ResolvedRemoteBinding {
             } => {
                 let manager_types::RemoteAzureCredentials::AccessToken(token) =
                     client_config.credentials;
-                // Read from the wire rather than assumed: the manager refuses to lease a sandbox
-                // declared with anything else, and a client that inferred `Allow` from an absent
-                // field would keep inferring it if that ever changed. Checked before the binding
-                // is consumed so the refusal can still name the group.
+                // Checked rather than assumed, so a future manager change in what it refuses
+                // still gets caught here. Checked before the binding is consumed so the refusal
+                // can still name the group.
                 if !binding.allow_egress {
                     return Err(AlienError::new(ErrorData::RemoteAccessFailed {
                         operation: format!(

--- a/crates/alien-bindings/src/remote/manager_conversion.rs
+++ b/crates/alien-bindings/src/remote/manager_conversion.rs
@@ -298,6 +298,56 @@ impl ResolvedRemoteBinding {
                     expires_at: parse_manager_expiry(expires_at, resource_id)?,
                 }
             }
+            manager_types::ResolveBindingResponse::SandboxAzure {
+                binding,
+                client_config,
+                expires_at,
+            } => {
+                let manager_types::RemoteAzureCredentials::AccessToken(token) =
+                    client_config.credentials;
+                // Read from the wire rather than assumed: the manager refuses to lease a sandbox
+                // declared with anything else, and a client that inferred `Allow` from an absent
+                // field would keep inferring it if that ever changed. Checked before the binding
+                // is consumed so the refusal can still name the group.
+                if !binding.allow_egress {
+                    return Err(AlienError::new(ErrorData::RemoteAccessFailed {
+                        operation: format!(
+                            "read remote sandbox binding '{}': a remote sandbox must be declared \
+                             with open egress",
+                            binding.sandbox_group
+                        ),
+                    }));
+                }
+                Self::SandboxAzure {
+                    binding: Box::new(alien_core::AzureSandboxBinding {
+                        sandbox_group: alien_core::BindingValue::Value(binding.sandbox_group),
+                        data_plane_endpoint: alien_core::BindingValue::Value(
+                            binding.data_plane_endpoint,
+                        ),
+                        region: alien_core::BindingValue::Value(binding.region),
+                        resource_group: alien_core::BindingValue::Value(binding.resource_group),
+                        disk_image: alien_core::BindingValue::Value(binding.disk_image),
+                        egress: alien_core::SandboxEgress::Allow,
+                        idle_suspend_seconds: binding
+                            .idle_suspend_seconds
+                            .map(|seconds| {
+                                narrow_manager_number(seconds, "idleSuspendSeconds", resource_id)
+                            })
+                            .transpose()?,
+                        cpu: binding.cpu.map(alien_core::BindingValue::Value),
+                        memory: binding.memory.map(alien_core::BindingValue::Value),
+                        disk: binding.disk.map(alien_core::BindingValue::Value),
+                    }),
+                    client_config: Box::new(alien_core::AzureClientConfig {
+                        subscription_id: client_config.subscription_id,
+                        tenant_id: client_config.tenant_id,
+                        region: client_config.region,
+                        credentials: alien_core::AzureCredentials::AccessToken { token },
+                        service_overrides: None,
+                    }),
+                    expires_at: parse_manager_expiry(expires_at, resource_id)?,
+                }
+            }
         };
         Ok(lease)
     }

--- a/crates/alien-bindings/src/remote/tests/manager_contract.rs
+++ b/crates/alien-bindings/src/remote/tests/manager_contract.rs
@@ -609,3 +609,136 @@ async fn remote_sandbox_lease_is_refused_when_a_preview_port_does_not_fit() {
         "the refusal should name the field and the value it read: {rendered}"
     );
 }
+
+fn azure_sandbox_lease_body(expires_at: DateTime<Utc>, allow_egress: bool) -> serde_json::Value {
+    json!({
+        "service": "sandbox-azure",
+        "binding": {
+            "sandboxGroup": "acme-agent",
+            "dataPlaneEndpoint": "https://management.westus2.azuredevcompute.io",
+            "region": "westus2",
+            "resourceGroup": "acme-rg",
+            "diskImage": "ubuntu",
+            "allowEgress": allow_egress,
+            "idleSuspendSeconds": 300,
+            "cpu": "1000m",
+            "memory": "2048Mi",
+            "disk": "20480Mi",
+        },
+        "clientConfig": {
+            "subscriptionId": "00000000-0000-0000-0000-000000000000",
+            "tenantId": "11111111-1111-1111-1111-111111111111",
+            "region": "westus2",
+            "credentials": { "type": "accessToken", "token": "SENTINEL_AZURE_TOKEN" },
+        },
+        "expiresAt": expires_at.to_rfc3339(),
+    })
+}
+
+/// The Azure sandbox lease decodes through the **generated** client, which is the only path a real
+/// deployment takes.
+///
+/// This is the test that fails when the manager grows a response variant and the OpenAPI spec is
+/// not regenerated: the hand-written types compile, the crate's own tests pass, and the generated
+/// client has no arm to decode into — so the feature is dead for every real consumer while looking
+/// finished from inside the crate.
+#[tokio::test]
+async fn remote_sandbox_decodes_every_declared_field_and_reaches_the_azure_provider() {
+    let expires_at = Utc::now() + ChronoDuration::minutes(5);
+    let response = Arc::new(StdRwLock::new((
+        StatusCode::OK,
+        azure_sandbox_lease_body(expires_at, true),
+    )));
+    let requests = Arc::new(StdMutex::new(Vec::new()));
+    let manager_url = spawn_generated_contract_server(GeneratedContractState {
+        response,
+        requests: requests.clone(),
+    })
+    .await;
+
+    let manager = DiscoveredManager {
+        deployment_id: DEPLOYMENT_ID.to_string(),
+        url: reqwest::Url::parse(&manager_url).expect("valid manager URL"),
+        http: authenticated_http_client(GENERATED_MANAGER_TOKEN, "generated manager fixture")
+            .expect("build generated contract client"),
+        refresh_at: expires_at,
+        generation: 0,
+    };
+    let lease = GeneratedManagerBindingResolver
+        .resolve(
+            &manager,
+            DEPLOYMENT_ID,
+            RemoteBindingSelector::Resource("agent"),
+        )
+        .await
+        .expect("generated client should decode an Azure sandbox lease");
+
+    let ResolvedRemoteBinding::SandboxAzure {
+        binding,
+        client_config,
+        expires_at: lease_expires_at,
+    } = lease
+    else {
+        panic!("generated client returned the wrong lease variant for an Azure sandbox");
+    };
+    let value = |raw: &str| alien_core::BindingValue::Value(raw.to_string());
+    assert_eq!(binding.sandbox_group, value("acme-agent"));
+    assert_eq!(
+        binding.data_plane_endpoint,
+        value("https://management.westus2.azuredevcompute.io")
+    );
+    assert_eq!(binding.region, value("westus2"));
+    assert_eq!(binding.resource_group, value("acme-rg"));
+    assert_eq!(binding.disk_image, value("ubuntu"));
+    assert_eq!(binding.egress, alien_core::SandboxEgress::Allow);
+    assert_eq!(binding.idle_suspend_seconds, Some(300));
+    assert_eq!(binding.cpu, Some(value("1000m")));
+    assert_eq!(binding.memory, Some(value("2048Mi")));
+    assert_eq!(binding.disk, Some(value("20480Mi")));
+    assert_eq!(client_config.region.as_deref(), Some("westus2"));
+    assert!(client_config.service_overrides.is_none());
+    let alien_core::AzureCredentials::AccessToken { token } = client_config.credentials else {
+        panic!("an Azure sandbox lease carries an access token");
+    };
+    assert_eq!(token, "SENTINEL_AZURE_TOKEN");
+    assert_eq!(lease_expires_at.timestamp(), expires_at.timestamp());
+}
+
+/// A lease claiming restricted egress is refused rather than quietly downgraded.
+///
+/// The manager will not mint one, so this pins the client's own half of that contract: the field
+/// is read from the wire rather than assumed, so the day the manager's rule changes the client
+/// refuses instead of silently reporting a restriction that does not exist.
+#[tokio::test]
+async fn an_azure_sandbox_lease_without_open_egress_is_refused() {
+    let expires_at = Utc::now() + ChronoDuration::minutes(5);
+    let response = Arc::new(StdRwLock::new((
+        StatusCode::OK,
+        azure_sandbox_lease_body(expires_at, false),
+    )));
+    let manager_url = spawn_generated_contract_server(GeneratedContractState {
+        response,
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    })
+    .await;
+
+    let manager = DiscoveredManager {
+        deployment_id: DEPLOYMENT_ID.to_string(),
+        url: reqwest::Url::parse(&manager_url).expect("valid manager URL"),
+        http: authenticated_http_client(GENERATED_MANAGER_TOKEN, "generated manager fixture")
+            .expect("build generated contract client"),
+        refresh_at: expires_at,
+        generation: 0,
+    };
+    let Err(error) = GeneratedManagerBindingResolver
+        .resolve(
+            &manager,
+            DEPLOYMENT_ID,
+            RemoteBindingSelector::Resource("agent"),
+        )
+        .await
+    else {
+        panic!("a restricted-egress sandbox lease is not usable remotely")
+    };
+    assert_eq!(error.code, "REMOTE_ACCESS_FAILED", "{error}");
+}

--- a/crates/alien-bindings/src/remote/tests/manager_contract.rs
+++ b/crates/alien-bindings/src/remote/tests/manager_contract.rs
@@ -635,13 +635,9 @@ fn azure_sandbox_lease_body(expires_at: DateTime<Utc>, allow_egress: bool) -> se
     })
 }
 
-/// The Azure sandbox lease decodes through the **generated** client, which is the only path a real
-/// deployment takes.
-///
-/// This is the test that fails when the manager grows a response variant and the OpenAPI spec is
-/// not regenerated: the hand-written types compile, the crate's own tests pass, and the generated
-/// client has no arm to decode into — so the feature is dead for every real consumer while looking
-/// finished from inside the crate.
+/// Decodes through the **generated** client, the only path a real deployment takes. This catches
+/// a manager response variant added without regenerating the OpenAPI spec: hand-written types and
+/// the crate's own tests would still pass, but the generated client would have no arm to decode into.
 #[tokio::test]
 async fn remote_sandbox_decodes_every_declared_field_and_reaches_the_azure_provider() {
     let expires_at = Utc::now() + ChronoDuration::minutes(5);
@@ -704,11 +700,9 @@ async fn remote_sandbox_decodes_every_declared_field_and_reaches_the_azure_provi
     assert_eq!(lease_expires_at.timestamp(), expires_at.timestamp());
 }
 
-/// A lease claiming restricted egress is refused rather than quietly downgraded.
-///
-/// The manager will not mint one, so this pins the client's own half of that contract: the field
-/// is read from the wire rather than assumed, so the day the manager's rule changes the client
-/// refuses instead of silently reporting a restriction that does not exist.
+/// A lease claiming restricted egress is refused rather than quietly downgraded — the field is
+/// read from the wire, not assumed, so a future change to the manager's rule still gets caught
+/// here.
 #[tokio::test]
 async fn an_azure_sandbox_lease_without_open_egress_is_refused() {
     let expires_at = Utc::now() + ChronoDuration::minutes(5);
@@ -741,4 +735,8 @@ async fn an_azure_sandbox_lease_without_open_egress_is_refused() {
         panic!("a restricted-egress sandbox lease is not usable remotely")
     };
     assert_eq!(error.code, "REMOTE_ACCESS_FAILED", "{error}");
+    assert!(
+        format!("{error}").contains("egress"),
+        "the code is shared with other refusals, so the reason has to be named: {error}"
+    );
 }

--- a/crates/alien-bindings/src/traits.rs
+++ b/crates/alien-bindings/src/traits.rs
@@ -969,7 +969,12 @@ pub trait Container: Binding {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSessionRequest {
-    /// Caller-chosen session id. Omitted means the provider allocates one.
+    /// Session id to reconnect to, for the verbs that take one.
+    ///
+    /// Not a name for a new session: `create` always allocates, on every backend, and returns the
+    /// id it allocated. `get_or_create` and `reconnect` read this as the id to look for. A caller
+    /// that sets it on `create` is answered with a different id in the response rather than
+    /// silently — the allocated one is the truth, and it is returned.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     /// Opaque tenant key. Never sent to a provider verbatim — the binding derives a
@@ -992,6 +997,16 @@ pub struct SandboxSession {
     pub state: SandboxSessionState,
     /// Lifecycle generation. A capability from another generation is rejected, which is how
     /// terminate revokes without distributing a revocation list.
+    ///
+    /// What it counts differs by backend, because what can be replaced differs. AWS and Azure
+    /// allocate a fresh id per session, so nothing can be swapped underneath one and a constant
+    /// carries the whole meaning. GCP addresses a session by a name that outlives the container
+    /// behind it, so it derives this from the guest's boot id — the only signal that distinguishes
+    /// a replaced container from the one a caller last spoke to.
+    ///
+    /// The boot id has a known limit: a sandbox restored from a snapshot reports its **source's**
+    /// boot id while holding a different filesystem, so it detects replacement and not restore.
+    /// Anything that needs to tell those apart must key on the resource name as well.
     pub generation: u64,
 }
 
@@ -1115,8 +1130,9 @@ pub trait Sandbox: Binding {
 
     /// Fetches a session by id, or `None` if it does not exist.
     ///
-    /// Requires `reconnect`. A GCP session id is scoped to one Cloud Run instance, so GCP
-    /// returns the typed error rather than a `None` a caller would read as "expired".
+    /// Requires `reconnect`. `None` means the session does not exist; a backend that cannot
+    /// answer the question returns the typed error instead, so an absent session and an
+    /// unreachable one are never the same result.
     async fn get(&self, session_id: &str) -> Result<Option<SandboxSession>>;
 
     /// Fetches a session, creating it if absent.
@@ -1124,9 +1140,10 @@ pub trait Sandbox: Binding {
 
     /// Lists sessions belonging to this sandbox's parent.
     ///
-    /// Not offered on AWS, Azure or GCP, where enumerating would cost an account-wide grant or
-    /// the API has no verb for it; those raise `OperationNotSupported`. Reaching a session whose
-    /// id is known is `get`..
+    /// Offered where the backend has a verb for it and the binding's grant covers it — GCP lists
+    /// under its engine. AWS and Azure raise `OperationNotSupported`: enumerating there costs an
+    /// account-wide grant the session role deliberately withholds. Reaching a session whose id is
+    /// known is `get`.
     async fn list(&self) -> Result<Vec<SandboxSession>>;
 
     /// Runs a command, streaming output frames until exactly one terminal frame.

--- a/crates/alien-bindings/src/traits.rs
+++ b/crates/alien-bindings/src/traits.rs
@@ -969,16 +969,9 @@ pub trait Container: Binding {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSessionRequest {
-    /// Session id to reconnect to, for the verbs that take one.
-    ///
-    /// `get_or_create` and `reconnect` read this as the id to look for. On the cloud backends it
-    /// is not a name for a new session: AWS, Azure and GCP all allocate on `create` and answer
-    /// with the id they allocated, so a caller that sets it here is answered with a different one
-    /// rather than silently. Local and Kubernetes do honour it as the new session's id, because
-    /// they own their own namespace and nothing upstream assigns one.
-    ///
-    /// Either way the response carries the truth; a caller must read the id back rather than
-    /// assume the one it sent.
+    /// Session id to reconnect to, for the verbs that take one. AWS, Azure and GCP always
+    /// allocate their own on `create` and ignore this; only Local and Kubernetes honor it as the
+    /// new session's id. Read the id back from the response rather than assume the one sent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     /// Opaque tenant key. Never sent to a provider verbatim — the binding derives a
@@ -1002,15 +995,9 @@ pub struct SandboxSession {
     /// Lifecycle generation. A capability from another generation is rejected, which is how
     /// terminate revokes without distributing a revocation list.
     ///
-    /// What it counts differs by backend, because what can be replaced differs. AWS and Azure
-    /// allocate a fresh id per session, so nothing can be swapped underneath one and a constant
-    /// carries the whole meaning. GCP addresses a session by a name that outlives the container
-    /// behind it, so it derives this from the guest's boot id — the only signal that distinguishes
-    /// a replaced container from the one a caller last spoke to.
-    ///
-    /// The boot id has a known limit: a sandbox restored from a snapshot reports its **source's**
-    /// boot id while holding a different filesystem, so it detects replacement and not restore.
-    /// Anything that needs to tell those apart must key on the resource name as well.
+    /// Differs by backend: AWS/Azure allocate a fresh id per session, so a constant carries the
+    /// whole meaning; GCP has none, so this is the guest's boot id — which a snapshot restore
+    /// reports unchanged, so restore and replacement need the resource name too to tell apart.
     pub generation: u64,
 }
 
@@ -1144,10 +1131,9 @@ pub trait Sandbox: Binding {
 
     /// Lists sessions belonging to this sandbox's parent.
     ///
-    /// Offered where the backend has a verb for it and the binding's grant covers it — GCP lists
+    /// Offered only where the backend has a verb for it and the grant covers it — GCP lists
     /// under its engine. AWS and Azure raise `OperationNotSupported`: enumerating there costs an
-    /// account-wide grant the session role deliberately withholds. Reaching a session whose id is
-    /// known is `get`.
+    /// account-wide grant the session role deliberately withholds. Reaching a known id is `get`.
     async fn list(&self) -> Result<Vec<SandboxSession>>;
 
     /// Runs a command, streaming output frames until exactly one terminal frame.

--- a/crates/alien-bindings/src/traits.rs
+++ b/crates/alien-bindings/src/traits.rs
@@ -971,10 +971,14 @@ pub trait Container: Binding {
 pub struct CreateSessionRequest {
     /// Session id to reconnect to, for the verbs that take one.
     ///
-    /// Not a name for a new session: `create` always allocates, on every backend, and returns the
-    /// id it allocated. `get_or_create` and `reconnect` read this as the id to look for. A caller
-    /// that sets it on `create` is answered with a different id in the response rather than
-    /// silently — the allocated one is the truth, and it is returned.
+    /// `get_or_create` and `reconnect` read this as the id to look for. On the cloud backends it
+    /// is not a name for a new session: AWS, Azure and GCP all allocate on `create` and answer
+    /// with the id they allocated, so a caller that sets it here is answered with a different one
+    /// rather than silently. Local and Kubernetes do honour it as the new session's id, because
+    /// they own their own namespace and nothing upstream assigns one.
+    ///
+    /// Either way the response carries the truth; a caller must read the id back rather than
+    /// assume the one it sent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     /// Opaque tenant key. Never sent to a provider verbatim — the binding derives a

--- a/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
@@ -253,7 +253,7 @@ fn global_permission_refs<'a>(
 fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
     permission_ref
         .resolve(|name| alien_permissions::get_permission_set(name).cloned())
-        .is_some_and(|set| alien_permissions::permission_set_reaches_a_microvm_session(&set))
+        .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
 }
 
 fn resource_scoped_permission_refs(

--- a/crates/alien-core/src/bindings/sandbox.rs
+++ b/crates/alien-core/src/bindings/sandbox.rs
@@ -110,6 +110,17 @@ pub struct AzureSandboxBinding {
     /// that knows it, and a sandbox running an image its author did not choose is the one Azure
     /// gap that fails without an error.
     pub disk_image: BindingValue<String>,
+    /// Session ceilings in the data plane's own units, from the declaration.
+    ///
+    /// Optional as a set: a binding rendered before Azure carried ceilings has none of them, and a
+    /// required field would fail to deserialize on a deployment that is already running. Absent
+    /// takes the data plane's own default rather than asserting a size nobody declared.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<BindingValue<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<BindingValue<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk: Option<BindingValue<String>>,
 }
 
 /// GCP Agent Platform sandbox binding configuration.
@@ -206,6 +217,11 @@ impl SandboxBinding {
             egress,
             idle_suspend_seconds,
             disk_image: disk_image.into(),
+            // Ceilings are set on the struct where a caller has them; a positional argument each
+            // would make this constructor ten wide for the case that rarely carries them.
+            cpu: None,
+            memory: None,
+            disk: None,
         })
     }
 

--- a/crates/alien-core/src/bindings/sandbox.rs
+++ b/crates/alien-core/src/bindings/sandbox.rs
@@ -110,11 +110,9 @@ pub struct AzureSandboxBinding {
     /// that knows it, and a sandbox running an image its author did not choose is the one Azure
     /// gap that fails without an error.
     pub disk_image: BindingValue<String>,
-    /// Session ceilings in the data plane's own units, from the declaration.
-    ///
-    /// Optional as a set: a binding rendered by an earlier release carries none of them, and a
-    /// required field would fail to deserialize on a deployment that is already running. Absent
-    /// takes the data plane's own default rather than asserting a size nobody declared.
+    /// Session ceilings in the data plane's own units, from the declaration. Optional because a
+    /// binding from an earlier release carries none — a required field would fail to deserialize
+    /// on an already-running deployment. Absent takes the data plane's own default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu: Option<BindingValue<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/alien-core/src/bindings/sandbox.rs
+++ b/crates/alien-core/src/bindings/sandbox.rs
@@ -112,7 +112,7 @@ pub struct AzureSandboxBinding {
     pub disk_image: BindingValue<String>,
     /// Session ceilings in the data plane's own units, from the declaration.
     ///
-    /// Optional as a set: a binding rendered before Azure carried ceilings has none of them, and a
+    /// Optional as a set: a binding rendered by an earlier release carries none of them, and a
     /// required field would fail to deserialize on a deployment that is already running. Absent
     /// takes the data plane's own default rather than asserting a size nobody declared.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/alien-core/src/remote_bindings.rs
+++ b/crates/alien-core/src/remote_bindings.rs
@@ -89,20 +89,33 @@ pub fn remote_binding_for_entry(entry: &ResourceEntry) -> Option<&'static Remote
 /// Why a declaration's remote binding is one a deployment cannot deliver, if it cannot.
 ///
 /// Two cases, both sandbox-only and both about a declared policy the remote grant cannot carry.
-/// Egress: starting a session is additionally authorized as `lambda:PassNetworkConnector`, and the
-/// remote grant passes only AWS's own connectors, so a customer-declared one is unreachable.
-/// Preview ports: `CreateMicrovmAuthToken` has no port condition key, so the list bounds a caller
-/// going through the provider but not a holder of the leased credentials — a bound that only looks
-/// like one. Preflight refuses either; emitters and generated docs read this so nothing advertises
-/// a grant that cannot be used.
+///
+/// **Egress.** The same refusal on both clouds that publish a sandbox remotely, for mechanisms
+/// that are worth telling apart. On AWS the declared connector is *unreachable*: starting a
+/// session is additionally authorized as `lambda:PassNetworkConnector` and the remote grant
+/// passes only AWS's own connectors. On Azure it is *bypassable*: the grant is the
+/// `SandboxGroup Data Owner` data-plane role, so its holder creates sandboxes against the group
+/// directly and the provider that would have applied the declared policy never runs. The Azure
+/// case is the security-relevant one — it is inherent to handing out a data-plane role, not a
+/// gap in an implementation that could later close it.
+///
+/// **Preview ports.** AWS's `CreateMicrovmAuthToken` has no port condition key, so a declared
+/// list bounds a caller going through the provider but not a holder of the leased credentials —
+/// a bound that only looks like one. On Azure and GCP this branch is unreachable rather than
+/// merely unused: `preview` is false for both, so `validate_capabilities` refuses a non-empty
+/// list at plan time before a stack gets this far.
+///
+/// Preflight refuses either; emitters and generated docs read this so nothing advertises a grant
+/// that cannot be used.
 pub fn remote_binding_undeliverable_reason(entry: &ResourceEntry) -> Option<&'static str> {
     remote_binding_for_entry(entry)?;
     let sandbox = entry.config.downcast_ref::<Sandbox>()?;
 
     if !matches!(sandbox.egress, SandboxEgress::Allow) {
         return Some(
-            "a remotely published sandbox must declare egress 'allow'; a sandbox that routes its \
-             traffic through an egress connector cannot be reached remotely",
+            "a remotely published sandbox must declare egress 'allow'; the remote grant either \
+             cannot pass a declared connector or lets its holder create sessions that ignore the \
+             declared policy, so the declaration would not bound the remote caller",
         );
     }
 

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -680,7 +680,8 @@ impl Sandbox {
     /// customer reads it as a runtime fault rather than a declaration they can fix.
     pub fn azure_session_limits(&self) -> Result<()> {
         let Some(limits) = self.limits.as_ref() else {
-            // Nothing declared takes the data plane's own default, which is inside the rule.
+            // Nothing declared means the binding substitutes Alien's own default sizing, which is
+            // inside the rule — asserted where those constants live, since this cannot see them.
             return Ok(());
         };
 

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -280,8 +280,8 @@ impl SandboxCapabilities {
                 // `CreateSessionRequest` has no field to consume an id with. Closing it also
                 // needs an owner for the artifact — Microsoft does not garbage collect snapshots
                 // and `stop` mints one on every suspend, so an id with no owner is a bill that
-                // grows. Declared false until all three are settled, because a capability that
-                // cannot be reached through the trait is a claim a caller cannot act on.
+                // grows. Declared false because a capability that cannot be reached through the
+                // trait is a claim a caller cannot act on.
                 snapshot: false,
                 domain_egress_rules: true,
                 egress_deny: true,

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -272,11 +272,11 @@ impl SandboxCapabilities {
                 // preview capability is. Returning the anonymous URL would publish the port.
                 preview: false,
                 suspend_resume: true,
-                // False for a client reason, not a cloud one, and measured rather than assumed:
-                // the data plane completes the round trip today — `POST …/snapshot` returns a
-                // document, and a sandbox created from `sourcesRef.snapshot.id` carries the
-                // pre-snapshot filesystem and drops the post-snapshot one. What is missing is
-                // ours on both ends: this client has no snapshot call at all, and
+                // False for a client reason, not a cloud one: the data plane completes the round
+                // trip — `POST …/snapshot` returns a document, and a sandbox created from
+                // `sourcesRef.snapshot.id` carries the pre-snapshot filesystem and drops the
+                // post-snapshot one. What is missing is on the client side, at both ends: this
+                // client has no snapshot call at all, and
                 // `CreateSessionRequest` has no field to consume an id with. Closing it also
                 // needs an owner for the artifact — Microsoft does not garbage collect snapshots
                 // and `stop` mints one on every suspend, so an id with no owner is a bill that
@@ -287,10 +287,10 @@ impl SandboxCapabilities {
                 egress_deny: true,
                 // The data plane takes a continuous cpu/memory/disk surface and refuses anything
                 // outside its own rule: `CPU must be n×250m for n=1..64 (0.25–16 cores);
-                // Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi`. The ceilings hold inside the
-                // session — `250m`/`512Mi` gives `nproc=1` and a 727 MB `MemTotal`, and an
-                // over-allocation raises `MemoryError` while the sandbox stays running. There is
-                // no tier enum; `azure_session_limits` checks the rule above at plan time.
+                // Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi`. The ceilings are enforced inside the
+                // session: an over-allocation raises `MemoryError` while the sandbox keeps
+                // running. There is no tier enum; `azure_session_limits` checks the rule at plan
+                // time.
                 enforced_limits: true,
                 process_limit: false,
                 // Auto-suspend and auto-delete exist; a wall-clock ceiling does not. Accepting
@@ -1523,10 +1523,9 @@ mod tests {
 
     /// Azure states its own sizing rule when it refuses, and this is that rule.
     ///
-    /// The wire disagrees with the vendor docs page, which shows a five-value XS-XL tier table
-    /// the API does not implement: `250m`, `1500m` and `4000m` are all accepted and honoured,
-    /// while `32000m` and `333m` are refused. Checked at plan time because the alternative is a
-    /// package that renders cleanly and dies at the first session.
+    /// Azure's published tier table does not match what the API accepts: `250m`, `1500m` and
+    /// `4000m` are valid sizes, `32000m` and `333m` are refused. Checked at plan time because the
+    /// alternative is a package that renders cleanly and dies at the first session.
     #[test]
     fn azure_sizes_follow_the_rule_the_data_plane_states() {
         let sized = |cpu: &str, memory: &str, disk: &str| {
@@ -1539,11 +1538,11 @@ mod tests {
         };
 
         sized("250m", "512Mi", "5120Mi").expect("the smallest step the data plane accepts");
-        sized("4000m", "8192Mi", "40960Mi").expect("all three honoured on the wire");
+        sized("4000m", "8192Mi", "40960Mi").expect("cpu, memory and disk are all honoured");
         sized("16000m", "32Gi", "320Gi").expect("the top of the range");
 
-        // A multiple, not just a range: `333m` sits inside 0.25-16 cores and the data plane still
-        // refuses it, so a bounds-only check would pass a declaration that fails at create.
+        // A multiple, not just a range: `333m` sits inside 0.25-16 cores and is still refused, so
+        // a bounds-only check would pass a declaration that fails at create.
         let off_step = sized("333m", "512Mi", "5120Mi").expect_err("333m is not a step of 250m");
         assert_eq!(off_step.code, "SANDBOX_LIMIT_INVALID", "{off_step}");
         assert!(off_step.to_string().contains("cpu"), "{off_step}");

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -263,44 +263,7 @@ impl SandboxCapabilities {
                 // runs under a different identity than the process supervising it.
                 supervisor_isolation: true,
             }),
-            Platform::Azure => Ok(Self {
-                files: true,
-                reconnect: true,
-                // A sandbox port carries a URL and an auth config, and the auth config offers two
-                // things: anonymous, or Entra ID with an allowlist of human email addresses.
-                // Neither is a credential scoped to a port for a fixed time, which is what a
-                // preview capability is. Returning the anonymous URL would publish the port.
-                preview: false,
-                suspend_resume: true,
-                // False for a client reason, not a cloud one: the data plane completes the round
-                // trip — `POST …/snapshot` returns a document, and a sandbox created from
-                // `sourcesRef.snapshot.id` carries the pre-snapshot filesystem and drops the
-                // post-snapshot one. What is missing is on the client side, at both ends: this
-                // client has no snapshot call at all, and
-                // `CreateSessionRequest` has no field to consume an id with. Closing it also
-                // needs an owner for the artifact — Microsoft does not garbage collect snapshots
-                // and `stop` mints one on every suspend, so an id with no owner is a bill that
-                // grows. Declared false because a capability that cannot be reached through the
-                // trait is a claim a caller cannot act on.
-                snapshot: false,
-                domain_egress_rules: true,
-                egress_deny: true,
-                // Enforced inside the session, not at create: an over-allocation raises
-                // `MemoryError` while the sandbox keeps running. There is no tier enum;
-                // `azure_session_limits` checks the sizing rule (see the `AZURE_*` constants)
-                // at plan time instead.
-                enforced_limits: true,
-                process_limit: false,
-                // Auto-suspend and auto-delete exist; a wall-clock ceiling does not. Accepting
-                // `maxLifetimeSeconds` here would be the silent no-op the capability set exists
-                // to prevent, so this is a decision rather than a gap.
-                session_lifetime: false,
-                // No Alien process inside an Azure sandbox, so there is no supervisor to isolate.
-                supervisor_pid_namespace: false,
-                // No Alien process runs the command at all — the platform's own data plane does,
-                // so there is no separate supervisor identity to speak of.
-                supervisor_isolation: false,
-            }),
+            Platform::Azure => Ok(Self::azure()),
             Platform::Gcp => Ok(Self::gcp_agent_platform()),
             // Preview needs a gateway that validates a session-and-port capability, and that
             // gateway does not exist yet.
@@ -355,6 +318,40 @@ impl SandboxCapabilities {
         }
     }
 
+    /// What the Azure sandbox backend supports; the body of the `Platform::Azure` arm.
+    pub fn azure() -> Self {
+        Self {
+            files: true,
+            reconnect: true,
+            // A sandbox port carries a URL and an auth config, and the auth config offers two
+            // things: anonymous, or Entra ID with an allowlist of human email addresses.
+            // Neither is a credential scoped to a port for a fixed time, which is what a
+            // preview capability is. Returning the anonymous URL would publish the port.
+            preview: false,
+            suspend_resume: true,
+            // False for a client reason, not a cloud one: this client has no snapshot call, and
+            // `CreateSessionRequest` has no field to consume the id it would return. Also
+            // unclaimed: Microsoft does not garbage-collect snapshots, so an id is a bill that grows.
+            snapshot: false,
+            domain_egress_rules: true,
+            egress_deny: true,
+            // Enforced inside the session, not at create: an over-allocation raises `MemoryError`
+            // while the sandbox keeps running. `azure_session_limits` checks the continuous
+            // sizing rule at plan time instead of matching a tier.
+            enforced_limits: true,
+            process_limit: false,
+            // Auto-suspend and auto-delete exist; a wall-clock ceiling does not. Accepting
+            // `maxLifetimeSeconds` here would be the silent no-op the capability set exists
+            // to prevent, so this is a decision rather than a gap.
+            session_lifetime: false,
+            // No Alien process inside an Azure sandbox, so there is no supervisor to isolate.
+            supervisor_pid_namespace: false,
+            // No Alien process runs the command at all — the platform's own data plane does,
+            // so there is no separate supervisor identity to speak of.
+            supervisor_isolation: false,
+        }
+    }
+
     /// What the GCP Agent Platform sandbox backend supports; the body of the `Platform::Gcp` arm.
     pub fn gcp_agent_platform() -> Self {
         Self {
@@ -368,8 +365,9 @@ impl SandboxCapabilities {
             preview: false,
             // `:pause` and `:resume` preserve the running container.
             suspend_resume: true,
-            // A session's state can be captured and used to create another.
-            snapshot: true,
+            // The create path never sends `sandbox_environment_snapshot`, so no session state is
+            // reachable through the trait; declared false until the client carries it.
+            snapshot: false,
             // Egress is shaped by VPC and DNS peering, which is not a hostname allowlist.
             domain_egress_rules: false,
             // A declared `deny` blocks both routed egress and DNS.
@@ -666,13 +664,9 @@ impl Sandbox {
         Ok(image)
     }
 
-    /// Checks the declared ceilings against Azure's sizing rule, quoted at the `AZURE_*` constants
-    /// above.
-    ///
-    /// The surface is continuous, not a tier enum, so Alien's own units map straight through with
-    /// nothing to snap to. Refused here rather than at the first session, for the same reason
-    /// [`Self::microvm_tier`] is: a bad value would otherwise render into the package and fail
-    /// only at create, where it reads as a runtime fault instead of a declaration to fix.
+    /// Checks the declared ceilings against Azure's sizing rule (the `AZURE_*` constants above).
+    /// Refused at plan time, like [`Self::microvm_tier`], so a bad value is a declaration to fix
+    /// rather than a runtime fault at create.
     pub fn azure_session_limits(&self) -> Result<()> {
         let Some(limits) = self.limits.as_ref() else {
             // Nothing declared means the binding substitutes Alien's own default sizing, which is
@@ -715,8 +709,10 @@ impl Sandbox {
             return Err(refused(
                 "memory",
                 &limits.memory,
-                &format!("Azure allows at most 2Gi of memory per core, or {memory_ceiling_mib}Mi \
-                          at the declared cpu"),
+                &format!(
+                    "Azure allows at most 2Gi of memory per core, or {memory_ceiling_mib}Mi \
+                          at the declared cpu"
+                ),
             ));
         }
 
@@ -726,8 +722,10 @@ impl Sandbox {
             return Err(refused(
                 "disk",
                 &limits.disk,
-                &format!("Azure allows at most 20Gi of disk per core, or {disk_ceiling_mib}Mi at \
-                          the declared cpu"),
+                &format!(
+                    "Azure allows at most 20Gi of disk per core, or {disk_ceiling_mib}Mi at \
+                          the declared cpu"
+                ),
             ));
         }
 
@@ -1363,8 +1361,8 @@ mod tests {
             ":pause and :resume preserve the container"
         );
         assert!(
-            row.snapshot,
-            "session state can be captured and restored into a new session"
+            !row.snapshot,
+            "the create path never sends a snapshot, so none is reachable through the trait"
         );
         assert!(
             !row.domain_egress_rules,
@@ -1494,10 +1492,6 @@ mod tests {
     /// `azure_sizes_follow_the_rule_the_data_plane_states`.
     #[test]
     fn a_sandbox_declaring_no_ceilings_takes_the_platforms_own() {
-        sandbox_with(SandboxEgress::Deny, Vec::new())
-            .validate_for_platform(Platform::Azure)
-            .expect("ceilings inside Azure's rule are accepted");
-
         let undeclared = Sandbox::new("sbx".to_string())
             .code(SandboxCode::Image {
                 image: "alpine".to_string(),
@@ -1517,16 +1511,17 @@ mod tests {
         assert_eq!(undeclared.resolved_limits().cpu, "1");
     }
 
-    /// Azure states its own sizing rule when it refuses, and this is that rule.
-    ///
-    /// Azure's published tier table does not match what the API accepts: `250m`, `1500m` and
-    /// `4000m` are valid sizes, `32000m` and `333m` are refused. Checked at plan time because the
-    /// alternative is a package that renders without error and dies at the first session.
+    /// Pins Azure's own sizing rule: `250m`, `1500m` and `4000m` are valid, `32000m` and `333m`
+    /// are refused. Checked at plan time so a bad value is a declaration to fix, not a package
+    /// that renders without error and dies at the first session.
     #[test]
     fn azure_sizes_follow_the_rule_the_data_plane_states() {
         let sized = |cpu: &str, memory: &str, disk: &str| {
             let mut sandbox = sandbox_with(SandboxEgress::Deny, vec![]);
-            let limits = sandbox.limits.as_mut().expect("the fixture declares limits");
+            let limits = sandbox
+                .limits
+                .as_mut()
+                .expect("the fixture declares limits");
             limits.cpu = cpu.to_string();
             limits.memory = memory.to_string();
             limits.disk = disk.to_string();

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -87,6 +87,13 @@ pub struct MicrovmTier {
 /// Longest life AWS will run a MicroVM for, from `RunMicrovm`'s `maximumDurationInSeconds`.
 const AWS_MAX_SESSION_LIFETIME_SECONDS: u32 = 28_800;
 
+/// Azure's session sizing rule, quoted from the data plane's own refusal of an oversized request:
+/// *CPU must be n×250m for n=1..64 (0.25–16 cores); Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi*.
+const AZURE_CPU_STEP_MILLICORES: i64 = 250;
+const AZURE_MAX_CPU_MILLICORES: i64 = 16_000;
+const AZURE_MEMORY_MIB_PER_CORE: i64 = 2 * 1024;
+const AZURE_DISK_MIB_PER_CORE: i64 = 20 * 1024;
+
 const MICROVM_TIERS: &[MicrovmTier] = &[
     MicrovmTier {
         baseline_memory_mib: 512,
@@ -265,15 +272,26 @@ impl SandboxCapabilities {
                 // preview capability is. Returning the anonymous URL would publish the port.
                 preview: false,
                 suspend_resume: true,
-                // The one cloud of the five that could offer this, and the blocker is ours:
-                // `snapshot()` returns an id and `CreateSessionRequest` has no field to consume
-                // one, so no backend can complete the round trip. Nothing in the resource model
-                // owns such an artifact either, and Microsoft states snapshots are not garbage
-                // collected — an id with no owner is a bill that grows.
+                // False for a client reason, not a cloud one, and measured rather than assumed:
+                // the data plane completes the round trip today — `POST …/snapshot` returns a
+                // document, and a sandbox created from `sourcesRef.snapshot.id` carries the
+                // pre-snapshot filesystem and drops the post-snapshot one. What is missing is
+                // ours on both ends: this client has no snapshot call at all, and
+                // `CreateSessionRequest` has no field to consume an id with. Closing it also
+                // needs an owner for the artifact — Microsoft does not garbage collect snapshots
+                // and `stop` mints one on every suspend, so an id with no owner is a bill that
+                // grows. Declared false until all three are settled, because a capability that
+                // cannot be reached through the trait is a claim a caller cannot act on.
                 snapshot: false,
                 domain_egress_rules: true,
                 egress_deny: true,
-                enforced_limits: false,
+                // Measured on the wire, twice: the data plane takes a continuous cpu/memory/disk
+                // surface and states its own rule in the refusal — `CPU must be n×250m for
+                // n=1..64 (0.25–16 cores); Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi`. A declared
+                // `250m`/`512Mi` gives `nproc=1` and a 727 MB `MemTotal` inside, and an
+                // over-allocation raises `MemoryError` while the sandbox stays running. There is
+                // no tier enum; `azure_session_limits` checks the rule above at plan time.
+                enforced_limits: true,
                 process_limit: false,
                 // Auto-suspend and auto-delete exist; a wall-clock ceiling does not. Accepting
                 // `maxLifetimeSeconds` here would be the silent no-op the capability set exists
@@ -578,6 +596,10 @@ impl Sandbox {
         // as bounded while the sandbox is not.
         capabilities.require(SandboxCapability::EnforcedLimits, platform)?;
 
+        if platform == Platform::Azure {
+            self.azure_session_limits()?;
+        }
+
         if platform == Platform::Aws {
             // Refused here rather than at emit so a customer sees it while planning, and so both
             // package formats inherit the same answer.
@@ -644,6 +666,76 @@ impl Sandbox {
             ));
         }
         Ok(image)
+    }
+
+    /// Checks the declared ceilings against the rule Azure states in its own refusal.
+    ///
+    /// Quoted from the data plane, which is where this rule is authoritative: *CPU must be n×250m
+    /// for n=1..64 (0.25–16 cores); Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi*. The surface is
+    /// continuous, not a size enum, so the values Alien already exposes map straight through and
+    /// there is nothing to snap to.
+    ///
+    /// Refused here rather than at the first session, for the same reason [`Self::microvm_tier`]
+    /// is: a value outside the rule renders into the package and fails at create, where the
+    /// customer reads it as a runtime fault rather than a declaration they can fix.
+    pub fn azure_session_limits(&self) -> Result<()> {
+        let Some(limits) = self.limits.as_ref() else {
+            // Nothing declared takes the data plane's own default, which is inside the rule.
+            return Ok(());
+        };
+
+        let refused = |field: &str, value: &str, reason: &str| {
+            AlienError::new(ErrorData::SandboxLimitInvalid {
+                resource_id: self.id.clone(),
+                field: field.to_string(),
+                value: value.to_string(),
+                reason: reason.to_string(),
+            })
+        };
+
+        let cpu_millicores = millicores(&limits.cpu)
+            .ok_or_else(|| refused("cpu", &limits.cpu, "expected cores or millicores"))?;
+
+        // The multiple is checked, not just the range: `333m` sits inside 0.25–16 cores and is
+        // still refused on the wire, so a bounds-only check would pass a declaration that fails
+        // at create.
+        if cpu_millicores % AZURE_CPU_STEP_MILLICORES != 0
+            || !(AZURE_CPU_STEP_MILLICORES..=AZURE_MAX_CPU_MILLICORES).contains(&cpu_millicores)
+        {
+            return Err(refused(
+                "cpu",
+                &limits.cpu,
+                "Azure allocates cpu in steps of 250m from 250m to 16000m",
+            ));
+        }
+
+        // Both ceilings are derived from the cpu, so they cannot be checked before it is known.
+        let memory_ceiling_mib = cpu_millicores * AZURE_MEMORY_MIB_PER_CORE / 1000;
+        let disk_ceiling_mib = cpu_millicores * AZURE_DISK_MIB_PER_CORE / 1000;
+
+        let memory_mib = quantity_mib(&limits.memory)
+            .ok_or_else(|| refused("memory", &limits.memory, "Azure sizes memory in whole MiB"))?;
+        if memory_mib > memory_ceiling_mib {
+            return Err(refused(
+                "memory",
+                &limits.memory,
+                &format!("Azure allows at most 2Gi of memory per core, or {memory_ceiling_mib}Mi \
+                          at the declared cpu"),
+            ));
+        }
+
+        let disk_mib = quantity_mib(&limits.disk)
+            .ok_or_else(|| refused("disk", &limits.disk, "Azure sizes disk in whole MiB"))?;
+        if disk_mib > disk_ceiling_mib {
+            return Err(refused(
+                "disk",
+                &limits.disk,
+                &format!("Azure allows at most 20Gi of disk per core, or {disk_ceiling_mib}Mi at \
+                          the declared cpu"),
+            ));
+        }
+
+        Ok(())
     }
 
     /// The MicroVM size that keeps every declared ceiling, or why none does.
@@ -1173,9 +1265,9 @@ mod tests {
         // one where `deny` and a hostname list are the same object.
         assert!(azure.domain_egress_rules);
         assert!(azure.egress_deny);
-        // The data plane takes no ceiling, so a declaration of one is refused rather than
-        // accepted and dropped.
-        assert!(!azure.enforced_limits);
+        // Measured, not assumed: the data plane honours a continuous cpu/memory/disk surface and
+        // refuses anything outside `n×250m` with the rule in the message.
+        assert!(azure.enforced_limits);
         assert!(azure.suspend_resume);
         // Both stay false for reasons that are not "unbuilt": a snapshot id has nothing to
         // consume it on any backend, and an Azure port's auth is anonymous or a human allowlist,
@@ -1401,15 +1493,19 @@ mod tests {
             .expect("Azure creates the sandbox under a Deny policy with full inspection");
     }
 
-    /// Ceilings are rejected per-platform where unsupported — rejected when *declared*. With
-    /// limits mandatory that would read as "GCP sandboxes cannot exist", contradicting the
-    /// create, exec, files and terminate GCP does support.
+    /// A sandbox naming no ceilings is valid everywhere, and still resolves to a concrete set.
+    ///
+    /// This used to assert the other half too — that Azure refused *declared* ceilings, because
+    /// it was the one platform with `enforcedLimits: false`. It no longer is: the data plane was
+    /// measured honouring cpu, memory and disk, so there is no platform left that takes a sandbox
+    /// and ignores its ceilings, and that half of the assertion has no subject. What replaces it
+    /// is `azure_sizes_follow_the_rule_the_data_plane_states`, which checks the rule Azure
+    /// actually applies rather than that it applies none.
     #[test]
-    fn a_platform_that_cannot_enforce_limits_still_takes_a_sandbox_without_them() {
-        let declared = sandbox_with(SandboxEgress::Deny, Vec::new());
-        declared
+    fn a_sandbox_declaring_no_ceilings_takes_the_platforms_own() {
+        sandbox_with(SandboxEgress::Deny, Vec::new())
             .validate_for_platform(Platform::Azure)
-            .expect_err("declaring ceilings Azure cannot enforce is rejected");
+            .expect("ceilings inside Azure's rule are accepted");
 
         let undeclared = Sandbox::new("sbx".to_string())
             .code(SandboxCode::Image {
@@ -1428,6 +1524,47 @@ mod tests {
 
         // A backend still gets a concrete set, so nothing downstream has to invent one.
         assert_eq!(undeclared.resolved_limits().cpu, "1");
+    }
+
+    /// Azure states its own sizing rule when it refuses, and this is that rule.
+    ///
+    /// Measured on the live data plane rather than taken from the docs page, which still shows a
+    /// five-value XS-XL tier table that does not exist: `250m`, `1500m` and `4000m` are all
+    /// accepted and honoured, `32000m` and `333m` are both refused. Checked at plan time because
+    /// the alternative is a package that renders cleanly and dies at the customer's first session.
+    #[test]
+    fn azure_sizes_follow_the_rule_the_data_plane_states() {
+        let sized = |cpu: &str, memory: &str, disk: &str| {
+            let mut sandbox = sandbox_with(SandboxEgress::Deny, vec![]);
+            let limits = sandbox.limits.as_mut().expect("the fixture declares limits");
+            limits.cpu = cpu.to_string();
+            limits.memory = memory.to_string();
+            limits.disk = disk.to_string();
+            sandbox.validate_for_platform(Platform::Azure)
+        };
+
+        sized("250m", "512Mi", "5120Mi").expect("the smallest step the data plane accepts");
+        sized("4000m", "8192Mi", "40960Mi").expect("all three honoured on the wire");
+        sized("16000m", "32Gi", "320Gi").expect("the top of the range");
+
+        // A multiple, not just a range: `333m` sits inside 0.25-16 cores and the data plane still
+        // refuses it, so a bounds-only check would pass a declaration that fails at create.
+        let off_step = sized("333m", "512Mi", "5120Mi").expect_err("333m is not a step of 250m");
+        assert_eq!(off_step.code, "SANDBOX_LIMIT_INVALID", "{off_step}");
+        assert!(off_step.to_string().contains("cpu"), "{off_step}");
+
+        let too_big = sized("32000m", "64Gi", "640Gi").expect_err("32 cores is over the ceiling");
+        assert_eq!(too_big.code, "SANDBOX_LIMIT_INVALID", "{too_big}");
+
+        // Both ceilings are derived from the cpu, so the same memory passes at one size and fails
+        // at another - which is what makes them worth checking rather than bounding absolutely.
+        sized("1000m", "2Gi", "20Gi").expect("2Gi is exactly one core's worth");
+        let over_memory = sized("250m", "2Gi", "5120Mi").expect_err("2Gi needs a full core");
+        assert_eq!(over_memory.code, "SANDBOX_LIMIT_INVALID", "{over_memory}");
+        assert!(over_memory.to_string().contains("memory"), "{over_memory}");
+
+        let over_disk = sized("250m", "512Mi", "20Gi").expect_err("20Gi needs a full core");
+        assert!(over_disk.to_string().contains("disk"), "{over_disk}");
     }
 
     #[test]

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -285,10 +285,10 @@ impl SandboxCapabilities {
                 snapshot: false,
                 domain_egress_rules: true,
                 egress_deny: true,
-                // Measured on the wire, twice: the data plane takes a continuous cpu/memory/disk
-                // surface and states its own rule in the refusal — `CPU must be n×250m for
-                // n=1..64 (0.25–16 cores); Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi`. A declared
-                // `250m`/`512Mi` gives `nproc=1` and a 727 MB `MemTotal` inside, and an
+                // The data plane takes a continuous cpu/memory/disk surface and refuses anything
+                // outside its own rule: `CPU must be n×250m for n=1..64 (0.25–16 cores);
+                // Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi`. The ceilings hold inside the
+                // session — `250m`/`512Mi` gives `nproc=1` and a 727 MB `MemTotal`, and an
                 // over-allocation raises `MemoryError` while the sandbox stays running. There is
                 // no tier enum; `azure_session_limits` checks the rule above at plan time.
                 enforced_limits: true,
@@ -1265,8 +1265,8 @@ mod tests {
         // one where `deny` and a hostname list are the same object.
         assert!(azure.domain_egress_rules);
         assert!(azure.egress_deny);
-        // Measured, not assumed: the data plane honours a continuous cpu/memory/disk surface and
-        // refuses anything outside `n×250m` with the rule in the message.
+        // The data plane honours a continuous cpu/memory/disk surface and refuses anything
+        // outside `n×250m`, with the rule in the message.
         assert!(azure.enforced_limits);
         assert!(azure.suspend_resume);
         // Both stay false for reasons that are not "unbuilt": a snapshot id has nothing to
@@ -1493,14 +1493,9 @@ mod tests {
             .expect("Azure creates the sandbox under a Deny policy with full inspection");
     }
 
-    /// A sandbox naming no ceilings is valid everywhere, and still resolves to a concrete set.
-    ///
-    /// This used to assert the other half too — that Azure refused *declared* ceilings, because
-    /// it was the one platform with `enforcedLimits: false`. It no longer is: the data plane was
-    /// measured honouring cpu, memory and disk, so there is no platform left that takes a sandbox
-    /// and ignores its ceilings, and that half of the assertion has no subject. What replaces it
-    /// is `azure_sizes_follow_the_rule_the_data_plane_states`, which checks the rule Azure
-    /// actually applies rather than that it applies none.
+    /// A sandbox naming no ceilings is valid on every platform and still resolves to a concrete
+    /// set. The rule Azure applies to ceilings that *are* declared is pinned separately, by
+    /// `azure_sizes_follow_the_rule_the_data_plane_states`.
     #[test]
     fn a_sandbox_declaring_no_ceilings_takes_the_platforms_own() {
         sandbox_with(SandboxEgress::Deny, Vec::new())
@@ -1528,10 +1523,10 @@ mod tests {
 
     /// Azure states its own sizing rule when it refuses, and this is that rule.
     ///
-    /// Measured on the live data plane rather than taken from the docs page, which still shows a
-    /// five-value XS-XL tier table that does not exist: `250m`, `1500m` and `4000m` are all
-    /// accepted and honoured, `32000m` and `333m` are both refused. Checked at plan time because
-    /// the alternative is a package that renders cleanly and dies at the customer's first session.
+    /// The wire disagrees with the vendor docs page, which shows a five-value XS-XL tier table
+    /// the API does not implement: `250m`, `1500m` and `4000m` are all accepted and honoured,
+    /// while `32000m` and `333m` are refused. Checked at plan time because the alternative is a
+    /// package that renders cleanly and dies at the first session.
     #[test]
     fn azure_sizes_follow_the_rule_the_data_plane_states() {
         let sized = |cpu: &str, memory: &str, disk: &str| {

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -285,12 +285,10 @@ impl SandboxCapabilities {
                 snapshot: false,
                 domain_egress_rules: true,
                 egress_deny: true,
-                // The data plane takes a continuous cpu/memory/disk surface and refuses anything
-                // outside its own rule: `CPU must be n×250m for n=1..64 (0.25–16 cores);
-                // Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi`. The ceilings are enforced inside the
-                // session: an over-allocation raises `MemoryError` while the sandbox keeps
-                // running. There is no tier enum; `azure_session_limits` checks the rule at plan
-                // time.
+                // Enforced inside the session, not at create: an over-allocation raises
+                // `MemoryError` while the sandbox keeps running. There is no tier enum;
+                // `azure_session_limits` checks the sizing rule (see the `AZURE_*` constants)
+                // at plan time instead.
                 enforced_limits: true,
                 process_limit: false,
                 // Auto-suspend and auto-delete exist; a wall-clock ceiling does not. Accepting
@@ -668,16 +666,13 @@ impl Sandbox {
         Ok(image)
     }
 
-    /// Checks the declared ceilings against the rule Azure states in its own refusal.
+    /// Checks the declared ceilings against Azure's sizing rule, quoted at the `AZURE_*` constants
+    /// above.
     ///
-    /// Quoted from the data plane, which is where this rule is authoritative: *CPU must be n×250m
-    /// for n=1..64 (0.25–16 cores); Memory ≤ cores × 2Gi; Disk ≤ cores × 20Gi*. The surface is
-    /// continuous, not a size enum, so the values Alien already exposes map straight through and
-    /// there is nothing to snap to.
-    ///
-    /// Refused here rather than at the first session, for the same reason [`Self::microvm_tier`]
-    /// is: a value outside the rule renders into the package and fails at create, where the
-    /// customer reads it as a runtime fault rather than a declaration they can fix.
+    /// The surface is continuous, not a tier enum, so Alien's own units map straight through with
+    /// nothing to snap to. Refused here rather than at the first session, for the same reason
+    /// [`Self::microvm_tier`] is: a bad value would otherwise render into the package and fail
+    /// only at create, where it reads as a runtime fault instead of a declaration to fix.
     pub fn azure_session_limits(&self) -> Result<()> {
         let Some(limits) = self.limits.as_ref() else {
             // Nothing declared means the binding substitutes Alien's own default sizing, which is
@@ -1526,7 +1521,7 @@ mod tests {
     ///
     /// Azure's published tier table does not match what the API accepts: `250m`, `1500m` and
     /// `4000m` are valid sizes, `32000m` and `333m` are refused. Checked at plan time because the
-    /// alternative is a package that renders cleanly and dies at the first session.
+    /// alternative is a package that renders without error and dies at the first session.
     #[test]
     fn azure_sizes_follow_the_rule_the_data_plane_states() {
         let sized = |cpu: &str, memory: &str, disk: &str| {
@@ -1542,8 +1537,7 @@ mod tests {
         sized("4000m", "8192Mi", "40960Mi").expect("cpu, memory and disk are all honoured");
         sized("16000m", "32Gi", "320Gi").expect("the top of the range");
 
-        // A multiple, not just a range: `333m` sits inside 0.25-16 cores and is still refused, so
-        // a bounds-only check would pass a declaration that fails at create.
+        // Same off-step case `azure_session_limits` checks the multiple for, not just the range.
         let off_step = sized("333m", "512Mi", "5120Mi").expect_err("333m is not a step of 250m");
         assert_eq!(off_step.code, "SANDBOX_LIMIT_INVALID", "{off_step}");
         assert!(off_step.to_string().contains("cpu"), "{off_step}");

--- a/crates/alien-manager/openapi.json
+++ b/crates/alien-manager/openapi.json
@@ -14607,6 +14607,73 @@
         },
         "additionalProperties": false
       },
+      "RemoteAzureSandboxBinding": {
+        "type": "object",
+        "description": "Concrete sandbox-group topology returned to remote clients.\n\nThe ceilings travel because Azure applies them at create and nowhere else, so a remote caller\nthat does not send them gets the data plane's default rather than the declared size.",
+        "required": [
+          "sandboxGroup",
+          "dataPlaneEndpoint",
+          "region",
+          "resourceGroup",
+          "diskImage",
+          "allowEgress"
+        ],
+        "properties": {
+          "allowEgress": {
+            "type": "boolean",
+            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied for the same reason the AWS binding sends it: the remote grant lets its holder\ncreate sessions the declared policy never reaches, so a client reconstructing the policy\nneeds the answer on the wire rather than inferring it from an absent field."
+          },
+          "cpu": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Declared session ceilings, where the declaration named them."
+          },
+          "dataPlaneEndpoint": {
+            "type": "string",
+            "description": "Per-region data-plane host, which is separate from the ARM control plane."
+          },
+          "disk": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "diskImage": {
+            "type": "string",
+            "description": "Catalog disk image every session is created from."
+          },
+          "idleSuspendSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Idle seconds after which a session suspends, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "memory": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "region": {
+            "type": "string",
+            "description": "Region the sandbox group lives in."
+          },
+          "resourceGroup": {
+            "type": "string",
+            "description": "Resource group the data-plane path is scoped by."
+          },
+          "sandboxGroup": {
+            "type": "string",
+            "description": "Sandbox group the credential lease authorizes sessions against."
+          }
+        },
+        "additionalProperties": false
+      },
       "RemoteBlobStorageBinding": {
         "type": "object",
         "description": "Concrete Azure Blob Storage topology returned to remote clients.",
@@ -15184,6 +15251,33 @@
                 "type": "string",
                 "enum": [
                   "sandbox-aws"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Azure Container Apps sandbox group and an Azure data-plane token.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteAzureSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteAzureClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-azure"
                 ]
               }
             }

--- a/crates/alien-manager/src/credential_materialization.rs
+++ b/crates/alien-manager/src/credential_materialization.rs
@@ -20,10 +20,9 @@ const GCP_CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-pl
 pub(crate) const AZURE_STORAGE_SCOPE: &str = "https://storage.azure.com/.default";
 pub(crate) const AZURE_KEY_VAULT_SCOPE: &str = "https://vault.azure.net/.default";
 pub(crate) const AZURE_AI_SCOPE: &str = "https://cognitiveservices.azure.com/.default";
-/// The sandbox data plane is signed for the dynamic-sessions audience while answering at
-/// `azuredevcompute.io`, so neither the endpoint host nor ARM's scope works here — a token minted
-/// for either is refused with a 401 that reads like a missing role assignment. Same constant the
-/// in-cloud client uses (`alien-azure-clients`, `sandbox_data_plane::ADC_SCOPE`).
+/// The sandbox data plane is signed for the dynamic-sessions audience despite answering at
+/// `azuredevcompute.io`, so a token minted for the endpoint host or ARM's scope is refused with a
+/// 401 that reads like a missing role. Same constant `sandbox_data_plane::ADC_SCOPE` uses.
 pub(crate) const AZURE_SANDBOX_SCOPE: &str = "https://dynamicsessions.io/.default";
 const REMOTE_STORAGE_DURATION_SECONDS: i32 = 3600;
 const AZURE_MINT_SCOPES: [&str; 5] = [

--- a/crates/alien-manager/src/credential_materialization.rs
+++ b/crates/alien-manager/src/credential_materialization.rs
@@ -20,6 +20,11 @@ const GCP_CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-pl
 pub(crate) const AZURE_STORAGE_SCOPE: &str = "https://storage.azure.com/.default";
 pub(crate) const AZURE_KEY_VAULT_SCOPE: &str = "https://vault.azure.net/.default";
 pub(crate) const AZURE_AI_SCOPE: &str = "https://cognitiveservices.azure.com/.default";
+/// The sandbox data plane is signed for the dynamic-sessions audience while answering at
+/// `azuredevcompute.io`, so neither the endpoint host nor ARM's scope works here — a token minted
+/// for either is refused with a 401 that reads like a missing role assignment. Same constant the
+/// in-cloud client uses (`alien-azure-clients`, `sandbox_data_plane::ADC_SCOPE`).
+pub(crate) const AZURE_SANDBOX_SCOPE: &str = "https://dynamicsessions.io/.default";
 const REMOTE_STORAGE_DURATION_SECONDS: i32 = 3600;
 const AZURE_MINT_SCOPES: [&str; 5] = [
     "https://management.azure.com/.default",
@@ -46,6 +51,7 @@ pub(crate) enum RemoteBindingCredentialScope {
     GcpAi,
     AzureAi,
     AwsSandbox,
+    AzureSandbox,
 }
 
 impl std::fmt::Debug for MaterializedCredentialLease {
@@ -165,6 +171,7 @@ pub(crate) async fn materialize_remote_binding_lease(
                 RemoteBindingCredentialScope::AzureBlob => AZURE_STORAGE_SCOPE,
                 RemoteBindingCredentialScope::AzureKeyVault => AZURE_KEY_VAULT_SCOPE,
                 RemoteBindingCredentialScope::AzureAi => AZURE_AI_SCOPE,
+                RemoteBindingCredentialScope::AzureSandbox => AZURE_SANDBOX_SCOPE,
                 _ => {
                     return Err(ErrorData::internal(
                         "Remote Bindings credential scope does not match Azure",
@@ -228,6 +235,7 @@ fn remote_binding_scope_platform(scope: &RemoteBindingCredentialScope) -> Platfo
         RemoteBindingCredentialScope::AwsKms => Platform::Aws,
         RemoteBindingCredentialScope::AwsAi => Platform::Aws,
         RemoteBindingCredentialScope::AwsSandbox => Platform::Aws,
+        RemoteBindingCredentialScope::AzureSandbox => Platform::Azure,
         RemoteBindingCredentialScope::GcpGcs => Platform::Gcp,
         RemoteBindingCredentialScope::GcpCloudKms => Platform::Gcp,
         RemoteBindingCredentialScope::GcpAi => Platform::Gcp,

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -206,10 +206,9 @@ pub struct RemoteAzureSandboxBinding {
     /// Idle seconds after which a session suspends, where the declaration asked for one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub idle_suspend_seconds: Option<u32>,
-    /// Whether the declaration asked for open egress. Always true here, and sent rather than
-    /// implied for the same reason the AWS binding sends it: the remote grant lets its holder
-    /// create sessions the declared policy never reaches, so a client reconstructing the policy
-    /// needs the answer on the wire rather than inferring it from an absent field.
+    /// Whether the declaration asked for open egress. Always true here, sent explicitly because
+    /// the remote grant lets its holder create sessions the declared policy never reaches — a
+    /// client must read this rather than assume it from an absent field.
     pub allow_egress: bool,
     /// Declared session ceilings, where the declaration named them.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1349,10 +1348,9 @@ fn remote_sandbox_binding(
     // resolve into an AWS credential lease for a sandbox that is not on AWS.
     match (deployment.platform, binding) {
         (Platform::Aws, SandboxBinding::Aws(binding)) => {
-            // The connector is unreachable rather than merely ungranted: starting a session on
-            // one is authorized as `lambda:PassNetworkConnector`, which `sandbox/remote-execute`
-            // withholds. Refused here rather than as an AccessDenied inside the caller's own
-            // `create()`; see `alien_core::remote_bindings::remote_binding_undeliverable_reason`.
+            // Unreachable, not merely ungranted: starting a session on a connector needs
+            // `lambda:PassNetworkConnector`, which `sandbox/remote-execute` withholds. Refused
+            // here rather than as an AccessDenied from inside `create()`.
             if !binding.egress_connector_arns.is_empty() {
                 return Err(ErrorData::bad_request(format!(
                     "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"
@@ -1382,13 +1380,14 @@ fn remote_sandbox_binding(
                 )));
             }
 
-            let optional = |value: Option<alien_core::bindings::BindingValue<String>>,
-                            field: &str|
-             -> Result<Option<String>, alien_error::AlienError<ErrorData>> {
-                value
-                    .map(|value| concrete_binding_value(&value, field))
-                    .transpose()
-            };
+            let optional =
+                |value: Option<alien_core::bindings::BindingValue<String>>,
+                 field: &str|
+                 -> Result<Option<String>, alien_error::AlienError<ErrorData>> {
+                    value
+                        .map(|value| concrete_binding_value(&value, field))
+                        .transpose()
+                };
 
             Ok(RemoteSandboxBinding::Azure(RemoteAzureSandboxBinding {
                 sandbox_group: concrete_binding_value(

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -1344,19 +1344,15 @@ fn remote_sandbox_binding(
                 reason: format!("Sandbox resource '{resource_id}' has an invalid remote binding"),
             })?;
 
-    // A restricted egress is refused on both clouds, for mechanisms worth telling apart. On AWS
-    // starting a session on a connector is a third authorization, `lambda:PassNetworkConnector`,
-    // scoped to no resource and no condition key, so `sandbox/remote-execute` withholds it and a
-    // restricted sandbox could not start at all. On Azure the grant is a data-plane role whose
-    // holder creates sandboxes directly, so a declared policy would simply not apply to them —
-    // handing out the lease would report a restriction that is not one. Refused here rather than
-    // reaching the caller as an AccessDenied from inside its own `create()`, and behind the
-    // preflight that already refuses the declaration at deploy.
     // The stored binding must be the deployment's own cloud. The platform gate above only says
     // the grant exists there; without this, an AWS binding recorded on an Azure deployment would
     // resolve into an AWS credential lease for a sandbox that is not on AWS.
     match (deployment.platform, binding) {
         (Platform::Aws, SandboxBinding::Aws(binding)) => {
+            // The connector is unreachable rather than merely ungranted: starting a session on
+            // one is authorized as `lambda:PassNetworkConnector`, which `sandbox/remote-execute`
+            // withholds. Refused here rather than as an AccessDenied inside the caller's own
+            // `create()`; see `alien_core::remote_bindings::remote_binding_undeliverable_reason`.
             if !binding.egress_connector_arns.is_empty() {
                 return Err(ErrorData::bad_request(format!(
                     "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"
@@ -1377,6 +1373,9 @@ fn remote_sandbox_binding(
             }))
         }
         (Platform::Azure, SandboxBinding::Azure(binding)) => {
+            // Bypassable rather than unreachable: the grant is a data-plane role whose holder
+            // creates sandboxes directly, so handing out the lease would report a restriction
+            // that is not one. Same reference as the AWS arm for the full contrast.
             if !matches!(binding.egress, alien_core::SandboxEgress::Allow) {
                 return Err(ErrorData::bad_request(format!(
                     "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -206,6 +206,11 @@ pub struct RemoteAzureSandboxBinding {
     /// Idle seconds after which a session suspends, where the declaration asked for one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub idle_suspend_seconds: Option<u32>,
+    /// Whether the declaration asked for open egress. Always true here, and sent rather than
+    /// implied for the same reason the AWS binding sends it: the remote grant lets its holder
+    /// create sessions the declared policy never reaches, so a client reconstructing the policy
+    /// needs the answer on the wire rather than inferring it from an absent field.
+    pub allow_egress: bool,
     /// Declared session ceilings, where the declaration named them.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu: Option<String>,
@@ -1401,6 +1406,8 @@ fn remote_sandbox_binding(
                     "Azure sandbox resourceGroup",
                 )?,
                 disk_image: concrete_binding_value(&binding.disk_image, "Azure sandbox diskImage")?,
+                // Checked immediately above, so this is the checked value rather than a literal.
+                allow_egress: matches!(binding.egress, alien_core::SandboxEgress::Allow),
                 idle_suspend_seconds: binding.idle_suspend_seconds,
                 cpu: optional(binding.cpu, "Azure sandbox cpu")?,
                 memory: optional(binding.memory, "Azure sandbox memory")?,

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -188,7 +188,8 @@ pub struct RemoteAwsSandboxBinding {
 /// Concrete sandbox-group topology returned to remote clients.
 ///
 /// The ceilings travel because Azure applies them at create and nowhere else, so a remote caller
-/// that does not send them gets the data plane's default rather than the declared size.
+/// that does not send them gets the data plane's default rather than the declared size. They are
+/// not a limit — a holder that ignores them gets whatever the data plane accepts.
 #[derive(Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -147,6 +147,15 @@ pub enum ResolveBindingResponse {
         #[serde(rename = "expiresAt")]
         expires_at: String,
     },
+    /// Azure Container Apps sandbox group and an Azure data-plane token.
+    #[serde(rename = "sandbox-azure")]
+    SandboxAzure {
+        binding: RemoteAzureSandboxBinding,
+        #[serde(rename = "clientConfig")]
+        client_config: RemoteAzureClientConfig,
+        #[serde(rename = "expiresAt")]
+        expires_at: String,
+    },
 }
 
 /// Concrete MicroVM sandbox topology returned to remote clients.
@@ -174,6 +183,36 @@ pub struct RemoteAwsSandboxBinding {
     /// Whether the declaration asked for open egress. Always true here, and sent rather than
     /// implied so the client's own fail-open check on an empty connector list still has an answer.
     pub allow_egress: bool,
+}
+
+/// Concrete sandbox-group topology returned to remote clients.
+///
+/// The ceilings travel because Azure applies them at create and nowhere else, so a remote caller
+/// that does not send them gets the data plane's default rather than the declared size.
+#[derive(Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RemoteAzureSandboxBinding {
+    /// Sandbox group the credential lease authorizes sessions against.
+    pub sandbox_group: String,
+    /// Per-region data-plane host, which is separate from the ARM control plane.
+    pub data_plane_endpoint: String,
+    /// Region the sandbox group lives in.
+    pub region: String,
+    /// Resource group the data-plane path is scoped by.
+    pub resource_group: String,
+    /// Catalog disk image every session is created from.
+    pub disk_image: String,
+    /// Idle seconds after which a session suspends, where the declaration asked for one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_suspend_seconds: Option<u32>,
+    /// Declared session ceilings, where the declaration named them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -375,6 +414,7 @@ enum RemoteAiBinding {
 
 enum RemoteSandboxBinding {
     Aws(RemoteAwsSandboxBinding),
+    Azure(RemoteAzureSandboxBinding),
 }
 
 enum ResolvedRemoteBinding {
@@ -399,6 +439,7 @@ impl RemoteSandboxBinding {
     fn credential_scope(&self) -> RemoteBindingCredentialScope {
         match self {
             Self::Aws(_) => RemoteBindingCredentialScope::AwsSandbox,
+            Self::Azure(_) => RemoteBindingCredentialScope::AzureSandbox,
         }
     }
 }
@@ -643,6 +684,13 @@ impl ResolveBindingResponse {
         match (binding, lease.client_config) {
             (RemoteSandboxBinding::Aws(binding), ClientConfig::Aws(client_config)) => {
                 Ok(Self::SandboxAws {
+                    binding,
+                    client_config: (*client_config).try_into()?,
+                    expires_at,
+                })
+            }
+            (RemoteSandboxBinding::Azure(binding), ClientConfig::Azure(client_config)) => {
+                Ok(Self::SandboxAzure {
                     binding,
                     client_config: (*client_config).try_into()?,
                     expires_at,
@@ -1238,12 +1286,15 @@ fn remote_sandbox_binding(
     deployment: &DeploymentRecord,
     resource_id: &str,
 ) -> Result<RemoteSandboxBinding, alien_error::AlienError<ErrorData>> {
-    // AWS alone: it is the only sandbox with a RemoteSandboxBinding, and the connector
-    // authorization below (`lambda:PassNetworkConnector`) is AWS-specific. Remote access to a
-    // GCP or Azure sandbox is not wired yet.
-    if deployment.platform != Platform::Aws {
+    // Derived from the permission set rather than named here: the set is the whole grant, so a
+    // platform it does not cover resolves to credentials that authorize nothing, and a second
+    // hardcoded list drifts from the first silently.
+    if !alien_permissions::permission_set_covers_platform(
+        "sandbox/remote-execute",
+        deployment.platform,
+    ) {
         return Err(ErrorData::bad_request(format!(
-            "Remote Sandbox is only supported on AWS, not deployment platform '{}'",
+            "Remote Sandbox is not supported on deployment platform '{}'",
             deployment.platform
         )));
     }
@@ -1288,31 +1339,79 @@ fn remote_sandbox_binding(
                 reason: format!("Sandbox resource '{resource_id}' has an invalid remote binding"),
             })?;
 
-    let SandboxBinding::Aws(binding) = binding else {
-        return Err(ErrorData::bad_request(format!(
+    // A restricted egress is refused on both clouds, for mechanisms worth telling apart. On AWS
+    // starting a session on a connector is a third authorization, `lambda:PassNetworkConnector`,
+    // scoped to no resource and no condition key, so `sandbox/remote-execute` withholds it and a
+    // restricted sandbox could not start at all. On Azure the grant is a data-plane role whose
+    // holder creates sandboxes directly, so a declared policy would simply not apply to them —
+    // handing out the lease would report a restriction that is not one. Refused here rather than
+    // reaching the caller as an AccessDenied from inside its own `create()`, and behind the
+    // preflight that already refuses the declaration at deploy.
+    // The stored binding must be the deployment's own cloud. The platform gate above only says
+    // the grant exists there; without this, an AWS binding recorded on an Azure deployment would
+    // resolve into an AWS credential lease for a sandbox that is not on AWS.
+    match (deployment.platform, binding) {
+        (Platform::Aws, SandboxBinding::Aws(binding)) => {
+            if !binding.egress_connector_arns.is_empty() {
+                return Err(ErrorData::bad_request(format!(
+                    "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"
+                )));
+            }
+
+            Ok(RemoteSandboxBinding::Aws(RemoteAwsSandboxBinding {
+                image_arn: concrete_binding_value(&binding.image_arn, "AWS sandbox imageArn")?,
+                image_version: concrete_binding_value(
+                    &binding.image_version,
+                    "AWS sandbox imageVersion",
+                )?,
+                region: concrete_binding_value(&binding.region, "AWS sandbox region")?,
+                preview_ports: binding.preview_ports,
+                idle_suspend_seconds: binding.idle_suspend_seconds,
+                max_lifetime_seconds: binding.max_lifetime_seconds,
+                allow_egress: binding.allow_egress,
+            }))
+        }
+        (Platform::Azure, SandboxBinding::Azure(binding)) => {
+            if !matches!(binding.egress, alien_core::SandboxEgress::Allow) {
+                return Err(ErrorData::bad_request(format!(
+                    "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"
+                )));
+            }
+
+            let optional = |value: Option<alien_core::bindings::BindingValue<String>>,
+                            field: &str|
+             -> Result<Option<String>, alien_error::AlienError<ErrorData>> {
+                value
+                    .map(|value| concrete_binding_value(&value, field))
+                    .transpose()
+            };
+
+            Ok(RemoteSandboxBinding::Azure(RemoteAzureSandboxBinding {
+                sandbox_group: concrete_binding_value(
+                    &binding.sandbox_group,
+                    "Azure sandbox sandboxGroup",
+                )?,
+                data_plane_endpoint: concrete_binding_value(
+                    &binding.data_plane_endpoint,
+                    "Azure sandbox dataPlaneEndpoint",
+                )?,
+                region: concrete_binding_value(&binding.region, "Azure sandbox region")?,
+                resource_group: concrete_binding_value(
+                    &binding.resource_group,
+                    "Azure sandbox resourceGroup",
+                )?,
+                disk_image: concrete_binding_value(&binding.disk_image, "Azure sandbox diskImage")?,
+                idle_suspend_seconds: binding.idle_suspend_seconds,
+                cpu: optional(binding.cpu, "Azure sandbox cpu")?,
+                memory: optional(binding.memory, "Azure sandbox memory")?,
+                disk: optional(binding.disk, "Azure sandbox disk")?,
+            }))
+        }
+        _ => Err(ErrorData::bad_request(format!(
             "Sandbox resource '{resource_id}' binding does not match deployment platform '{}'",
             deployment.platform
-        )));
-    };
-    // Starting a session on a connector is a third authorization, `lambda:PassNetworkConnector`,
-    // which AWS scopes to no resource and no condition key. `sandbox/remote-execute` therefore
-    // withholds it, and a sandbox that restricts egress is refused here rather than reaching the
-    // caller as an AccessDenied from inside its own `create()`.
-    if !binding.egress_connector_arns.is_empty() {
-        return Err(ErrorData::bad_request(format!(
-            "Sandbox resource '{resource_id}' restricts egress; Remote Bindings can only reach a sandbox declared with open egress"
-        )));
+        ))),
     }
-
-    Ok(RemoteSandboxBinding::Aws(RemoteAwsSandboxBinding {
-        image_arn: concrete_binding_value(&binding.image_arn, "AWS sandbox imageArn")?,
-        image_version: concrete_binding_value(&binding.image_version, "AWS sandbox imageVersion")?,
-        region: concrete_binding_value(&binding.region, "AWS sandbox region")?,
-        preview_ports: binding.preview_ports,
-        idle_suspend_seconds: binding.idle_suspend_seconds,
-        max_lifetime_seconds: binding.max_lifetime_seconds,
-        allow_egress: binding.allow_egress,
-    }))
 }
 
 #[cfg(test)]

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -234,6 +234,26 @@ fn open_sandbox_binding() -> SandboxBinding {
     SandboxBinding::Aws(binding)
 }
 
+/// The binding a deployment on `platform` would actually carry.
+///
+/// Per-platform rather than one AWS binding reused: a resolve refusing an AWS binding on an Azure
+/// deployment proves only that the two disagree, which every platform would pass. The question is
+/// whether resolve accepts that platform's own binding exactly when the permission set covers it.
+fn open_sandbox_binding_for(platform: Platform) -> SandboxBinding {
+    match platform {
+        Platform::Azure => SandboxBinding::azure(
+            "stack-agents",
+            "https://management.westus2.azuredevcompute.io",
+            "westus2",
+            "rg",
+            "ubuntu",
+            alien_core::SandboxEgress::Allow,
+            None,
+        ),
+        _ => open_sandbox_binding(),
+    }
+}
+
 #[test]
 fn remote_sandbox_validation_returns_the_topology_a_session_is_started_from() {
     let deployment = deployment(sandbox_stack_state(open_sandbox_binding(), Platform::Aws));
@@ -316,7 +336,7 @@ fn remote_sandbox_validation_refuses_a_sandbox_that_restricts_egress() {
 fn remote_sandbox_resolve_agrees_with_the_permission_set_platform_coverage() {
     for platform in [Platform::Aws, Platform::Gcp, Platform::Azure] {
         let deployment = deployment_on_platform(
-            sandbox_stack_state(open_sandbox_binding(), platform),
+            sandbox_stack_state(open_sandbox_binding_for(platform), platform),
             platform,
         );
 
@@ -328,22 +348,38 @@ fn remote_sandbox_resolve_agrees_with_the_permission_set_platform_coverage() {
     }
 }
 
+/// Two distinct refusals: a platform carrying no remote-execute grant, and a platform that
+/// carries one but is handed a binding belonging to another cloud.
 #[test]
 fn remote_sandbox_validation_refuses_platforms_without_a_durable_parent() {
-    for platform in [Platform::Gcp, Platform::Azure, Platform::Local] {
+    for platform in [Platform::Gcp, Platform::Local] {
         let deployment = deployment_on_platform(
             sandbox_stack_state(open_sandbox_binding(), platform),
             platform,
         );
         let Err(error) = remote_sandbox_binding(&deployment, "agents") else {
-            panic!("only AWS provisions a sandbox parent a setup identity can be scoped to")
+            panic!("{platform} provisions no sandbox parent a setup identity can be scoped to")
         };
         assert_eq!(error.code, "BAD_REQUEST");
-        assert!(
-            error.message.contains("only supported on AWS"),
-            "{platform}"
-        );
+        assert!(error.message.contains("not supported"), "{platform}");
     }
+
+    // Azure carries the grant, so it clears the platform gate, and is still refused an AWS
+    // binding: without the pairing check that resolves into an AWS credential lease for a sandbox
+    // which is not on AWS.
+    let mismatched = deployment_on_platform(
+        sandbox_stack_state(open_sandbox_binding(), Platform::Azure),
+        Platform::Azure,
+    );
+    let Err(error) = remote_sandbox_binding(&mismatched, "agents") else {
+        panic!("an AWS binding on an Azure deployment must not resolve")
+    };
+    assert_eq!(error.code, "BAD_REQUEST");
+    assert!(
+        error.message.contains("does not match deployment platform"),
+        "{}",
+        error.message
+    );
 }
 
 /// The wire contract remote clients decode. `service` selects the variant, so a rename is a silent

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -234,11 +234,9 @@ fn open_sandbox_binding() -> SandboxBinding {
     SandboxBinding::Aws(binding)
 }
 
-/// The binding a deployment on `platform` would actually carry.
-///
-/// Per-platform rather than one AWS binding reused: a resolve refusing an AWS binding on an Azure
-/// deployment proves only that the two disagree, which every platform would pass. The question is
-/// whether resolve accepts that platform's own binding exactly when the permission set covers it.
+/// The binding a deployment on `platform` would actually carry. Per-platform rather than one AWS
+/// binding reused, so the test asks whether resolve accepts each platform's own binding exactly
+/// when the permission set covers it — not merely that a mismatched binding disagrees.
 fn open_sandbox_binding_for(platform: Platform) -> SandboxBinding {
     match platform {
         Platform::Azure => SandboxBinding::azure(
@@ -364,9 +362,9 @@ fn remote_sandbox_validation_refuses_platforms_without_a_durable_parent() {
         assert!(error.message.contains("not supported"), "{platform}");
     }
 
-    // Azure carries the grant, so it clears the platform gate, and is still refused an AWS
-    // binding: without the pairing check that resolves into an AWS credential lease for a sandbox
-    // which is not on AWS.
+    // Azure carries the grant and clears the platform gate, but the binding is still AWS's — the
+    // pairing check must refuse it, or this resolves into an AWS credential lease for a sandbox
+    // that is not on AWS.
     let mismatched = deployment_on_platform(
         sandbox_stack_state(open_sandbox_binding(), Platform::Azure),
         Platform::Azure,
@@ -714,7 +712,11 @@ async fn remote_access_accepts_a_live_sandbox_and_refuses_a_live_bucket() {
         .await
         .expect_err("setup renders nothing for a Live bucket, so no grant exists");
     assert_eq!(error.code, "BAD_REQUEST");
-    assert!(error.message.contains("renders nothing"), "{}", error.message);
+    assert!(
+        error.message.contains("renders nothing"),
+        "{}",
+        error.message
+    );
 }
 
 #[tokio::test]

--- a/crates/alien-permissions/permission-sets/sandbox/execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/execute.jsonc
@@ -66,7 +66,7 @@
         // resource link, which binds to the sandbox's own group.
         "binding": {
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -38,15 +38,16 @@
         // The stack binding is the resource group, wider than the one group this heartbeat reports
         // on: it can read the state of every sandbox group there, including one the deployment
         // did not create — a deployment can be pointed at a resource group its owner already uses,
-        // as `provision` notes. It exists for the same reason `provision` is resource-group-scoped:
-        // the target does not exist yet. `Microsoft.App/sandboxGroups` has no ARM template
-        // representation, so setup cannot create the group and cannot scope an assignment to one,
-        // and Azure expresses no scope between a group and its resource group. The resource
-        // binding is the narrower grant, but on Azure it is not deliverable for a sandbox today:
-        // the setup path compiles resource-scoped management only for `worker/dispatch-command`,
-        // and the runtime path only for a Kubernetes cluster, so a per-sandbox entry reaches
-        // nobody. It stays declared for the day one of those paths learns to deliver it. What the
-        // stack grant reaches is provisioning state, and no session contents.
+        // as `provision` notes. Azure expresses no scope between a group and its resource group.
+        //
+        // The resource binding is the narrower grant and is not deliverable for a sandbox today,
+        // but no longer because the group cannot be named: setup creates the group, so an
+        // assignment can be scoped to it. What is missing is the setup path, which compiles
+        // resource-scoped management only for `worker/dispatch-command`, and the runtime path,
+        // which compiles it only for a Kubernetes cluster. It stays declared for the day one of
+        // those learns to deliver it, and narrowing the stack binding is worth revisiting now
+        // that the target exists. What the stack grant reaches is provisioning state, and no
+        // session contents.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -45,8 +45,7 @@
         // what blocks delivery is the setup path, which compiles resource-scoped management only
         // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
         // Kubernetes cluster. It stays declared for the day one of
-        // those learns to deliver it, and narrowing the stack binding is worth revisiting now
-        // that the target exists. What the stack grant reaches is provisioning state, and no
+        // those learns to deliver it. What the stack grant reaches is provisioning state, and no
         // session contents.
         "binding": {
           "stack": {

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -44,9 +44,8 @@
         // The group is nameable — setup creates it, so an assignment can be scoped to it — so
         // what blocks delivery is the setup path, which compiles resource-scoped management only
         // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster. It stays declared for the day one of
-        // those learns to deliver it. What the stack grant reaches is provisioning state, and no
-        // session contents.
+        // Kubernetes cluster. What the stack grant reaches is
+        // provisioning state, and no session contents.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -36,11 +36,8 @@
           "actions": ["Microsoft.App/sandboxGroups/read"]
         },
         // The stack binding is the resource group, wider than the one group this heartbeat reports
-        // on: it can read the state of every sandbox group there, including one the deployment
-        // did not create — a deployment can be pointed at a resource group its owner already uses,
-        // as `provision` notes. The resource binding is the narrower grant and is not deliverable
-        // for a sandbox today; see the fuller note in `sandbox/management`. What the stack grant
-        // reaches here is provisioning state, and no session contents.
+        // on, as `provision` notes. The resource binding is narrower but not deliverable for a
+        // sandbox today; see `sandbox/management`. The stack grant reaches provisioning state only.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -40,11 +40,11 @@
         // did not create — a deployment can be pointed at a resource group its owner already uses,
         // as `provision` notes. Azure expresses no scope between a group and its resource group.
         //
-        // The resource binding is the narrower grant and is not deliverable for a sandbox today,
-        // but no longer because the group cannot be named: setup creates the group, so an
-        // assignment can be scoped to it. What is missing is the setup path, which compiles
-        // resource-scoped management only for `worker/dispatch-command`, and the runtime path,
-        // which compiles it only for a Kubernetes cluster. It stays declared for the day one of
+        // The resource binding is the narrower grant and is not deliverable for a sandbox today.
+        // The group is nameable — setup creates it, so an assignment can be scoped to it — so
+        // what blocks delivery is the setup path, which compiles resource-scoped management only
+        // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
+        // Kubernetes cluster. It stays declared for the day one of
         // those learns to deliver it, and narrowing the stack binding is worth revisiting now
         // that the target exists. What the stack grant reaches is provisioning state, and no
         // session contents.

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -38,14 +38,9 @@
         // The stack binding is the resource group, wider than the one group this heartbeat reports
         // on: it can read the state of every sandbox group there, including one the deployment
         // did not create — a deployment can be pointed at a resource group its owner already uses,
-        // as `provision` notes. Azure expresses no scope between a group and its resource group.
-        //
-        // The resource binding is the narrower grant and is not deliverable for a sandbox today.
-        // The group is nameable — setup creates it, so an assignment can be scoped to it — so
-        // what blocks delivery is the setup path, which compiles resource-scoped management only
-        // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster -- so no assignment is created from it. What the stack grant reaches
-        // is provisioning state, and no session contents.
+        // as `provision` notes. The resource binding is the narrower grant and is not deliverable
+        // for a sandbox today; see the fuller note in `sandbox/management`. What the stack grant
+        // reaches here is provisioning state, and no session contents.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -51,7 +51,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -44,8 +44,8 @@
         // The group is nameable — setup creates it, so an assignment can be scoped to it — so
         // what blocks delivery is the setup path, which compiles resource-scoped management only
         // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster. What the stack grant reaches is
-        // provisioning state, and no session contents.
+        // Kubernetes cluster -- so no assignment is created from it. What the stack grant reaches
+        // is provisioning state, and no session contents.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -93,7 +93,7 @@
         // The group is nameable — setup creates it, so an assignment can be scoped to it — so
         // what blocks delivery is the setup path, which compiles resource-scoped management only
         // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster.
+        // Kubernetes cluster -- so no assignment is created from it.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -85,15 +85,9 @@
           ]
         },
         // The stack binding is the resource group, and at that scope a holder can terminate
-        // sessions in every sandbox group there — including one the deployment did not create,
-        // since a deployment can be pointed at a resource group its owner already uses, as
-        // `provision` notes. Azure has no scope between a group and its resource group.
-        //
-        // The resource binding is the narrower grant and is not deliverable for a sandbox today.
-        // The group is nameable — setup creates it, so an assignment can be scoped to it — so
-        // what blocks delivery is the setup path, which compiles resource-scoped management only
-        // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster -- so no assignment is created from it.
+        // sessions in every sandbox group there, as `provision` notes. The resource binding is
+        // narrower but undeliverable today: neither the setup path (`worker/dispatch-command`
+        // only) nor the runtime path (Kubernetes only) compiles resource-scoped management for it.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -93,8 +93,7 @@
         // The group is nameable — setup creates it, so an assignment can be scoped to it — so
         // what blocks delivery is the setup path, which compiles resource-scoped management only
         // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster. It stays declared for when one of them
-        // can, and narrowing the stack binding is worth revisiting now that the target exists.
+        // Kubernetes cluster. It stays declared for when one of them can.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -99,7 +99,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -87,13 +87,14 @@
         // The stack binding is the resource group, and at that scope a holder can terminate
         // sessions in every sandbox group there — including one the deployment did not create,
         // since a deployment can be pointed at a resource group its owner already uses, as
-        // `provision` notes. It exists for the same reason `provision` is resource-group-scoped:
-        // the target does not exist yet. `Microsoft.App/sandboxGroups` has no ARM template
-        // representation, so setup can neither create the group nor scope an assignment to one,
-        // and Azure has no scope between a group and its resource group. The resource binding is
-        // the narrower grant, but on Azure it is not deliverable for a sandbox today — the setup
-        // path compiles resource-scoped management only for `worker/dispatch-command`, the runtime
-        // path only for a Kubernetes cluster — so it stays declared for when one of them can.
+        // `provision` notes. Azure has no scope between a group and its resource group.
+        //
+        // The resource binding is the narrower grant and is not deliverable for a sandbox today,
+        // but no longer because the group cannot be named: setup creates the group, so an
+        // assignment can be scoped to it. What is missing is the setup path, which compiles
+        // resource-scoped management only for `worker/dispatch-command`, and the runtime path,
+        // which compiles it only for a Kubernetes cluster. It stays declared for when one of them
+        // can, and narrowing the stack binding is worth revisiting now that the target exists.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -89,11 +89,11 @@
         // since a deployment can be pointed at a resource group its owner already uses, as
         // `provision` notes. Azure has no scope between a group and its resource group.
         //
-        // The resource binding is the narrower grant and is not deliverable for a sandbox today,
-        // but no longer because the group cannot be named: setup creates the group, so an
-        // assignment can be scoped to it. What is missing is the setup path, which compiles
-        // resource-scoped management only for `worker/dispatch-command`, and the runtime path,
-        // which compiles it only for a Kubernetes cluster. It stays declared for when one of them
+        // The resource binding is the narrower grant and is not deliverable for a sandbox today.
+        // The group is nameable — setup creates it, so an assignment can be scoped to it — so
+        // what blocks delivery is the setup path, which compiles resource-scoped management only
+        // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
+        // Kubernetes cluster. It stays declared for when one of them
         // can, and narrowing the stack binding is worth revisiting now that the target exists.
         "binding": {
           "stack": {

--- a/crates/alien-permissions/permission-sets/sandbox/management.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/management.jsonc
@@ -93,7 +93,7 @@
         // The group is nameable — setup creates it, so an assignment can be scoped to it — so
         // what blocks delivery is the setup path, which compiles resource-scoped management only
         // for `worker/dispatch-command`, and the runtime path, which compiles it only for a
-        // Kubernetes cluster. It stays declared for when one of them can.
+        // Kubernetes cluster.
         "binding": {
           "stack": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"

--- a/crates/alien-permissions/permission-sets/sandbox/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/provision.jsonc
@@ -209,7 +209,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -109,9 +109,13 @@
         // name, so the assignment names a resource the same template built. A resource-group
         // scope would reach every sibling sandbox in the deployment, which is what makes the
         // stack scope deliberately absent rather than merely unset.
+        //
+        // No `${stackPrefix}`: on Azure the emitter already resolves `${resourceName}` to the
+        // prefixed group name, so naming the prefix again renders a scope matching nothing in
+        // the document a security team approves this grant from.
         "binding": {
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -85,18 +85,19 @@
     "azure": [
       {
         "label": "session-lifecycle-and-exec",
-        "description": "Create, drive and tear down sessions of the selected sandbox group.",
+        "description": "Create, drive and tear down sessions of the selected sandbox group. Session image and size come from the create request; this grant does not limit them.",
         "grant": {
           // The role Microsoft documents as sufficient for the sandbox data plane, and the same
           // one `sandbox/execute` uses — it bundles lifecycle and exec, so this set can't grant
           // exec without lifecycle. All entries are `dataAction`s: no control-plane rights.
           "predefinedRoles": ["Container Apps SandboxGroup Data Owner"]
         },
-        // Resource-scoped only, the same boundary the AWS block draws around one `microvm-image`:
-        // a resource-group scope would reach every sibling sandbox in the deployment. No
-        // `${stackPrefix}` — the emitter already resolves `${resourceName}` to the prefixed name.
+        // Resource-scoped: the only stack-level scope Azure RBAC can express is the resource
+        // group, which would reach every sibling sandbox. The scope bounds which group, not what
+        // runs in it — image and sizing are sent per session and applied at create.
         "binding": {
           "resource": {
+            // `${resourceName}` already resolves to the prefixed name, so no `${stackPrefix}`.
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
           }
         }

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -2,19 +2,14 @@
   "id": "sandbox/remote-execute",
   "description": "Allows a remote caller to create sandbox sessions and run arbitrary code inside them",
   "platforms": {
-    // AWS and Azure: the two clouds whose sandbox parent setup creates, and can therefore scope
-    // a grant to. Both refuse an assignment naming a resource that does not exist, so the parent
-    // and the grant have to come from the same template — an AWS MicroVM image, and an Azure
-    // `Microsoft.App/sandboxGroups` at `2026-02-01-preview`.
+    // AWS and Azure: the two clouds whose sandbox parent setup creates, and can therefore scope a
+    // grant to. Both refuse an assignment naming a resource that doesn't exist yet, so parent and
+    // grant must come from the same template.
     //
-    // GCP is absent for two reasons, and the first is the one that has to hold before the second
-    // is worth solving. `sandbox/execute` binds GCP at `projects/${projectName}` for both stack
-    // and resource, so a grant compiled from this set would reach every sandbox in the project
-    // rather than the one published — a different security proposition from the AWS and Azure
-    // blocks above, and not one worth handing to a remote caller. Second, the reasoning engine a
-    // narrower grant would be scoped to is created by a Live controller after apply rather than by
-    // setup, so there is nothing for the assignment to name. A GCP remote binding is refused by
-    // the remote-bindings preflight.
+    // GCP is absent for two reasons: `sandbox/execute` binds it at `projects/${projectName}` for
+    // both stack and resource, so a grant here would reach every sandbox in the project, not just
+    // the one published; and the engine a narrower grant would scope to is created by a Live
+    // controller after apply, not by setup, so there is nothing to name it against.
     "aws": [
       {
         "label": "session-lifecycle",
@@ -92,29 +87,14 @@
         "label": "session-lifecycle-and-exec",
         "description": "Create, drive and tear down sessions of the selected sandbox group.",
         "grant": {
-          // The one role Microsoft documents as sufficient for the sandbox data plane, and the
-          // same one `sandbox/execute` uses. It carries session lifecycle and exec together, so
-          // this set cannot hand out exec without lifecycle — and it is a data-plane role, which
-          // is why subscription-level management rights do not substitute for it.
-          //
-          // Its `actions` array is empty and every entry is a `dataAction`
-          // (`Microsoft.App/sandboxGroups/*/{read,write,delete,action}`). So the holder drives
-          // sessions inside the group and has no control-plane right over the group itself: it
-          // cannot delete, move or reconfigure the resource setup created, and its `delete`
-          // reaches sandboxes rather than their parent.
+          // The role Microsoft documents as sufficient for the sandbox data plane, and the same
+          // one `sandbox/execute` uses — it bundles lifecycle and exec, so this set can't grant
+          // exec without lifecycle. All entries are `dataAction`s: no control-plane rights.
           "predefinedRoles": ["Container Apps SandboxGroup Data Owner"]
         },
-        // Resource-scoped only, and this is the whole boundary — the same one the AWS block
-        // draws around a single `microvm-image`. The group is created by setup under this exact
-        // name, so the assignment names a resource the same template built. A resource-group
-        // scope would reach every sibling sandbox in the deployment, which is what makes the
-        // stack scope deliberately absent rather than merely unset.
-        //
-        // No `${stackPrefix}`: on Azure the emitter already resolves `${resourceName}` to the
-        // prefixed group name, so naming the prefix again renders a scope matching nothing in
-        // the document a security team approves this grant from. The rendered string reaches
-        // only that document while this entry stays predefined-role-only -- adding actions here
-        // would also render it as a custom role's assignable scope, from a different context.
+        // Resource-scoped only, the same boundary the AWS block draws around one `microvm-image`:
+        // a resource-group scope would reach every sibling sandbox in the deployment. No
+        // `${stackPrefix}` — the emitter already resolves `${resourceName}` to the prefixed name.
         "binding": {
           "resource": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -112,7 +112,9 @@
         //
         // No `${stackPrefix}`: on Azure the emitter already resolves `${resourceName}` to the
         // prefixed group name, so naming the prefix again renders a scope matching nothing in
-        // the document a security team approves this grant from.
+        // the document a security team approves this grant from. The rendered string reaches
+        // only that document while this entry stays predefined-role-only -- adding actions here
+        // would also render it as a custom role's assignable scope, from a different context.
         "binding": {
           "resource": {
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -7,9 +7,14 @@
     // and the grant have to come from the same template — an AWS MicroVM image, and an Azure
     // `Microsoft.App/sandboxGroups` at `2026-02-01-preview`.
     //
-    // GCP is absent because the reasoning engine a resource-level grant would be scoped to is
-    // created by a Live controller after apply rather than by setup, so there is nothing for the
-    // assignment to name. A GCP remote binding is refused by the remote-bindings preflight.
+    // GCP is absent for two reasons, and the first is the one that has to hold before the second
+    // is worth solving. `sandbox/execute` binds GCP at `projects/${projectName}` for both stack
+    // and resource, so a grant compiled from this set would reach every sandbox in the project
+    // rather than the one published — a different security proposition from the AWS and Azure
+    // blocks above, and not one worth handing to a remote caller. Second, the reasoning engine a
+    // narrower grant would be scoped to is created by a Live controller after apply rather than by
+    // setup, so there is nothing for the assignment to name. A GCP remote binding is refused by
+    // the remote-bindings preflight.
     "aws": [
       {
         "label": "session-lifecycle",

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -2,14 +2,14 @@
   "id": "sandbox/remote-execute",
   "description": "Allows a remote caller to create sandbox sessions and run arbitrary code inside them",
   "platforms": {
-    // AWS alone, for a different reason on each of the other two. GCP scopes every sandbox
-    // permission at `projects/${projectName}` and offers nothing narrower, so a remote grant
-    // would reach every sandbox in the project rather than this one. On Azure the name is
-    // knowable (`${stackPrefix}-${resourceName}`) but not grantable: `Microsoft.App/sandboxGroups`
-    // has no ARM template representation, so setup neither creates the group nor can scope a role
-    // assignment to one that does not exist, and the sandbox emitter attaches nothing to the
-    // `-access` identity — see the fuller note in `sandbox/management`.
-    // A remote binding declared on either is refused by the remote-bindings preflight.
+    // AWS and Azure: the two clouds whose sandbox parent setup creates, and can therefore scope
+    // a grant to. Both refuse an assignment naming a resource that does not exist, so the parent
+    // and the grant have to come from the same template — an AWS MicroVM image, and an Azure
+    // `Microsoft.App/sandboxGroups` at `2026-02-01-preview`.
+    //
+    // GCP is absent because the reasoning engine a resource-level grant would be scoped to is
+    // created by a Live controller after apply rather than by setup, so there is nothing for the
+    // assignment to name. A GCP remote binding is refused by the remote-bindings preflight.
     "aws": [
       {
         "label": "session-lifecycle",
@@ -78,6 +78,35 @@
             "resources": [
               "arn:aws:lambda:${awsRegion}:${awsAccountId}:microvm-image:${stackPrefix}-${resourceName}"
             ]
+          }
+        }
+      }
+    ],
+    "azure": [
+      {
+        "label": "session-lifecycle-and-exec",
+        "description": "Create, drive and tear down sessions of the selected sandbox group.",
+        "grant": {
+          // The one role Microsoft documents as sufficient for the sandbox data plane, and the
+          // same one `sandbox/execute` uses. It carries session lifecycle and exec together, so
+          // this set cannot hand out exec without lifecycle — and it is a data-plane role, which
+          // is why subscription-level management rights do not substitute for it.
+          //
+          // Its `actions` array is empty and every entry is a `dataAction`
+          // (`Microsoft.App/sandboxGroups/*/{read,write,delete,action}`). So the holder drives
+          // sessions inside the group and has no control-plane right over the group itself: it
+          // cannot delete, move or reconfigure the resource setup created, and its `delete`
+          // reaches sandboxes rather than their parent.
+          "predefinedRoles": ["Container Apps SandboxGroup Data Owner"]
+        },
+        // Resource-scoped only, and this is the whole boundary — the same one the AWS block
+        // draws around a single `microvm-image`. The group is created by setup under this exact
+        // name, so the assignment names a resource the same template built. A resource-group
+        // scope would reach every sibling sandbox in the deployment, which is what makes the
+        // stack scope deliberately absent rather than merely unset.
+        "binding": {
+          "resource": {
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/src/generators/azure_runtime.rs
+++ b/crates/alien-permissions/src/generators/azure_runtime.rs
@@ -604,7 +604,9 @@ pub fn azure_predefined_role_id(role_name: &str) -> Option<&'static str> {
         "Cognitive Services User" => Some("a97b65f3-24c7-4388-baec-2e87135dc908"),
         // Gates the whole ACA Sandboxes data plane. Subscription Owner is refused against it,
         // so this assignment is required for any sandbox operation, not merely convenient.
-        "Container Apps SandboxGroup Data Owner" => Some("c24cf47c-5077-412d-a19c-45202126392c"),
+        // The constant, not the literal: the reach predicate and the sensitive-content invariant
+        // both key off it, and a copy here could drift out of all three silently.
+        crate::AZURE_SANDBOX_DATA_PLANE_ROLE => Some("c24cf47c-5077-412d-a19c-45202126392c"),
         "Key Vault Contributor" => Some("f25e0fa2-a7c8-4377-a976-54943a77a395"),
         "Key Vault Reader" => Some("21090545-7ca7-4776-b22c-e363652d74d2"),
         "Key Vault Secrets User" => Some("4633458b-17de-408a-b874-0445c86b69e6"),

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -9,8 +9,8 @@ use alien_core::{ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_T
 pub use error::*;
 pub use registry::{
     get_permission_set, has_permission_set, list_permission_set_ids, permission_set_covers_platform,
-    data_action_reaches_a_sandbox_session, permission_set_reaches_a_sandbox_session,
-    AZURE_SANDBOX_DATA_PLANE_ROLE, MICROVM_SESSION_LIFECYCLE_ACTIONS,
+    permission_set_reaches_a_sandbox_session, AZURE_SANDBOX_DATA_PLANE_ROLE,
+    MICROVM_SESSION_LIFECYCLE_ACTIONS,
     SENSITIVE_MICROVM_ACTIONS,
 };
 pub use variables::VariableInterpolator;

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -8,10 +8,9 @@ use alien_core::{ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_T
 
 pub use error::*;
 pub use registry::{
-    get_permission_set, has_permission_set, list_permission_set_ids, permission_set_covers_platform,
-    permission_set_reaches_a_sandbox_session, AZURE_SANDBOX_DATA_PLANE_ROLE,
-    MICROVM_SESSION_LIFECYCLE_ACTIONS,
-    SENSITIVE_MICROVM_ACTIONS,
+    get_permission_set, has_permission_set, list_permission_set_ids,
+    permission_set_covers_platform, permission_set_reaches_a_sandbox_session,
+    AZURE_SANDBOX_DATA_PLANE_ROLE, MICROVM_SESSION_LIFECYCLE_ACTIONS, SENSITIVE_MICROVM_ACTIONS,
 };
 pub use variables::VariableInterpolator;
 

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -9,7 +9,7 @@ use alien_core::{ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_T
 pub use error::*;
 pub use registry::{
     get_permission_set, has_permission_set, list_permission_set_ids, permission_set_covers_platform,
-    permission_set_reaches_a_microvm_session, MICROVM_SESSION_LIFECYCLE_ACTIONS,
+    permission_set_reaches_a_sandbox_session, MICROVM_SESSION_LIFECYCLE_ACTIONS,
     SENSITIVE_MICROVM_ACTIONS,
 };
 pub use variables::VariableInterpolator;

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -9,7 +9,8 @@ use alien_core::{ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_T
 pub use error::*;
 pub use registry::{
     get_permission_set, has_permission_set, list_permission_set_ids, permission_set_covers_platform,
-    permission_set_reaches_a_sandbox_session, MICROVM_SESSION_LIFECYCLE_ACTIONS,
+    data_action_reaches_a_sandbox_session, permission_set_reaches_a_sandbox_session,
+    AZURE_SANDBOX_DATA_PLANE_ROLE, MICROVM_SESSION_LIFECYCLE_ACTIONS,
     SENSITIVE_MICROVM_ACTIONS,
 };
 pub use variables::VariableInterpolator;

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -222,7 +222,10 @@ fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
 /// Compared lowercased throughout, because AWS matches action names case-insensitively — a set
 /// granting `lambda:runmicrovm` reaches a session exactly as `lambda:RunMicrovm` does.
 fn action_reaches_a_microvm_session(action: &str) -> bool {
-    let action = action.to_ascii_lowercase();
+    // IAM matches an action name with two wildcards, `*` for many characters and `?` for one.
+    // Reading only `*` sends `lambda:CreateMicrov?AuthToken` down the exact branch, where it
+    // matches no verb and is answered no while authorizing the real one.
+    let action = action.to_ascii_lowercase().replace('?', "*");
     if action.contains('*') {
         let literal = action.split('*').next().unwrap_or_default();
         let covers_a_known_verb = SENSITIVE_MICROVM_ACTIONS
@@ -396,6 +399,10 @@ mod tests {
             // so it is claimed anyway. Over-approximating here withholds a grant; under-
             // approximating leaves one on an identity a second tenant holds.
             "lambda:*MicrovmImage",
+            // IAM's single-character wildcard. Read as a literal these match no verb at all,
+            // while the grants authorize `CreateMicrovmAuthToken` and `RunMicrovm`.
+            "lambda:CreateMicrov?AuthToken",
+            "lambda:Run?icrovm",
         ] {
             assert!(
                 action_reaches_a_microvm_session(action),

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -182,22 +182,30 @@ pub fn permission_set_reaches_a_sandbox_session(
 }
 
 /// The predefined role carrying Azure's whole sandbox data plane, session contents included.
-const AZURE_SANDBOX_DATA_PLANE_ROLE: &str = "Container Apps SandboxGroup Data Owner";
+///
+/// Public because three places have to agree on it — this predicate, the invariant test that keeps
+/// it out of the implicit-management sets, and the allowlist of roles an author may name. A second
+/// sandbox data-plane role added to that allowlist and not here drops silently out of both checks.
+pub const AZURE_SANDBOX_DATA_PLANE_ROLE: &str = "Container Apps SandboxGroup Data Owner";
 
 /// Whether one Azure `dataAction`, possibly carrying a `*`, addresses a sandbox session.
 ///
 /// Lifecycle counts as reach for the same reason `RunMicrovm` does on AWS: whoever starts a
-/// session can put whatever it likes inside the one it started. A wildcard under the sandbox
-/// namespace is cleared rather than matched literally, so `…/sandboxes/*` fails closed.
-fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
+/// session can put whatever it likes inside the one it started.
+///
+/// A wildcard is compared as a prefix in **both** directions, which is what makes it fail closed:
+/// `*` and `Microsoft.App/*` sit above the sandbox namespace and still reach into it, while
+/// `…/sandboxes/*` sits below. Matching only downwards would clear the two that matter most. Every
+/// verb under the namespace counts rather than a suffix allowlist, so a verb Azure adds later is
+/// reach until someone decides otherwise.
+pub fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
     const SANDBOX_NAMESPACE: &str = "microsoft.app/sandboxgroups/sandboxes";
     let action = action.to_ascii_lowercase();
+    if action.contains('*') {
+        let literal = action.split('*').next().unwrap_or_default();
+        return SANDBOX_NAMESPACE.starts_with(literal) || literal.starts_with(SANDBOX_NAMESPACE);
+    }
     action.starts_with(SANDBOX_NAMESPACE)
-        && (action.contains('*')
-            || action.ends_with("/write")
-            || action.ends_with("/delete")
-            || action.ends_with("/action")
-            || action.ends_with("/read"))
 }
 
 /// Whether one IAM action, possibly carrying a `*`, can authorize an operation on a session.

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -229,7 +229,12 @@ fn action_reaches_a_microvm_session(action: &str) -> bool {
             .iter()
             .chain(MICROVM_SESSION_LIFECYCLE_ACTIONS)
             .any(|known| known.to_ascii_lowercase().starts_with(literal));
-        return covers_a_known_verb || reaches_the_microvm_namespace(literal);
+        // Every literal run, not only the one before the first `*`: `lambda:Foo*Microvm` names
+        // the namespace after the wildcard, and reading the head alone would answer no while the
+        // grant authorizes a MicroVM verb. Each run is cleared the same way, so the `MicrovmImage`
+        // exclusion still applies to whichever run carries the name.
+        return covers_a_known_verb
+            || action.split('*').any(reaches_the_microvm_namespace);
     }
     action
         .strip_prefix("lambda:")
@@ -371,6 +376,47 @@ mod tests {
             "nonexistent/permission",
             Platform::Aws
         ));
+    }
+
+    /// The wildcard branch decides whether a grant is claimed by the remote caller instead of the
+    /// deployment's management identity, so a shape it answers no to stays on an identity a second
+    /// tenant holds. Reading only the run before the first `*` answered no to a pattern naming the
+    /// namespace after it.
+    #[test]
+    fn a_wildcard_naming_microvm_anywhere_reaches_a_session() {
+        for action in [
+            "lambda:Foo*Microvm",
+            "lambda:*Microvm",
+            "lambda:RunMicrovm",
+            "lambda:Run*",
+            "lambda:*",
+            "*",
+            "lambda:runmicrovm",
+            // Matches only image verbs, but a `lambda:` head prefixes every known session verb,
+            // so it is claimed anyway. Over-approximating here withholds a grant; under-
+            // approximating leaves one on an identity a second tenant holds.
+            "lambda:*MicrovmImage",
+        ] {
+            assert!(
+                action_reaches_a_microvm_session(action),
+                "{action} authorizes a MicroVM verb"
+            );
+        }
+
+        // The image a session launches from is not the session: `sandbox/provision` and
+        // `sandbox/heartbeat` hold these, and claiming them would strip a grant they need.
+        for action in [
+            "lambda:GetMicrovmImage",
+            "lambda:GetMicrovmImage*",
+            "lambda:GetMicrovmImage*Version",
+            "logs:PutLogEvents",
+            "s3:GetObject*",
+        ] {
+            assert!(
+                !action_reaches_a_microvm_session(action),
+                "{action} does not reach a session"
+            );
+        }
     }
 
     #[test]

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -169,7 +169,7 @@ pub fn permission_set_reaches_a_sandbox_session(
                 .predefined_roles
                 .iter()
                 .flatten()
-                .any(|role| role == AZURE_SANDBOX_DATA_PLANE_ROLE)
+                .any(|role| role.eq_ignore_ascii_case(AZURE_SANDBOX_DATA_PLANE_ROLE))
                 || entry
                     .grant
                     .data_actions
@@ -350,7 +350,9 @@ mod tests {
             assert!(
                 !permission_set_covers_platform("sandbox/remote-execute", platform),
                 "widening sandbox/remote-execute to {platform} must be done together with \
-                 alien-manager's resolve route and alien-preflights' platform gate"
+                 alien-manager's resolve route, alien-preflights' platform gate, and \
+                 permission_set_reaches_a_sandbox_session — which has no {platform} branch, so \
+                 the single-tenancy gate would not see a set that reaches a session there"
             );
         }
 

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -382,9 +382,8 @@ mod tests {
     }
 
     /// The wildcard branch decides whether a grant is claimed by the remote caller instead of the
-    /// deployment's management identity, so a shape it answers no to stays on an identity a second
-    /// tenant holds. Reading only the run before the first `*` answered no to a pattern naming the
-    /// namespace after it.
+    /// deployment's management identity, so a pattern it misses leaves reach on an identity a
+    /// second tenant holds.
     #[test]
     fn a_wildcard_naming_microvm_anywhere_reaches_a_session() {
         for action in [

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -134,25 +134,70 @@ pub const MICROVM_SESSION_LIFECYCLE_ACTIONS: &[&str] = &[
     "lambda:GetMicrovm",
 ];
 
-/// Whether `permission_set` grants anything that addresses a MicroVM session.
+/// Whether `permission_set` grants anything that addresses a sandbox session, on any cloud that
+/// publishes one.
 ///
 /// Bindings are deliberately not consulted. `${stackPrefix}` is uninterpolated this early and an
 /// inline set's ARNs are free-form user strings, so any ARN comparison is either unsound or
 /// widened past by writing `*`. Carrying the verb at all is the answer.
 ///
-/// AWS only: it scans for the verbs that reach an AWS MicroVM session. The other clouds do not
-/// expose a session through the stack grants this inspects.
-pub fn permission_set_reaches_a_microvm_session(
+/// Per-cloud rather than per-verb-list, because the verbs are not comparable: AWS names actions,
+/// Azure grants the same reach through a predefined role or through `dataActions`. A set is
+/// inspected on every cloud it declares — a caller asking "can anything else here reach this
+/// sandbox" is asking about the deployment, and a set carrying an Azure block alone would
+/// otherwise answer no while granting the whole data plane.
+pub fn permission_set_reaches_a_sandbox_session(
     permission_set: &alien_core::permissions::PermissionSet,
 ) -> bool {
-    permission_set
+    let reaches_on_aws = permission_set
         .platforms
         .aws
         .iter()
         .flatten()
         .filter(|entry| entry.effect.is_allow())
         .flat_map(|entry| entry.grant.actions.iter().flatten())
-        .any(|action| action_reaches_a_microvm_session(action))
+        .any(|action| action_reaches_a_microvm_session(action));
+
+    let reaches_on_azure = permission_set
+        .platforms
+        .azure
+        .iter()
+        .flatten()
+        .any(|entry| {
+            entry
+                .grant
+                .predefined_roles
+                .iter()
+                .flatten()
+                .any(|role| role == AZURE_SANDBOX_DATA_PLANE_ROLE)
+                || entry
+                    .grant
+                    .data_actions
+                    .iter()
+                    .flatten()
+                    .any(|action| data_action_reaches_a_sandbox_session(action))
+        });
+
+    reaches_on_aws || reaches_on_azure
+}
+
+/// The predefined role carrying Azure's whole sandbox data plane, session contents included.
+const AZURE_SANDBOX_DATA_PLANE_ROLE: &str = "Container Apps SandboxGroup Data Owner";
+
+/// Whether one Azure `dataAction`, possibly carrying a `*`, addresses a sandbox session.
+///
+/// Lifecycle counts as reach for the same reason `RunMicrovm` does on AWS: whoever starts a
+/// session can put whatever it likes inside the one it started. A wildcard under the sandbox
+/// namespace is cleared rather than matched literally, so `…/sandboxes/*` fails closed.
+fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
+    const SANDBOX_NAMESPACE: &str = "microsoft.app/sandboxgroups/sandboxes";
+    let action = action.to_ascii_lowercase();
+    action.starts_with(SANDBOX_NAMESPACE)
+        && (action.contains('*')
+            || action.ends_with("/write")
+            || action.ends_with("/delete")
+            || action.ends_with("/action")
+            || action.ends_with("/read"))
 }
 
 /// Whether one IAM action, possibly carrying a `*`, can authorize an operation on a session.
@@ -264,8 +309,9 @@ mod tests {
     }
 
     /// The Remote Bindings platform gate refuses a kind whose set does not cover the deployment's
-    /// platform, so this data is what decides where each kind may be published. `sandbox/remote-execute`
-    /// is AWS-only, and `alien-manager`'s resolve route hardcodes the same answer.
+    /// platform, so this data is what decides where each kind may be published.
+    /// `sandbox/remote-execute` covers AWS and Azure; `alien-manager`'s resolve route carries the
+    /// matching pair of arms.
     #[test]
     fn remote_binding_permission_sets_cover_the_platforms_that_support_them() {
         use alien_core::Platform;
@@ -283,11 +329,16 @@ mod tests {
             }
         }
 
-        assert!(permission_set_covers_platform(
-            "sandbox/remote-execute",
-            Platform::Aws
-        ));
-        for platform in [Platform::Gcp, Platform::Azure, Platform::Local] {
+        // Both clouds whose sandbox parent setup can create and then scope a grant to: an AWS
+        // MicroVM image, and an Azure sandbox group.
+        for platform in [Platform::Aws, Platform::Azure] {
+            assert!(permission_set_covers_platform(
+                "sandbox/remote-execute",
+                platform
+            ));
+        }
+
+        for platform in [Platform::Gcp, Platform::Local] {
             assert!(
                 !permission_set_covers_platform("sandbox/remote-execute", platform),
                 "widening sandbox/remote-execute to {platform} must be done together with \

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -198,7 +198,7 @@ pub const AZURE_SANDBOX_DATA_PLANE_ROLE: &str = "Container Apps SandboxGroup Dat
 /// `…/sandboxes/*` sits below. Matching only downwards would clear the two that matter most. Every
 /// verb under the namespace counts rather than a suffix allowlist, so a verb Azure adds later is
 /// reach until someone decides otherwise.
-pub fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
+fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
     const SANDBOX_NAMESPACE: &str = "microsoft.app/sandboxgroups/sandboxes";
     let action = action.to_ascii_lowercase();
     if action.contains('*') {

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -134,18 +134,10 @@ pub const MICROVM_SESSION_LIFECYCLE_ACTIONS: &[&str] = &[
     "lambda:GetMicrovm",
 ];
 
-/// Whether `permission_set` grants anything that addresses a sandbox session, on any cloud that
-/// publishes one.
-///
-/// Bindings are deliberately not consulted. `${stackPrefix}` is uninterpolated this early and an
-/// inline set's ARNs are free-form user strings, so any ARN comparison is either unsound or
-/// widened past by writing `*`. Carrying the verb at all is the answer.
-///
-/// Per-cloud rather than per-verb-list, because the verbs are not comparable: AWS names actions,
-/// Azure grants the same reach through a predefined role or through `dataActions`. A set is
-/// inspected on every cloud it declares — a caller asking "can anything else here reach this
-/// sandbox" is asking about the deployment, and a set carrying an Azure block alone would
-/// otherwise answer no while granting the whole data plane.
+/// Whether `permission_set` grants anything that addresses a sandbox session, on any cloud it
+/// declares. Bindings are skipped — `${stackPrefix}` is uninterpolated this early and ARNs are
+/// free-form, so any comparison is unsound. Checked per-cloud rather than by one verb list: AWS
+/// names actions, Azure grants reach through a role or `dataActions`.
 pub fn permission_set_reaches_a_sandbox_session(
     permission_set: &alien_core::permissions::PermissionSet,
 ) -> bool {
@@ -182,22 +174,19 @@ pub fn permission_set_reaches_a_sandbox_session(
 }
 
 /// The predefined role carrying Azure's whole sandbox data plane, session contents included.
-///
-/// Public because three places have to agree on it — this predicate, the invariant test that keeps
-/// it out of the implicit-management sets, and the allowlist of roles an author may name. A second
-/// sandbox data-plane role added to that allowlist and not here drops silently out of both checks.
+/// Public because four places must agree on it — this predicate, the invariant test, the role
+/// allowlist an author may name from, and the Azure role-id map — or a second data-plane role
+/// added to one silently drops out of the others.
 pub const AZURE_SANDBOX_DATA_PLANE_ROLE: &str = "Container Apps SandboxGroup Data Owner";
 
 /// Whether one Azure `dataAction`, possibly carrying a `*`, addresses a sandbox session.
 ///
-/// Lifecycle counts as reach for the same reason `RunMicrovm` does on AWS: whoever starts a
-/// session can put whatever it likes inside the one it started.
+/// **Lifecycle.** Counts as reach for the same reason `RunMicrovm` does on AWS: whoever starts a
+/// session can put whatever it likes inside it.
 ///
-/// A wildcard is compared as a prefix in **both** directions, which is what makes it fail closed:
-/// `*` and `Microsoft.App/*` sit above the sandbox namespace and still reach into it, while
-/// `…/sandboxes/*` sits below. Matching only downwards would clear the two that matter most. Every
-/// verb under the namespace counts rather than a suffix allowlist, so a verb Azure adds later is
-/// reach until someone decides otherwise.
+/// **Wildcard, both directions.** `*` and `Microsoft.App/*` sit above the sandbox namespace and
+/// still reach into it; `…/sandboxes/*` sits below. Checking only downwards would clear the two
+/// that matter most, so every verb under the namespace counts rather than a suffix allowlist.
 fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
     const SANDBOX_NAMESPACE: &str = "microsoft.app/sandboxgroups/sandboxes";
     let action = action.to_ascii_lowercase();
@@ -210,17 +199,16 @@ fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
 
 /// Whether one IAM action, possibly carrying a `*`, can authorize an operation on a session.
 ///
-/// Three cases sit together here: a wildcard is cleared against the known verbs *and* the MicroVM
-/// namespace, an exact action is matched on that namespace so a verb AWS adds later fails closed,
-/// and the `MicrovmImage` family is excluded because it addresses the image a session launches
-/// from — `sandbox/provision` and `sandbox/heartbeat` legitimately hold those.
+/// **Wildcard.** Cleared against the known verbs *and* the MicroVM namespace — clearing against
+/// today's names alone would miss `lambda:SomeFutureMicrovmVerb*`, letting the broader grant slip
+/// through.
 ///
-/// The namespace half of the wildcard case is what keeps the two branches agreeing: clearing a
-/// wildcard against today's names alone would answer no for `lambda:SomeFutureMicrovmVerb*` while
-/// the un-wildcarded form answers yes, so the broader grant would be the one that slipped through.
+/// **Exact action.** Matched on the MicroVM namespace, so a verb AWS adds later fails closed.
 ///
-/// Compared lowercased throughout, because AWS matches action names case-insensitively — a set
-/// granting `lambda:runmicrovm` reaches a session exactly as `lambda:RunMicrovm` does.
+/// **`MicrovmImage`.** Excluded: it addresses the image a session launches from, which
+/// `sandbox/provision` and `sandbox/heartbeat` legitimately hold.
+///
+/// Compared lowercased throughout — AWS matches action names case-insensitively.
 fn action_reaches_a_microvm_session(action: &str) -> bool {
     // IAM matches an action name with two wildcards, `*` for many characters and `?` for one.
     // Reading only `*` sends `lambda:CreateMicrov?AuthToken` down the exact branch, where it
@@ -232,12 +220,10 @@ fn action_reaches_a_microvm_session(action: &str) -> bool {
             .iter()
             .chain(MICROVM_SESSION_LIFECYCLE_ACTIONS)
             .any(|known| known.to_ascii_lowercase().starts_with(literal));
-        // Every literal run, not only the one before the first `*`: `lambda:Foo*Microvm` names
-        // the namespace after the wildcard, and reading the head alone would answer no while the
-        // grant authorizes a MicroVM verb. Each run is cleared the same way, so the `MicrovmImage`
-        // exclusion still applies to whichever run carries the name.
-        return covers_a_known_verb
-            || action.split('*').any(reaches_the_microvm_namespace);
+        // Every literal run counts, not only the one before the first `*`: `lambda:Foo*Microvm`
+        // names the namespace after the wildcard. Each run is cleared the same way, so the
+        // `MicrovmImage` exclusion still applies to whichever run carries the name.
+        return covers_a_known_verb || action.split('*').any(reaches_the_microvm_namespace);
     }
     action
         .strip_prefix("lambda:")
@@ -336,9 +322,8 @@ mod tests {
     }
 
     /// The Remote Bindings platform gate refuses a kind whose set does not cover the deployment's
-    /// platform, so this data is what decides where each kind may be published.
-    /// `sandbox/remote-execute` covers AWS and Azure; `alien-manager`'s resolve route carries the
-    /// matching pair of arms.
+    /// platform. `sandbox/remote-execute` covers AWS and Azure; `alien-manager`'s resolve route
+    /// carries the matching pair of arms.
     #[test]
     fn remote_binding_permission_sets_cover_the_platforms_that_support_them() {
         use alien_core::Platform;

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -210,10 +210,14 @@ fn data_action_reaches_a_sandbox_session(action: &str) -> bool {
 
 /// Whether one IAM action, possibly carrying a `*`, can authorize an operation on a session.
 ///
-/// Three cases sit together here: a wildcard is cleared only against the known verbs, an exact
-/// action is matched on the `Microvm` namespace so a verb AWS adds later fails closed, and the
-/// `MicrovmImage` family is excluded because it addresses the image a session launches from —
-/// `sandbox/provision` and `sandbox/heartbeat` legitimately hold those.
+/// Three cases sit together here: a wildcard is cleared against the known verbs *and* the MicroVM
+/// namespace, an exact action is matched on that namespace so a verb AWS adds later fails closed,
+/// and the `MicrovmImage` family is excluded because it addresses the image a session launches
+/// from — `sandbox/provision` and `sandbox/heartbeat` legitimately hold those.
+///
+/// The namespace half of the wildcard case is what keeps the two branches agreeing: clearing a
+/// wildcard against today's names alone would answer no for `lambda:SomeFutureMicrovmVerb*` while
+/// the un-wildcarded form answers yes, so the broader grant would be the one that slipped through.
 ///
 /// Compared lowercased throughout, because AWS matches action names case-insensitively — a set
 /// granting `lambda:runmicrovm` reaches a session exactly as `lambda:RunMicrovm` does.
@@ -221,14 +225,21 @@ fn action_reaches_a_microvm_session(action: &str) -> bool {
     let action = action.to_ascii_lowercase();
     if action.contains('*') {
         let literal = action.split('*').next().unwrap_or_default();
-        return SENSITIVE_MICROVM_ACTIONS
+        let covers_a_known_verb = SENSITIVE_MICROVM_ACTIONS
             .iter()
             .chain(MICROVM_SESSION_LIFECYCLE_ACTIONS)
             .any(|known| known.to_ascii_lowercase().starts_with(literal));
+        return covers_a_known_verb || reaches_the_microvm_namespace(literal);
     }
     action
         .strip_prefix("lambda:")
-        .is_some_and(|verb| verb.contains("microvm") && !verb.contains("microvmimage"))
+        .is_some_and(reaches_the_microvm_namespace)
+}
+
+/// Whether a `lambda:`-stripped verb addresses a MicroVM rather than its image.
+fn reaches_the_microvm_namespace(verb: &str) -> bool {
+    let verb = verb.strip_prefix("lambda:").unwrap_or(verb);
+    verb.contains("microvm") && !verb.contains("microvmimage")
 }
 
 /// Whether `permission_set_id` grants anything at all on `platform`.

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -388,7 +388,7 @@ fn sandbox_heartbeat_stack_scope_stops_at_the_resource_group() {
 
     let stack_plan = generator
         .generate_grant_plan(permission_set, BindingTarget::Stack, &context)
-        .expect("the heartbeat has to reach the manager before the group exists");
+        .expect("the heartbeat grant is only ever compiled at stack scope");
     assert_eq!(stack_plan.bindings.len(), 1);
     let scope = &stack_plan.bindings[0].scope;
     assert!(
@@ -447,10 +447,10 @@ fn sandbox_execute_grants_nothing_at_stack_scope() {
 /// Management's stack binding stops at the resource group, and never reaches session contents.
 ///
 /// At that scope a holder can terminate sessions in a sibling sandbox group, so the resource
-/// binding is the one to prefer; the stack binding exists only because setup cannot scope an
-/// assignment to a group that `Microsoft.App/sandboxGroups` gives it no way to create. The
-/// boundary this pins is the one `sandbox/execute` exists to hold: session lifecycle here,
-/// never a read or exec that reaches inside a session.
+/// binding is the one to prefer. The stack binding stands because the sandbox management grants
+/// are compiled at stack scope and nothing compiles the resource one — setup does create the
+/// group an assignment could name. The boundary this pins is the one `sandbox/execute` exists to
+/// hold: session lifecycle here, never a read or exec that reaches inside a session.
 #[test]
 fn sandbox_management_stack_scope_stops_at_the_resource_group() {
     let generator = AzureRuntimePermissionsGenerator::new();
@@ -459,7 +459,7 @@ fn sandbox_management_stack_scope_stops_at_the_resource_group() {
 
     let stack_plan = generator
         .generate_grant_plan(permission_set, BindingTarget::Stack, &context)
-        .expect("management has to reach the manager before the group exists");
+        .expect("the management grant is only ever compiled at stack scope");
     assert_eq!(stack_plan.bindings.len(), 1);
     let scope = &stack_plan.bindings[0].scope;
     assert!(

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -388,7 +388,7 @@ fn sandbox_heartbeat_stack_scope_stops_at_the_resource_group() {
 
     let stack_plan = generator
         .generate_grant_plan(permission_set, BindingTarget::Stack, &context)
-        .expect("the heartbeat grant is only ever compiled at stack scope");
+        .expect("the sandbox heartbeat set declares an Azure stack binding");
     assert_eq!(stack_plan.bindings.len(), 1);
     let scope = &stack_plan.bindings[0].scope;
     assert!(
@@ -448,9 +448,9 @@ fn sandbox_execute_grants_nothing_at_stack_scope() {
 ///
 /// At that scope a holder can terminate sessions in a sibling sandbox group, so the resource
 /// binding is the one to prefer. The stack binding stands because the sandbox management grants
-/// are compiled at stack scope and nothing compiles the resource one — setup does create the
-/// group an assignment could name. The boundary this pins is the one `sandbox/execute` exists to
-/// hold: session lifecycle here, never a read or exec that reaches inside a session.
+/// are compiled at stack scope and nothing compiles the resource one. The boundary this pins is
+/// the one `sandbox/execute` exists to hold: session lifecycle here, never a read or exec that
+/// reaches inside a session.
 #[test]
 fn sandbox_management_stack_scope_stops_at_the_resource_group() {
     let generator = AzureRuntimePermissionsGenerator::new();
@@ -459,7 +459,7 @@ fn sandbox_management_stack_scope_stops_at_the_resource_group() {
 
     let stack_plan = generator
         .generate_grant_plan(permission_set, BindingTarget::Stack, &context)
-        .expect("the management grant is only ever compiled at stack scope");
+        .expect("the sandbox management set declares an Azure stack binding");
     assert_eq!(stack_plan.bindings.len(), 1);
     let scope = &stack_plan.bindings[0].scope;
     assert!(

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -377,11 +377,9 @@ fn test_azure_wildcard_scope_error() {
 /// The heartbeat's stack binding stops at the resource group, and reads only.
 ///
 /// A resource-group scope enumerates sibling sandbox groups, which the resource binding does not,
-/// so the resource binding is the one to prefer. The stack binding exists for the reason
-/// `provision` is resource-group-scoped: `Microsoft.App/sandboxGroups` has no ARM template
-/// representation, so setup can neither create the group nor scope an assignment to one. What
-/// this pins is how far that concession goes — the resource group and no further, and a read
-/// rather than anything that reaches a session.
+/// so the resource binding is the one to prefer. The stack binding stands because nothing
+/// compiles the resource one for a sandbox yet. What this pins is how far that concession goes —
+/// the resource group and no further, and a read rather than anything that reaches a session.
 #[test]
 fn sandbox_heartbeat_stack_scope_stops_at_the_resource_group() {
     let generator = AzureRuntimePermissionsGenerator::new();

--- a/crates/alien-permissions/tests/azure_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/azure_sensitive_invariant.rs
@@ -1,6 +1,4 @@
-use alien_permissions::{
-    data_action_reaches_a_sandbox_session, list_permission_set_ids, AZURE_SANDBOX_DATA_PLANE_ROLE,
-};
+use alien_permissions::{list_permission_set_ids, AZURE_SANDBOX_DATA_PLANE_ROLE};
 
 const SENSITIVE_IMPLICIT_ACTIONS: &[&str] = &[
     "Microsoft.Storage/storageAccounts/listKeys/action",
@@ -81,12 +79,19 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
                         !SENSITIVE_IMPLICIT_DATA_ACTIONS.contains(&data_action.as_str()),
                         "{permission_set_id} Azure entry {index} grants sensitive data action {data_action}"
                     );
-                    // By reach rather than by equality, so a wildcard cannot pass a list of exact
-                    // strings: `Microsoft.App/sandboxGroups/*` grants every one of them and
-                    // matches none of them.
+                    // A wildcard grants every action it covers while matching none of them by
+                    // string, so the list above cannot catch one on its own.
+                    //
+                    // Deliberately narrower than "reaches a session": creating and deleting
+                    // sandboxes *is* session reach for the single-tenancy gate, because whoever
+                    // starts one decides what runs in it — but it is not access to the contents
+                    // of a session someone else started, which is what this invariant is about.
+                    // `sandbox/management` legitimately carries the lifecycle verbs and must
+                    // keep passing here.
                     assert!(
-                        !data_action_reaches_a_sandbox_session(data_action),
-                        "{permission_set_id} Azure entry {index} reaches a sandbox session through {data_action}"
+                        !wildcard_covers_a_sensitive_data_action(data_action),
+                        "{permission_set_id} Azure entry {index} covers a sensitive data action \
+                         through the wildcard {data_action}"
                     );
                 }
             }
@@ -98,4 +103,18 @@ fn is_implicit_management_set(permission_set_id: &str) -> bool {
     permission_set_id.ends_with("/heartbeat")
         || permission_set_id.ends_with("/management")
         || permission_set_id.ends_with("/provision")
+}
+
+/// Whether a granted `dataAction` carrying a `*` covers any action on the sensitive list.
+///
+/// Compared as a prefix because that is what a wildcard means: `Microsoft.App/sandboxGroups/*`
+/// grants `…/sandboxes/executeShellCommand/action` while sharing no exact string with it.
+fn wildcard_covers_a_sensitive_data_action(granted: &str) -> bool {
+    let Some((literal, _)) = granted.split_once('*') else {
+        return false;
+    };
+    let literal = literal.to_ascii_lowercase();
+    SENSITIVE_IMPLICIT_DATA_ACTIONS
+        .iter()
+        .any(|sensitive| sensitive.to_ascii_lowercase().starts_with(&literal))
 }

--- a/crates/alien-permissions/tests/azure_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/azure_sensitive_invariant.rs
@@ -2,6 +2,10 @@ use alien_permissions::{list_permission_set_ids, AZURE_SANDBOX_DATA_PLANE_ROLE};
 
 const SENSITIVE_IMPLICIT_ACTIONS: &[&str] = &[
     "Microsoft.Storage/storageAccounts/listKeys/action",
+    // The account API key, which is the whole inference surface. Azure spells it `listkeys` in
+    // the role definition and `listKeys` in its docs, which is why every comparison below is
+    // case-insensitive.
+    "Microsoft.CognitiveServices/accounts/listKeys/action",
     "Microsoft.App/containerApps/listSecrets/action",
     "Microsoft.App/managedEnvironments/listSecrets/action",
 ];
@@ -28,6 +32,9 @@ const SENSITIVE_IMPLICIT_DATA_ACTIONS: &[&str] = &[
 const SENSITIVE_IMPLICIT_ROLES: &[&str] = &[
     "AcrPull",
     "AcrPush",
+    // Carries `Microsoft.CognitiveServices/accounts/listkeys/action` and a
+    // `Microsoft.CognitiveServices/*` dataAction, so it hands over the account key.
+    "Cognitive Services User",
     // Carries the whole sandbox data plane, session contents included, so it belongs only to the
     // sets that are meant to reach inside a session — `sandbox/execute` and
     // `sandbox/remote-execute`. Lifecycle-only callers use the granular actions instead. Named
@@ -58,7 +65,7 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
             if let Some(roles) = &entry.grant.predefined_roles {
                 for role in roles {
                     assert!(
-                        !SENSITIVE_IMPLICIT_ROLES.contains(&role.as_str()),
+                        !names_a_sensitive_entry(role, SENSITIVE_IMPLICIT_ROLES),
                         "{permission_set_id} Azure entry {index} uses sensitive predefined role {role}"
                     );
                 }
@@ -67,8 +74,13 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
             if let Some(actions) = &entry.grant.actions {
                 for action in actions {
                     assert!(
-                        !SENSITIVE_IMPLICIT_ACTIONS.contains(&action.as_str()),
+                        !names_a_sensitive_entry(action, SENSITIVE_IMPLICIT_ACTIONS),
                         "{permission_set_id} Azure entry {index} grants sensitive action {action}"
+                    );
+                    assert!(
+                        !wildcard_covers(action, SENSITIVE_IMPLICIT_ACTIONS),
+                        "{permission_set_id} Azure entry {index} covers a sensitive action \
+                         through the wildcard {action}"
                     );
                 }
             }
@@ -76,7 +88,7 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
             if let Some(data_actions) = &entry.grant.data_actions {
                 for data_action in data_actions {
                     assert!(
-                        !SENSITIVE_IMPLICIT_DATA_ACTIONS.contains(&data_action.as_str()),
+                        !names_a_sensitive_entry(data_action, SENSITIVE_IMPLICIT_DATA_ACTIONS),
                         "{permission_set_id} Azure entry {index} grants sensitive data action {data_action}"
                     );
                     // A wildcard grants every action it covers while matching none of them by
@@ -89,7 +101,7 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
                     // `sandbox/management` legitimately carries the lifecycle verbs and must
                     // keep passing here.
                     assert!(
-                        !wildcard_covers_a_sensitive_data_action(data_action),
+                        !wildcard_covers(data_action, SENSITIVE_IMPLICIT_DATA_ACTIONS),
                         "{permission_set_id} Azure entry {index} covers a sensitive data action \
                          through the wildcard {data_action}"
                     );
@@ -105,16 +117,25 @@ fn is_implicit_management_set(permission_set_id: &str) -> bool {
         || permission_set_id.ends_with("/provision")
 }
 
-/// Whether a granted `dataAction` carrying a `*` covers any action on the sensitive list.
+/// Whether a granted action carrying a `*` covers anything on `sensitive`.
 ///
 /// Compared as a prefix because that is what a wildcard means: `Microsoft.App/sandboxGroups/*`
 /// grants `…/sandboxes/executeShellCommand/action` while sharing no exact string with it.
-fn wildcard_covers_a_sensitive_data_action(granted: &str) -> bool {
+/// Case-insensitively, because Azure matches action names that way and spells the same action
+/// both ways itself — the role definition says `listkeys`, the docs say `listKeys`.
+fn wildcard_covers(granted: &str, sensitive: &[&str]) -> bool {
     let Some((literal, _)) = granted.split_once('*') else {
         return false;
     };
     let literal = literal.to_ascii_lowercase();
-    SENSITIVE_IMPLICIT_DATA_ACTIONS
+    sensitive
         .iter()
-        .any(|sensitive| sensitive.to_ascii_lowercase().starts_with(&literal))
+        .any(|entry| entry.to_ascii_lowercase().starts_with(&literal))
+}
+
+/// Whether `granted` names something on `sensitive`, ignoring case for the same reason.
+fn names_a_sensitive_entry(granted: &str, sensitive: &[&str]) -> bool {
+    sensitive
+        .iter()
+        .any(|entry| entry.eq_ignore_ascii_case(granted))
 }

--- a/crates/alien-permissions/tests/azure_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/azure_sensitive_invariant.rs
@@ -1,4 +1,6 @@
-use alien_permissions::list_permission_set_ids;
+use alien_permissions::{
+    data_action_reaches_a_sandbox_session, list_permission_set_ids, AZURE_SANDBOX_DATA_PLANE_ROLE,
+};
 
 const SENSITIVE_IMPLICIT_ACTIONS: &[&str] = &[
     "Microsoft.Storage/storageAccounts/listKeys/action",
@@ -30,8 +32,9 @@ const SENSITIVE_IMPLICIT_ROLES: &[&str] = &[
     "AcrPush",
     // Carries the whole sandbox data plane, session contents included, so it belongs only to the
     // sets that are meant to reach inside a session — `sandbox/execute` and
-    // `sandbox/remote-execute`. Lifecycle-only callers use the granular actions instead.
-    "Container Apps SandboxGroup Data Owner",
+    // `sandbox/remote-execute`. Lifecycle-only callers use the granular actions instead. Named
+    // from the shared constant so this list and the reach predicate cannot disagree.
+    AZURE_SANDBOX_DATA_PLANE_ROLE,
     "Azure Service Bus Data Receiver",
     "Key Vault Secrets User",
     "Storage Blob Data Contributor",
@@ -77,6 +80,13 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
                     assert!(
                         !SENSITIVE_IMPLICIT_DATA_ACTIONS.contains(&data_action.as_str()),
                         "{permission_set_id} Azure entry {index} grants sensitive data action {data_action}"
+                    );
+                    // By reach rather than by equality, so a wildcard cannot pass a list of exact
+                    // strings: `Microsoft.App/sandboxGroups/*` grants every one of them and
+                    // matches none of them.
+                    assert!(
+                        !data_action_reaches_a_sandbox_session(data_action),
+                        "{permission_set_id} Azure entry {index} reaches a sandbox session through {data_action}"
                     );
                 }
             }

--- a/crates/alien-permissions/tests/azure_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/azure_sensitive_invariant.rs
@@ -28,8 +28,9 @@ const SENSITIVE_IMPLICIT_DATA_ACTIONS: &[&str] = &[
 const SENSITIVE_IMPLICIT_ROLES: &[&str] = &[
     "AcrPull",
     "AcrPush",
-    // Carries the whole sandbox data plane, session contents included, so it belongs to
-    // sandbox/execute alone. Lifecycle-only callers use the granular actions instead.
+    // Carries the whole sandbox data plane, session contents included, so it belongs only to the
+    // sets that are meant to reach inside a session — `sandbox/execute` and
+    // `sandbox/remote-execute`. Lifecycle-only callers use the granular actions instead.
     "Container Apps SandboxGroup Data Owner",
     "Azure Service Bus Data Receiver",
     "Key Vault Secrets User",

--- a/crates/alien-permissions/tests/azure_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/azure_sensitive_invariant.rs
@@ -35,9 +35,8 @@ const SENSITIVE_IMPLICIT_ROLES: &[&str] = &[
     // Carries `Microsoft.CognitiveServices/accounts/listkeys/action` and a
     // `Microsoft.CognitiveServices/*` dataAction, so it hands over the account key.
     "Cognitive Services User",
-    // Carries the whole sandbox data plane, session contents included, so it belongs only to the
-    // sets that are meant to reach inside a session — `sandbox/execute` and
-    // `sandbox/remote-execute`. Lifecycle-only callers use the granular actions instead. Named
+    // Carries the whole sandbox data plane, session contents included, so it belongs only to sets
+    // meant to reach inside a session — `sandbox/execute` and `sandbox/remote-execute`. Named
     // from the shared constant so this list and the reach predicate cannot disagree.
     AZURE_SANDBOX_DATA_PLANE_ROLE,
     "Azure Service Bus Data Receiver",
@@ -91,15 +90,10 @@ fn azure_implicit_management_sets_do_not_grant_sensitive_content() {
                         !names_a_sensitive_entry(data_action, SENSITIVE_IMPLICIT_DATA_ACTIONS),
                         "{permission_set_id} Azure entry {index} grants sensitive data action {data_action}"
                     );
-                    // A wildcard grants every action it covers while matching none of them by
-                    // string, so the list above cannot catch one on its own.
-                    //
-                    // Deliberately narrower than "reaches a session": creating and deleting
-                    // sandboxes *is* session reach for the single-tenancy gate, because whoever
-                    // starts one decides what runs in it — but it is not access to the contents
-                    // of a session someone else started, which is what this invariant is about.
-                    // `sandbox/management` legitimately carries the lifecycle verbs and must
-                    // keep passing here.
+                    // A wildcard covers every action it grants without matching any by string, so
+                    // the list above alone would miss it. Narrower than "reaches a session":
+                    // creating/deleting is reach for the single-tenancy gate but not another
+                    // session's contents, so `sandbox/management`'s lifecycle verbs still pass.
                     assert!(
                         !wildcard_covers(data_action, SENSITIVE_IMPLICIT_DATA_ACTIONS),
                         "{permission_set_id} Azure entry {index} covers a sensitive data action \
@@ -117,12 +111,9 @@ fn is_implicit_management_set(permission_set_id: &str) -> bool {
         || permission_set_id.ends_with("/provision")
 }
 
-/// Whether a granted action carrying a `*` covers anything on `sensitive`.
-///
-/// Compared as a prefix because that is what a wildcard means: `Microsoft.App/sandboxGroups/*`
-/// grants `…/sandboxes/executeShellCommand/action` while sharing no exact string with it.
-/// Case-insensitively, because Azure matches action names that way and spells the same action
-/// both ways itself — the role definition says `listkeys`, the docs say `listKeys`.
+/// Whether a granted action carrying a `*` covers anything on `sensitive`. Compared as a prefix
+/// — that's what a wildcard means — and case-insensitively, since Azure spells the same action
+/// both ways itself (`listkeys` in role definitions, `listKeys` in docs).
 fn wildcard_covers(granted: &str, sensitive: &[&str]) -> bool {
     let Some((literal, _)) = granted.split_once('*') else {
         return false;

--- a/crates/alien-preflights/src/compile_time/frozen_resource_lifecycle.rs
+++ b/crates/alien-preflights/src/compile_time/frozen_resource_lifecycle.rs
@@ -58,9 +58,11 @@ impl CompileTimeCheck for FrozenResourceLifecycleCheck {
                 ));
             }
 
-            // Only AWS has a runtime sandbox controller that builds the image itself. On the
-            // other backends a Live sandbox would be accepted, emitted nowhere, and provisioned
-            // by nobody.
+            // Two reasons, and the second outlives the first. Only AWS has a runtime sandbox
+            // controller, so elsewhere a Live sandbox is emitted nowhere and provisioned by
+            // nobody. And a remote grant on Azure or GCP names a parent that must exist when the
+            // package applies, which only the package that creates it can do — so publishing a
+            // Live sandbox stays impossible on those clouds even once they gain a controller.
             if resource_entry.config.downcast_ref::<Sandbox>().is_some()
                 && resource_entry.lifecycle == ResourceLifecycle::Live
                 && platform != Platform::Aws

--- a/crates/alien-preflights/src/compile_time/sandbox_platform_support.rs
+++ b/crates/alien-preflights/src/compile_time/sandbox_platform_support.rs
@@ -104,18 +104,23 @@ mod tests {
         }
     }
 
-    /// Azure applies no per-sandbox ceiling. A stack that declares one reads as bounded while the
-    /// sandbox is not, so plan time refuses it rather than letting it run unbounded.
+    /// A ceiling outside the platform's own sizing rule is refused at plan time.
+    ///
+    /// Azure sizes cpu in steps of 250m, so `333m` is a size it will not create. Caught while the
+    /// customer is planning rather than at the first session, where it reads as a runtime fault
+    /// rather than a declaration they can fix.
     #[tokio::test]
-    async fn ceilings_on_a_platform_that_ignores_them_fail_at_plan_time() {
-        let stack = stack_with(sandbox("agent", Some(ceilings()), SandboxEgress::Deny));
+    async fn ceilings_outside_the_platform_rule_fail_at_plan_time() {
+        let mut limits = ceilings();
+        limits.cpu = "333m".to_string();
+        let stack = stack_with(sandbox("agent", Some(limits), SandboxEgress::Deny));
 
         let result = SandboxPlatformSupportCheck
             .check(&stack, Platform::Azure)
             .await
             .expect("check runs");
 
-        assert!(!result.success, "unenforceable ceilings must not pass");
+        assert!(!result.success, "a size the platform refuses must not pass");
         let rendered = result.errors.join(" ");
         assert!(rendered.contains("agent"), "names the sandbox: {rendered}");
     }
@@ -125,7 +130,7 @@ mod tests {
     async fn the_same_ceilings_pass_where_they_are_enforced() {
         let stack = stack_with(sandbox("agent", Some(ceilings()), SandboxEgress::Deny));
 
-        for platform in [Platform::Aws, Platform::Kubernetes] {
+        for platform in [Platform::Aws, Platform::Azure, Platform::Kubernetes] {
             let result = SandboxPlatformSupportCheck
                 .check(&stack, platform)
                 .await

--- a/crates/alien-preflights/src/compile_time/sandbox_platform_support.rs
+++ b/crates/alien-preflights/src/compile_time/sandbox_platform_support.rs
@@ -104,11 +104,9 @@ mod tests {
         }
     }
 
-    /// A ceiling outside the platform's own sizing rule is refused at plan time.
-    ///
-    /// Azure sizes cpu in steps of 250m, so `333m` is a size it will not create. Caught while the
-    /// customer is planning rather than at the first session, where it reads as a runtime fault
-    /// rather than a declaration they can fix.
+    /// A ceiling outside the platform's own sizing rule is refused at plan time: Azure sizes cpu
+    /// in steps of 250m, so `333m` is a size it will not create. Caught while planning rather
+    /// than at the first session, where it reads as a runtime fault, not a fixable declaration.
     #[tokio::test]
     async fn ceilings_outside_the_platform_rule_fail_at_plan_time() {
         let mut limits = ceilings();

--- a/crates/alien-preflights/src/mutations/azure_service_activation.rs
+++ b/crates/alien-preflights/src/mutations/azure_service_activation.rs
@@ -144,6 +144,11 @@ impl AzureServiceActivationMutation {
                         );
                     }
                 }
+                // A sandbox group is a `Microsoft.App` resource, and a bindings-only sandbox stack
+                // has no worker to carry the signal. Shares the `worker` arm's key so they dedupe.
+                "sandbox" if include_azure_workload_scaffolding => {
+                    services.insert("enable-app".to_string(), "Microsoft.App".to_string());
+                }
                 "storage" | "kv" => {
                     services.insert(
                         "enable-storage".to_string(),
@@ -239,5 +244,38 @@ mod tests {
             services.get("enable-servicebus").map(String::as_str),
             Some("Microsoft.ServiceBus")
         );
+    }
+
+    /// A sandbox published through a Remote Binding is the whole stack — no worker, no build —
+    /// so nothing else asks for `Microsoft.App`. Without this the module creates a
+    /// `Microsoft.App/sandboxGroups` on a subscription that may never have registered the
+    /// provider, and `terraform apply` fails where nothing warned at plan.
+    #[test]
+    fn an_azure_sandbox_alone_still_registers_the_app_provider() {
+        let sandbox = alien_core::Sandbox::new("agent-sbx".to_string())
+            .code(alien_core::SandboxCode::Image {
+                image: "ubuntu".to_string(),
+            })
+            .egress(alien_core::SandboxEgress::Allow)
+            .session(alien_core::SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build();
+        let stack = Stack::new("test".to_string())
+            .add(sandbox, ResourceLifecycle::Frozen)
+            .build();
+
+        let services =
+            AzureServiceActivationMutation.get_required_services(&stack, Platform::Azure);
+
+        assert_eq!(
+            services.get("enable-app").map(String::as_str),
+            Some("Microsoft.App")
+        );
+        // On AWS the same stack must ask Azure for nothing at all.
+        assert!(AzureServiceActivationMutation
+            .get_required_services(&stack, Platform::Aws)
+            .is_empty());
     }
 }

--- a/crates/alien-preflights/src/mutations/azure_service_activation.rs
+++ b/crates/alien-preflights/src/mutations/azure_service_activation.rs
@@ -247,9 +247,12 @@ mod tests {
     }
 
     /// A sandbox published through a Remote Binding is the whole stack — no worker, no build —
-    /// so nothing else asks for `Microsoft.App`. Without this the module creates a
-    /// `Microsoft.App/sandboxGroups` on a subscription that may never have registered the
-    /// provider, and `terraform apply` fails where nothing warned at plan.
+    /// so nothing else asks for `Microsoft.App`, and the registration payload named no provider
+    /// for a module that creates a `Microsoft.App/sandboxGroups`.
+    ///
+    /// What this pins is the payload entry, not an apply-time outcome: the activation emitter
+    /// renders no Terraform resource, so the provider still has to be registered out of band.
+    /// The generated README states that as a prerequisite.
     #[test]
     fn an_azure_sandbox_alone_still_registers_the_app_provider() {
         let sandbox = alien_core::Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-preflights/src/mutations/azure_service_activation.rs
+++ b/crates/alien-preflights/src/mutations/azure_service_activation.rs
@@ -247,9 +247,8 @@ mod tests {
     }
 
     /// A sandbox published through a Remote Binding is the whole stack — no worker, no build — so
-    /// nothing else asks for `Microsoft.App`. This pins the payload entry only: the activation
-    /// emitter renders no Terraform resource for it, so the provider is registered out of band
-    /// (the generated README states that as a prerequisite).
+    /// nothing else asks for `Microsoft.App`. Pins the payload entry only: the activation emitter
+    /// renders no Terraform resource for it, so the provider is registered out of band.
     #[test]
     fn an_azure_sandbox_alone_still_registers_the_app_provider() {
         let sandbox = alien_core::Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-preflights/src/mutations/azure_service_activation.rs
+++ b/crates/alien-preflights/src/mutations/azure_service_activation.rs
@@ -246,13 +246,10 @@ mod tests {
         );
     }
 
-    /// A sandbox published through a Remote Binding is the whole stack — no worker, no build —
-    /// so nothing else asks for `Microsoft.App`, and the registration payload named no provider
-    /// for a module that creates a `Microsoft.App/sandboxGroups`.
-    ///
-    /// What this pins is the payload entry, not an apply-time outcome: the activation emitter
-    /// renders no Terraform resource, so the provider still has to be registered out of band.
-    /// The generated README states that as a prerequisite.
+    /// A sandbox published through a Remote Binding is the whole stack — no worker, no build — so
+    /// nothing else asks for `Microsoft.App`. This pins the payload entry only: the activation
+    /// emitter renders no Terraform resource for it, so the provider is registered out of band
+    /// (the generated README states that as a prerequisite).
     #[test]
     fn an_azure_sandbox_alone_still_registers_the_app_provider() {
         let sandbox = alien_core::Sandbox::new("agent-sbx".to_string())

--- a/crates/alien-preflights/src/mutations/management_permission_profile.rs
+++ b/crates/alien-preflights/src/mutations/management_permission_profile.rs
@@ -515,7 +515,10 @@ mod tests {
             .management()
             .profile()
             .expect("auto management profile should be generated");
-        let global = permissions.0.get("*").expect("global management permissions");
+        let global = permissions
+            .0
+            .get("*")
+            .expect("global management permissions");
         assert!(
             global
                 .iter()

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -199,11 +199,9 @@ fn validate_remote_sandboxes_are_deliverable(stack: &Stack, mutation_name: &str)
 /// Refuses a remotely published sandbox that the deployment's own workloads can also reach.
 ///
 /// Neither cloud that publishes a sandbox remotely can scope the grant to a subset of its
-/// sessions, so the grant reaches every session of the sandbox whoever started it. On AWS one
-/// MicroVM image serves them all and a token mint scopes no finer than the image; on Azure the
-/// `SandboxGroup Data Owner` role covers `sandboxGroups/*` on the one group the sandbox is. Either
-/// way a remote caller holding raw credentials can read, suspend, terminate or reach into sessions
-/// the customer's own compute started, and single tenancy is the only containment available.
+/// sessions: one AWS MicroVM image serves them all, and Azure's `SandboxGroup Data Owner` role
+/// covers every sandbox in the group. So a remote caller can reach sessions the customer's own
+/// compute started; single tenancy is the only containment available.
 fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &str) -> Result<()> {
     for (resource_id, entry) in &stack.resources {
         if !entry.has_remote_bindings() || entry.config.resource_type() != Sandbox::RESOURCE_TYPE {
@@ -226,22 +224,10 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 
 /// How the deployment's own workloads can reach `sandbox_id`, if any can.
 ///
-/// Three routes, none of which the vendor's own `-access` grant travels: a compute link, a
-/// permission profile, and a stack permission set on a user-declared ServiceAccount. Reach is
-/// decided by the resolved set's session-reaching verbs, never by a set id — an inline set an
-/// author names anything defeats a prefix test.
+/// Three routes: a compute link, a permission profile, and a stack permission set on a
+/// user-declared ServiceAccount — never by set id, since an inline set can be named anything.
 ///
-/// Three routes, not every route. The management profile is a fourth and is not scanned, so an
-/// author-written `management: extend` naming this sandbox passes and then compiles onto the
-/// deployment's own management identity — the second tenant this gate exists to refuse. Left open
-/// deliberately: closing it changes production AWS behaviour and depends on a mutation phase order
-/// nothing asserts, so it is tracked separately rather than fixed in a sandbox-parity change.
-///
-/// The three routes are declaration-level — a link, a profile or a stack set is the same edge
-/// whichever cloud renders it — but the verb test two of them reach is not, so this calls
-/// `permission_set_reaches_a_sandbox_session`, which inspects every cloud a set declares (see its
-/// doc). What keeps this honest for GCP is the platform gate refusing a GCP remote sandbox before
-/// this answer is used, not anything this function checks.
+/// The management profile is a fourth route this scan does not cover.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
@@ -285,17 +271,9 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     })
 }
 
-/// Whether a profile entry filed under `target` reaches `sandbox_id`.
-///
-/// The profile key is not the scope. A **named** set is scoped by the key — `${resourceName}`
-/// interpolates to the target, so `{"some-worker": ["sandbox/execute"]}` compiles a grant on a
-/// group belonging to that worker and cannot touch this sandbox. An **inline** set carries its own
-/// scope string, which the author writes, and `${stackPrefix}` interpolates for them — so an
-/// inline set filed under any third resource can name this sandbox's group and be granted on it.
-///
-/// So an inline set that reaches a session counts under every key, and a named one only under this
-/// sandbox or the wildcard. Anything else either misses the reachable case or refuses a legitimate
-/// second sandbox that a worker is meant to drive.
+/// Whether a profile entry filed under `target` reaches `sandbox_id`. A **named** set is scoped
+/// by its key, so it can't touch this sandbox from another worker's entry; an **inline** set
+/// carries its own scope and can name this sandbox's group from under any key.
 fn reaches_this_sandbox(
     reference: &PermissionSetReference,
     target: &str,
@@ -463,14 +441,10 @@ mod tests {
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
     }
 
-    /// `sandbox/remote-execute` grants on AWS and Azure and nothing on GCP. Without this gate a
-    /// GCP deployment installs an identity with no sandbox role binding, and the customer's
-    /// security team approves a PERMISSIONS.md heading promising arbitrary code execution and
-    /// listing nothing.
-    ///
-    /// Both directions, because the gate is derived from the permission set rather than a list
-    /// kept here: a covered platform must pass it, or a set gaining a cloud silently stops
-    /// deploying there.
+    /// `sandbox/remote-execute` grants on AWS and Azure, nothing on GCP. Without this gate, a GCP
+    /// deployment's security review approves a PERMISSIONS.md heading promising arbitrary code
+    /// execution while listing nothing. Checked both directions: a covered platform must pass
+    /// too, or a set gaining a cloud silently stops deploying there.
     #[tokio::test]
     async fn a_remote_sandbox_is_refused_where_its_permission_set_grants_nothing() {
         let covered = Stack::new("byo-sandbox".to_string())
@@ -844,13 +818,13 @@ mod tests {
     }
 
     /// The same single-tenancy escape as the AWS case above, in Azure's vocabulary: the reach scan
-    /// has to catch a set granting Azure's whole sandbox data plane the same way it catches an AWS
-    /// one, or the stack deploys with the remote caller and the deployment's own compute both
-    /// holding it. Two shapes, because Azure spells reach two ways — the predefined role and the
-    /// `dataActions` underneath it.
+    /// must catch a set granting Azure's whole sandbox data plane the same way it catches AWS, or
+    /// the remote caller and the deployment's own compute both end up holding it.
     #[tokio::test]
     async fn a_remote_sandbox_reached_by_an_azure_only_service_account_set_is_refused() {
-        let azure_set = |id: &str, grant: serde_json::Value| -> alien_core::permissions::PermissionSet {
+        let azure_set = |id: &str,
+                         grant: serde_json::Value|
+         -> alien_core::permissions::PermissionSet {
             serde_json::from_value(serde_json::json!({
                 "id": id,
                 "description": "custom",
@@ -878,7 +852,10 @@ mod tests {
             // Wildcards above the sandbox namespace reach into it, so they have to fail closed.
             // A predicate that only matches downwards clears exactly the two broadest grants an
             // author can write, which is the wrong way round.
-            ("a bare wildcard", serde_json::json!({ "dataActions": ["*"] })),
+            (
+                "a bare wildcard",
+                serde_json::json!({ "dataActions": ["*"] }),
+            ),
             (
                 "a wildcard on the provider",
                 serde_json::json!({ "dataActions": ["Microsoft.App/*"] }),
@@ -947,9 +924,15 @@ mod tests {
             .mutate(stack, &StackState::new(Platform::Azure), &config())
             .await
         else {
-            panic!("an inline set naming this sandbox's group reaches it, whatever key it sits under")
+            panic!(
+                "an inline set naming this sandbox's group reaches it, whatever key it sits under"
+            )
         };
         assert_eq!(error.code, "STACK_MUTATION_FAILED", "{error}");
+        assert!(
+            error.to_string().contains("permission profile 'execution'"),
+            "the refusal must come from the reach scan, got: {error}"
+        );
     }
 
     /// And a named set under another resource is still allowed, because the key is its scope.
@@ -978,17 +961,16 @@ mod tests {
     /// today's verb names alone would let the broader grant through and refuse the narrower one.
     #[tokio::test]
     async fn a_wildcard_over_an_unknown_microvm_verb_still_reaches_a_session() {
-        let future_verb: alien_core::permissions::PermissionSet = serde_json::from_value(
-            serde_json::json!({
+        let future_verb: alien_core::permissions::PermissionSet =
+            serde_json::from_value(serde_json::json!({
                 "id": "custom/telemetry",
                 "description": "custom",
                 "platforms": { "aws": [{
                     "grant": { "actions": ["lambda:SomeFutureMicrovmVerb*"] },
                     "binding": { "stack": { "resources": ["*"] } }
                 }]}
-            }),
-        )
-        .expect("valid inline permission set");
+            }))
+            .expect("valid inline permission set");
 
         let stack = Stack::new("application".to_string())
             .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
@@ -1002,22 +984,25 @@ mod tests {
             panic!("a wildcard reaching the MicroVM namespace is reach, known verb or not")
         };
         assert_eq!(error.code, "STACK_MUTATION_FAILED", "{error}");
+        assert!(
+            error.to_string().contains("permission profile 'execution'"),
+            "the refusal must come from the reach scan, got: {error}"
+        );
     }
 
     /// And the image family stays out, since `provision` and `heartbeat` legitimately hold it.
     #[tokio::test]
     async fn a_wildcard_over_the_microvm_image_family_is_not_session_reach() {
-        let image_only: alien_core::permissions::PermissionSet = serde_json::from_value(
-            serde_json::json!({
+        let image_only: alien_core::permissions::PermissionSet =
+            serde_json::from_value(serde_json::json!({
                 "id": "custom/images",
                 "description": "custom",
                 "platforms": { "aws": [{
                     "grant": { "actions": ["lambda:GetMicrovmImage*"] },
                     "binding": { "stack": { "resources": ["*"] } }
                 }]}
-            }),
-        )
-        .expect("valid inline permission set");
+            }))
+            .expect("valid inline permission set");
 
         let stack = Stack::new("application".to_string())
             .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -256,8 +256,9 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
                 .0
                 .iter()
                 .any(|(target, permission_sets)| {
-                    (target == sandbox_id || target == "*")
-                        && permission_sets.iter().any(reference_reaches_a_session)
+                    permission_sets
+                        .iter()
+                        .any(|reference| reaches_this_sandbox(reference, target, sandbox_id))
                 })
                 .then(|| format!("permission profile '{profile_name}' grants access to it"))
         });
@@ -279,17 +280,30 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     })
 }
 
-/// Whether a profile's permission set, once resolved, reaches a session.
+/// Whether a profile entry filed under `target` reaches `sandbox_id`.
 ///
-/// A named reference is looked up in the built-in registry rather than trusted by name; an
-/// inline set is inspected directly. An unresolvable name is treated as no reach — the manager
-/// rejects an unknown set before it grants anything.
-fn reference_reaches_a_session(reference: &PermissionSetReference) -> bool {
+/// The profile key is not the scope. A **named** set is scoped by the key — `${resourceName}`
+/// interpolates to the target, so `{"some-worker": ["sandbox/execute"]}` compiles a grant on a
+/// group belonging to that worker and cannot touch this sandbox. An **inline** set carries its own
+/// scope string, which the author writes, and `${stackPrefix}` interpolates for them — so an
+/// inline set filed under any third resource can name this sandbox's group and be granted on it.
+///
+/// So an inline set that reaches a session counts under every key, and a named one only under this
+/// sandbox or the wildcard. Anything else either misses the reachable case or refuses a legitimate
+/// second sandbox that a worker is meant to drive.
+fn reaches_this_sandbox(
+    reference: &PermissionSetReference,
+    target: &str,
+    sandbox_id: &str,
+) -> bool {
     match reference {
-        PermissionSetReference::Inline(set) => permission_set_reaches_a_sandbox_session(set),
+        // An unresolvable name is no reach: the manager rejects an unknown set before it grants
+        // anything.
         PermissionSetReference::Name(name) => {
-            get_permission_set(name).is_some_and(permission_set_reaches_a_sandbox_session)
+            (target == sandbox_id || target == "*")
+                && get_permission_set(name).is_some_and(permission_set_reaches_a_sandbox_session)
         }
+        PermissionSetReference::Inline(set) => permission_set_reaches_a_sandbox_session(set),
     }
 }
 
@@ -903,6 +917,65 @@ mod tests {
                 "{label}: the refusal must name the service account, got: {error}"
             );
         }
+    }
+
+    /// An inline set does not have to be filed under the sandbox to reach it.
+    ///
+    /// The profile key scopes a *named* set, because `${resourceName}` interpolates to it. An
+    /// inline set carries its own scope string and `${stackPrefix}` interpolates for the author,
+    /// so one filed under an unrelated worker can name this sandbox's group and be granted on it —
+    /// a second tenant on a sandbox published to a remote caller, arriving through a key the gate
+    /// was not looking at.
+    #[tokio::test]
+    async fn a_remote_sandbox_reached_by_an_inline_set_under_another_resource_is_refused() {
+        let reaching_set: alien_core::permissions::PermissionSet = serde_json::from_value(
+            serde_json::json!({
+                "id": "custom/telemetry",
+                "description": "custom",
+                "platforms": { "azure": [{
+                    "grant": { "dataActions": ["Microsoft.App/sandboxGroups/sandboxes/executeShellCommand/action"] },
+                    "binding": { "resource": { "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-agents" } }
+                }]}
+            }),
+        )
+        .expect("valid inline permission set");
+
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission(
+                "execution",
+                // Filed under a worker, not under the sandbox and not under `*`.
+                PermissionProfile::new().resource("some-worker", [reaching_set]),
+            )
+            .build();
+
+        let Err(error) = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Azure), &config())
+            .await
+        else {
+            panic!("an inline set naming this sandbox's group reaches it, whatever key it sits under")
+        };
+        assert_eq!(error.code, "STACK_MUTATION_FAILED", "{error}");
+    }
+
+    /// And a named set under another resource is still allowed, because the key is its scope.
+    ///
+    /// Without this the fix above reads as "any session-reaching set anywhere refuses the stack",
+    /// which would refuse a second, unpublished sandbox a worker is meant to drive.
+    #[tokio::test]
+    async fn a_named_session_set_targeted_at_another_resource_is_allowed() {
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission(
+                "execution",
+                PermissionProfile::new().resource("some-worker", ["sandbox/execute"]),
+            )
+            .build();
+
+        RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Azure), &config())
+            .await
+            .expect("a named set is scoped by its profile key and cannot name this sandbox");
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -238,11 +238,10 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 /// nothing asserts, so it is tracked separately rather than fixed in a sandbox-parity change.
 ///
 /// The three routes are declaration-level — a link, a profile or a stack set is the same edge
-/// whichever cloud renders it — but the verb test two of them reach is not, so
-/// `permission_set_reaches_a_sandbox_session` inspects every cloud a set declares. A set carrying
-/// an Azure block alone would otherwise answer "reaches nothing" while granting the whole sandbox
-/// data plane. What keeps this honest for GCP is the platform gate refusing a GCP remote sandbox
-/// before this answer is used, not anything this function checks.
+/// whichever cloud renders it — but the verb test two of them reach is not, so this calls
+/// `permission_set_reaches_a_sandbox_session`, which inspects every cloud a set declares (see its
+/// doc). What keeps this honest for GCP is the platform gate refusing a GCP remote sandbox before
+/// this answer is used, not anything this function checks.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
@@ -844,17 +843,10 @@ mod tests {
         );
     }
 
-    /// The same escape, written in Azure's vocabulary instead of AWS's.
-    ///
-    /// A `ServiceAccount`'s `stack_permission_sets` are always inline and always author-written,
-    /// so the reach scan is the only thing standing between the deployment's own compute and a
-    /// sandbox published to a remote caller. A scan that reads AWS actions alone answers "reaches
-    /// nothing" for a set that grants Azure's entire sandbox data plane at resource-group scope,
-    /// and the stack deploys with the customer's compute and the remote caller both holding it —
-    /// which is the single condition `sandbox/remote-execute` says is the only containment
-    /// available.
-    ///
-    /// Two shapes, because Azure spells the same reach two ways: the predefined role, and the
+    /// The same single-tenancy escape as the AWS case above, in Azure's vocabulary: the reach scan
+    /// has to catch a set granting Azure's whole sandbox data plane the same way it catches an AWS
+    /// one, or the stack deploys with the remote caller and the deployment's own compute both
+    /// holding it. Two shapes, because Azure spells reach two ways — the predefined role and the
     /// `dataActions` underneath it.
     #[tokio::test]
     async fn a_remote_sandbox_reached_by_an_azure_only_service_account_set_is_refused() {
@@ -925,13 +917,9 @@ mod tests {
         }
     }
 
-    /// An inline set does not have to be filed under the sandbox to reach it.
-    ///
-    /// The profile key scopes a *named* set, because `${resourceName}` interpolates to it. An
-    /// inline set carries its own scope string and `${stackPrefix}` interpolates for the author,
-    /// so one filed under an unrelated worker can name this sandbox's group and be granted on it —
-    /// a second tenant on a sandbox published to a remote caller, arriving through a key the gate
-    /// was not looking at.
+    /// An inline set does not have to be filed under the sandbox to reach it (see
+    /// `reaches_this_sandbox`'s doc for why). A second tenant on a sandbox published to a remote
+    /// caller, arriving through a key the gate was not looking at.
     #[tokio::test]
     async fn a_remote_sandbox_reached_by_an_inline_set_under_another_resource_is_refused() {
         let reaching_set: alien_core::permissions::PermissionSet = serde_json::from_value(

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -7,7 +7,7 @@ use alien_core::{
     Stack, StackState,
 };
 use alien_error::AlienError;
-use alien_permissions::{get_permission_set, permission_set_reaches_a_microvm_session};
+use alien_permissions::{get_permission_set, permission_set_reaches_a_sandbox_session};
 use async_trait::async_trait;
 
 pub const REMOTE_BINDINGS_ID: &str = "access";
@@ -198,9 +198,12 @@ fn validate_remote_sandboxes_are_deliverable(stack: &Stack, mutation_name: &str)
 
 /// Refuses a remotely published sandbox that the deployment's own workloads can also reach.
 ///
-/// One MicroVM image serves every session of a sandbox and AWS scopes a token mint no finer than
-/// the image, so a remote caller holding raw credentials can read, suspend, terminate or mint into
-/// sessions the customer's own compute started. Single tenancy is the only containment available.
+/// Neither cloud that publishes a sandbox remotely can scope the grant to a subset of its
+/// sessions, so the grant reaches every session of the sandbox whoever started it. On AWS one
+/// MicroVM image serves them all and a token mint scopes no finer than the image; on Azure the
+/// `SandboxGroup Data Owner` role covers `sandboxGroups/*` on the one group the sandbox is. Either
+/// way a remote caller holding raw credentials can read, suspend, terminate or reach into sessions
+/// the customer's own compute started, and single tenancy is the only containment available.
 fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &str) -> Result<()> {
     for (resource_id, entry) in &stack.resources {
         if !entry.has_remote_bindings() || entry.config.resource_type() != Sandbox::RESOURCE_TYPE {
@@ -226,9 +229,14 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 /// Three routes, none of which the vendor's own `-access` grant travels: a compute link, a
 /// permission profile, and a stack permission set on a user-declared ServiceAccount. Reach is
 /// decided by the resolved set's session-reaching verbs, never by a set id — an inline set an
-/// author names anything defeats a prefix test. This scan is shaped for the AWS routes; what
-/// keeps it honest for GCP is the platform gate refusing a GCP remote sandbox before this answer
-/// is used, not anything this function checks.
+/// author names anything defeats a prefix test.
+///
+/// The three routes are declaration-level — a link, a profile or a stack set is the same edge
+/// whichever cloud renders it — but the verb test two of them reach is not, so
+/// `permission_set_reaches_a_sandbox_session` inspects every cloud a set declares. A set carrying
+/// an Azure block alone would otherwise answer "reaches nothing" while granting the whole sandbox
+/// data plane. What keeps this honest for GCP is the platform gate refusing a GCP remote sandbox
+/// before this answer is used, not anything this function checks.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
@@ -265,7 +273,7 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
                 account
                     .stack_permission_sets
                     .iter()
-                    .any(permission_set_reaches_a_microvm_session)
+                    .any(permission_set_reaches_a_sandbox_session)
             })
             .map(|_| format!("service account '{id}' can start sessions in it"))
     })
@@ -278,9 +286,9 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
 /// rejects an unknown set before it grants anything.
 fn reference_reaches_a_session(reference: &PermissionSetReference) -> bool {
     match reference {
-        PermissionSetReference::Inline(set) => permission_set_reaches_a_microvm_session(set),
+        PermissionSetReference::Inline(set) => permission_set_reaches_a_sandbox_session(set),
         PermissionSetReference::Name(name) => {
-            get_permission_set(name).is_some_and(permission_set_reaches_a_microvm_session)
+            get_permission_set(name).is_some_and(permission_set_reaches_a_sandbox_session)
         }
     }
 }
@@ -801,6 +809,71 @@ mod tests {
                 .contains("service account 'runner' can start sessions in it"),
             "the refusal must name the service account, got: {error}"
         );
+    }
+
+    /// The same escape, written in Azure's vocabulary instead of AWS's.
+    ///
+    /// A `ServiceAccount`'s `stack_permission_sets` are always inline and always author-written,
+    /// so the reach scan is the only thing standing between the deployment's own compute and a
+    /// sandbox published to a remote caller. A scan that reads AWS actions alone answers "reaches
+    /// nothing" for a set that grants Azure's entire sandbox data plane at resource-group scope,
+    /// and the stack deploys with the customer's compute and the remote caller both holding it —
+    /// which is the single condition `sandbox/remote-execute` says is the only containment
+    /// available.
+    ///
+    /// Two shapes, because Azure spells the same reach two ways: the predefined role, and the
+    /// `dataActions` underneath it.
+    #[tokio::test]
+    async fn a_remote_sandbox_reached_by_an_azure_only_service_account_set_is_refused() {
+        let azure_set = |id: &str, grant: serde_json::Value| -> alien_core::permissions::PermissionSet {
+            serde_json::from_value(serde_json::json!({
+                "id": id,
+                "description": "custom",
+                "platforms": { "azure": [{
+                    "grant": grant,
+                    "binding": { "stack": { "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}" } }
+                }]}
+            }))
+            .expect("valid inline permission set")
+        };
+
+        for (label, grant) in [
+            (
+                "the predefined role",
+                serde_json::json!({ "predefinedRoles": ["Container Apps SandboxGroup Data Owner"] }),
+            ),
+            (
+                "the dataActions underneath it",
+                serde_json::json!({
+                    "dataActions": [
+                        "Microsoft.App/sandboxGroups/sandboxes/executeShellCommand/action"
+                    ]
+                }),
+            ),
+        ] {
+            let account = ServiceAccount::new("runner".to_string())
+                .stack_permission_set(azure_set("custom/telemetry", grant))
+                .build();
+            let stack = Stack::new("application".to_string())
+                .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+                .add(account, ResourceLifecycle::Live)
+                .build();
+
+            let Err(error) = RemoteBindingsMutation
+                .mutate(stack, &StackState::new(Platform::Azure), &config())
+                .await
+            else {
+                panic!("{label} reaches the session and must be refused")
+            };
+
+            assert_eq!(error.code, "STACK_MUTATION_FAILED", "{label}");
+            assert!(
+                error
+                    .to_string()
+                    .contains("service account 'runner' can start sessions in it"),
+                "{label}: the refusal must name the service account, got: {error}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -444,12 +444,25 @@ mod tests {
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
     }
 
-    /// `sandbox/remote-execute` has an AWS block alone. Without this gate the deployment installs
-    /// a GCP or Azure identity with no sandbox role binding, and the customer's security team
-    /// approves a PERMISSIONS.md heading promising arbitrary code execution and listing nothing.
+    /// `sandbox/remote-execute` grants on AWS and Azure and nothing on GCP. Without this gate a
+    /// GCP deployment installs an identity with no sandbox role binding, and the customer's
+    /// security team approves a PERMISSIONS.md heading promising arbitrary code execution and
+    /// listing nothing.
+    ///
+    /// Both directions, because the gate is derived from the permission set rather than a list
+    /// kept here: a covered platform must pass it, or a set gaining a cloud silently stops
+    /// deploying there.
     #[tokio::test]
     async fn a_remote_sandbox_is_refused_where_its_permission_set_grants_nothing() {
-        for platform in [Platform::Gcp, Platform::Azure] {
+        let covered = Stack::new("byo-sandbox".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .build();
+        RemoteBindingsMutation
+            .mutate(covered, &StackState::new(Platform::Azure), &config())
+            .await
+            .expect("Azure carries a remote-execute grant, so the gate must let it through");
+
+        for platform in [Platform::Gcp] {
             let stack = Stack::new("byo-sandbox".to_string())
                 .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
                 .build();
@@ -849,6 +862,22 @@ mod tests {
                         "Microsoft.App/sandboxGroups/sandboxes/executeShellCommand/action"
                     ]
                 }),
+            ),
+            // Wildcards above the sandbox namespace reach into it, so they have to fail closed.
+            // A predicate that only matches downwards clears exactly the two broadest grants an
+            // author can write, which is the wrong way round.
+            ("a bare wildcard", serde_json::json!({ "dataActions": ["*"] })),
+            (
+                "a wildcard on the provider",
+                serde_json::json!({ "dataActions": ["Microsoft.App/*"] }),
+            ),
+            (
+                "a wildcard on the group, in the shape the role itself carries",
+                serde_json::json!({ "dataActions": ["Microsoft.App/sandboxGroups/*/action"] }),
+            ),
+            (
+                "a wildcard below the namespace",
+                serde_json::json!({ "dataActions": ["Microsoft.App/sandboxGroups/sandboxes/*"] }),
             ),
         ] {
             let account = ServiceAccount::new("runner".to_string())

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -978,6 +978,64 @@ mod tests {
             .expect("a named set is scoped by its profile key and cannot name this sandbox");
     }
 
+    /// A wildcard over a MicroVM verb AWS has not shipped yet still reaches a session.
+    ///
+    /// The un-wildcarded form is caught by the namespace test, so clearing a wildcard against
+    /// today's verb names alone would let the broader grant through and refuse the narrower one.
+    #[tokio::test]
+    async fn a_wildcard_over_an_unknown_microvm_verb_still_reaches_a_session() {
+        let future_verb: alien_core::permissions::PermissionSet = serde_json::from_value(
+            serde_json::json!({
+                "id": "custom/telemetry",
+                "description": "custom",
+                "platforms": { "aws": [{
+                    "grant": { "actions": ["lambda:SomeFutureMicrovmVerb*"] },
+                    "binding": { "stack": { "resources": ["*"] } }
+                }]}
+            }),
+        )
+        .expect("valid inline permission set");
+
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission("execution", PermissionProfile::new().global([future_verb]))
+            .build();
+
+        let Err(error) = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Aws), &config())
+            .await
+        else {
+            panic!("a wildcard reaching the MicroVM namespace is reach, known verb or not")
+        };
+        assert_eq!(error.code, "STACK_MUTATION_FAILED", "{error}");
+    }
+
+    /// And the image family stays out, since `provision` and `heartbeat` legitimately hold it.
+    #[tokio::test]
+    async fn a_wildcard_over_the_microvm_image_family_is_not_session_reach() {
+        let image_only: alien_core::permissions::PermissionSet = serde_json::from_value(
+            serde_json::json!({
+                "id": "custom/images",
+                "description": "custom",
+                "platforms": { "aws": [{
+                    "grant": { "actions": ["lambda:GetMicrovmImage*"] },
+                    "binding": { "stack": { "resources": ["*"] } }
+                }]}
+            }),
+        )
+        .expect("valid inline permission set");
+
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .permission("execution", PermissionProfile::new().global([image_only]))
+            .build();
+
+        RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Aws), &config())
+            .await
+            .expect("the image a session launches from is not the session");
+    }
+
     #[tokio::test]
     async fn reserved_access_id_is_never_overwritten() {
         let stack = Stack::new("byo-bucket".to_string())

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -231,6 +231,12 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 /// decided by the resolved set's session-reaching verbs, never by a set id — an inline set an
 /// author names anything defeats a prefix test.
 ///
+/// Three routes, not every route. The management profile is a fourth and is not scanned, so an
+/// author-written `management: extend` naming this sandbox passes and then compiles onto the
+/// deployment's own management identity — the second tenant this gate exists to refuse. Left open
+/// deliberately: closing it changes production AWS behaviour and depends on a mutation phase order
+/// nothing asserts, so it is tracked separately rather than fixed in a sandbox-parity change.
+///
 /// The three routes are declaration-level — a link, a profile or a stack set is the same edge
 /// whichever cloud renders it — but the verb test two of them reach is not, so
 /// `permission_set_reaches_a_sandbox_session` inspects every cloud a set declares. A set carrying

--- a/crates/alien-preflights/tests/sandbox_platform_gate.rs
+++ b/crates/alien-preflights/tests/sandbox_platform_gate.rs
@@ -45,14 +45,17 @@ fn sandbox(limits: Option<SandboxLimits>) -> Sandbox {
     }
 }
 
-/// Azure applies no per-sandbox ceiling. Declaring one has to fail before anything is provisioned,
-/// or the stack reads as bounded while the sandbox is not.
+/// A ceiling the platform will not allocate has to fail before anything is provisioned, or the
+/// stack reads as bounded while the sandbox is not.
+///
+/// Azure sizes cpu in steps of 250m, so `333m` is a size it refuses to create. The failure has to
+/// arrive at preflight rather than at the first session.
 #[tokio::test]
-async fn declared_ceilings_fail_preflight_on_a_platform_that_ignores_them() {
+async fn declared_ceilings_fail_preflight_when_the_platform_will_not_allocate_them() {
     let stack = stack_with(sandbox(Some(SandboxLimits {
-        cpu: "1".to_string(),
-        memory: "2Gi".to_string(),
-        disk: "20Gi".to_string(),
+        cpu: "333m".to_string(),
+        memory: "512Mi".to_string(),
+        disk: "5120Mi".to_string(),
         max_processes: None,
     })));
 
@@ -71,8 +74,8 @@ async fn declared_ceilings_fail_preflight_on_a_platform_that_ignores_them() {
         "the failure must name the sandbox to change: {rendered}"
     );
     assert!(
-        rendered.contains("enforcedLimits"),
-        "and the capability that is missing: {rendered}"
+        rendered.contains("cpu"),
+        "and the field to change: {rendered}"
     );
 }
 

--- a/crates/alien-preflights/tests/sandbox_platform_gate.rs
+++ b/crates/alien-preflights/tests/sandbox_platform_gate.rs
@@ -45,11 +45,9 @@ fn sandbox(limits: Option<SandboxLimits>) -> Sandbox {
     }
 }
 
-/// A ceiling the platform will not allocate has to fail before anything is provisioned, or the
-/// stack reads as bounded while the sandbox is not.
-///
-/// Azure sizes cpu in steps of 250m, so `333m` is a size it refuses to create. The failure has to
-/// arrive at preflight rather than at the first session.
+/// A ceiling the platform will not allocate must fail before anything is provisioned, or the
+/// stack reads as bounded while the sandbox is not. Azure sizes cpu in steps of 250m, so `333m`
+/// is refused here rather than at the first session.
 #[tokio::test]
 async fn declared_ceilings_fail_preflight_when_the_platform_will_not_allocate_them() {
     let stack = stack_with(sandbox(Some(SandboxLimits {

--- a/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
@@ -228,7 +228,7 @@ fn self_read_policy(label: &str) -> Expression {
 fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
     permission_ref
         .resolve(|name| alien_permissions::get_permission_set(name).cloned())
-        .is_some_and(|set| alien_permissions::permission_set_reaches_a_microvm_session(&set))
+        .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
 }
 
 fn global_permission_refs<'a>(

--- a/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
@@ -69,7 +69,7 @@ impl TfEmitter for AzureRemoteStackManagementEmitter {
             .stack
             .management()
             .profile()
-            .map(management_permission_refs)
+            .map(|profile| management_permission_refs(ctx, profile))
             .unwrap_or_default();
         let grant_plan =
             generate_management_grant_plan(label, &global_refs, &resource_scoped_refs)?;
@@ -207,23 +207,51 @@ fn emit_existing_network_reader_assignments(fragment: &mut TfFragment, label: &s
     // safely own that shared VNet grant per deployment.
 }
 
-fn global_permission_refs(profile: &PermissionProfile) -> Vec<&PermissionSetReference> {
+/// Session-reaching sets belong to the remote caller's identity alone, whatever their id.
+fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
+    permission_ref
+        .resolve(|name| alien_permissions::get_permission_set(name).cloned())
+        .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
+}
+
+/// The global refs this deployment's own management identity keeps.
+///
+/// A set the remote caller claims is dropped: once a sandbox is published remotely the caller
+/// drives those sessions, and leaving the same reach on the deployment's management identity is
+/// the second tenant the single-tenancy gate exists to prevent. The auto-generated profile gives
+/// a Frozen remote sandbox only `sandbox/heartbeat`, which reaches no session — an `extend`-mode
+/// profile is where this matters.
+fn global_permission_refs<'a>(
+    ctx: &EmitContext<'_>,
+    profile: &'a PermissionProfile,
+) -> Vec<&'a PermissionSetReference> {
     profile
         .0
         .get("*")
-        .map(|refs| refs.iter().collect())
+        .map(|refs| {
+            refs.iter()
+                .filter(|permission_ref| {
+                    !alien_core::remote_bindings::remote_binding_claims_management_set(
+                        ctx.stack.resources.values(),
+                        permission_ref.id(),
+                        || reaches_a_session(permission_ref),
+                    )
+                })
+                .collect()
+        })
         .unwrap_or_default()
 }
 
 /// Global refs, plus resource-scoped refs paired with the resource that asked
 /// for them — the pairing is what lets a grant follow that resource's gate.
-fn management_permission_refs(
-    profile: &PermissionProfile,
+fn management_permission_refs<'a>(
+    ctx: &EmitContext<'_>,
+    profile: &'a PermissionProfile,
 ) -> (
-    Vec<&PermissionSetReference>,
-    Vec<(&String, &PermissionSetReference)>,
+    Vec<&'a PermissionSetReference>,
+    Vec<(&'a String, &'a PermissionSetReference)>,
 ) {
-    let global_refs = global_permission_refs(profile);
+    let global_refs = global_permission_refs(ctx, profile);
     let resource_scoped_refs = profile
         .0
         .iter()

--- a/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
@@ -214,13 +214,9 @@ fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
         .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
 }
 
-/// The global refs this deployment's own management identity keeps.
-///
-/// A set the remote caller claims is dropped: once a sandbox is published remotely the caller
-/// drives those sessions, and leaving the same reach on the deployment's management identity is
-/// the second tenant the single-tenancy gate exists to prevent. The auto-generated profile gives
-/// a Frozen remote sandbox only `sandbox/heartbeat`, which reaches no session — an `extend`-mode
-/// profile is where this matters.
+/// The global refs this deployment's own management identity keeps. A set the remote caller
+/// claims is dropped — leaving the same reach on the management identity would be the second
+/// tenant the single-tenancy gate exists to prevent.
 fn global_permission_refs<'a>(
     ctx: &EmitContext<'_>,
     profile: &'a PermissionProfile,
@@ -512,12 +508,16 @@ fn resolve_permission_set(reference: &&PermissionSetReference) -> Option<Permiss
     reference.resolve(|name| alien_permissions::get_permission_set(name).cloned())
 }
 
+/// The one set compiled at stack scope onto the management identity.
+///
+/// Matched on a name from the built-in registry, never on `id()`: an inline set carries whatever
+/// id its author typed, so deciding by id would let one named after this set compile here.
 fn resolve_stack_management_permission_set(
     reference: &&PermissionSetReference,
 ) -> Option<PermissionSet> {
-    match reference.id() {
-        "worker/dispatch-command" => {
-            reference.resolve(|name| alien_permissions::get_permission_set(name).cloned())
+    match reference {
+        PermissionSetReference::Name(name) if name == "worker/dispatch-command" => {
+            alien_permissions::get_permission_set(name).cloned()
         }
         _ => None,
     }

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -15,7 +15,7 @@ use crate::{
     emitter::{TfEmitter, TfFragment},
     emitters::azure::helpers::{
         downcast, emit_remote_bindings_role_definitions, permission_context,
-        remote_bindings_role_label, required_label, resource_prefix_template, tags,
+        remote_bindings_role_label, required_label, tags,
     },
     expr,
 };
@@ -47,8 +47,16 @@ pub struct AzureSandboxEmitter;
 /// `local.resource_prefix` — the deployer's `var.resource_prefix` defaults to empty and is
 /// replaced by a generated one, so naming from the variable registers a group of `-<id>` while
 /// the management grant is scoped to the real one.
+///
+/// Normalized the way every other Azure resource names itself, for two reasons: a deployer's
+/// prefix may carry underscores and uppercase Azure rejects, and this is the form `PERMISSIONS.md`
+/// states as the grant's scope. A security team approves the grant from that document, so a name
+/// only the template knows would document a boundary they cannot check.
 fn sandbox_group(ctx: &EmitContext<'_>) -> Expression {
-    resource_prefix_template(&ctx.resource_id)
+    expr::raw(format!(
+        "replace(lower(\"${{local.resource_prefix}}-{}\"), \"_\", \"-\")",
+        ctx.resource_id
+    ))
 }
 
 /// The declared outbound policy, in the shape the binding carries.

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -29,8 +29,11 @@ use alien_permissions::{
 };
 use hcl::expr::Expression;
 
-/// The preview API version the sandbox group is created at. Pinned rather than floating: it is the
-/// only version the provider manifest lists, and a preview type's shape moves between them.
+/// The preview API version the sandbox group is created at.
+///
+/// Pinned rather than floating, and the same version the ARM and data-plane clients use: ARM still
+/// answers older previews, so a version that drifts here fails as a shape difference rather than
+/// as a rejected request.
 const SANDBOX_GROUP_TYPE: &str = "Microsoft.App/sandboxGroups@2026-02-01-preview";
 
 /// Emits the Azure sandbox group's identity for the runtime to address.
@@ -100,9 +103,10 @@ impl TfEmitter for AzureSandboxEmitter {
                 attr("tags", tags(ctx, "sandbox")),
                 // The azapi provider ships a bundled schema index and refuses a type it does not
                 // carry — `Microsoft.App/sandboxGroups can't be found` at validate. The type is
-                // real: it is in the live ARM provider manifest at this version and ARM creates
-                // one. So the index lags the service, and the check being disabled here is a
-                // client-side pre-check, not ARM's — which still validates the request at apply.
+                // real: the ARM provider manifest lists it at this version and ARM creates one, so
+                // the index lags the service. What is disabled is a client-side pre-check, not
+                // ARM's, which still validates the request at apply. Remove this once the azapi
+                // provider carries the type.
                 attr("schema_validation_enabled", Expression::Bool(false)),
             ],
         ));

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -29,11 +29,9 @@ use alien_permissions::{
 };
 use hcl::expr::Expression;
 
-/// The preview API version the sandbox group is created at.
-///
-/// Pinned rather than floating, and the same version the ARM and data-plane clients use: ARM still
-/// answers older previews, so a version that drifts here fails as a response mismatch rather than
-/// as a rejected request.
+/// The preview API version the sandbox group is created at. Must match the ARM and data-plane
+/// clients: ARM still answers older previews, so a version that drifts here fails as a response
+/// mismatch, not a rejected request.
 const SANDBOX_GROUP_TYPE: &str = "Microsoft.App/sandboxGroups@2026-02-01-preview";
 
 /// Emits the Azure sandbox group's identity for the runtime to address.
@@ -48,15 +46,20 @@ pub struct AzureSandboxEmitter;
 /// replaced by a generated one, so naming from the variable registers a group of `-<id>` while
 /// the management grant is scoped to the real one.
 ///
-/// Normalized the way every other Azure resource names itself, for two reasons: a deployer's
-/// prefix may carry underscores and uppercase Azure rejects, and this is the form `PERMISSIONS.md`
-/// states as the grant's scope. A security team approves the grant from that document, so a name
-/// only the template knows would document a boundary they cannot check.
+/// Normalized the way every other Azure resource names itself: a deployer's prefix may carry
+/// underscores and uppercase Azure rejects, and this is the form `PERMISSIONS.md` states as the
+/// grant's scope, which a security team approves the grant from.
 fn sandbox_group(ctx: &EmitContext<'_>) -> Expression {
-    expr::raw(format!(
-        "replace(lower(\"${{local.resource_prefix}}-{}\"), \"_\", \"-\")",
-        ctx.resource_id
-    ))
+    expr::raw(sandbox_group_expression(ctx.resource_id))
+}
+
+/// The same name as an interpolation, for a permission scope built as a string.
+fn sandbox_group_name(ctx: &EmitContext<'_>) -> String {
+    format!("${{{}}}", sandbox_group_expression(ctx.resource_id))
+}
+
+fn sandbox_group_expression(resource_id: &str) -> String {
+    format!("replace(lower(\"${{local.resource_prefix}}-{resource_id}\"), \"_\", \"-\")")
 }
 
 /// The declared outbound policy, in the shape the binding carries.
@@ -109,12 +112,9 @@ impl TfEmitter for AzureSandboxEmitter {
                     expr::object(Vec::<(&str, Expression)>::new()),
                 ),
                 attr("tags", tags(ctx, "sandbox")),
-                // The azapi provider ships a bundled schema index and refuses a type it does not
-                // carry — `Microsoft.App/sandboxGroups can't be found` at validate. The type is
-                // real: the ARM provider manifest lists it at this version and ARM creates one, so
-                // the index lags the service. What is disabled is a client-side pre-check, not
-                // ARM's, which still validates the request at apply. Remove this once the azapi
-                // provider carries the type.
+                // The azapi provider's bundled schema index doesn't carry this type yet, so validate
+                // fails with "can't be found" though ARM creates it fine. Only this client-side
+                // pre-check is disabled; remove once azapi's index catches up.
                 attr("schema_validation_enabled", Expression::Bool(false)),
             ],
         ));
@@ -174,10 +174,9 @@ impl TfEmitter for AzureSandboxEmitter {
 
 /// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
 ///
-/// Scoped to the group this emitter just created, and nothing wider. The role is a data-plane one
-/// covering `sandboxGroups/*` on whatever it is scoped to, so a resource-group scope would hand a
-/// remote caller every sibling sandbox in the deployment — the assignment names the group by
-/// reference so the scope cannot drift from the resource.
+/// Scoped to the group this emitter just created, and nothing wider: the role is a data-plane
+/// one covering `sandboxGroups/*` on whatever it's scoped to, so a resource-group scope would
+/// hand a remote caller every sibling sandbox in the deployment.
 fn emit_remote_access(ctx: &EmitContext<'_>, label: &str, fragment: &mut TfFragment) -> Result<()> {
     let (Some(definition), Some(access_label)) = (
         alien_core::remote_bindings::remote_binding_is_deliverable(ctx.resource)
@@ -197,7 +196,7 @@ fn emit_remote_access(ctx: &EmitContext<'_>, label: &str, fragment: &mut TfFragm
             })
         })?;
 
-    let context = permission_context(label).with_resource_name(ctx.resource_id.to_string());
+    let context = permission_context(label).with_resource_name(sandbox_group_name(ctx));
     let plan = AzureRuntimePermissionsGenerator::new()
         .generate_grant_plan(permission_set, BindingTarget::Resource, &context)
         .context(ErrorData::GenericError {
@@ -276,6 +275,41 @@ mod tests {
 
     fn binding_for(egress: SandboxEgress) -> String {
         binding_with(egress, None)
+    }
+
+    fn emit_for(lifecycle: ResourceLifecycle) -> TfFragment {
+        let stack = Stack::new("acme".to_string())
+            .add(
+                Sandbox::new("agents".to_string())
+                    .code(SandboxCode::Image {
+                        image: "ubuntu".to_string(),
+                    })
+                    .egress(SandboxEgress::Allow)
+                    .session(SandboxSessionPolicy {
+                        max_lifetime_seconds: None,
+                        idle_suspend_seconds: None,
+                    })
+                    .build(),
+                lifecycle,
+            )
+            .build();
+        let resource = stack
+            .resources
+            .get("agents")
+            .expect("the sandbox is in the stack");
+        let names = IndexMap::from([("agents".to_string(), "agents".to_string())]);
+        let settings = StackSettings::default();
+        let ctx = EmitContext {
+            stack: &stack,
+            resource,
+            resource_id: "agents",
+            platform: alien_core::Platform::Azure,
+            targets_kubernetes: false,
+            stack_settings: &settings,
+            names: &names,
+        };
+
+        AzureSandboxEmitter.emit(&ctx).expect("the sandbox renders")
     }
 
     fn binding_with(egress: SandboxEgress, idle_suspend_seconds: Option<u32>) -> String {
@@ -379,12 +413,16 @@ mod tests {
         };
         let keys = serde_json::to_value(&binding).expect("the binding serializes");
 
-        for key in keys.as_object().expect("an object").keys() {
-            assert!(
-                rendered.contains(&format!("{key} = ")),
-                "the emitter never writes '{key}': {rendered}"
-            );
-        }
+        let keys = keys.as_object().expect("an object");
+        assert!(!keys.is_empty(), "the binding serializes at least one key");
+        let missing: Vec<&String> = keys
+            .keys()
+            .filter(|key| !rendered.contains(&format!("{key} = ")))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "the emitter never writes {missing:?}: {rendered}"
+        );
     }
 
     /// The idle-suspend policy travels the same way, and only when it was declared.

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -19,9 +19,7 @@ use crate::{
     },
     expr,
 };
-use alien_core::{
-    import::EmitContext, ErrorData, RemoteBindings, Result, Sandbox, SandboxEgress,
-};
+use alien_core::{import::EmitContext, ErrorData, RemoteBindings, Result, Sandbox, SandboxEgress};
 use alien_error::{AlienError, Context};
 use alien_permissions::{
     generators::{AzureRoleDefinitionRef, AzureRuntimePermissionsGenerator},

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -32,7 +32,7 @@ use hcl::expr::Expression;
 /// The preview API version the sandbox group is created at.
 ///
 /// Pinned rather than floating, and the same version the ARM and data-plane clients use: ARM still
-/// answers older previews, so a version that drifts here fails as a shape difference rather than
+/// answers older previews, so a version that drifts here fails as a response mismatch rather than
 /// as a rejected request.
 const SANDBOX_GROUP_TYPE: &str = "Microsoft.App/sandboxGroups@2026-02-01-preview";
 

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -98,6 +98,15 @@ impl TfEmitter for AzureSandboxEmitter {
             ));
         }
 
+        // The data plane takes the ceilings at create and nowhere else, so a declaration that
+        // stops here is one the sandbox never hears about. Emitted only when declared: absent
+        // means the data plane's own default, which is not the same as asserting a size.
+        if let Some(limits) = sandbox.limits.as_ref() {
+            fields.push(("cpu", Expression::String(limits.cpu.clone())));
+            fields.push(("memory", Expression::String(limits.memory.clone())));
+            fields.push(("disk", Expression::String(limits.disk.clone())));
+        }
+
         Ok(Some(expr::object(fields)))
     }
 }
@@ -200,6 +209,9 @@ mod tests {
             egress: SandboxEgress::Allow,
             idle_suspend_seconds: Some(900),
             disk_image: BindingValue::Value("ubuntu".to_string()),
+            cpu: Some(BindingValue::Value("1000m".to_string())),
+            memory: Some(BindingValue::Value("2048Mi".to_string())),
+            disk: Some(BindingValue::Value("20480Mi".to_string())),
         };
         let keys = serde_json::to_value(&binding).expect("the binding serializes");
 

--- a/crates/alien-terraform/src/emitters/azure/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/azure/sandbox.rs
@@ -1,21 +1,37 @@
-//! Azure Sandbox — a named group, and nothing built at setup.
+//! Azure Sandbox — the group setup creates, and the remote grant scoped to it.
 //!
-//! No sandbox controller is registered for Azure, and `create_or_update_sandbox_group` has no
-//! caller, so nothing here creates the group a session lives in — it has to exist already. Setup
-//! emits no Azure resource for the same reason it would not be useful to: a group is cheap to
-//! create by name and pointless to hold open while no session wants one.
+//! Setup emits the group because a role assignment cannot name a resource that does not exist:
+//! Azure answers `ResourceNotFound` for a scope whose resource is absent, so a remote grant is
+//! only placeable if the same template that grants also creates. `Microsoft.App/sandboxGroups`
+//! gained an ARM representation at `2026-02-01-preview`, which is what makes that possible; it is
+//! reached through `azapi_resource` because the AzureRM provider has no typed resource for it.
 //!
-//! What this emitter contributes is the three names the data plane is addressed by, which the
-//! Azure client config does not carry: the group, the region that selects the per-region endpoint,
-//! and the resource group the data-plane path is scoped by.
+//! Beside the group this emitter contributes the three names the data plane is addressed by,
+//! which the Azure client config does not carry: the group, the region that selects the
+//! per-region endpoint, and the resource group the data-plane path is scoped by.
 
 use crate::{
+    block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
-    emitters::azure::helpers::{downcast, required_label, resource_prefix_template},
+    emitters::azure::helpers::{
+        downcast, emit_remote_bindings_role_definitions, permission_context,
+        remote_bindings_role_label, required_label, resource_prefix_template, tags,
+    },
     expr,
 };
-use alien_core::{import::EmitContext, Result, Sandbox, SandboxEgress};
+use alien_core::{
+    import::EmitContext, ErrorData, RemoteBindings, Result, Sandbox, SandboxEgress,
+};
+use alien_error::{AlienError, Context};
+use alien_permissions::{
+    generators::{AzureRoleDefinitionRef, AzureRuntimePermissionsGenerator},
+    BindingTarget,
+};
 use hcl::expr::Expression;
+
+/// The preview API version the sandbox group is created at. Pinned rather than floating: it is the
+/// only version the provider manifest lists, and a preview type's shape moves between them.
+const SANDBOX_GROUP_TYPE: &str = "Microsoft.App/sandboxGroups@2026-02-01-preview";
 
 /// Emits the Azure sandbox group's identity for the runtime to address.
 #[derive(Debug, Clone, Copy, Default)]
@@ -56,10 +72,43 @@ fn egress(sandbox: &Sandbox) -> Expression {
 }
 
 impl TfEmitter for AzureSandboxEmitter {
-    fn emit(&self, _ctx: &EmitContext<'_>) -> Result<TfFragment> {
-        // Deliberately empty: see the module note. A group emitted here would sit idle until a
-        // session asked for one, and it is addressed by name rather than by reference.
-        Ok(TfFragment::default())
+    fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
+        let _ = downcast::<Sandbox>(ctx, Sandbox::RESOURCE_TYPE)?;
+        let label = required_label(ctx)?;
+        let mut fragment = TfFragment::default();
+
+        fragment.resource_blocks.push(resource_block(
+            "azapi_resource",
+            label,
+            [
+                attr("type", Expression::String(SANDBOX_GROUP_TYPE.to_string())),
+                attr("name", sandbox_group(ctx)),
+                attr(
+                    "parent_id",
+                    expr::template(
+                        "/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}",
+                    ),
+                ),
+                attr("location", expr::raw("var.azure_location")),
+                // The group takes no configuration Alien expresses — sizing, egress and image are
+                // all per-session and travel in the create body — so the body is the empty object
+                // the API requires rather than a field this would have to keep in step.
+                attr(
+                    "body",
+                    expr::object(Vec::<(&str, Expression)>::new()),
+                ),
+                attr("tags", tags(ctx, "sandbox")),
+                // The azapi provider ships a bundled schema index and refuses a type it does not
+                // carry — `Microsoft.App/sandboxGroups can't be found` at validate. The type is
+                // real: it is in the live ARM provider manifest at this version and ARM creates
+                // one. So the index lags the service, and the check being disabled here is a
+                // client-side pre-check, not ARM's — which still validates the request at apply.
+                attr("schema_validation_enabled", Expression::Bool(false)),
+            ],
+        ));
+
+        emit_remote_access(ctx, label, &mut fragment)?;
+        Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
@@ -111,6 +160,100 @@ impl TfEmitter for AzureSandboxEmitter {
     }
 }
 
+/// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
+///
+/// Scoped to the group this emitter just created, and nothing wider. The role is a data-plane one
+/// covering `sandboxGroups/*` on whatever it is scoped to, so a resource-group scope would hand a
+/// remote caller every sibling sandbox in the deployment — the assignment names the group by
+/// reference so the scope cannot drift from the resource.
+fn emit_remote_access(ctx: &EmitContext<'_>, label: &str, fragment: &mut TfFragment) -> Result<()> {
+    let (Some(definition), Some(access_label)) = (
+        alien_core::remote_bindings::remote_binding_is_deliverable(ctx.resource)
+            .then(|| alien_core::remote_bindings::remote_binding_for_entry(ctx.resource))
+            .flatten(),
+        remote_bindings_label(ctx),
+    ) else {
+        return Ok(());
+    };
+    let permission_set = alien_permissions::get_permission_set(definition.permission_set)
+        .ok_or_else(|| {
+            AlienError::new(ErrorData::GenericError {
+                message: format!(
+                    "{} permission set is not registered",
+                    definition.permission_set
+                ),
+            })
+        })?;
+
+    let context = permission_context(label).with_resource_name(ctx.resource_id.to_string());
+    let plan = AzureRuntimePermissionsGenerator::new()
+        .generate_grant_plan(permission_set, BindingTarget::Resource, &context)
+        .context(ErrorData::GenericError {
+            message: "failed to generate Azure remote Sandbox permissions".to_string(),
+        })?;
+
+    emit_remote_bindings_role_definitions(fragment, permission_set)?;
+    for (index, binding) in plan.bindings.iter().enumerate() {
+        let role_definition_id = match &binding.role_definition {
+            AzureRoleDefinitionRef::Predefined { role_definition_id } => {
+                expr::template(role_definition_id.clone())
+            }
+            AzureRoleDefinitionRef::Custom { key } => {
+                let custom_index = plan
+                    .custom_roles
+                    .iter()
+                    .position(|role| &role.key == key)
+                    .ok_or_else(|| {
+                        AlienError::new(ErrorData::GenericError {
+                            message: format!("missing generated Azure role '{key}'"),
+                        })
+                    })?;
+                let role_label = remote_bindings_role_label(&binding.role_name, custom_index);
+                expr::traversal([
+                    "azurerm_role_definition",
+                    role_label.as_str(),
+                    "role_definition_resource_id",
+                ])
+            }
+        };
+        fragment.resource_blocks.push(resource_block(
+            "azurerm_role_assignment",
+            &format!("{label}_access_{index}"),
+            [
+                attr(
+                    "name",
+                    expr::raw(format!(
+                        "uuidv5(\"oid\", \"deployment:azure:sandbox-access:${{local.resource_prefix}}:{label}:{index}\")"
+                    )),
+                ),
+                // The created group rather than the rendered scope string: both spell the same
+                // name, and referencing it is what orders the assignment after the group Azure
+                // refuses to grant on before it exists.
+                attr("scope", expr::traversal(["azapi_resource", label, "id"])),
+                attr("role_definition_id", role_definition_id),
+                attr(
+                    "principal_id",
+                    expr::traversal([
+                        "azurerm_user_assigned_identity",
+                        access_label,
+                        "principal_id",
+                    ]),
+                ),
+            ],
+        ));
+    }
+
+    Ok(())
+}
+
+fn remote_bindings_label<'a>(ctx: &'a EmitContext<'_>) -> Option<&'a str> {
+    ctx.stack.resources().find_map(|(id, entry)| {
+        (entry.config.resource_type() == RemoteBindings::RESOURCE_TYPE)
+            .then(|| ctx.name_for(id))
+            .flatten()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,6 +272,15 @@ mod tests {
                 Sandbox::new("agents".to_string())
                     .code(SandboxCode::Image {
                         image: "ubuntu".to_string(),
+                    })
+                    // Declared, so the ceilings are in the rendered binding: Azure takes them at
+                    // create and nowhere else, and the key-coverage assertion below is what pins
+                    // that they travel under the names the binding deserializes.
+                    .limits(alien_core::SandboxLimits {
+                        cpu: "1000m".to_string(),
+                        memory: "2048Mi".to_string(),
+                        disk: "20480Mi".to_string(),
+                        max_processes: None,
                     })
                     .egress(egress)
                     .session(SandboxSessionPolicy {

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -617,7 +617,7 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
                     append_permission_entry(
                         &mut lines,
                         entry.description.as_deref(),
-                        entry.grant.actions.as_deref(),
+                        &code_spans(entry.grant.actions.as_deref()),
                         entry.binding.resource.as_ref().map(|binding| {
                             permission_doc_scope(&binding.resources.join(", "), target, resource_id)
                         }),
@@ -629,7 +629,7 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
                     append_permission_entry(
                         &mut lines,
                         entry.description.as_deref(),
-                        entry.grant.permissions.as_deref(),
+                        &code_spans(entry.grant.permissions.as_deref()),
                         entry.binding.resource.as_ref().map(|binding| {
                             permission_doc_scope(&binding.scope, target, resource_id)
                         }),
@@ -652,13 +652,23 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
                         .predefined_roles
                         .iter()
                         .flatten()
-                        .map(|role| format!("{role} (role)"))
+                        // The annotation sits outside the code span: a reader has to be able to
+                        // tell the role's real name from a note about it, and this is the
+                        // strongest grant in the package.
+                        .map(|role| format!("`{role}` (built-in role)"))
                         .collect();
-                    granted.extend(entry.grant.data_actions.iter().flatten().cloned());
+                    granted.extend(
+                        entry
+                            .grant
+                            .data_actions
+                            .iter()
+                            .flatten()
+                            .map(|action| format!("`{action}`")),
+                    );
                     append_permission_entry(
                         &mut lines,
                         entry.description.as_deref(),
-                        Some(&granted),
+                        &granted,
                         entry.binding.resource.as_ref().map(|binding| {
                             permission_doc_scope(&binding.scope, target, resource_id)
                         }),
@@ -690,10 +700,21 @@ fn permission_doc_scope(scope: &str, target: TerraformTarget, resource_id: &str)
         )
 }
 
+/// Wraps each name in a code span, for the callers whose entries are names and nothing else.
+fn code_spans(permissions: Option<&[String]>) -> Vec<String> {
+    permissions
+        .unwrap_or_default()
+        .iter()
+        .map(|permission| format!("`{permission}`"))
+        .collect()
+}
+
+/// `permissions` arrives already rendered as markdown, so a caller can annotate an entry outside
+/// its code span rather than inside the name.
 fn append_permission_entry(
     lines: &mut Vec<String>,
     description: Option<&str>,
-    permissions: Option<&[String]>,
+    permissions: &[String],
     scope: Option<String>,
 ) {
     if let Some(description) = description {
@@ -702,8 +723,8 @@ fn append_permission_entry(
     if let Some(scope) = scope {
         lines.push(format!("  Scope: `{scope}`"));
     }
-    for permission in permissions.unwrap_or_default() {
-        lines.push(format!("  - `{permission}`"));
+    for permission in permissions {
+        lines.push(format!("  - {permission}"));
     }
 }
 
@@ -3314,6 +3335,16 @@ fn readme_md(
     } else {
         ""
     };
+    // The two things an Azure platform approver stops on -- a preview API version and a provider
+    // check turned off -- with the reason in the artifact rather than only in Alien's source.
+    let azure_sandbox_note = if target.cloud_platform() == alien_core::Platform::Azure
+        && stack.resources().any(|(_, entry)| {
+            entry.config.resource_type() == alien_core::Sandbox::RESOURCE_TYPE
+        }) {
+        "\n\n## The sandbox group\n\nThe sandbox group is created through the `azapi` provider at a pinned preview API version, because the AzureRM provider has no typed resource for `Microsoft.App/sandboxGroups`. That resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.\n\nThe subscription must have the `Microsoft.App` resource provider registered."
+    } else {
+        ""
+    };
     let inputs = input_sections.join("\n\n");
     format!(
         "# Deployment setup - {display_name}\n\n\
@@ -3332,7 +3363,7 @@ Use your organization's normal backend and approval workflow. A typical local re
 - `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.\n\
 - `deployment_input_values`: deployer input values JSON, emitted only when the stack declares deployer inputs.\n\
 - `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.\
-{kubernetes_operations}{retained_key_operations}",
+{kubernetes_operations}{retained_key_operations}{azure_sandbox_note}",
         display_name = display_name,
         target = target.name(),
         inputs = inputs,
@@ -3340,7 +3371,8 @@ Use your organization's normal backend and approval workflow. A typical local re
         runtime_sandbox_note = runtime_sandbox_note,
         registration_note = registration_note,
         kubernetes_operations = kubernetes_operations,
-        retained_key_operations = retained_key_operations
+        retained_key_operations = retained_key_operations,
+        azure_sandbox_note = azure_sandbox_note
     )
 }
 

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -344,9 +344,9 @@ pub fn generate_terraform_module(
         target.is_kubernetes() && has_resource_type(&per_resource, "kubernetes_manifest");
     let include_helm_provider =
         target.is_kubernetes() && options.registration.is_some() && options.helm_install.is_some();
-    // All three azapi resource kinds, not only the two that happened to exist first: the sandbox
-    // group is a plain `azapi_resource`, and a missing provider block fails at `terraform init`
-    // rather than at plan, which reads as a broken package rather than a missing declaration.
+    // All three azapi resource kinds: the sandbox group is a plain `azapi_resource`, and a
+    // missing provider block fails at `terraform init` rather than at plan, which reads as a
+    // broken package rather than a missing declaration.
     let include_azapi_provider = has_resource_type(&per_resource, "azapi_update_resource")
         || has_resource_type(&per_resource, "azapi_resource_action")
         || has_resource_type(&per_resource, "azapi_resource");
@@ -593,7 +593,7 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
     let mut lines = vec![
         "# Application access permissions".to_string(),
         String::new(),
-        "The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive Alien's management permissions.".to_string(),
+        "The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.".to_string(),
     ];
     for (resource_id, definition) in resources {
         lines.extend([
@@ -643,10 +643,22 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
                     .as_deref()
                     .unwrap_or_default()
                 {
+                    // Roles and data actions together: an Azure grant may carry either, and a
+                    // set granting only a predefined role would otherwise render as a heading
+                    // with nothing under it — the strongest grant in the package documented as
+                    // if it were empty.
+                    let mut granted: Vec<String> = entry
+                        .grant
+                        .predefined_roles
+                        .iter()
+                        .flatten()
+                        .map(|role| format!("{role} (role)"))
+                        .collect();
+                    granted.extend(entry.grant.data_actions.iter().flatten().cloned());
                     append_permission_entry(
                         &mut lines,
                         entry.description.as_deref(),
-                        entry.grant.data_actions.as_deref(),
+                        Some(&granted),
                         entry.binding.resource.as_ref().map(|binding| {
                             permission_doc_scope(&binding.scope, target, resource_id)
                         }),
@@ -1177,7 +1189,12 @@ fn versions_body(
             provider_decl_attr("hashicorp/azurerm", ">= 3.100, < 5.0"),
         ));
         if include_azapi_provider {
-            provider_attrs.push(attr("azapi", provider_decl_attr("Azure/azapi", ">= 2.6")));
+            // Bounded for the same reason as azurerm, and more sharply: the sandbox group is a
+            // preview type whose `body` shape a major bump is free to move.
+            provider_attrs.push(attr(
+                "azapi",
+                provider_decl_attr("Azure/azapi", ">= 2.6, < 3.0"),
+            ));
         }
     }
     if include_time_provider {

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -581,8 +581,11 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
         .resources()
         .filter_map(|(resource_id, entry)| {
             // The document a security team approves the grant from, so it lists only bindings the
-            // module actually installs a policy for.
-            alien_core::remote_bindings::remote_binding_is_deliverable(entry)
+            // module actually installs a policy for. A Kubernetes target skips sandbox emission
+            // altogether, so a sandbox entry here would document a grant it never installs.
+            let skipped = target.is_kubernetes()
+                && entry.config.resource_type() == alien_core::Sandbox::RESOURCE_TYPE;
+            (!skipped && alien_core::remote_bindings::remote_binding_is_deliverable(entry))
                 .then(|| alien_core::remote_bindings::remote_binding_for_entry(entry))
                 .flatten()
                 .map(|definition| (resource_id, definition))
@@ -645,10 +648,9 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
                     .as_deref()
                     .unwrap_or_default()
                 {
-                    // Roles and data actions together: an Azure grant may carry either, and a
-                    // set granting only a predefined role would otherwise render as a heading
-                    // with nothing under it — the strongest grant in the package documented as
-                    // if it were empty.
+                    // Roles and data actions together: an Azure grant may carry either, and a set
+                    // granting only a predefined role would otherwise render as a heading with
+                    // nothing under it — the strongest grant in the package documented as empty.
                     let mut granted: Vec<String> = entry
                         .grant
                         .predefined_roles
@@ -3282,8 +3284,8 @@ fn readme_md(
         };
         format!(
             "\nA completed apply installs the sandbox's {scaffolding} but not the sandbox image \
-             itself. The image is built after the deployment registers; the deployment's status \
-             in Alien reports when the sandbox can accept sessions.\n"
+             itself. The image is built after the deployment registers, and the deployment's \
+             status reports when the sandbox can accept sessions.\n"
         )
     };
 
@@ -3337,16 +3339,16 @@ fn readme_md(
     } else {
         ""
     };
-    // The two things an Azure platform approver stops on -- a preview API version and a provider
-    // check turned off -- with the reason in the artifact rather than only in Alien's source.
-    // Keyed off what was actually emitted, not off the platform: an AKS target is
-    // `Platform::Azure` but skips sandbox emission entirely, so a platform test would document
-    // an `azapi` resource, a preview API and a provider prerequisite that package does not have.
+    // The two things an Azure approver stops on — a preview API version and a validation check
+    // turned off — documented in the artifact, not only in the source. Keyed off what was
+    // emitted, not the platform: an AKS target is `Platform::Azure` but skips sandbox emission
+    // entirely.
     let azure_sandbox_note = if emits_azapi_resource
-        && stack.resources().any(|(_, entry)| {
-            entry.config.resource_type() == alien_core::Sandbox::RESOURCE_TYPE
-        }) {
-        "## The sandbox group\n\nThe sandbox group is created through the `azapi` provider at `Microsoft.App/sandboxGroups@2026-02-01-preview`, because the AzureRM provider has no typed resource for it. Being a preview API, its shape and regional availability can change.\n\nThat resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.\n\nThe subscription must have the `Microsoft.App` resource provider registered before you apply:\n\n```bash\naz provider register --namespace Microsoft.App\n```\n\nAt teardown the deployment runtime deletes the sandbox group before you run `terraform destroy`, so this resource leaves your state without Terraform removing it.\n\n"
+        && stack
+            .resources()
+            .any(|(_, entry)| entry.config.resource_type() == alien_core::Sandbox::RESOURCE_TYPE)
+    {
+        "## The sandbox group\n\nThe sandbox group is created through the `azapi` provider at `Microsoft.App/sandboxGroups@2026-02-01-preview`, because the AzureRM provider has no typed resource for it. Being a preview API, its shape and regional availability can change.\n\nThat resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.\n\nThe subscription must have the `Microsoft.App` resource provider registered before you apply:\n\n```bash\naz provider register --namespace Microsoft.App\n```\n\n`terraform destroy` removes the group, and removing it deletes every sandbox inside it.\n\n"
     } else {
         ""
     };

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -344,8 +344,12 @@ pub fn generate_terraform_module(
         target.is_kubernetes() && has_resource_type(&per_resource, "kubernetes_manifest");
     let include_helm_provider =
         target.is_kubernetes() && options.registration.is_some() && options.helm_install.is_some();
+    // All three azapi resource kinds, not only the two that happened to exist first: the sandbox
+    // group is a plain `azapi_resource`, and a missing provider block fails at `terraform init`
+    // rather than at plan, which reads as a broken package rather than a missing declaration.
     let include_azapi_provider = has_resource_type(&per_resource, "azapi_update_resource")
-        || has_resource_type(&per_resource, "azapi_resource_action");
+        || has_resource_type(&per_resource, "azapi_resource_action")
+        || has_resource_type(&per_resource, "azapi_resource");
     // Cloud Control, for AWS APIs the main provider has not caught up with. Keyed off what was
     // actually emitted, so a stack without one of those resources is unchanged.
     // Keyed off the connector, not the image: the image is a Cloud Control resource from the

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -347,9 +347,10 @@ pub fn generate_terraform_module(
     // All three azapi resource kinds: the sandbox group is a plain `azapi_resource`, and a
     // missing provider block fails at `terraform init` rather than at plan, which reads as a
     // broken package rather than a missing declaration.
+    let emits_azapi_resource = has_resource_type(&per_resource, "azapi_resource");
     let include_azapi_provider = has_resource_type(&per_resource, "azapi_update_resource")
         || has_resource_type(&per_resource, "azapi_resource_action")
-        || has_resource_type(&per_resource, "azapi_resource");
+        || emits_azapi_resource;
     // Cloud Control, for AWS APIs the main provider has not caught up with. Keyed off what was
     // actually emitted, so a stack without one of those resources is unchanged.
     // Keyed off the connector, not the image: the image is a Cloud Control resource from the
@@ -502,6 +503,7 @@ pub fn generate_terraform_module(
             options.helm_install.as_ref(),
             &stack_inputs,
             retained_key_detach.is_some(),
+            emits_azapi_resource,
         ),
     );
 
@@ -3233,6 +3235,7 @@ fn readme_md(
     helm_install: Option<&TerraformHelmInstall>,
     stack_inputs: &[StackInputDefinition],
     has_retained_keys: bool,
+    emits_azapi_resource: bool,
 ) -> String {
     let required_env = if registration.is_some() {
         "export TF_VAR_token=\"...\"".to_string()
@@ -3337,11 +3340,14 @@ fn readme_md(
     };
     // The two things an Azure platform approver stops on -- a preview API version and a provider
     // check turned off -- with the reason in the artifact rather than only in Alien's source.
-    let azure_sandbox_note = if target.cloud_platform() == alien_core::Platform::Azure
+    // Keyed off what was actually emitted, not off the platform: an AKS target is
+    // `Platform::Azure` but skips sandbox emission entirely, so a platform test would document
+    // an `azapi` resource, a preview API and a provider prerequisite that package does not have.
+    let azure_sandbox_note = if emits_azapi_resource
         && stack.resources().any(|(_, entry)| {
             entry.config.resource_type() == alien_core::Sandbox::RESOURCE_TYPE
         }) {
-        "\n\n## The sandbox group\n\nThe sandbox group is created through the `azapi` provider at a pinned preview API version, because the AzureRM provider has no typed resource for `Microsoft.App/sandboxGroups`. That resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.\n\nThe subscription must have the `Microsoft.App` resource provider registered."
+        "## The sandbox group\n\nThe sandbox group is created through the `azapi` provider at `Microsoft.App/sandboxGroups@2026-02-01-preview`, because the AzureRM provider has no typed resource for it. Being a preview API, its shape and regional availability can change.\n\nThat resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.\n\nThe subscription must have the `Microsoft.App` resource provider registered before you apply:\n\n```bash\naz provider register --namespace Microsoft.App\n```\n\nAt teardown the deployment runtime deletes the sandbox group before you run `terraform destroy`, so this resource leaves your state without Terraform removing it.\n\n"
     } else {
         ""
     };
@@ -3352,7 +3358,7 @@ Target: `{target}`.\n\n\
 This module creates setup-owned infrastructure, grants the management access needed after setup, and prepares deployment registration metadata. Review the generated `.tf` files before applying; each resource file maps to one setup resource.\n\n\
 ## Inputs\n\n\
 {inputs}\n\n\
-## Run\n\n\
+{azure_sandbox_note}## Run\n\n\
 Use your organization's normal backend and approval workflow. A typical local review looks like:\n\n\
 ```bash\n{required_env}\nterraform init\nterraform validate\nterraform plan -out=tfplan\nterraform apply tfplan\n```\n{runtime_sandbox_note}\n\
 ## Registration\n\n\
@@ -3363,7 +3369,7 @@ Use your organization's normal backend and approval workflow. A typical local re
 - `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.\n\
 - `deployment_input_values`: deployer input values JSON, emitted only when the stack declares deployer inputs.\n\
 - `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.\
-{kubernetes_operations}{retained_key_operations}{azure_sandbox_note}",
+{kubernetes_operations}{retained_key_operations}",
         display_name = display_name,
         target = target.name(),
         inputs = inputs,

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -655,8 +655,7 @@ fn remote_bindings_permissions_md(stack: &Stack, target: TerraformTarget) -> Opt
                         .iter()
                         .flatten()
                         // The annotation sits outside the code span: a reader has to be able to
-                        // tell the role's real name from a note about it, and this is the
-                        // strongest grant in the package.
+                        // tell the role's real name from a note about it.
                         .map(|role| format!("`{role}` (built-in role)"))
                         .collect();
                     granted.extend(
@@ -1213,7 +1212,7 @@ fn versions_body(
         ));
         if include_azapi_provider {
             // Bounded for the same reason as azurerm, and more sharply: the sandbox group is a
-            // preview type whose `body` shape a major bump is free to move.
+            // preview type, and a major bump is free to change what `body` accepts.
             provider_attrs.push(attr(
                 "azapi",
                 provider_decl_attr("Azure/azapi", ">= 2.6, < 3.0"),

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -706,16 +706,30 @@ fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
         .build();
 
     let module = render(&stack, TerraformTarget::Azure, StackSettings::default());
-    let rendered = module
-        .files
-        .values()
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("\n");
 
-    assert!(
-        rendered.contains(r#"resource "azapi_resource" "agents""#),
-        "the sandbox group must render:\n{rendered}"
+    // The claim this shape is here to pin: with no other resource declared there is no resource
+    // group of Alien's own to parent to, so the group must hang off the one the deployer names.
+    // A reference to a resource this stack does not create would fail `terraform validate` below,
+    // but a *wrong variable* would not — so the attribute is read rather than searched for.
+    let parent_id = module
+        .files
+        .get("agents.tf")
+        .expect("the sandbox group renders into its own file")
+        .lines()
+        .find_map(|line| {
+            let normalized = line.split_whitespace().collect::<Vec<_>>();
+            match normalized.split_first() {
+                Some((first, rest)) if *first == "parent_id" && rest.first() == Some(&"=") => {
+                    Some(rest[1..].join(" "))
+                }
+                _ => None,
+            }
+        })
+        .expect("the group carries a parent_id");
+    assert_eq!(
+        parent_id,
+        "\"/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}\""
     );
+
     assert_terraform_valid(&module, "azure remote sandbox alone");
 }

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -665,9 +665,18 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
         scope, "azapi_resource.agents.id",
         "the grant must be scoped to the created group by reference, and nothing wider"
     );
-    assert!(
-        assignment.contains("azurerm_user_assigned_identity.access.principal_id"),
-        "the grant belongs to the Remote Bindings identity, not the deployment's own:\n{assignment}"
+    // Extracted like the scope rather than searched for: a `contains` would also pass on an
+    // identity whose name merely starts with this one.
+    let principal_id = assignment
+        .split("principal_id = ")
+        .nth(1)
+        .expect("the assignment names a principal")
+        .split(' ')
+        .next()
+        .expect("the principal is one token");
+    assert_eq!(
+        principal_id, "azurerm_user_assigned_identity.access.principal_id",
+        "the grant belongs to the Remote Bindings identity, not the deployment's own"
     );
 
     // `terraform init` is what proves the azapi provider block was emitted: an `azapi_resource`
@@ -685,6 +694,49 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
 /// resource group, and this pins that it resolves to the deployer-supplied
 /// `var.azure_resource_group_name` rather than to a resource the module would have had to
 /// declare. `terraform validate` is as far as this reaches — it does not prove apply.
+/// An AKS target is `Platform::Azure` but skips sandbox emission, so a note keyed off the platform
+/// would tell that installer to register a provider for a resource their package does not contain.
+#[test]
+fn an_aks_package_is_not_told_about_a_sandbox_group_it_does_not_get() {
+    let sandbox = Sandbox::new("agents".to_string())
+        .code(SandboxCode::Image {
+            image: "ubuntu".to_string(),
+        })
+        .egress(SandboxEgress::Allow)
+        .session(SandboxSessionPolicy {
+            max_lifetime_seconds: None,
+            idle_suspend_seconds: None,
+        })
+        .build();
+    let stack = Stack::new("byo-sandbox".to_string())
+        .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    for (target, expects_group) in [
+        (TerraformTarget::Aks, false),
+        (TerraformTarget::Azure, true),
+    ] {
+        let module = render(&stack, target, StackSettings::default());
+        let emitted_group = module
+            .iter()
+            .any(|(_, contents)| contents.contains("azapi_resource\" \"agents\""));
+        let readme = module.get("README.md").expect("every package has a README");
+        assert_eq!(
+            emitted_group, expects_group,
+            "{target:?} emits the sandbox group"
+        );
+        assert_eq!(
+            readme.contains("## The sandbox group"),
+            expects_group,
+            "the README documents the group exactly when the package contains one:\n{readme}"
+        );
+    }
+}
+
 #[test]
 fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
     let sandbox = Sandbox::new("agents".to_string())

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -688,12 +688,6 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
 }
 
 
-/// A remote sandbox renders on its own, with no other resource declared.
-///
-/// The shape worth checking is a bindings-only stack: the sandbox group's `parent_id` names a
-/// resource group, and this pins that it resolves to the deployer-supplied
-/// `var.azure_resource_group_name` rather than to a resource the module would have had to
-/// declare. `terraform validate` is as far as this reaches — it does not prove apply.
 /// An AKS target is `Platform::Azure` but skips sandbox emission, so a note keyed off the platform
 /// would tell that installer to register a provider for a resource their package does not contain.
 #[test]
@@ -737,6 +731,11 @@ fn an_aks_package_is_not_told_about_a_sandbox_group_it_does_not_get() {
     }
 }
 
+/// A remote sandbox renders on its own, with no other resource declared.
+///
+/// A bindings-only stack is what makes `parent_id` worth pinning: it must resolve to the
+/// deployer-supplied `var.azure_resource_group_name` rather than to a resource group the module
+/// would have had to declare. `terraform validate` is as far as this reaches — not apply.
 #[test]
 fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
     let sandbox = Sandbox::new("agents".to_string())
@@ -759,7 +758,7 @@ fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
 
     let module = render(&stack, TerraformTarget::Azure, StackSettings::default());
 
-    // The claim this shape is here to pin: with no other resource declared there is no resource
+    // The claim this test is here to pin: with no other resource declared there is no resource
     // group of Alien's own to parent to, so the group must hang off the one the deployer names.
     // A reference to a resource this stack does not create would fail `terraform validate` below,
     // but a *wrong variable* would not — so the attribute is read rather than searched for.

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -15,7 +15,8 @@ use super::helpers::{assert_terraform_valid, render, snapshot_module};
 use alien_core::{
     Ai, AzureResourceGroup, AzureServiceBusNamespace, AzureStorageAccount, Key, Kv, LifecycleRule,
     PermissionProfile, Queue, RemoteBindings, RemoteStackManagement, ResourceLifecycle,
-    ResourceRef, ServiceAccount, Stack, StackSettings, Storage, Vault,
+    ResourceRef, Sandbox, SandboxCode, SandboxEgress, SandboxSessionPolicy, ServiceAccount, Stack,
+    StackSettings, Storage, Vault,
 };
 use alien_terraform::{generate_terraform_module, TerraformOptions, TerraformTarget, TfRegistry};
 
@@ -538,4 +539,140 @@ fn azure_remote_ai_setup_does_not_request_application_vnet_access() {
         "a bindings-only setup must not grant its management identity access to the application VNet"
     );
     assert_terraform_valid(&module, "azure_remote_ai_setup_without_vnet_reader");
+}
+
+
+/// The remote sandbox grant reaches one group and nothing wider, and the group exists to be
+/// granted on.
+///
+/// Both halves matter and neither is provable alone. Azure refuses a role assignment scoped to a
+/// resource that does not exist, so a grant is only placeable because setup creates the group in
+/// the same module — which is why the scope is asserted as a *reference* to that resource rather
+/// than as a rendered path: a literal would render identically today and silently lose the
+/// ordering the reference creates.
+///
+/// The width is the security half. `Container Apps SandboxGroup Data Owner` covers
+/// `sandboxGroups/*` on whatever it is scoped to, so a resource-group or subscription scope would
+/// hand a remote caller every sibling sandbox in the deployment.
+#[test]
+fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wider() {
+    let sandbox = Sandbox::new("agents".to_string())
+        .code(SandboxCode::Image {
+            image: "ubuntu".to_string(),
+        })
+        .egress(SandboxEgress::Allow)
+        .session(SandboxSessionPolicy {
+            max_lifetime_seconds: None,
+            idle_suspend_seconds: None,
+        })
+        .build();
+    let stack = Stack::new("byo-sandbox".to_string())
+        .add(resource_group(), ResourceLifecycle::Frozen)
+        .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Azure, StackSettings::default());
+    let rendered = module
+        .files
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Setup creates the group, at the pinned preview version.
+    assert!(
+        rendered.contains(r#"resource "azapi_resource" "agents""#),
+        "setup must create the sandbox group it grants on:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Microsoft.App/sandboxGroups@2026-02-01-preview"),
+        "the group is created at the pinned preview version:\n{rendered}"
+    );
+
+    let assignment = rendered
+        .split(r#"resource "azurerm_role_assignment" "agents_access_0""#)
+        .nth(1)
+        .expect("the remote grant attaches to the Remote Bindings identity")
+        .split("\nresource ")
+        .next()
+        .expect("block ends");
+    // HCL pads `=` to align an attribute with its siblings, so the column an assertion would
+    // match on moves whenever a neighbouring attribute is added or renamed.
+    let assignment = assignment
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let assignment = assignment.as_str();
+
+    // The scope attribute itself, not merely a mention of the group somewhere in the block: the
+    // resource group legitimately appears in `depends_on`, so a substring search over the whole
+    // assignment would pass on a scope that reached the entire group.
+    let scope = assignment
+        .split("scope = ")
+        .nth(1)
+        .expect("the assignment carries a scope")
+        .split(' ')
+        .next()
+        .expect("the scope is one token");
+
+    // A reference, not a path. This is what orders the assignment after the group Azure refuses
+    // to grant on before it exists.
+    assert_eq!(
+        scope, "azapi_resource.agents.id",
+        "the grant must be scoped to the created group by reference, and nothing wider"
+    );
+    assert!(
+        assignment.contains("azurerm_user_assigned_identity.access.principal_id"),
+        "the grant belongs to the Remote Bindings identity, not the deployment's own:\n{assignment}"
+    );
+
+    // `terraform init` is what proves the azapi provider block was emitted: an `azapi_resource`
+    // without one fails at init, not at plan.
+    assert_terraform_valid(&module, "azure remote sandbox");
+}
+
+
+/// A remote sandbox is deployable on its own, with no other resource declared.
+///
+/// The failing shape is a bindings-only stack: the sandbox group's `parent_id` names a resource
+/// group, so if nothing pulls that resource group into the module the package renders and then
+/// fails at apply against a resource group that does not exist. Asserted by rendering the stack a
+/// vendor publishing only a sandbox would actually get.
+#[test]
+fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
+    let sandbox = Sandbox::new("agents".to_string())
+        .code(SandboxCode::Image {
+            image: "ubuntu".to_string(),
+        })
+        .egress(SandboxEgress::Allow)
+        .session(SandboxSessionPolicy {
+            max_lifetime_seconds: None,
+            idle_suspend_seconds: None,
+        })
+        .build();
+    let stack = Stack::new("byo-sandbox".to_string())
+        .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Azure, StackSettings::default());
+    let rendered = module
+        .files
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        rendered.contains(r#"resource "azapi_resource" "agents""#),
+        "the sandbox group must render:\n{rendered}"
+    );
+    assert_terraform_valid(&module, "azure remote sandbox alone");
 }

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -583,15 +583,55 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
         .collect::<Vec<_>>()
         .join("\n");
 
-    // Setup creates the group, at the pinned preview version.
+    // The scope PERMISSIONS.md documents has to name the group the module creates. A security
+    // team approves the grant from that document and cannot see the traversal the assignment
+    // actually uses, so a scope that renders to a different name -- or to an unsubstituted
+    // template token -- shows them a boundary the deployment does not have.
+    let group_name = module
+        .files
+        .get("agents.tf")
+        .expect("the sandbox group renders into its own file")
+        .lines()
+        // HCL pads `=` to align an attribute with its siblings, so match on the token.
+        .find_map(|line| line.split_whitespace().collect::<Vec<_>>().split_first().and_then(
+            |(first, rest)| (*first == "name" && rest.first() == Some(&"=")).then(|| rest[1..].join(" ")),
+        ))
+        .expect("the group carries a name");
+    let documented_scope = module
+        .files
+        .get("PERMISSIONS.md")
+        .expect("a remote binding publishes a permissions document")
+        .lines()
+        .find(|line| line.trim_start().starts_with("Scope:"))
+        .expect("the document states the grant's scope")
+        .to_string();
     assert!(
-        rendered.contains(r#"resource "azapi_resource" "agents""#),
-        "setup must create the sandbox group it grants on:\n{rendered}"
+        documented_scope.ends_with(&format!("/Microsoft.App/sandboxGroups/${{{group_name}}}`")),
+        "the documented scope must end at the created group.\n  documented: {documented_scope}\n  \
+         group name: {group_name}"
     );
-    assert!(
-        rendered.contains("Microsoft.App/sandboxGroups@2026-02-01-preview"),
-        "the group is created at the pinned preview version:\n{rendered}"
-    );
+    // Terraform's own interpolations survive into the document by design; a permission-set token
+    // does not. One left behind renders a scope that resolves to nothing, and the document is the
+    // only place a reader would ever see it.
+    let permissions_md = module
+        .files
+        .get("PERMISSIONS.md")
+        .expect("a remote binding publishes a permissions document");
+    for token in [
+        "${stackPrefix}",
+        "${resourceName}",
+        "${subscriptionId}",
+        "${resourceGroup}",
+        "${projectName}",
+        "${awsRegion}",
+        "${awsAccountId}",
+        "${storageAccountName}",
+    ] {
+        assert!(
+            !permissions_md.contains(token),
+            "{token} reached the approver's document unsubstituted:\n{permissions_md}"
+        );
+    }
 
     let assignment = rendered
         .split(r#"resource "azurerm_role_assignment" "agents_access_0""#)

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -633,15 +633,18 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
     // `terraform init` is what proves the azapi provider block was emitted: an `azapi_resource`
     // without one fails at init, not at plan.
     assert_terraform_valid(&module, "azure remote sandbox");
+    // The module as a whole, so the artifact an approver reads is the thing CI compares — the
+    // group's body and tags, the provider block, and the rendered PERMISSIONS.md.
+    snapshot_module("azure_remote_sandbox", &module);
 }
 
 
-/// A remote sandbox is deployable on its own, with no other resource declared.
+/// A remote sandbox renders on its own, with no other resource declared.
 ///
-/// The failing shape is a bindings-only stack: the sandbox group's `parent_id` names a resource
-/// group, so if nothing pulls that resource group into the module the package renders and then
-/// fails at apply against a resource group that does not exist. Asserted by rendering the stack a
-/// vendor publishing only a sandbox would actually get.
+/// The shape worth checking is a bindings-only stack: the sandbox group's `parent_id` names a
+/// resource group, and this pins that it resolves to the deployer-supplied
+/// `var.azure_resource_group_name` rather than to a resource the module would have had to
+/// declare. `terraform validate` is as far as this reaches — it does not prove apply.
 #[test]
 fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
     let sandbox = Sandbox::new("agents".to_string())

--- a/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_data_layer_tests.rs
@@ -541,19 +541,11 @@ fn azure_remote_ai_setup_does_not_request_application_vnet_access() {
     assert_terraform_valid(&module, "azure_remote_ai_setup_without_vnet_reader");
 }
 
-
 /// The remote sandbox grant reaches one group and nothing wider, and the group exists to be
-/// granted on.
-///
-/// Both halves matter and neither is provable alone. Azure refuses a role assignment scoped to a
-/// resource that does not exist, so a grant is only placeable because setup creates the group in
-/// the same module — which is why the scope is asserted as a *reference* to that resource rather
-/// than as a rendered path: a literal would render identically today and silently lose the
-/// ordering the reference creates.
-///
-/// The width is the security half. `Container Apps SandboxGroup Data Owner` covers
-/// `sandboxGroups/*` on whatever it is scoped to, so a resource-group or subscription scope would
-/// hand a remote caller every sibling sandbox in the deployment.
+/// granted on. The scope is asserted as a *reference*, not a rendered path — a literal would
+/// render identically today but lose the ordering that makes setup create the group first.
+/// `Container Apps SandboxGroup Data Owner` covers `sandboxGroups/*` on whatever it's scoped to,
+/// so a resource-group or subscription scope would hand a remote caller every sibling sandbox.
 #[test]
 fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wider() {
     let sandbox = Sandbox::new("agents".to_string())
@@ -583,19 +575,23 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
         .collect::<Vec<_>>()
         .join("\n");
 
-    // The scope PERMISSIONS.md documents has to name the group the module creates. A security
-    // team approves the grant from that document and cannot see the traversal the assignment
-    // actually uses, so a scope that renders to a different name -- or to an unsubstituted
-    // template token -- shows them a boundary the deployment does not have.
+    // The scope PERMISSIONS.md documents must name the group the module creates: a security team
+    // approves the grant from that document and cannot see the traversal the assignment actually
+    // uses, so a name that differs — or an unsubstituted template token — misdocuments the boundary.
     let group_name = module
         .files
         .get("agents.tf")
         .expect("the sandbox group renders into its own file")
         .lines()
         // HCL pads `=` to align an attribute with its siblings, so match on the token.
-        .find_map(|line| line.split_whitespace().collect::<Vec<_>>().split_first().and_then(
-            |(first, rest)| (*first == "name" && rest.first() == Some(&"=")).then(|| rest[1..].join(" ")),
-        ))
+        .find_map(|line| {
+            line.split_whitespace()
+                .collect::<Vec<_>>()
+                .split_first()
+                .and_then(|(first, rest)| {
+                    (*first == "name" && rest.first() == Some(&"=")).then(|| rest[1..].join(" "))
+                })
+        })
         .expect("the group carries a name");
     let documented_scope = module
         .files
@@ -642,10 +638,7 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
         .expect("block ends");
     // HCL pads `=` to align an attribute with its siblings, so the column an assertion would
     // match on moves whenever a neighbouring attribute is added or renamed.
-    let assignment = assignment
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
+    let assignment = assignment.split_whitespace().collect::<Vec<_>>().join(" ");
     let assignment = assignment.as_str();
 
     // The scope attribute itself, not merely a mention of the group somewhere in the block: the
@@ -659,8 +652,7 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
         .next()
         .expect("the scope is one token");
 
-    // A reference, not a path. This is what orders the assignment after the group Azure refuses
-    // to grant on before it exists.
+    // A reference, not a path — see the test doc for why the ordering matters.
     assert_eq!(
         scope, "azapi_resource.agents.id",
         "the grant must be scoped to the created group by reference, and nothing wider"
@@ -686,7 +678,6 @@ fn azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wid
     // group's body and tags, the provider block, and the rendered PERMISSIONS.md.
     snapshot_module("azure_remote_sandbox", &module);
 }
-
 
 /// An AKS target is `Platform::Azure` but skips sandbox emission, so a note keyed off the platform
 /// would tell that installer to register a provider for a resource their package does not contain.
@@ -728,14 +719,21 @@ fn an_aks_package_is_not_told_about_a_sandbox_group_it_does_not_get() {
             expects_group,
             "the README documents the group exactly when the package contains one:\n{readme}"
         );
+        // The document a security team approves the grant from. Naming a data-plane role on a
+        // group the module never creates asks them to approve a scope that does not exist.
+        let permissions = module.get("PERMISSIONS.md").unwrap_or("");
+        assert_eq!(
+            permissions.contains("sandboxGroups"),
+            expects_group,
+            "{target:?} documents the sandbox grant exactly when it installs one:\n{permissions}"
+        );
     }
 }
 
-/// A remote sandbox renders on its own, with no other resource declared.
-///
-/// A bindings-only stack is what makes `parent_id` worth pinning: it must resolve to the
-/// deployer-supplied `var.azure_resource_group_name` rather than to a resource group the module
-/// would have had to declare. `terraform validate` is as far as this reaches — not apply.
+/// A remote sandbox renders on its own, with no other resource declared — which is what makes
+/// `parent_id` worth pinning: it must resolve to the deployer-supplied
+/// `var.azure_resource_group_name`, not a resource group the module would have had to declare.
+/// Reaches `terraform validate` only, not apply.
 #[test]
 fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
     let sandbox = Sandbox::new("agents".to_string())
@@ -758,10 +756,9 @@ fn an_azure_remote_sandbox_renders_without_any_other_resource_declared() {
 
     let module = render(&stack, TerraformTarget::Azure, StackSettings::default());
 
-    // The claim this test is here to pin: with no other resource declared there is no resource
-    // group of Alien's own to parent to, so the group must hang off the one the deployer names.
-    // A reference to a resource this stack does not create would fail `terraform validate` below,
-    // but a *wrong variable* would not — so the attribute is read rather than searched for.
+    // With no other resource declared there's no resource group of this stack's own to parent to,
+    // so the group must hang off the one the deployer names. A wrong reference would fail
+    // `terraform validate` below, but a wrong *variable* would not — so this reads the attribute.
     let parent_id = module
         .files
         .get("agents.tf")

--- a/crates/alien-terraform/tests/generator/azure_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_identity_tests.rs
@@ -384,14 +384,9 @@ fn azure_network_byo_vnet_emits_data_lookups() {
     assert_terraform_valid(&module, "azure_network_byo_vnet");
 }
 
-/// The sandbox management grants have to reach the module.
-///
-/// Both are compiled at stack scope: Azure expresses no scope between a sandbox group and its
-/// resource group, and the setup path compiles resource-scoped management only for
-/// `worker/dispatch-command`. Generation
-/// hard-errors if a platform doesn't declare the binding target, so success alone doesn't prove
-/// the actions rendered — a grant compiled to a scope no emitter renders leaves the module valid
-/// and the manager unable to read the sandbox it owns.
+/// The sandbox management grants have to reach the module: both are compiled at stack scope, so
+/// success alone doesn't prove the actions rendered — a grant compiled to a scope no emitter
+/// renders leaves the module valid while the manager can't read the sandbox it owns.
 #[test]
 fn azure_sandbox_management_grants_reach_the_module() {
     let stack = Stack::new("acme-sbx".to_string())

--- a/crates/alien-terraform/tests/generator/azure_identity_tests.rs
+++ b/crates/alien-terraform/tests/generator/azure_identity_tests.rs
@@ -386,8 +386,9 @@ fn azure_network_byo_vnet_emits_data_lookups() {
 
 /// The sandbox management grants have to reach the module.
 ///
-/// Both are compiled at stack scope, because an Azure sandbox group is created at runtime and
-/// `Microsoft.App/sandboxGroups` has no ARM representation for setup to scope against. Generation
+/// Both are compiled at stack scope: Azure expresses no scope between a sandbox group and its
+/// resource group, and the setup path compiles resource-scoped management only for
+/// `worker/dispatch-command`. Generation
 /// hard-errors if a platform doesn't declare the binding target, so success alone doesn't prove
 /// the actions rendered — a grant compiled to a scope no emitter renders leaves the module valid
 /// and the manager unable to read the sandbox it owns.

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_byo_bucket.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_byo_bucket.snap
@@ -358,7 +358,7 @@ output "deployment_resources" {
 === PERMISSIONS.md ===
 # Application access permissions
 
-The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive Alien's management permissions.
+The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.
 
 ## `files` (storage)
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
@@ -340,6 +340,20 @@ Azure settings:
 - `azure_resource_group_name`: target resource group name.
 - `azure_managing_tenant_id`, `azure_oidc_issuer`, `azure_oidc_subject`: management identity trust settings when this setup grants Azure management access.
 
+## The sandbox group
+
+The sandbox group is created through the `azapi` provider at `Microsoft.App/sandboxGroups@2026-02-01-preview`, because the AzureRM provider has no typed resource for it. Being a preview API, its shape and regional availability can change.
+
+That resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.
+
+The subscription must have the `Microsoft.App` resource provider registered before you apply:
+
+```bash
+az provider register --namespace Microsoft.App
+```
+
+At teardown the deployment runtime deletes the sandbox group before you run `terraform destroy`, so this resource leaves your state without Terraform removing it.
+
 ## Run
 
 Use your organization's normal backend and approval workflow. A typical local review looks like:
@@ -364,9 +378,3 @@ This module exposes `deployment_management_config`, `deployment_stack_settings`,
 - `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.
 - `deployment_input_values`: deployer input values JSON, emitted only when the stack declares deployer inputs.
 - `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.
-
-## The sandbox group
-
-The sandbox group is created through the `azapi` provider at a pinned preview API version, because the AzureRM provider has no typed resource for `Microsoft.App/sandboxGroups`. That resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.
-
-The subscription must have the `Microsoft.App` resource provider registered.

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
@@ -312,7 +312,7 @@ Permission set: `sandbox/remote-execute` (revision 1).
 
 - Create, drive and tear down sessions of the selected sandbox group.
   Scope: `/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}/providers/Microsoft.App/sandboxGroups/${replace(lower("${local.resource_prefix}-agents"), "_", "-")}`
-  - `Container Apps SandboxGroup Data Owner (role)`
+  - `Container Apps SandboxGroup Data Owner` (built-in role)
 
 === README.md ===
 # Deployment setup - byo-sandbox
@@ -364,3 +364,9 @@ This module exposes `deployment_management_config`, `deployment_stack_settings`,
 - `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.
 - `deployment_input_values`: deployer input values JSON, emitted only when the stack declares deployer inputs.
 - `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.
+
+## The sandbox group
+
+The sandbox group is created through the `azapi` provider at a pinned preview API version, because the AzureRM provider has no typed resource for `Microsoft.App/sandboxGroups`. That resource sets `schema_validation_enabled = false`: the `azapi` provider ships a bundled schema index that does not yet carry the type, so its client-side pre-check would reject a request ARM accepts. Azure Resource Manager still validates the request in full at apply.
+
+The subscription must have the `Microsoft.App` resource provider registered.

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
@@ -7,9 +7,13 @@ terraform {
   required_version = ">= 1.5.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0"
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.100, < 5.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 2.6, < 3.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -47,27 +51,45 @@ variable "management_url" {
   default     = ""
 }
 
-variable "aws_region" {
+variable "azure_location" {
   type        = string
-  description = "AWS region used by the AWS provider."
-  default     = "us-east-1"
+  description = "Azure location."
+  default     = "eastus"
 }
 
-variable "managing_role_arn" {
+variable "azure_subscription_id" {
   type        = string
-  description = "ARN of the management identity allowed to assume setup-created roles."
+  description = "Azure subscription ID hosting the stack."
+}
+
+variable "azure_resource_group_name" {
+  type        = string
+  description = "Azure resource group name."
+}
+
+variable "azure_managing_tenant_id" {
+  type        = string
+  description = "Azure tenant ID that hosts the management identity for cross-tenant access."
+}
+
+variable "azure_oidc_issuer" {
+  type        = string
+  description = "OIDC issuer URL for Azure Federated Identity Credential."
+}
+
+variable "azure_oidc_subject" {
+  type        = string
+  description = "OIDC subject claim for Azure Federated Identity Credential."
 }
 
 === providers.tf ===
-provider "aws" {
-  region = var.aws_region
+provider "azurerm" {
+  resource_provider_registrations = "none"
+
+  features {}
 }
 
-data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {}
-
-data "aws_partition" "current" {}
+provider "azapi" {}
 
 === resource_prefix.tf ===
 resource "random_id" "resource_prefix" {
@@ -78,9 +100,9 @@ resource "random_id" "resource_prefix" {
 locals {
   resource_prefix              = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
   deployment_name              = var.name
-  deployment_platform          = "aws"
-  deployment_target            = "aws"
-  deployment_region            = data.aws_region.current.region
+  deployment_platform          = "azure"
+  deployment_target            = "azure"
+  deployment_region            = var.azure_location
   deployment_management_config = null
   deployment_settings = {
     deploymentModel = "push"
@@ -90,83 +112,108 @@ locals {
   }
   deployment_resources = [
     {
-      id   = "files"
-      type = "storage"
+      id   = "default-resource-group"
+      type = "azure_resource_group"
       importData = {
-        bucketName = aws_s3_bucket.files.bucket
-        bucketArn  = aws_s3_bucket.files.arn
+        subscriptionId = var.azure_subscription_id
+        resourceGroup  = azurerm_resource_group.default_resource_group.name
+        location       = azurerm_resource_group.default_resource_group.location
+      }
+    },
+    {
+      id   = "agents"
+      type = "sandbox"
+      importData = {
+        sandboxGroup  = "${local.resource_prefix}-agents"
+        region        = var.azure_location
+        resourceGroup = var.azure_resource_group_name
       }
     },
     {
       id   = "access"
       type = "resource-access"
       importData = {
-        roleName = aws_iam_role.access.name
-        roleArn  = aws_iam_role.access.arn
+        tenantId    = data.azurerm_client_config.access_current.tenant_id
+        identityId  = azurerm_user_assigned_identity.access.id
+        principalId = azurerm_user_assigned_identity.access.principal_id
+        clientId    = azurerm_user_assigned_identity.access.client_id
       }
     }
   ]
 }
 
-=== files.tf ===
-resource "aws_s3_bucket" "files" {
-  bucket        = "${local.resource_prefix}-files"
-  force_destroy = false
+=== default_resource_group.tf ===
+resource "azurerm_resource_group" "default_resource_group" {
+  name     = var.azure_resource_group_name
+  location = var.azure_location
   tags = {
     "managed-by"    = "setup"
     deployment      = local.resource_prefix
-    resource        = "files"
-    "resource-type" = "storage"
+    resource        = "default-resource-group"
+    "resource-type" = "resource-group"
   }
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "files" {
-  bucket = aws_s3_bucket.files.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
+=== agents.tf ===
+resource "azapi_resource" "agents" {
+  type      = "Microsoft.App/sandboxGroups@2026-02-01-preview"
+  name      = "${local.resource_prefix}-agents"
+  parent_id = "/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}"
+  location  = var.azure_location
+  body      = {}
+  tags = {
+    "managed-by"    = "setup"
+    deployment      = local.resource_prefix
+    resource        = "agents"
+    "resource-type" = "sandbox"
   }
+  schema_validation_enabled = false
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
 }
 
-resource "aws_s3_bucket_ownership_controls" "files" {
-  bucket = aws_s3_bucket.files.id
-
-  rule {
-    object_ownership = "BucketOwnerEnforced"
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "files" {
-  bucket                  = aws_s3_bucket.files.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_policy" "files" {
-  bucket = aws_s3_bucket.files.id
-  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "DenyInsecureTransport", Effect = "Deny", Principal = "*", Action = "s3:*", Resource = [aws_s3_bucket.files.arn, "${aws_s3_bucket.files.arn}/*"], Condition = { Bool = { "aws:SecureTransport" = "false" } } }] })
-}
-
-resource "aws_iam_role_policy" "files_access_storage-remote-data-write_0" {
-  name   = "files-storage-remote-data-write-0"
-  role   = aws_iam_role.access.id
-  policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "ListBucketAndUploads", Effect = "Allow", Action = ["s3:ListBucket", "s3:GetBucketLocation", "s3:ListBucketMultipartUploads"], Resource = ["arn:aws:s3:::${aws_s3_bucket.files.bucket}"] }, { Sid = "ReadWriteBucketObjects", Effect = "Allow", Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"], Resource = ["arn:aws:s3:::${aws_s3_bucket.files.bucket}/*"] }] })
+resource "azurerm_role_assignment" "agents_access_0" {
+  name               = uuidv5("oid", "deployment:azure:sandbox-access:${local.resource_prefix}:agents:0")
+  scope              = azapi_resource.agents.id
+  role_definition_id = "/subscriptions/${var.azure_subscription_id}/providers/Microsoft.Authorization/roleDefinitions/c24cf47c-5077-412d-a19c-45202126392c"
+  principal_id       = azurerm_user_assigned_identity.access.principal_id
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
 }
 
 === access.tf ===
-resource "aws_iam_role" "access" {
-  name               = length(format("%s-%s", local.resource_prefix, "access")) <= 64 ? format("%s-%s", local.resource_prefix, "access") : format("%s-%s", substr(format("%s-%s", local.resource_prefix, "access"), 0, 55), substr(sha1(format("%s-%s", local.resource_prefix, "access")), 0, 8))
-  assume_role_policy = jsonencode({ Version = "2012-10-17", Statement = [{ Sid = "AllowManagingRole", Effect = "Allow", Principal = { AWS = var.managing_role_arn }, Action = "sts:AssumeRole", Condition = { StringEquals = { "aws:PrincipalArn" = var.managing_role_arn } } }] })
+data "azurerm_client_config" "access_current" {}
+
+resource "azurerm_user_assigned_identity" "access" {
+  name                = "${local.resource_prefix}-access-identity"
+  resource_group_name = var.azure_resource_group_name
+  location            = var.azure_location
   tags = {
     "managed-by"    = "setup"
     deployment      = local.resource_prefix
     resource        = "access"
     "resource-type" = "resource-access"
   }
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
+}
+
+resource "azurerm_federated_identity_credential" "access_fic" {
+  count               = var.azure_oidc_issuer != "" && var.azure_oidc_subject != "" ? 1 : 0
+  name                = "${local.resource_prefix}-access-federated-credential"
+  resource_group_name = var.azure_resource_group_name
+  parent_id           = azurerm_user_assigned_identity.access.id
+  audience = [
+    "api://AzureADTokenExchange"
+  ]
+  issuer  = var.azure_oidc_issuer
+  subject = var.azure_oidc_subject
+  depends_on = [
+    azurerm_resource_group.default_resource_group
+  ]
 }
 
 === registration.tf ===
@@ -187,19 +234,17 @@ resource "terraform_data" "deployment_registration" {
     inputValues                 = {}
   }
   depends_on = [
-    aws_s3_bucket.files,
-    aws_s3_bucket_server_side_encryption_configuration.files,
-    aws_s3_bucket_ownership_controls.files,
-    aws_s3_bucket_public_access_block.files,
-    aws_s3_bucket_policy.files,
-    aws_iam_role_policy.files_access_storage-remote-data-write_0,
-    aws_iam_role.access
+    azurerm_resource_group.default_resource_group,
+    azapi_resource.agents,
+    azurerm_role_assignment.agents_access_0,
+    azurerm_user_assigned_identity.access,
+    azurerm_federated_identity_credential.access_fic
   ]
 }
 
 === outputs.tf ===
 output "deployment_target" {
-  value       = "aws"
+  value       = "azure"
   description = "Terraform module target."
 }
 
@@ -259,30 +304,20 @@ output "deployment_resources" {
 
 The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.
 
-## `files` (storage)
+## `agents` (sandbox)
 
-Read and write objects in this storage resource.
+Create and terminate sessions in this sandbox, and run arbitrary code inside them.
 
-Permission set: `storage/remote-data-write` (revision 1).
+Permission set: `sandbox/remote-execute` (revision 1).
 
-- List the selected S3 bucket and its in-progress multipart uploads.
-  Scope: `arn:aws:s3:::${local.resource_prefix}-files`
-  - `s3:ListBucket`
-  - `s3:GetBucketLocation`
-  - `s3:ListBucketMultipartUploads`
-
-- Read, write, delete, and complete multipart uploads for objects in the selected S3 bucket.
-  Scope: `arn:aws:s3:::${local.resource_prefix}-files/*`
-  - `s3:GetObject`
-  - `s3:PutObject`
-  - `s3:DeleteObject`
-  - `s3:AbortMultipartUpload`
-  - `s3:ListMultipartUploadParts`
+- Create, drive and tear down sessions of the selected sandbox group.
+  Scope: `/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${replace(lower("${local.resource_prefix}-agents"), "_", "-")}`
+  - `Container Apps SandboxGroup Data Owner (role)`
 
 === README.md ===
-# Deployment setup - acme-remote-storage
+# Deployment setup - byo-sandbox
 
-Target: `aws`.
+Target: `azure`.
 
 This module creates setup-owned infrastructure, grants the management access needed after setup, and prepares deployment registration metadata. Review the generated `.tf` files before applying; each resource file maps to one setup resource.
 
@@ -298,18 +333,19 @@ Common optional settings:
 - `resource_prefix`: stable physical-name prefix. Leave empty to generate one.
 - `management_url`: management endpoint used to register this deployment. The generated installation snippet supplies the endpoint selected for the deployment target.
 
-AWS settings:
+Azure settings:
 
-- `aws_region`: AWS region used by the provider.
-- `managing_role_arn`: management identity allowed to assume setup-created roles.
-- `managing_account_id`: account that hosts application container images. Empty disables scoped cross-account image-pull grants.
+- `azure_subscription_id`: target subscription ID.
+- `azure_location`: Azure location.
+- `azure_resource_group_name`: target resource group name.
+- `azure_managing_tenant_id`, `azure_oidc_issuer`, `azure_oidc_subject`: management identity trust settings when this setup grants Azure management access.
 
 ## Run
 
 Use your organization's normal backend and approval workflow. A typical local review looks like:
 
 ```bash
-export TF_VAR_name="acme-remote-storage"
+export TF_VAR_name="byo-sandbox"
 export TF_VAR_token="..."
 terraform init
 terraform validate

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
@@ -124,7 +124,7 @@ locals {
       id   = "agents"
       type = "sandbox"
       importData = {
-        sandboxGroup  = "${local.resource_prefix}-agents"
+        sandboxGroup  = replace(lower("${local.resource_prefix}-agents"), "_", "-")
         region        = var.azure_location
         resourceGroup = var.azure_resource_group_name
       }
@@ -157,7 +157,7 @@ resource "azurerm_resource_group" "default_resource_group" {
 === agents.tf ===
 resource "azapi_resource" "agents" {
   type      = "Microsoft.App/sandboxGroups@2026-02-01-preview"
-  name      = "${local.resource_prefix}-agents"
+  name      = replace(lower("${local.resource_prefix}-agents"), "_", "-")
   parent_id = "/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}"
   location  = var.azure_location
   body      = {}
@@ -311,7 +311,7 @@ Create and terminate sessions in this sandbox, and run arbitrary code inside the
 Permission set: `sandbox/remote-execute` (revision 1).
 
 - Create, drive and tear down sessions of the selected sandbox group.
-  Scope: `/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}/providers/Microsoft.App/sandboxGroups/${stackPrefix}-${replace(lower("${local.resource_prefix}-agents"), "_", "-")}`
+  Scope: `/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}/providers/Microsoft.App/sandboxGroups/${replace(lower("${local.resource_prefix}-agents"), "_", "-")}`
   - `Container Apps SandboxGroup Data Owner (role)`
 
 === README.md ===

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
@@ -310,7 +310,7 @@ Create and terminate sessions in this sandbox, and run arbitrary code inside the
 
 Permission set: `sandbox/remote-execute` (revision 1).
 
-- Create, drive and tear down sessions of the selected sandbox group.
+- Create, drive and tear down sessions of the selected sandbox group. Session image and size come from the create request; this grant does not limit them.
   Scope: `/subscriptions/${var.azure_subscription_id}/resourceGroups/${var.azure_resource_group_name}/providers/Microsoft.App/sandboxGroups/${replace(lower("${local.resource_prefix}-agents"), "_", "-")}`
   - `Container Apps SandboxGroup Data Owner` (built-in role)
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__azure_remote_sandbox.snap
@@ -352,7 +352,7 @@ The subscription must have the `Microsoft.App` resource provider registered befo
 az provider register --namespace Microsoft.App
 ```
 
-At teardown the deployment runtime deletes the sandbox group before you run `terraform destroy`, so this resource leaves your state without Terraform removing it.
+`terraform destroy` removes the group, and removing it deletes every sandbox inside it.
 
 ## Run
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_byo_bucket.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_byo_bucket.snap
@@ -285,7 +285,7 @@ output "deployment_resources" {
 === PERMISSIONS.md ===
 # Application access permissions
 
-The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive Alien's management permissions.
+The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.
 
 ## `files` (storage)
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_remote_access.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_storage_remote_access.snap
@@ -374,7 +374,7 @@ output "deployment_resources" {
 === PERMISSIONS.md ===
 # Application access permissions
 
-The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive Alien's management permissions.
+The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.
 
 ## `uploads` (storage)
 


### PR DESCRIPTION
## Summary

Brings the Azure sandbox backend to remote-binding parity with AWS, and corrects the GCP and Azure capability rows against what the backends actually do. GCP remote publication is a separate change; this one leaves it refused.

What happens when a deployment publishes an Azure sandbox to a remote caller:

1. **Preflight scans the rest of the deployment for anything that can also reach that sandbox's sessions, and refuses the stack if it finds one** — single tenancy is the only containment a remotely published sandbox has, and three wildcard shapes used to slip past this scan.
2. Setup renders the `azapi` sandbox group and exactly one `Container Apps SandboxGroup Data Owner` assignment scoped to that group.
3. The manager resolves the Azure sandbox binding and leases a session to the remote caller.

This PR changes remote sandbox publication from AWS-only to AWS and Azure, with the Azure grant bounded to one sandbox group.

## What was broken

Azure had no remote sandbox binding at all, so an Azure sandbox could not be published to a remote caller. The scan that certifies single tenancy read three wildcard shapes as reaching nothing — `*`, a namespace after the wildcard (`lambda:Foo*Microvm`), and IAM's single-character `?` — so a stack relying on one of those passed a gate it should have failed, and an inline set was judged by the profile key it sat under rather than by its own scope. The GCP and Azure capability rows claimed behaviour the backends do not have.

## What I did

- Added the Azure remote binding end to end: setup emits the `azapi` sandbox group and one `Container Apps SandboxGroup Data Owner` assignment scoped to it, and the manager gained the arm that leases a session from it.
- Renamed `permission_set_reaches_a_microvm_session` to `permission_set_reaches_a_sandbox_session` and made it dispatch per cloud. The AWS arm is the same predicate.
- Closed the three wildcard shapes that read as "reaches nothing" and now read as reach. A stack that relied on one of those to pass the single-tenancy gate is now refused — which is the point.
- An inline permission set is now judged by its own scope rather than by the profile key it sits under.
- Reverted the per-instance narrowing of the capability rows. Azure and GCP now declare what the wire does.
- Bounded what a generated package may claim: `sandbox/remote-execute`'s description and the rendered `PERMISSIONS.md` change wording, and the README stops implying a registration setup never made.
- Nothing changes what an AWS deployment installs. The three items above are what an AWS reader will see in the diff.
- Test assertions now name the reason they fired, and comments are cut back to the cases they actually carry.

## Files touched

- `crates/alien-permissions/src/registry.rs` — the reach predicate, renamed, per-cloud, and with the wildcard shapes closed.
- `crates/alien-preflights/src/mutations/remote_bindings.rs` — the single-tenancy gate and its scan over inline sets.
- `crates/alien-terraform/src/emitters/azure/sandbox.rs`, `.../azure/remote_stack_management.rs` — the sandbox group and the group-scoped role assignment.
- `crates/alien-manager/src/routes/bindings.rs`, `crates/alien-bindings/src/remote/manager_conversion.rs` — the manager arm that leases an Azure sandbox session.
- `crates/alien-core/src/resources/sandbox.rs`, `crates/alien-bindings/src/provider.rs` — the capability rows.
- `crates/alien-permissions/permission-sets/sandbox/*.jsonc` — `remote-execute`, `execute`, `heartbeat`, `management`, `provision`.
- `crates/alien-azure-clients/src/azure/sandbox_groups.rs`, `.../sandbox_data_plane.rs` — the client calls behind the lease.
- Plus 49 files in total, the remainder being tests, generated OpenAPI copies and Terraform snapshots.

## How I tested

- **Manually:** Azure end to end on a live subscription, in two parts. The setup half was re-run against this branch's code: `terraform apply` created the group, the registration output deserialized into the Azure sandbox import payload with the prefixed group name and exactly one `Container Apps SandboxGroup Data Owner` assignment, and `destroy` removed both. The session half — resolve a lease, run a command, terminate — was proven on an earlier run.
- **Unit tests:** `cargo test` across `alien-core`, `alien-preflights`, `alien-permissions`, `alien-terraform`, `alien-cloudformation`, `alien-helm`, `alien-manager`, `alien-bindings --all-features`, and `alien-infra sandbox`. The Terraform generator suite runs `terraform init/validate` per rendered module; set `TF_PLUGIN_CACHE_DIR` or the parallel provider downloads flake.
- **Anything I couldn't test:** the session half of the Azure run did not reproduce on the re-run — the data plane refused this machine's principal with `audience '(null)'`, an environment limit rather than a result about the code. No logic changed after that run; every commit since touches comment and description text only, and no permission action, scope or binding moved. The generator suite also has no lock file under `crates/alien-terraform/tests/`, so `terraform init` resolves the newest provider allowed and every `terraform validate` test exercises the ceiling of the version range only.

I also ran a security review on the diff. What it checked:

- A wildcard grant hiding session reach from the single-tenancy gate — `a_wildcard_over_an_unknown_microvm_verb_still_reaches_a_session` and `a_lowercase_run_microvm_grant_does_not_slip_the_reach_scan` in `crates/alien-preflights/src/mutations/remote_bindings.rs` pin the shapes that used to fail open.
- An inline set smuggled in under another resource, reaching the published sandbox without being scoped by it — `a_remote_sandbox_reached_by_an_inline_set_under_another_resource_is_refused`.
- A second identity in the deployment reaching the published sandbox through a service account — `a_remote_sandbox_reached_by_a_service_account_set_is_refused` and `a_remote_sandbox_reached_by_an_azure_only_service_account_set_is_refused`.
- The Azure role assignment reaching wider than the one group it is meant to bound — `azure_remote_sandbox_grants_the_access_identity_its_own_group_and_nothing_wider` in `crates/alien-terraform/tests/generator/azure_data_layer_tests.rs`.
- A management set picking up session contents on Azure — `azure_implicit_management_sets_do_not_grant_sensitive_content` in `crates/alien-permissions/tests/azure_sensitive_invariant.rs`.
- GCP being certified single-tenant when it has no reach arm yet — `a_gcp_remote_sandbox_is_refused_before_single_tenancy_can_certify_it` refuses it before the gate can answer.

Nothing turned up.

## Out of scope

- **A Live sandbox is still refused on every non-AWS platform.** `FrozenResourceLifecycleCheck` already enforces that. Its comment now also names the reason that outlives the current one: a remote grant on Azure or GCP names a parent that must exist when the package applies, so publishing a Live sandbox stays impossible there even once those clouds gain a runtime controller. An earlier draft of this branch added a second rule in `remote_binding_undeliverable_reason`; it was unreachable behind that gate and was removed rather than shipped as dead code.
- **The management profile is not scanned by the single-tenancy gate.** Stated in the code as a scope limit. #584 carries the fix, which changes production AWS behaviour and wants its own change.
- **`registered = true` in the Azure service-activation import payload is still unconditional.** Corrected in #583. The README now tells the installer to register `Microsoft.App` themselves, which is the honest half.
- **`dataPlaneEndpoint` is carried in the Azure binding and read by nobody.** Left as-is; noted so it is not mistaken for a live field.
- **`azurerm_federated_identity_credential` keeps `resource_group_name`, and the provider warns it is deprecated.** Keep it. The emitted module pins `azurerm >= 3.100, < 5.0`, and the argument is *Required* at 3.100 and at 4.0 — it only becomes optional late in 4.x and is removed in 5.0, which the constraint excludes. Dropping it turns a warning at the top of the range into `Missing required argument` across most of it.
- **`client-sdks/manager/typescript` is not regenerated and still lacks the `sandbox-azure` variant,** so a caller of the generated TypeScript manager client resolving a sandbox binding against an Azure deployment gets a validation error rather than a lease. Regenerating needs the pinned Speakeasy version (1.680.11 — the installed CLI is 1.761.10) or the repo's release workflow, which is where `gen.lock`/`gen.yaml` are managed; a login alone is not enough. Regeneration is being run separately. It fails loudly rather than decoding wrong, and the staleness itself is already tracked as its own issue.
- **Found while reviewing, filed rather than fixed here:** on Azure the sandbox group carries no configuration, so a `sandbox/remote-execute` lease holder chooses its own image and sizing — the grant bounds which group, not what runs in it, where AWS bounds both because it narrows to a single image ARN. The false parity claim is corrected in this PR; real enforcement needs group-level configuration the preview API does not expose. Separately, the Local build backend reports every exit as success, never enforces `timeout_seconds`, and never drains its child's pipes.
