### PR TITLE
fix(permissions): stop eight Azure scopes naming a token nothing substitutes

### DIFF
--- a/crates/alien-permissions/permission-sets/AGENTS.md
+++ b/crates/alien-permissions/permission-sets/AGENTS.md
@@ -5,6 +5,10 @@
 3. Make sure all permissions / actions are accurate according to the cloud documentation.
 4. Prefer two scopes in bindings: `stack` and `resource`.
    - AWS: use ARNs with `${stackPrefix}-*` and `${stackPrefix}-${resourceName}-*` patterns.
+   - A set that reaches a sandbox session leaves no wildcard in the resource-name segment:
+     `${stackPrefix}-${resourceName}-*` also matches sibling `agents-2` when filed under `agents`.
+     The single-tenancy gate scopes such a set by its profile key, which holds only while the
+     scope names one resource.
    - GCP: use project‑scoped CEL conditions on `resource.name.startsWith('projects/${projectName}/secrets/${stackPrefix}-')` etc.
    - Azure: use subscription/resourceGroup scoped paths with bare `${resourceName}`. What the token resolves to decides this: AWS callers pass the bare resource id, so an AWS binding has to name `${stackPrefix}-${resourceName}`, while every Azure caller passes the already-prefixed cloud name, so naming the prefix again renders it twice.
 5. Use existing resources as references (e.g., `permission-sets/vault/*`).

--- a/crates/alien-permissions/permission-sets/AGENTS.md
+++ b/crates/alien-permissions/permission-sets/AGENTS.md
@@ -6,5 +6,5 @@
 4. Prefer two scopes in bindings: `stack` and `resource`.
    - AWS: use ARNs with `${stackPrefix}-*` and `${stackPrefix}-${resourceName}-*` patterns.
    - GCP: use project‑scoped CEL conditions on `resource.name.startsWith('projects/${projectName}/secrets/${stackPrefix}-')` etc.
-   - Azure: use subscription/resourceGroup scoped paths with `${stackPrefix}-${resourceName}`.
+   - Azure: use subscription/resourceGroup scoped paths with bare `${resourceName}`. What the token resolves to decides this: AWS callers pass the bare resource id, so an AWS binding has to name `${stackPrefix}-${resourceName}`, while every Azure caller passes the already-prefixed cloud name, so naming the prefix again renders it twice.
 5. Use existing resources as references (e.g., `permission-sets/vault/*`).

--- a/crates/alien-permissions/permission-sets/postgres/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/postgres/heartbeat.jsonc
@@ -79,7 +79,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/postgres/management.jsonc
+++ b/crates/alien-permissions/permission-sets/postgres/management.jsonc
@@ -66,7 +66,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/postgres/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/postgres/provision.jsonc
@@ -316,7 +316,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.DBforPostgreSQL/flexibleServers/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/service-account/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/service-account/heartbeat.jsonc
@@ -55,7 +55,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/service-account/management.jsonc
+++ b/crates/alien-permissions/permission-sets/service-account/management.jsonc
@@ -61,7 +61,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/service-account/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/service-account/provision.jsonc
@@ -69,7 +69,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/vault/management.jsonc
+++ b/crates/alien-permissions/permission-sets/vault/management.jsonc
@@ -54,7 +54,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.KeyVault/vaults/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.KeyVault/vaults/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/vault/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/vault/provision.jsonc
@@ -61,7 +61,7 @@
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}"
           },
           "resource": {
-            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.KeyVault/vaults/${stackPrefix}-${resourceName}"
+            "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.KeyVault/vaults/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/src/generators/aws_runtime.rs
+++ b/crates/alien-permissions/src/generators/aws_runtime.rs
@@ -296,4 +296,46 @@ mod tests {
             );
         }
     }
+
+    /// The controller passes the service account's bare id as `${resourceName}` and the deployment
+    /// prefix separately, while the IAM role it grants on is named `{prefix}-{id}`. A resource
+    /// binding that drops `${stackPrefix}` renders an account-level role name outside the
+    /// deployment, and no snapshot covers it because none renders this binding.
+    #[test]
+    fn a_service_account_resource_grant_names_the_prefixed_role() {
+        let context = PermissionContext::new()
+            .with_aws_region("us-east-1")
+            .with_aws_account_id("123456789012")
+            .with_stack_prefix("acme-prod")
+            .with_resource_id("agents")
+            .with_resource_name("agents");
+        let generator = AwsRuntimePermissionsGenerator::new();
+
+        for id in [
+            "service-account/heartbeat",
+            "service-account/management",
+            "service-account/provision",
+            "service-account/impersonate",
+        ] {
+            let permission_set = get_permission_set(id).expect("a service-account set resolves");
+            let policy = generator
+                .generate_policy(permission_set, BindingTarget::Resource, &context)
+                .expect("AWS policy should generate");
+            let resources = policy
+                .statement
+                .iter()
+                .flat_map(|statement| statement.resource.iter())
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+
+            assert!(
+                resources.contains(&"arn:aws:iam::123456789012:role/acme-prod-agents"),
+                "'{id}' never names the role the controller creates; got {resources:?}"
+            );
+            assert!(
+                !resources.contains(&"arn:aws:iam::123456789012:role/agents"),
+                "'{id}' grants an unprefixed role name outside the deployment; got {resources:?}"
+            );
+        }
+    }
 }

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -155,20 +155,7 @@ pub fn permission_set_reaches_a_sandbox_session(
         .azure
         .iter()
         .flatten()
-        .any(|entry| {
-            entry
-                .grant
-                .predefined_roles
-                .iter()
-                .flatten()
-                .any(|role| role.eq_ignore_ascii_case(AZURE_SANDBOX_DATA_PLANE_ROLE))
-                || entry
-                    .grant
-                    .data_actions
-                    .iter()
-                    .flatten()
-                    .any(|action| data_action_reaches_a_sandbox_session(action))
-        });
+        .any(azure_entry_reaches_a_sandbox_session);
 
     reaches_on_aws || reaches_on_azure
 }
@@ -178,6 +165,24 @@ pub fn permission_set_reaches_a_sandbox_session(
 /// allowlist an author may name from, and the Azure role-id map — or a second data-plane role
 /// added to one silently drops out of the others.
 pub const AZURE_SANDBOX_DATA_PLANE_ROLE: &str = "Container Apps SandboxGroup Data Owner";
+
+/// Whether one Azure permission entry reaches a sandbox session, by role or by data action.
+fn azure_entry_reaches_a_sandbox_session(
+    entry: &alien_core::permissions::AzurePlatformPermission,
+) -> bool {
+    entry
+        .grant
+        .predefined_roles
+        .iter()
+        .flatten()
+        .any(|role| role.eq_ignore_ascii_case(AZURE_SANDBOX_DATA_PLANE_ROLE))
+        || entry
+            .grant
+            .data_actions
+            .iter()
+            .flatten()
+            .any(|action| data_action_reaches_a_sandbox_session(action))
+}
 
 /// Whether one Azure `dataAction`, possibly carrying a `*`, addresses a sandbox session.
 ///
@@ -261,6 +266,66 @@ pub fn permission_set_covers_platform(
     entries.is_some_and(|count| count > 0)
 }
 
+/// Whether the session-reaching part of a set is scoped to the resource it is filed under.
+///
+/// The single-tenancy gate treats a **named** set as scoped by the profile key it sits under. That
+/// only holds where every entry carrying the session-reaching grant interpolates `${resourceName}`
+/// and stops there: one scoped to a whole project or subscription, or one that appends `*` to the
+/// token, reaches siblings whatever key it is filed under. Entries that reach no session are not
+/// consulted — `sandbox/remote-execute` binds AWS's own network connector by a fixed ARN, which
+/// names no sandbox and grants nothing inside one.
+#[cfg(test)]
+fn permission_set_is_resource_scoped_on(
+    permission_set: &alien_core::permissions::PermissionSet,
+    platform: alien_core::Platform,
+) -> bool {
+    fn names_one_resource(scope: &str) -> bool {
+        const TOKEN: &str = "${resourceName}";
+        scope
+            .split_once(TOKEN)
+            .is_some_and(|(_, rest)| !rest.starts_with('*'))
+    }
+
+    let platforms = &permission_set.platforms;
+    match platform {
+        alien_core::Platform::Aws => platforms
+            .aws
+            .iter()
+            .flatten()
+            .filter(|entry| {
+                entry.effect.is_allow()
+                    && entry
+                        .grant
+                        .actions
+                        .iter()
+                        .flatten()
+                        .any(|action| action_reaches_a_microvm_session(action))
+            })
+            .all(|entry| {
+                entry.binding.resource.as_ref().is_some_and(|spec| {
+                    spec.resources
+                        .iter()
+                        .all(|resource| names_one_resource(resource))
+                })
+            }),
+        alien_core::Platform::Azure => platforms
+            .azure
+            .iter()
+            .flatten()
+            .filter(|entry| azure_entry_reaches_a_sandbox_session(entry))
+            .all(|entry| {
+                entry
+                    .binding
+                    .resource
+                    .as_ref()
+                    .is_some_and(|spec| names_one_resource(&spec.scope))
+            }),
+        // The reach scan behind this predicate reads only the AWS and Azure blocks, so on any
+        // other platform there is no session-reaching entry to judge and nothing to answer.
+        _ => unreachable!("only AWS and Azure carry a session-reaching entry to judge"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,6 +384,28 @@ mod tests {
 
         // Should be sorted or at least consistent
         println!("Available permission sets: {:?}", ids);
+    }
+
+    /// The single-tenancy gate scopes a **named** session-reaching set by the profile key it sits
+    /// under, which only holds while every such set's resource binding names `${resourceName}`.
+    /// A set that reaches a session through a project- or subscription-wide resource binding has
+    /// to fall through to the inline treatment instead, so this pins the assumption at the source.
+    #[test]
+    fn every_session_reaching_set_is_resource_scoped_by_resource_name() {
+        for id in list_permission_set_ids() {
+            let permission_set = get_permission_set(id).expect("a listed set resolves");
+            if !permission_set_reaches_a_sandbox_session(permission_set) {
+                continue;
+            }
+            for platform in [alien_core::Platform::Aws, alien_core::Platform::Azure] {
+                assert!(
+                    permission_set_is_resource_scoped_on(permission_set, platform),
+                    "'{}' reaches a session but its {platform} resource binding does not name \
+                     ${{resourceName}}; the reach scan must judge it by scope, not by its key",
+                    permission_set.id
+                );
+            }
+        }
     }
 
     /// The Remote Bindings platform gate refuses a kind whose set does not cover the deployment's

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -266,26 +266,33 @@ pub fn permission_set_covers_platform(
     entries.is_some_and(|count| count > 0)
 }
 
+/// Whether a scope naming `${resourceName}` is bounded to that one resource.
+///
+/// Either IAM wildcard inside the token's own name segment spans siblings:
+/// `${stackPrefix}-${resourceName}-*` renders `acme-agents-*`, which matches sibling sandbox
+/// `agents-2`'s `acme-agents-2`. Only `/` and `:` end that segment — no id or prefix holds either.
+#[cfg(test)]
+fn names_one_resource(scope: &str) -> bool {
+    const TOKEN: &str = "${resourceName}";
+    scope.split_once(TOKEN).is_some_and(|(_, rest)| {
+        let segment = rest.split(['/', ':']).next().unwrap_or_default();
+        !segment.contains('*') && !segment.contains('?')
+    })
+}
+
 /// Whether the session-reaching part of a set is scoped to the resource it is filed under.
 ///
 /// The single-tenancy gate treats a **named** set as scoped by the profile key it sits under. That
-/// only holds where every entry carrying the session-reaching grant interpolates `${resourceName}`
-/// and stops there: one scoped to a whole project or subscription, or one that appends `*` to the
-/// token, reaches siblings whatever key it is filed under. Entries that reach no session are not
-/// consulted — `sandbox/remote-execute` binds AWS's own network connector by a fixed ARN, which
-/// names no sandbox and grants nothing inside one.
+/// only holds where every entry carrying the session-reaching grant names `${resourceName}` and
+/// bounds the segment it sits in: one scoped to a whole project or subscription, or one whose
+/// wildcard runs past the name, reaches siblings whatever key it is filed under. Entries that reach
+/// no session are not consulted — `sandbox/remote-execute` binds AWS's own network connector by a
+/// fixed ARN, which names no sandbox and grants nothing inside one.
 #[cfg(test)]
 fn permission_set_is_resource_scoped_on(
     permission_set: &alien_core::permissions::PermissionSet,
     platform: alien_core::Platform,
 ) -> bool {
-    fn names_one_resource(scope: &str) -> bool {
-        const TOKEN: &str = "${resourceName}";
-        scope
-            .split_once(TOKEN)
-            .is_some_and(|(_, rest)| !rest.starts_with('*'))
-    }
-
     let platforms = &permission_set.platforms;
     match platform {
         alien_core::Platform::Aws => platforms
@@ -384,6 +391,42 @@ mod tests {
 
         // Should be sorted or at least consistent
         println!("Available permission sets: {:?}", ids);
+    }
+
+    /// A resource id may be another id plus a separator — `agents` and `agents-2` are both valid,
+    /// and both render an image named `{prefix}-{id}` — so a wildcard left in the segment the
+    /// resource name sits in matches the sibling's resource and the gate's key scoping is void.
+    #[test]
+    fn only_a_bounded_resource_name_segment_names_one_resource() {
+        for bounded in [
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}",
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}:*",
+            "arn:aws:s3:::${resourceName}/sandbox/*",
+            "/subscriptions/s/resourceGroups/g/providers/Microsoft.App/sandboxGroups/${resourceName}",
+        ] {
+            assert!(
+                names_one_resource(bounded),
+                "'{bounded}' names one resource and nothing beside it"
+            );
+        }
+
+        for reaches_a_sibling in [
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}*",
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}-*",
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}-?",
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}_*",
+            "arn:aws:lambda:us-east-1:1:microvm-image:acme-${resourceName}-build*",
+        ] {
+            assert!(
+                !names_one_resource(reaches_a_sibling),
+                "'{reaches_a_sibling}' also matches the resource a sibling id renders"
+            );
+        }
+
+        assert!(
+            !names_one_resource("/subscriptions/${subscriptionId}"),
+            "a scope that never names the resource is bounded to no resource"
+        );
     }
 
     /// The single-tenancy gate scopes a **named** session-reaching set by the profile key it sits

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -552,3 +552,44 @@ fn sandbox_provision_can_manage_its_group_at_stack_scope() {
         "provision must not be able to assign roles: {stack_actions:?}"
     );
 }
+
+/// `${resourceName}` already carries the stack prefix — every Azure emitter builds it as
+/// `<prefix>-<id>` — so a resource scope that also names `${stackPrefix}` renders the prefix twice
+/// and grants on a resource that does not exist. Nothing fails when that happens: the assignment
+/// is well-formed and simply covers nothing, which is why it needs a test rather than a reviewer.
+#[test]
+fn azure_resource_scopes_do_not_repeat_the_stack_prefix() {
+    let generator = AzureRuntimePermissionsGenerator::new();
+    let context = create_test_context();
+    let mut checked = 0;
+
+    for id in [
+        "postgres/heartbeat",
+        "postgres/management",
+        "postgres/provision",
+        "service-account/heartbeat",
+        "service-account/management",
+        "service-account/provision",
+        "vault/management",
+        "vault/provision",
+    ] {
+        let permission_set = get_permission_set(id).expect("a declared permission set");
+        let plan = generator
+            .generate_grant_plan(permission_set, BindingTarget::Resource, &context)
+            .unwrap_or_else(|error| panic!("{id} should generate a resource grant plan: {error}"));
+
+        for binding in &plan.bindings {
+            checked += 1;
+            assert!(
+                !binding.scope.contains("my-stack-my-stack"),
+                "{id} names the stack prefix twice: {}",
+                binding.scope
+            );
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "no resource-scoped Azure binding rendered, so this test pins nothing"
+    );
+}

--- a/crates/alien-permissions/tests/azure_runtime.rs
+++ b/crates/alien-permissions/tests/azure_runtime.rs
@@ -557,33 +557,50 @@ fn sandbox_provision_can_manage_its_group_at_stack_scope() {
 /// `<prefix>-<id>` — so a resource scope that also names `${stackPrefix}` renders the prefix twice
 /// and grants on a resource that does not exist. Nothing fails when that happens: the assignment
 /// is well-formed and simply covers nothing, which is why it needs a test rather than a reviewer.
+///
+/// Asserted as the whole scope rather than as the absence of a doubled prefix, so any spelling
+/// that changes the resource this grant lands on fails here, not only `${stackPrefix}-`.
 #[test]
-fn azure_resource_scopes_do_not_repeat_the_stack_prefix() {
+fn azure_resource_scopes_name_exactly_the_resource_they_are_filed_under() {
+    // `create_test_context` renders `${stackPrefix}` as `my-stack` and `${resourceName}` as
+    // `my-stack-payments-data`, which is the prefixed form every Azure emitter builds.
+    const RESOURCE_GROUP: &str = "/subscriptions/00000000-0000-0000-0000-000000000000\
+/resourceGroups/rg-observability-prod";
     let generator = AzureRuntimePermissionsGenerator::new();
     let context = create_test_context();
     let mut checked = 0;
 
-    for id in [
-        "postgres/heartbeat",
-        "postgres/management",
-        "postgres/provision",
-        "service-account/heartbeat",
-        "service-account/management",
-        "service-account/provision",
-        "vault/management",
-        "vault/provision",
+    for (id, provider_path) in [
+        ("postgres/heartbeat", "Microsoft.DBforPostgreSQL/flexibleServers"),
+        ("postgres/management", "Microsoft.DBforPostgreSQL/flexibleServers"),
+        ("postgres/provision", "Microsoft.DBforPostgreSQL/flexibleServers"),
+        (
+            "service-account/heartbeat",
+            "Microsoft.ManagedIdentity/userAssignedIdentities",
+        ),
+        (
+            "service-account/management",
+            "Microsoft.ManagedIdentity/userAssignedIdentities",
+        ),
+        (
+            "service-account/provision",
+            "Microsoft.ManagedIdentity/userAssignedIdentities",
+        ),
+        ("vault/management", "Microsoft.KeyVault/vaults"),
+        ("vault/provision", "Microsoft.KeyVault/vaults"),
     ] {
         let permission_set = get_permission_set(id).expect("a declared permission set");
         let plan = generator
             .generate_grant_plan(permission_set, BindingTarget::Resource, &context)
             .unwrap_or_else(|error| panic!("{id} should generate a resource grant plan: {error}"));
 
+        let expected =
+            format!("{RESOURCE_GROUP}/providers/{provider_path}/my-stack-payments-data");
         for binding in &plan.bindings {
             checked += 1;
-            assert!(
-                !binding.scope.contains("my-stack-my-stack"),
-                "{id} names the stack prefix twice: {}",
-                binding.scope
+            assert_eq!(
+                binding.scope, expected,
+                "{id} grants on a resource other than the one it is filed under"
             );
         }
     }

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -281,7 +281,9 @@ fn reaches_this_sandbox(
 ) -> bool {
     match reference {
         // An unresolvable name is no reach: the manager rejects an unknown set before it grants
-        // anything.
+        // anything. The key scopes a named set because every session-reaching set interpolates
+        // `${resourceName}`, which `every_session_reaching_set_is_resource_scoped_by_resource_name`
+        // pins in the registry.
         PermissionSetReference::Name(name) => {
             (target == sandbox_id || target == "*")
                 && get_permission_set(name).is_some_and(permission_set_reaches_a_sandbox_session)


### PR DESCRIPTION
## Summary

Eight Azure permission-set scopes were written with `${stackPrefix}`, a token nothing substitutes on the Azure path. This fixes the scopes, corrects the authoring guide that told authors to write them that way, and adds a guard test for the assumption the single-tenancy gate rests on.

Stacked on #580 — review that first; this PR's diff against it is four files. What happens when a scope is rendered into a package:

1. `permission_doc_scope` substitutes every token it knows: `${resourceName}`, `${projectName}`, `${region}`, `${subscriptionId}`, `${resourceGroup}` and `${storageAccountName}`.
2. **`${stackPrefix}` is left untouched on the Azure path, and the Azure emitters have already resolved `${resourceName}` to the prefixed, normalized name** — so a scope written `${stackPrefix}-${resourceName}` renders a path that resolves to nothing and prefixes twice.
3. The rendered path lands in the customer's `PERMISSIONS.md`.

This PR changes eight Azure scopes from a double-prefixed path that resolves to nothing to the bare `${resourceName}` the emitters already prefix.

## What was broken

`permission_doc_scope` has never substituted `${stackPrefix}` on the Azure path, while the Azure emitters already resolve `${resourceName}` to the prefixed, normalized name. Eight scopes carried the token anyway, across `postgres`, `service-account` and `vault`. The authoring guide told authors to write it that way, which is how it kept happening.

## What I did

- Rewrote the eight scopes to bare `${resourceName}`, across `postgres`, `service-account` and `vault`.
- Updated the authoring guide: it now says bare `${resourceName}`, and that `${stackPrefix}` is AWS-only.
- Added `every_session_reaching_set_is_resource_scoped_by_resource_name`, which pins what the single-tenancy gate silently assumes. That gate treats a **named** permission set as scoped by the profile key it sits under; that only holds because every session-reaching set interpolates `${resourceName}` in the entries carrying the reaching grant.
- Narrowed the guard to the entries that actually reach a session. `sandbox/remote-execute` binds AWS's own network connector by a fixed ARN that names no sandbox, so requiring `${resourceName}` there would have failed for a grant that reaches nothing.

## Files touched

- `crates/alien-permissions/permission-sets/postgres/{heartbeat,management,provision}.jsonc`, `service-account/{heartbeat,management,provision}.jsonc`, `vault/{management,provision}.jsonc` — the eight scopes.
- `crates/alien-permissions/permission-sets/AGENTS.md` — the authoring guide line that produced them.
- `crates/alien-permissions/src/registry.rs`, `crates/alien-permissions/src/generators/aws_runtime.rs` — the guard test and its helper.
- `crates/alien-preflights/src/mutations/remote_bindings.rs` — one call site.

## How I tested

- **Unit tests:** `cargo test -p alien-permissions -p alien-preflights -p alien-terraform -p alien-cloudformation -p alien-helm` — all pass. The guard test was confirmed to bite: it failed on `sandbox/remote-execute` before the predicate was narrowed to reaching entries.
- **Anything I couldn't test:** no manual run. None of the eight scopes is on a rendered path today, so there is no package to render them into and nothing has reached a customer's `PERMISSIONS.md` — the sandbox sets that *were* on a rendered path were fixed where they were found. A separate filed change would make some of these compile, at which point they render broken.

I also ran a security review on the diff. What it checked:

- A broken scope silently widening a grant: it does the opposite — an unsubstituted `${stackPrefix}` resolves to nothing, so the path names no resource rather than a wider one.
- The single-tenancy gate trusting a profile key that no longer scopes the set — `every_session_reaching_set_is_resource_scoped_by_resource_name` fails the moment that stops holding. GCP's `sandbox/execute` is `projects/${projectName}` on both its stack and resource bindings, and is not session-reaching today only because `permission_set_reaches_a_sandbox_session` has no GCP arm; the day one lands, this test fails and says exactly why.

Nothing turned up.
