### PR TITLE
fix(permissions): stop the runtime re-granting the reach setup withheld

### DIFF
--- a/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs
@@ -232,28 +232,7 @@ fn global_permission_refs<'a>(
     ctx: &EmitContext<'_>,
     profile: &'a PermissionProfile,
 ) -> Vec<&'a PermissionSetReference> {
-    profile
-        .0
-        .get("*")
-        .map(|refs| {
-            refs.iter()
-                .filter(|permission_ref| {
-                    !alien_core::remote_bindings::remote_binding_claims_management_set(
-                        ctx.stack.resources.values(),
-                        permission_ref.id(),
-                        || reaches_a_session(permission_ref),
-                    )
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-/// Session-reaching sets belong to the remote caller's identity alone, whatever their id.
-fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
-    permission_ref
-        .resolve(|name| alien_permissions::get_permission_set(name).cloned())
-        .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
+    alien_permissions::management_identity_global_refs(ctx.stack.resources.values(), profile)
 }
 
 fn resource_scoped_permission_refs(

--- a/crates/alien-infra/src/remote_stack_management/aws.rs
+++ b/crates/alien-infra/src/remote_stack_management/aws.rs
@@ -602,29 +602,33 @@ impl AwsRemoteStackManagementController {
         // statement effects and conditions remain intact.
         let generator = AwsRuntimePermissionsGenerator::new();
         let mut all_statements = Vec::new();
-        if let Some(global_permission_set_ids) = management_profile.0.get("*") {
-            for permission_set_ref in global_permission_set_ids {
-                let permission_set =
-                    permission_set_ref.resolve(|name| get_permission_set(name).cloned());
-                let Some(permission_set) = permission_set else {
-                    continue;
-                };
-                if permission_set.platforms.aws.is_none() {
-                    continue;
-                }
-
-                let policy = generator
-                    .generate_policy(&permission_set, BindingTarget::Stack, &permission_context)
-                    .context(ErrorData::InfrastructureError {
-                        message: format!(
-                            "Failed to generate IAM policy for management permission set '{}'",
-                            permission_set.id
-                        ),
-                        operation: Some("generate_management_policy_document".to_string()),
-                        resource_id: Some("management".to_string()),
-                    })?;
-                all_statements.extend(policy.statement);
+        // Unfiltered, the first update re-grants the reach the package withheld; see
+        // `alien_permissions::management_identity_global_refs`.
+        let global_refs = alien_permissions::management_identity_global_refs(
+            ctx.desired_stack.resources.values(),
+            management_profile,
+        );
+        for permission_set_ref in global_refs {
+            let permission_set =
+                permission_set_ref.resolve(|name| get_permission_set(name).cloned());
+            let Some(permission_set) = permission_set else {
+                continue;
+            };
+            if permission_set.platforms.aws.is_none() {
+                continue;
             }
+
+            let policy = generator
+                .generate_policy(&permission_set, BindingTarget::Stack, &permission_context)
+                .context(ErrorData::InfrastructureError {
+                    message: format!(
+                        "Failed to generate IAM policy for management permission set '{}'",
+                        permission_set.id
+                    ),
+                    operation: Some("generate_management_policy_document".to_string()),
+                    resource_id: Some("management".to_string()),
+                })?;
+            all_statements.extend(policy.statement);
         }
 
         self.append_resource_scoped_management_statements(

--- a/crates/alien-infra/src/remote_stack_management/azure.rs
+++ b/crates/alien-infra/src/remote_stack_management/azure.rs
@@ -1077,6 +1077,7 @@ mod tests {
 
         let grant_plan = generate_stack_management_grant_plan(
             &profile,
+            std::iter::empty(),
             &permission_context(),
             &Default::default(),
         )
@@ -1126,6 +1127,71 @@ mod tests {
         );
     }
 
+    /// A remotely published sandbox puts `sandbox/management` under `*` by auto-derivation, and
+    /// that set reaches a session. The setup template strips it so the remote caller is the only
+    /// tenant; before this, the runtime rebuilt the role from the unfiltered profile and the first
+    /// update handed the same reach back to the deployment's own identity.
+    #[test]
+    fn stack_management_grant_plan_drops_a_set_the_remote_caller_claims() {
+        use alien_core::{ResourceLifecycle, Sandbox, SandboxCode, SandboxEgress};
+
+        let sandbox = Sandbox::new("agents".to_string())
+            .code(SandboxCode::Image {
+                image: "ubuntu".to_string(),
+            })
+            .egress(SandboxEgress::Allow)
+            .session(alien_core::SandboxSessionPolicy {
+                max_lifetime_seconds: None,
+                idle_suspend_seconds: None,
+            })
+            .build();
+        let stack = alien_core::Stack::new("byo-sandbox".to_string())
+            .add_with_remote_access(sandbox, ResourceLifecycle::Frozen)
+            .build();
+        let profile = PermissionProfile::new()
+            .global([PermissionSetReference::from_name("sandbox/management")]);
+
+        let granted = generate_stack_management_grant_plan(
+            &profile,
+            stack.resources.values(),
+            &permission_context(),
+            &Default::default(),
+        )
+        .unwrap();
+        assert!(
+            granted.bindings.is_empty() && granted.custom_roles.is_empty(),
+            "the remote caller claims sandbox/management, so the management identity keeps nothing"
+        );
+
+        // Without the remote binding the same set is this identity's, so the drop is not blanket.
+        let own = alien_core::Stack::new("byo-sandbox".to_string())
+            .add(
+                Sandbox::new("agents".to_string())
+                    .code(SandboxCode::Image {
+                        image: "ubuntu".to_string(),
+                    })
+                    .egress(SandboxEgress::Allow)
+                    .session(alien_core::SandboxSessionPolicy {
+                        max_lifetime_seconds: None,
+                        idle_suspend_seconds: None,
+                    })
+                    .build(),
+                ResourceLifecycle::Frozen,
+            )
+            .build();
+        let kept = generate_stack_management_grant_plan(
+            &profile,
+            own.resources.values(),
+            &permission_context(),
+            &Default::default(),
+        )
+        .unwrap();
+        assert!(
+            !kept.bindings.is_empty() || !kept.custom_roles.is_empty(),
+            "with no remote binding the management identity keeps sandbox/management"
+        );
+    }
+
     #[test]
     fn stack_management_grant_plan_includes_worker_dispatch_command_once() {
         let profile = PermissionProfile::new()
@@ -1141,8 +1207,13 @@ mod tests {
         let live: std::collections::HashSet<String> = ["api".to_string(), "jobs".to_string()]
             .into_iter()
             .collect();
-        let grant_plan =
-            generate_stack_management_grant_plan(&profile, &permission_context(), &live).unwrap();
+        let grant_plan = generate_stack_management_grant_plan(
+            &profile,
+            std::iter::empty(),
+            &permission_context(),
+            &live,
+        )
+        .unwrap();
 
         assert_eq!(
             grant_plan
@@ -1168,6 +1239,7 @@ mod tests {
 
         let grant_plan = generate_stack_management_grant_plan(
             &profile,
+            std::iter::empty(),
             &permission_context(),
             &Default::default(),
         )
@@ -1252,54 +1324,59 @@ fn existing_azure_vnet_resource_id(ctx: &ResourceControllerContext<'_>) -> Optio
 /// resource the deployer declined. Absence from the desired stack is that
 /// decline, and the grant has to go with it — the setup template withholds it
 /// the same way, and the two must agree.
-fn generate_stack_management_grant_plan(
+fn generate_stack_management_grant_plan<'r, I>(
     management_profile: &PermissionProfile,
+    resources: I,
     permission_context: &PermissionContext,
     live_resource_ids: &std::collections::HashSet<String>,
-) -> Result<AzureGrantPlan> {
+) -> Result<AzureGrantPlan>
+where
+    I: IntoIterator<Item = &'r alien_core::ResourceEntry> + Clone,
+{
     let mut custom_roles = Vec::new();
     let mut bindings = Vec::new();
     let generator = AzureRuntimePermissionsGenerator::new();
 
-    if let Some(global_refs) = management_profile.0.get("*") {
-        for permission_set_ref in global_refs {
-            let Some(permission_set) =
-                permission_set_ref.resolve(|name| get_permission_set(name).cloned())
-            else {
-                tracing::warn!(
-                    permission_set_id = %permission_set_ref.id(),
-                    "Management permission set not found, skipping"
-                );
-                continue;
-            };
-            // Skipped on the same condition the Terraform emitter uses, so push and runtime agree.
-            // A set can decline the stack target deliberately — `sandbox/execute` does, because at
-            // the only stack-level scope Azure RBAC can express, the resource group, its Data Owner
-            // role would reach inside every session in every sibling sandbox group. Asking the
-            // generator for a target a set does not declare is a hard error, so without this a
-            // stack containing a sandbox fails management-role generation outright.
-            let declines_stack_scope =
-                permission_set.platforms.azure.as_ref().is_none_or(|azure| {
-                    azure.is_empty() || azure.iter().all(|entry| entry.binding.stack.is_none())
-                });
-            if declines_stack_scope {
-                continue;
-            }
-
-            let grant_plan = generator
-                .generate_grant_plan(&permission_set, BindingTarget::Stack, permission_context)
-                .context(ErrorData::InfrastructureError {
-                    message: format!(
-                        "Failed to generate Azure role definition for permission set '{}'",
-                        permission_set.id
-                    ),
-                    operation: Some("generate_management_grant_plan".to_string()),
-                    resource_id: Some("management".to_string()),
-                })?;
-
-            custom_roles.extend(grant_plan.custom_roles);
-            bindings.extend(grant_plan.bindings);
+    // Setup and runtime have to answer the same way; see
+    // `alien_permissions::management_identity_global_refs`.
+    let global_refs =
+        alien_permissions::management_identity_global_refs(resources, management_profile);
+    for permission_set_ref in global_refs {
+        let Some(permission_set) =
+            permission_set_ref.resolve(|name| get_permission_set(name).cloned())
+        else {
+            tracing::warn!(
+                permission_set_id = %permission_set_ref.id(),
+                "Management permission set not found, skipping"
+            );
+            continue;
+        };
+        // Skipped on the same condition the Terraform emitter uses, so push and runtime agree.
+        // A set can decline the stack target deliberately — `sandbox/execute` does, because at
+        // the only stack-level scope Azure RBAC can express, the resource group, its Data Owner
+        // role would reach inside every session in every sibling sandbox group. Asking the
+        // generator for a target a set does not declare is a hard error, so without this a
+        // stack containing a sandbox fails management-role generation outright.
+        let declines_stack_scope = permission_set.platforms.azure.as_ref().is_none_or(|azure| {
+            azure.is_empty() || azure.iter().all(|entry| entry.binding.stack.is_none())
+        });
+        if declines_stack_scope {
+            continue;
         }
+
+        let grant_plan = generator
+            .generate_grant_plan(&permission_set, BindingTarget::Stack, permission_context)
+            .context(ErrorData::InfrastructureError {
+                message: format!(
+                    "Failed to generate Azure role definition for permission set '{}'",
+                    permission_set.id
+                ),
+                operation: Some("generate_management_grant_plan".to_string()),
+                resource_id: Some("management".to_string()),
+            })?;
+
+        custom_roles.extend(grant_plan.custom_roles);
+        bindings.extend(grant_plan.bindings);
     }
 
     let mut seen_stack_management_refs = BTreeSet::new();
@@ -1309,7 +1386,15 @@ fn generate_stack_management_grant_plan(
         .filter(|(scope, _)| scope.as_str() != "*")
         .filter(|(resource_id, _)| live_resource_ids.contains(resource_id.as_str()))
         .flat_map(|(_, refs)| refs.iter())
-        .filter(|reference| reference.id() == "worker/dispatch-command")
+        // By registry name, never by `id()`: an inline set carries whatever id its author typed,
+        // so deciding by id would let one named after this set compile at stack scope here.
+        .filter(|reference| {
+            matches!(
+                reference,
+                alien_core::permissions::PermissionSetReference::Name(name)
+                    if name == "worker/dispatch-command"
+            )
+        })
     {
         let Some(permission_set) =
             permission_set_ref.resolve(|name| get_permission_set(name).cloned())
@@ -1459,6 +1544,7 @@ impl AzureRemoteStackManagementController {
         let generator = AzureRuntimePermissionsGenerator::new();
         let grant_plan = generate_stack_management_grant_plan(
             management_profile,
+            ctx.desired_stack.resources.values(),
             &permission_context,
             &ctx.desired_stack.resources.keys().cloned().collect(),
         )?;

--- a/crates/alien-infra/src/remote_stack_management/gcp.rs
+++ b/crates/alien-infra/src/remote_stack_management/gcp.rs
@@ -688,10 +688,12 @@ impl GcpRemoteStackManagementController {
             None => return Ok(Vec::new()),
         };
 
-        let global_permission_set_refs = match management_profile.0.get("*") {
-            Some(refs) => refs,
-            None => return Ok(Vec::new()),
-        };
+        // Filtered exactly as the setup emitter filters it; see
+        // `alien_permissions::management_identity_global_refs`.
+        let global_permission_set_refs = alien_permissions::management_identity_global_refs(
+            ctx.desired_stack.resources.values(),
+            management_profile,
+        );
 
         let mut permission_sets = Vec::new();
 

--- a/crates/alien-permissions/src/lib.rs
+++ b/crates/alien-permissions/src/lib.rs
@@ -9,8 +9,9 @@ use alien_core::{ALIEN_MANAGED_BY_TAG_KEY, ALIEN_RESOURCE_TAG_KEY, ALIEN_STACK_T
 pub use error::*;
 pub use registry::{
     get_permission_set, has_permission_set, list_permission_set_ids,
-    permission_set_covers_platform, permission_set_reaches_a_sandbox_session,
-    AZURE_SANDBOX_DATA_PLANE_ROLE, MICROVM_SESSION_LIFECYCLE_ACTIONS, SENSITIVE_MICROVM_ACTIONS,
+    management_identity_global_refs, permission_set_covers_platform,
+    permission_set_reaches_a_sandbox_session, AZURE_SANDBOX_DATA_PLANE_ROLE,
+    MICROVM_SESSION_LIFECYCLE_ACTIONS, SENSITIVE_MICROVM_ACTIONS,
 };
 pub use variables::VariableInterpolator;
 

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -336,6 +336,61 @@ fn permission_set_is_resource_scoped_on(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alien_core::{
+        permissions::PermissionProfile, Resource, ResourceEntry, ResourceLifecycle, Storage,
+    };
+
+    fn storage(remote_access: bool) -> ResourceEntry {
+        ResourceEntry {
+            enabled_when: None,
+            config: Resource::new(Storage::new("assets".to_string()).build()),
+            dependencies: Vec::new(),
+            lifecycle: ResourceLifecycle::Frozen,
+            remote_access,
+        }
+    }
+
+    /// The filter reaches every remote binding kind, not only sandbox, so this pins the case that
+    /// carries the rest of the product: a deployment that declares no remote binding at all keeps
+    /// exactly the management reach it had.
+    #[test]
+    fn a_deployment_without_remote_bindings_keeps_every_global_management_ref() {
+        let profile =
+            PermissionProfile::new().global(["storage/remote-data-write", "worker/provision"]);
+        let resources = [storage(false)];
+
+        let kept = management_identity_global_refs(resources.iter(), &profile);
+
+        assert_eq!(
+            kept.len(),
+            2,
+            "nothing is claimed when nothing is bound remotely: {:?}",
+            kept.iter().map(|r| r.id()).collect::<Vec<_>>()
+        );
+    }
+
+    /// A remote storage binding carries its own set on the caller's identity. Leaving it on the
+    /// management identity too is the reach setup deliberately withheld.
+    #[test]
+    fn a_remote_storage_binding_claims_its_set_from_the_management_identity() {
+        let profile =
+            PermissionProfile::new().global(["storage/remote-data-write", "worker/provision"]);
+        let resources = [storage(true)];
+
+        let kept = management_identity_global_refs(resources.iter(), &profile);
+
+        let ids = kept.iter().map(|r| r.id()).collect::<Vec<_>>();
+        assert!(
+            !ids.contains(&"storage/remote-data-write"),
+            "the remotely bound set stays off the management identity: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"worker/provision"),
+            "and a set nothing claims is untouched: {ids:?}"
+        );
+    }
+
+    use super::*;
 
     #[test]
     fn test_registry_contains_expected_permission_sets() {

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -561,3 +561,37 @@ mod tests {
         }
     }
 }
+
+/// The global management refs this deployment's own identity keeps.
+///
+/// A set the remote caller claims is dropped. Leaving the same reach on the management identity
+/// makes it the second tenant the single-tenancy gate exists to refuse, and the gate runs at plan
+/// time while this runs on every apply and every update — so setup and runtime have to answer the
+/// same way or the first update re-grants what the package withheld.
+pub fn management_identity_global_refs<'p, 'r, I>(
+    resources: I,
+    profile: &'p alien_core::permissions::PermissionProfile,
+) -> Vec<&'p alien_core::permissions::PermissionSetReference>
+where
+    I: IntoIterator<Item = &'r alien_core::ResourceEntry> + Clone,
+{
+    profile
+        .0
+        .get("*")
+        .map(|refs| {
+            refs.iter()
+                .filter(|permission_ref| {
+                    !alien_core::remote_bindings::remote_binding_claims_management_set(
+                        resources.clone(),
+                        permission_ref.id(),
+                        || {
+                            permission_ref
+                                .resolve(|name| get_permission_set(name).cloned())
+                                .is_some_and(|set| permission_set_reaches_a_sandbox_session(&set))
+                        },
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/aws/remote_stack_management.rs
@@ -224,32 +224,11 @@ fn self_read_policy(label: &str) -> Expression {
     ]))
 }
 
-/// Session-reaching sets belong to the remote caller's identity alone, whatever their id.
-fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
-    permission_ref
-        .resolve(|name| alien_permissions::get_permission_set(name).cloned())
-        .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
-}
-
 fn global_permission_refs<'a>(
     ctx: &EmitContext<'_>,
     profile: &'a PermissionProfile,
 ) -> Vec<&'a PermissionSetReference> {
-    profile
-        .0
-        .get("*")
-        .map(|refs| {
-            refs.iter()
-                .filter(|permission_ref| {
-                    !alien_core::remote_bindings::remote_binding_claims_management_set(
-                        ctx.stack.resources.values(),
-                        permission_ref.id(),
-                        || reaches_a_session(permission_ref),
-                    )
-                })
-                .collect()
-        })
-        .unwrap_or_default()
+    alien_permissions::management_identity_global_refs(ctx.stack.resources.values(), profile)
 }
 
 fn resource_scoped_permission_refs(

--- a/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/azure/remote_stack_management.rs
@@ -207,35 +207,11 @@ fn emit_existing_network_reader_assignments(fragment: &mut TfFragment, label: &s
     // safely own that shared VNet grant per deployment.
 }
 
-/// Session-reaching sets belong to the remote caller's identity alone, whatever their id.
-fn reaches_a_session(permission_ref: &PermissionSetReference) -> bool {
-    permission_ref
-        .resolve(|name| alien_permissions::get_permission_set(name).cloned())
-        .is_some_and(|set| alien_permissions::permission_set_reaches_a_sandbox_session(&set))
-}
-
-/// The global refs this deployment's own management identity keeps. A set the remote caller
-/// claims is dropped — leaving the same reach on the management identity would be the second
-/// tenant the single-tenancy gate exists to prevent.
 fn global_permission_refs<'a>(
     ctx: &EmitContext<'_>,
     profile: &'a PermissionProfile,
 ) -> Vec<&'a PermissionSetReference> {
-    profile
-        .0
-        .get("*")
-        .map(|refs| {
-            refs.iter()
-                .filter(|permission_ref| {
-                    !alien_core::remote_bindings::remote_binding_claims_management_set(
-                        ctx.stack.resources.values(),
-                        permission_ref.id(),
-                        || reaches_a_session(permission_ref),
-                    )
-                })
-                .collect()
-        })
-        .unwrap_or_default()
+    alien_permissions::management_identity_global_refs(ctx.stack.resources.values(), profile)
 }
 
 /// Global refs, plus resource-scoped refs paired with the resource that asked

--- a/crates/alien-terraform/src/emitters/gcp/remote_stack_management.rs
+++ b/crates/alien-terraform/src/emitters/gcp/remote_stack_management.rs
@@ -69,7 +69,7 @@ impl TfEmitter for GcpRemoteStackManagementEmitter {
         let member = service_account_member_for_label(label);
         let context = permission_context(label, ctx.stack.id());
         if let Some(profile) = ctx.stack.management().profile() {
-            for permission_set_ref in global_permission_refs(profile) {
+            for permission_set_ref in global_permission_refs(ctx, profile) {
                 if let Some(permission_set) = permission_set_ref
                     .resolve(|name| alien_permissions::get_permission_set(name).cloned())
                 {
@@ -204,12 +204,11 @@ fn emit_project_management_bindings(
     Ok(())
 }
 
-fn global_permission_refs(profile: &PermissionProfile) -> Vec<&PermissionSetReference> {
-    profile
-        .0
-        .get("*")
-        .map(|refs| refs.iter().collect())
-        .unwrap_or_default()
+fn global_permission_refs<'a>(
+    ctx: &EmitContext<'_>,
+    profile: &'a PermissionProfile,
+) -> Vec<&'a PermissionSetReference> {
+    alien_permissions::management_identity_global_refs(ctx.stack.resources.values(), profile)
 }
 
 fn resource_scoped_permission_refs(


### PR DESCRIPTION
## Summary

The setup emitters withhold a session-reaching global management set from the deployment's own identity, because a remotely published sandbox has claimed it. The runtime controllers did not, and handed it straight back on the first update.

Stacked on #581, which is stacked on #580. Its own diff is seven files. What happens to a management set on a remote-sandbox stack:

1. `sandbox` ownership requires management permissions, so the auto-generated management profile puts `sandbox/management` under `*`, and that set reaches a session on both clouds.
2. Setup strips it, because `remote_binding_claims_management_set` decides it belongs to the remote caller rather than to the deployment's own identity.
3. **The runtime controllers rebuilt the management role from the unfiltered `*` entry** — on `applying_management_permissions` and again on every `update_start` — so the first update restored what setup withheld.

This PR changes the claim from something three setup emitters apply to something all six sites apply, runtime included.

## What was broken

Single tenancy is the only containment a remotely published sandbox has — `sandbox/remote-execute` says so in its own description — and `remote_binding_claims_management_set` is the mechanism enforcing it. It was applied in the three setup emitters and nowhere else. This is the default path, not an edge case: the auto-generated management profile puts `sandbox/management` under `*`, that set reaches a session on both clouds (AWS `lambda:RunMicrovm`/`Suspend`/`Resume`/`Terminate`, Azure `sandboxGroups/sandboxes/{write,delete,read}`), the setup template strips it, and the first update handed it back.

## What I did

- Added one helper, `management_identity_global_refs`, that produces the refs the management identity keeps. All six sites consume it: the three setup emitters and the AWS, Azure and GCP runtime paths.
- Put it in `alien-permissions` rather than `alien-core` because the reach predicate lives there — `alien-core` cannot see it, which is why `remote_binding_claims_management_set` takes a closure.
- Fixed the Azure runtime selecting `worker/dispatch-command` by `reference.id()`, which is author-written for an inline set, so a set merely *named* after it compiled at stack scope onto the management identity. It matches a registry name now, the way the setup emitter already does after #580.

## Files touched

- `crates/alien-permissions/src/registry.rs`, `crates/alien-permissions/src/lib.rs` — `management_identity_global_refs`.
- `crates/alien-infra/src/remote_stack_management/{aws,azure,gcp}.rs` — the three runtime paths, and the Azure name-matching fix.
- `crates/alien-terraform/src/emitters/{aws,azure,gcp}/remote_stack_management.rs`, `crates/alien-cloudformation/src/emitters/aws/remote_stack_management.rs` — the setup emitters, now calling the shared helper instead of open-coding it.

## How I tested

- **Unit tests:** `stack_management_grant_plan_drops_a_set_the_remote_caller_claims` runs both directions — with the sandbox remotely published the plan is empty, and with the same profile on a sandbox that is not published the grant is kept, so the drop is the claim and not a blanket removal. `cargo test -p alien-permissions -p alien-preflights -p alien-terraform -p alien-cloudformation -p alien-helm` and `cargo test -p alien-infra --features all-platforms,test-utils --lib` (612 tests) pass.
- **Anything I couldn't test:** no manual run against a live stack. The first remote-stack-management update on an installed remote-sandbox stack drops `sandbox/management` from the deployment's management role, on AWS and Azure. That is the intended correction — the package already withholds it — but it is a live permission change, so it wants a staging update before merge.

I also ran a security review on the diff. What it checked:

- The deployment's own identity holding session access on a sandbox published to a remote third party — this is the hole being closed; `stack_management_grant_plan_drops_a_set_the_remote_caller_claims` proves the runtime now drops it, and `aws_sandbox_tests.rs` already asserted the setup template does.
- The drop being blanket, so an ordinary non-remote deployment loses management permissions it needs — the same test's second direction keeps the grant when the sandbox is not published.
- An inline set named `worker/dispatch-command` compiling at stack scope onto the management identity on Azure — the runtime now matches a registry name rather than the author-written `reference.id()`.

Nothing turned up.
