### PR TITLE
feat(manager): accept sandbox-gateway as a gateway log source

### DIFF
--- a/crates/alien-manager/src/auth/subject.rs
+++ b/crates/alien-manager/src/auth/subject.rs
@@ -288,7 +288,7 @@ mod tests {
     }
 
     /// The source is server-controlled and travels inside a `deny_unknown_fields` capability, so
-    /// a gateway that Platform has not minted a token for cannot name itself into the log store.
+    /// a gateway the control plane has not minted a token for cannot name itself into the log store.
     #[test]
     fn a_gateway_logs_capability_carries_its_source_and_refuses_an_unknown_one() {
         let capability: TelemetryCapability = serde_json::from_value(serde_json::json!({

--- a/crates/alien-manager/src/auth/subject.rs
+++ b/crates/alien-manager/src/auth/subject.rs
@@ -117,6 +117,8 @@ pub enum GatewayLogSource {
     AiGateway,
     /// Encryption Gateway request diagnostics.
     EncryptionGateway,
+    /// Sandbox Gateway request diagnostics.
+    SandboxGateway,
 }
 
 impl GatewayLogSource {
@@ -125,6 +127,7 @@ impl GatewayLogSource {
         match self {
             Self::AiGateway => "ai-gateway",
             Self::EncryptionGateway => "encryption-gateway",
+            Self::SandboxGateway => "sandbox-gateway",
         }
     }
 }
@@ -282,6 +285,26 @@ mod tests {
             role,
             bearer_token: "bearer".to_string(),
         }
+    }
+
+    /// The source is server-controlled and travels inside a `deny_unknown_fields` capability, so
+    /// a gateway that Platform has not minted a token for cannot name itself into the log store.
+    #[test]
+    fn a_gateway_logs_capability_carries_its_source_and_refuses_an_unknown_one() {
+        let capability: TelemetryCapability = serde_json::from_value(serde_json::json!({
+            "type": "gatewayLogs",
+            "source": "sandbox-gateway",
+        }))
+        .expect("a minted sandbox-gateway source deserializes");
+        let TelemetryCapability::GatewayLogs { source } = capability;
+        assert_eq!(source, GatewayLogSource::SandboxGateway);
+        assert_eq!(source.as_str(), "sandbox-gateway");
+
+        serde_json::from_value::<TelemetryCapability>(serde_json::json!({
+            "type": "gatewayLogs",
+            "source": "storage-gateway",
+        }))
+        .expect_err("a source the manager does not know is not a source");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`GatewayLogSource` names which gateway sent a batch of per-request diagnostics, and it gains a third variant, `sandbox-gateway`.

Stacked on #585. Its own diff is one file. What happens when a gateway sends its diagnostics to the customer's own Manager:

1. The gateway sends under a telemetry token that names which gateway it is.
2. **That name travels inside `TelemetryCapability::GatewayLogs`, which is `deny_unknown_fields`, so a source has to be named here before a token carrying it can be minted at all** — the source is server-controlled, not caller-supplied.
3. The Manager deserializes the source and maps it to its stable OTLP string before the batch reaches the log store.

This PR changes the accepted gateway log sources from two to three.

## What was broken

Nothing was broken; this is additive. A `sandbox-gateway` source could not be named, so no token could carry it and those diagnostics had nowhere to go.

## What I did

- Added the `sandbox-gateway` variant to `GatewayLogSource`, with its stable OTLP string.
- Added a test that pins the property from both directions: a minted `sandbox-gateway` source deserializes and round-trips to its OTLP string, and a source the Manager does not know fails to deserialize rather than reaching the log store.

## Files touched

- `crates/alien-manager/src/auth/subject.rs` — the enum variant and the round-trip test.

## How I tested

- **Unit tests:** `cargo test -p alien-manager auth` — 40 pass.
- **Anything I couldn't test:** no manual run — there is no gateway emitting this source yet, which is why the variant is being added. The enum is not exposed in the Manager's OpenAPI, so no regeneration was needed.

I also ran a security review on the diff. What it checked:

- A caller naming its own log source to impersonate another gateway: it cannot. The source travels inside `TelemetryCapability::GatewayLogs`, which is `deny_unknown_fields` in `crates/alien-manager/src/auth/subject.rs`, so the source is server-controlled and has to be named in this enum before the control plane can mint a token carrying it.
- An unknown source reaching the log store — the new test asserts it fails to deserialize instead.

Nothing turned up.
