### PR TITLE
fix(preflights): read the management profile in the single-tenancy gate

### DIFF
--- a/crates/alien-preflights/src/lib.rs
+++ b/crates/alien-preflights/src/lib.rs
@@ -470,6 +470,16 @@ impl PreflightRegistry {
     }
 
     /// Add a compile-time check
+    /// The registered mutations in run order, for a test that depends on one running before
+    /// another. Test-only: the order is an implementation detail everywhere else.
+    #[cfg(test)]
+    pub(crate) fn mutation_descriptions(&self) -> Vec<&'static str> {
+        self.mutations
+            .iter()
+            .map(|mutation| mutation.description())
+            .collect()
+    }
+
     pub fn add_compile_time_check(&mut self, check: Box<dyn CompileTimeCheck>) {
         self.register_check_code(check.code());
         self.compile_time_checks.push(check);

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -224,10 +224,16 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 
 /// How the deployment's own workloads can reach `sandbox_id`, if any can.
 ///
-/// Three routes: a compute link, a permission profile, and a stack permission set on a
-/// user-declared ServiceAccount — never by set id, since an inline set can be named anything.
+/// Four routes: a compute link, a permission profile, a stack permission set on a user-declared
+/// ServiceAccount, and a resource-scoped entry in the author's management profile — never by set
+/// id, since an inline set can be named anything.
 ///
-/// The management profile is a fourth route this scan does not cover.
+/// The management profile's `*` entries are deliberately not scanned. A global set that reaches a
+/// session is claimed by the remote binding and stripped from the management identity by setup and
+/// runtime alike, so refusing on it would reject stacks those two make safe. A resource-scoped
+/// entry is stripped by neither. This runs before `ManagementPermissionProfileMutation`, so the
+/// profile here is what the author wrote, not the auto-derived baseline —
+/// `remote_bindings_is_gated_before_the_management_profile_is_derived` pins that order.
 fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
@@ -257,7 +263,7 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
         return by_profile;
     }
 
-    stack.resources().find_map(|(id, entry)| {
+    let by_account = stack.resources().find_map(|(id, entry)| {
         entry
             .config
             .downcast_ref::<ServiceAccount>()
@@ -268,6 +274,27 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
                     .any(permission_set_reaches_a_sandbox_session)
             })
             .map(|_| format!("service account '{id}' can start sessions in it"))
+    });
+    if by_account.is_some() {
+        return by_account;
+    }
+
+    stack.management().profile().and_then(|profile| {
+        profile
+            .0
+            .iter()
+            .filter(|(target, _)| target.as_str() != "*")
+            .find_map(|(target, permission_sets)| {
+                permission_sets
+                    .iter()
+                    .find(|reference| reaches_this_sandbox(reference, target, sandbox_id))
+                    .map(|reference| {
+                        format!(
+                            "the management profile grants '{}' on '{target}', which reaches it",
+                            reference.id()
+                        )
+                    })
+            })
     })
 }
 
@@ -676,6 +703,73 @@ mod tests {
         assert!(
             error.to_string().contains("resource 'processor' links it"),
             "the refusal must name the workload that shares the sandbox, got: {error}"
+        );
+    }
+
+    /// The management profile is the fourth route, and the one the gate read past. An author who
+    /// hands their own management identity `sandbox/execute` on the published sandbox makes it the
+    /// second tenant — resource-scoped entries are stripped by neither the setup emitter nor the
+    /// runtime, unlike the global ones.
+    #[tokio::test]
+    async fn a_remote_sandbox_granted_to_the_management_profile_is_refused() {
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .management(alien_core::ManagementPermissions::extend(
+                PermissionProfile::new().resource("agents", ["sandbox/execute"]),
+            ))
+            .build();
+
+        let error = RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Aws), &config())
+            .await
+            .expect_err("the deployment's own management identity is a second tenant");
+
+        assert_eq!(error.code, "STACK_MUTATION_FAILED");
+        assert!(
+            error.to_string().contains("management profile"),
+            "the refusal must name the route, got: {error}"
+        );
+    }
+
+    /// A global entry is not the hole: a session-reaching set under `*` is claimed by the remote
+    /// binding and stripped from the management identity by setup and runtime alike, so refusing
+    /// it here would reject a stack those two make safe.
+    #[tokio::test]
+    async fn a_global_management_entry_is_left_to_the_claim_filter() {
+        let stack = Stack::new("application".to_string())
+            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+            .management(alien_core::ManagementPermissions::extend(
+                PermissionProfile::new().global(["sandbox/execute"]),
+            ))
+            .build();
+
+        RemoteBindingsMutation
+            .mutate(stack, &StackState::new(Platform::Aws), &config())
+            .await
+            .expect("a global set the remote binding claims is not a second tenant");
+    }
+
+    /// The fix above reads the author's own profile, which only holds while this mutation runs
+    /// before the one that merges the auto-derived baseline in. That baseline puts
+    /// `sandbox/management` under every Frozen sandbox, and it reaches a session — so moving
+    /// `ManagementPermissionProfileMutation` earlier would refuse every remotely published sandbox.
+    #[test]
+    fn remote_bindings_is_gated_before_the_management_profile_is_derived() {
+        let registry = crate::PreflightRegistry::with_built_ins();
+        let names: Vec<&str> = registry.mutation_descriptions();
+        let remote = names
+            .iter()
+            .position(|name| *name == RemoteBindingsMutation.description())
+            .expect("RemoteBindingsMutation is registered");
+        let management = names
+            .iter()
+            .position(|name| name.contains("management permission profile"))
+            .expect("ManagementPermissionProfileMutation is registered");
+
+        assert!(
+            remote < management,
+            "the single-tenancy gate reads the author's management profile, so it must run before \
+             the auto-derived baseline is merged in: {names:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

The single-tenancy gate inspected three routes by which something else in a deployment could reach a remotely published sandbox, and never read the management profile. A resource-scoped management entry naming the published sandbox handed the deployment's own identity session contents, and preflight said yes.

Stacked on #583 → #582 → #581 → #580. Its own diff is two files. What happens when a deployment declares a remotely published sandbox:

1. `RemoteBindingsMutation` runs in Phase 2 and calls `validate_remote_sandboxes_are_single_tenant`, which refuses the sandbox if anything else in the deployment can also reach it.
2. **`in_cloud_reach_to` inspected resource links, `stack.permissions.profiles`, and a user-declared ServiceAccount's stack permission sets — but never `stack.permissions.management`.**
3. `ManagementPermissionProfileMutation` runs afterwards in Phase 3b and derives the baseline management profile.

This PR changes the gate from reading three reach routes to reading four, adding the author's own management profile.

## What was broken

Both `Extend` and `Override` survive to the gate and are readable through `stack.management().profile()`, and a resource-scoped management entry naming the published sandbox is unfiltered on every path that consumes it. So this:

```
management: extend { "<sandbox-id>": ["sandbox/execute"] }
```

beside a remotely published sandbox handed the deployment's own management identity `lambda:CreateMicrovmAuthToken` on the image (AWS) or `Container Apps SandboxGroup Data Owner` on the group (Azure) — session *contents* on a sandbox published to a remote third party — and preflight accepted it. The intent was already established and enforced only against auto-derivation, never the author-written path: `management_permission_profile.rs` refuses to let heartbeat drag session execution onto the management identity, and `azure_identity_tests.rs` asserts session-content access belongs to `sandbox/execute` rather than the management role.

## What I did

- Added `stack.permissions.management` as a fourth reach route in `in_cloud_reach_to`, covering both `Extend` and `Override`.
- Scoped the refusal to resource-scoped entries only. A global (`*`) set that reaches a session is claimed by the remote binding and stripped from the management identity by the setup emitters and, since #582, by the runtime too — refusing on one here would reject a stack those two already make safe. A resource-scoped entry is stripped by neither, which is exactly the hole.
- Pinned the mutation ordering the gate rests on. It reads the author's own profile, not the auto-derived baseline — that baseline puts `sandbox/management` under every Frozen sandbox and it reaches a session, so scanning it would refuse every remotely published sandbox. That only holds because Phase 2 runs before Phase 3b, and nothing asserted it; `remote_bindings_is_gated_before_the_management_profile_is_derived` does now, so moving either mutation fails a test instead of silently refusing every remote sandbox.

## Files touched

- `crates/alien-preflights/src/mutations/remote_bindings.rs` — the fourth reach route, the resource-scoped narrowing, and two of the three tests.
- `crates/alien-preflights/src/lib.rs` — the phase-order assertion.

## How I tested

- **Unit tests:** three. The resource-scoped extend is refused and the message names the route; a global entry still passes, so the drop is not blanket; and the phase order is asserted. `cargo test -p alien-preflights -p alien-permissions -p alien-terraform -p alien-cloudformation -p alien-helm -p alien-core` passes.
- **Anything I couldn't test:** no manual run. This is a plan-time refusal, so the blast radius is at plan time: a declaration that granted its own management identity session access on a remotely published sandbox now fails preflight on AWS and Azure. That is the intended refusal, but it breaks anyone who wrote one.

I also ran a security review on the diff. What it checked:

- The deployment's own management identity holding `lambda:CreateMicrovmAuthToken` on the image, or `Container Apps SandboxGroup Data Owner` on the group, for a sandbox published to a remote third party — this is the hole; the refusal test in `crates/alien-preflights/src/mutations/remote_bindings.rs` proves it is now caught, and the message names the route so the author can find it.
- Over-refusing, so a safe stack stops deploying — the global-entry test still passes, because #582 and the setup emitters already strip that case.
- The gate quietly reading the auto-derived baseline instead of the author's profile, which would refuse every remote sandbox — `remote_bindings_is_gated_before_the_management_profile_is_derived` fails if either mutation moves.

Nothing turned up.
