### PR TITLE
feat(sandbox): grant remote sandbox execution on GCP, scoped to the engine

### DIFF
--- a/client-sdks/manager/openapi.json
+++ b/client-sdks/manager/openapi.json
@@ -14621,7 +14621,7 @@
         "properties": {
           "allowEgress": {
             "type": "boolean",
-            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied for the same reason the AWS binding sends it: the remote grant lets its holder\ncreate sessions the declared policy never reaches, so a client reconstructing the policy\nneeds the answer on the wire rather than inferring it from an absent field."
+            "description": "Whether the declaration asked for open egress. Always true here, sent explicitly because\nthe remote grant lets its holder create sessions the declared policy never reaches — a\nclient must read this rather than assume it from an absent field."
           },
           "cpu": {
             "type": [
@@ -14760,6 +14760,39 @@
           }
         ],
         "description": "The only GCP credential form remote binding resolution can return."
+      },
+      "RemoteGcpSandboxBinding": {
+        "type": "object",
+        "description": "Concrete Agent Platform topology returned to remote clients.\n\nNo egress field, unlike the other two clouds: the policy lives on the environment template\nnamed below, so it travels with the template rather than as a flag the client must read.",
+        "required": [
+          "engine",
+          "template",
+          "region"
+        ],
+        "properties": {
+          "engine": {
+            "type": "string",
+            "description": "Reasoning engine the credential lease authorizes sessions under."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region selecting the regional aiplatform endpoint."
+          },
+          "sessionTtlSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Seconds a session may live, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "template": {
+            "type": "string",
+            "description": "Environment template every session is created from; it carries the image and the ceilings."
+          }
+        },
+        "additionalProperties": false
       },
       "RemoteGcpVertexAiBinding": {
         "type": "object",
@@ -15278,6 +15311,33 @@
                 "type": "string",
                 "enum": [
                   "sandbox-azure"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "GCP Agent Platform reasoning engine and a GCP access token.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteGcpSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteGcpClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-gcp-agent-platform"
                 ]
               }
             }

--- a/client-sdks/manager/rust/openapi-3.0.json
+++ b/client-sdks/manager/rust/openapi-3.0.json
@@ -12640,7 +12640,7 @@
         "properties": {
           "allowEgress": {
             "type": "boolean",
-            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied for the same reason the AWS binding sends it: the remote grant lets its holder\ncreate sessions the declared policy never reaches, so a client reconstructing the policy\nneeds the answer on the wire rather than inferring it from an absent field."
+            "description": "Whether the declaration asked for open egress. Always true here, sent explicitly because\nthe remote grant lets its holder create sessions the declared policy never reaches — a\nclient must read this rather than assume it from an absent field."
           },
           "cpu": {
             "type": "string",
@@ -12769,6 +12769,37 @@
           }
         ],
         "description": "The only GCP credential form remote binding resolution can return."
+      },
+      "RemoteGcpSandboxBinding": {
+        "type": "object",
+        "description": "Concrete Agent Platform topology returned to remote clients.\n\nNo egress field, unlike the other two clouds: the policy lives on the environment template\nnamed below, so it travels with the template rather than as a flag the client must read.",
+        "required": [
+          "engine",
+          "template",
+          "region"
+        ],
+        "properties": {
+          "engine": {
+            "type": "string",
+            "description": "Reasoning engine the credential lease authorizes sessions under."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region selecting the regional aiplatform endpoint."
+          },
+          "sessionTtlSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Seconds a session may live, where the declaration asked for one.",
+            "minimum": 0,
+            "nullable": true
+          },
+          "template": {
+            "type": "string",
+            "description": "Environment template every session is created from; it carries the image and the ceilings."
+          }
+        },
+        "additionalProperties": false
       },
       "RemoteGcpVertexAiBinding": {
         "type": "object",
@@ -13271,6 +13302,33 @@
                 "type": "string",
                 "enum": [
                   "sandbox-azure"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "GCP Agent Platform reasoning engine and a GCP access token.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteGcpSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteGcpClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-gcp-agent-platform"
                 ]
               }
             }

--- a/crates/alien-bindings/src/remote.rs
+++ b/crates/alien-bindings/src/remote.rs
@@ -572,6 +572,14 @@ enum ResolvedRemoteBinding {
         #[serde(rename = "expiresAt")]
         expires_at: DateTime<Utc>,
     },
+    #[serde(rename = "sandbox-gcp-agent-platform")]
+    SandboxGcpAgentPlatform {
+        binding: Box<alien_core::GcpAgentPlatformSandboxBinding>,
+        #[serde(rename = "clientConfig")]
+        client_config: Box<alien_core::GcpClientConfig>,
+        #[serde(rename = "expiresAt")]
+        expires_at: DateTime<Utc>,
+    },
     #[cfg(test)]
     #[serde(rename = "local-storage")]
     Local {
@@ -754,6 +762,20 @@ impl ResolvedRemoteBinding {
                 (
                     alien_core::ClientConfig::Azure(client_config),
                     serialize_remote_binding(alien_core::SandboxBinding::Azure(*binding))?,
+                    expires_at,
+                )
+            }
+            Self::SandboxGcpAgentPlatform {
+                binding,
+                client_config,
+                expires_at,
+            } => {
+                validate_gcp_remote_client_config(&client_config)?;
+                (
+                    alien_core::ClientConfig::Gcp(client_config),
+                    serialize_remote_binding(alien_core::SandboxBinding::GcpAgentPlatform(
+                        *binding,
+                    ))?,
                     expires_at,
                 )
             }

--- a/crates/alien-bindings/src/remote/manager_conversion.rs
+++ b/crates/alien-bindings/src/remote/manager_conversion.rs
@@ -347,6 +347,35 @@ impl ResolvedRemoteBinding {
                     expires_at: parse_manager_expiry(expires_at, resource_id)?,
                 }
             }
+            manager_types::ResolveBindingResponse::SandboxGcpAgentPlatform {
+                binding,
+                client_config,
+                expires_at,
+            } => {
+                let manager_types::RemoteGcpCredentials::AccessToken(token) =
+                    client_config.credentials;
+                Self::SandboxGcpAgentPlatform {
+                    binding: Box::new(alien_core::GcpAgentPlatformSandboxBinding {
+                        engine: alien_core::BindingValue::Value(binding.engine),
+                        template: alien_core::BindingValue::Value(binding.template),
+                        region: alien_core::BindingValue::Value(binding.region),
+                        session_ttl_seconds: binding
+                            .session_ttl_seconds
+                            .map(|seconds| {
+                                narrow_manager_number(seconds, "sessionTtlSeconds", resource_id)
+                            })
+                            .transpose()?,
+                    }),
+                    client_config: Box::new(alien_core::GcpClientConfig {
+                        project_id: client_config.project_id,
+                        region: client_config.region,
+                        credentials: alien_core::GcpCredentials::AccessToken { token },
+                        service_overrides: None,
+                        project_number: None,
+                    }),
+                    expires_at: parse_manager_expiry(expires_at, resource_id)?,
+                }
+            }
         };
         Ok(lease)
     }

--- a/crates/alien-bindings/src/remote/tests/manager_contract.rs
+++ b/crates/alien-bindings/src/remote/tests/manager_contract.rs
@@ -740,3 +740,78 @@ async fn an_azure_sandbox_lease_without_open_egress_is_refused() {
         "the code is shared with other refusals, so the reason has to be named: {error}"
     );
 }
+
+/// The GCP arm of the same contract, decoded through the **generated** client.
+///
+/// The `sandbox-gcp-agent-platform` tag is what selects the variant, and both names a session is
+/// addressed by — the engine and the template — must survive the trip: a session created without
+/// the template runs an unpinned image with none of the declared limits or egress applied.
+#[tokio::test]
+async fn remote_sandbox_decodes_every_declared_field_and_reaches_the_gcp_provider() {
+    let expires_at = Utc::now() + ChronoDuration::minutes(5);
+    let engine = "projects/acme/locations/us-central1/reasoningEngines/4242";
+    let response = Arc::new(StdRwLock::new((
+        StatusCode::OK,
+        json!({
+            "service": "sandbox-gcp-agent-platform",
+            "binding": {
+                "engine": engine,
+                "template": format!("{engine}/sandboxEnvironmentTemplates/7"),
+                "region": "us-central1",
+                "sessionTtlSeconds": 3600,
+            },
+            "clientConfig": {
+                "projectId": "acme",
+                "region": "us-central1",
+                "credentials": { "type": "accessToken", "token": "SENTINEL_GCP_TOKEN" },
+            },
+            "expiresAt": expires_at.to_rfc3339(),
+        }),
+    )));
+    let manager_url = spawn_generated_contract_server(GeneratedContractState {
+        response,
+        requests: Arc::new(StdMutex::new(Vec::new())),
+    })
+    .await;
+
+    let manager = DiscoveredManager {
+        deployment_id: DEPLOYMENT_ID.to_string(),
+        url: reqwest::Url::parse(&manager_url).expect("valid manager URL"),
+        http: authenticated_http_client(GENERATED_MANAGER_TOKEN, "generated manager fixture")
+            .expect("build generated contract client"),
+        refresh_at: expires_at,
+        generation: 0,
+    };
+    let lease = GeneratedManagerBindingResolver
+        .resolve(
+            &manager,
+            DEPLOYMENT_ID,
+            RemoteBindingSelector::Resource("agent"),
+        )
+        .await
+        .expect("generated client should decode a GCP Agent Platform sandbox lease");
+
+    let ResolvedRemoteBinding::SandboxGcpAgentPlatform {
+        binding,
+        client_config,
+        expires_at: lease_expires_at,
+    } = lease
+    else {
+        panic!("generated client returned the wrong lease variant for a GCP sandbox");
+    };
+    let value = |raw: &str| alien_core::BindingValue::Value(raw.to_string());
+    assert_eq!(binding.engine, value(engine));
+    assert_eq!(
+        binding.template,
+        value(&format!("{engine}/sandboxEnvironmentTemplates/7"))
+    );
+    assert_eq!(binding.region, value("us-central1"));
+    assert_eq!(binding.session_ttl_seconds, Some(3600));
+    assert_eq!(client_config.project_id, "acme");
+    assert!(client_config.service_overrides.is_none());
+    let alien_core::GcpCredentials::AccessToken { token } = client_config.credentials else {
+        panic!("a GCP sandbox lease carries an access token");
+    };
+    assert_eq!(token, "SENTINEL_GCP_TOKEN");
+    assert_eq!(lease_expires_at.timestamp(), expires_at.timestamp());
+}

--- a/crates/alien-bindings/src/remote/tests/manager_contract.rs
+++ b/crates/alien-bindings/src/remote/tests/manager_contract.rs
@@ -741,11 +741,9 @@ async fn an_azure_sandbox_lease_without_open_egress_is_refused() {
     );
 }
 
-/// The GCP arm of the same contract, decoded through the **generated** client.
-///
-/// The `sandbox-gcp-agent-platform` tag is what selects the variant, and both names a session is
-/// addressed by — the engine and the template — must survive the trip: a session created without
-/// the template runs an unpinned image with none of the declared limits or egress applied.
+/// The GCP arm of the same contract, decoded through the **generated** client. Both names a
+/// session is addressed by — engine and template — must survive the trip: created without the
+/// template, a session runs an unpinned image with none of the declared limits or egress applied.
 #[tokio::test]
 async fn remote_sandbox_decodes_every_declared_field_and_reaches_the_gcp_provider() {
     let expires_at = Utc::now() + ChronoDuration::minutes(5);

--- a/crates/alien-core/src/remote_bindings.rs
+++ b/crates/alien-core/src/remote_bindings.rs
@@ -90,14 +90,15 @@ pub fn remote_binding_for_entry(entry: &ResourceEntry) -> Option<&'static Remote
 ///
 /// Two cases, both sandbox-only and both about a declared policy the remote grant cannot carry.
 ///
-/// **Egress.** The same refusal on both clouds that publish a sandbox remotely, for mechanisms
+/// **Egress.** The same refusal on every cloud that publishes a sandbox remotely, for mechanisms
 /// that are worth telling apart. On AWS the declared connector is *unreachable*: starting a
 /// session is additionally authorized as `lambda:PassNetworkConnector` and the remote grant
 /// passes only AWS's own connectors. On Azure it is *bypassable*: the grant is the
 /// `SandboxGroup Data Owner` data-plane role, so its holder creates sandboxes against the group
 /// directly and the provider that would have applied the declared policy never runs. The Azure
 /// case is the security-relevant one — it is inherent to handing out a data-plane role, not a
-/// gap in an implementation that could later close it.
+/// gap in an implementation that could later close it. On GCP the policy lives on the environment
+/// template, which the remote grant carries no verb to create or replace.
 ///
 /// **Preview ports.** AWS's `CreateMicrovmAuthToken` has no port condition key, so a declared
 /// list bounds a caller going through the provider but not a holder of the leased credentials —

--- a/crates/alien-manager/openapi.json
+++ b/crates/alien-manager/openapi.json
@@ -14621,7 +14621,7 @@
         "properties": {
           "allowEgress": {
             "type": "boolean",
-            "description": "Whether the declaration asked for open egress. Always true here, and sent rather than\nimplied for the same reason the AWS binding sends it: the remote grant lets its holder\ncreate sessions the declared policy never reaches, so a client reconstructing the policy\nneeds the answer on the wire rather than inferring it from an absent field."
+            "description": "Whether the declaration asked for open egress. Always true here, sent explicitly because\nthe remote grant lets its holder create sessions the declared policy never reaches — a\nclient must read this rather than assume it from an absent field."
           },
           "cpu": {
             "type": [
@@ -14760,6 +14760,39 @@
           }
         ],
         "description": "The only GCP credential form remote binding resolution can return."
+      },
+      "RemoteGcpSandboxBinding": {
+        "type": "object",
+        "description": "Concrete Agent Platform topology returned to remote clients.\n\nNo egress field, unlike the other two clouds: the policy lives on the environment template\nnamed below, so it travels with the template rather than as a flag the client must read.",
+        "required": [
+          "engine",
+          "template",
+          "region"
+        ],
+        "properties": {
+          "engine": {
+            "type": "string",
+            "description": "Reasoning engine the credential lease authorizes sessions under."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region selecting the regional aiplatform endpoint."
+          },
+          "sessionTtlSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Seconds a session may live, where the declaration asked for one.",
+            "minimum": 0
+          },
+          "template": {
+            "type": "string",
+            "description": "Environment template every session is created from; it carries the image and the ceilings."
+          }
+        },
+        "additionalProperties": false
       },
       "RemoteGcpVertexAiBinding": {
         "type": "object",
@@ -15278,6 +15311,33 @@
                 "type": "string",
                 "enum": [
                   "sandbox-azure"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "GCP Agent Platform reasoning engine and a GCP access token.",
+            "required": [
+              "binding",
+              "clientConfig",
+              "expiresAt",
+              "service"
+            ],
+            "properties": {
+              "binding": {
+                "$ref": "#/components/schemas/RemoteGcpSandboxBinding"
+              },
+              "clientConfig": {
+                "$ref": "#/components/schemas/RemoteGcpClientConfig"
+              },
+              "expiresAt": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string",
+                "enum": [
+                  "sandbox-gcp-agent-platform"
                 ]
               }
             }

--- a/crates/alien-manager/src/credential_materialization.rs
+++ b/crates/alien-manager/src/credential_materialization.rs
@@ -51,6 +51,7 @@ pub(crate) enum RemoteBindingCredentialScope {
     AzureAi,
     AwsSandbox,
     AzureSandbox,
+    GcpSandbox,
 }
 
 impl std::fmt::Debug for MaterializedCredentialLease {
@@ -238,6 +239,7 @@ fn remote_binding_scope_platform(scope: &RemoteBindingCredentialScope) -> Platfo
         RemoteBindingCredentialScope::GcpGcs => Platform::Gcp,
         RemoteBindingCredentialScope::GcpCloudKms => Platform::Gcp,
         RemoteBindingCredentialScope::GcpAi => Platform::Gcp,
+        RemoteBindingCredentialScope::GcpSandbox => Platform::Gcp,
         RemoteBindingCredentialScope::AzureBlob => Platform::Azure,
         RemoteBindingCredentialScope::AzureKeyVault => Platform::Azure,
         RemoteBindingCredentialScope::AzureAi => Platform::Azure,

--- a/crates/alien-manager/src/routes/bindings.rs
+++ b/crates/alien-manager/src/routes/bindings.rs
@@ -156,6 +156,15 @@ pub enum ResolveBindingResponse {
         #[serde(rename = "expiresAt")]
         expires_at: String,
     },
+    /// GCP Agent Platform reasoning engine and a GCP access token.
+    #[serde(rename = "sandbox-gcp-agent-platform")]
+    SandboxGcpAgentPlatform {
+        binding: RemoteGcpSandboxBinding,
+        #[serde(rename = "clientConfig")]
+        client_config: RemoteGcpClientConfig,
+        #[serde(rename = "expiresAt")]
+        expires_at: String,
+    },
 }
 
 /// Concrete MicroVM sandbox topology returned to remote clients.
@@ -218,6 +227,25 @@ pub struct RemoteAzureSandboxBinding {
     pub memory: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disk: Option<String>,
+}
+
+/// Concrete Agent Platform topology returned to remote clients.
+///
+/// No egress field, unlike the other two clouds: the policy lives on the environment template
+/// named below, so it travels with the template rather than as a flag the client must read.
+#[derive(Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RemoteGcpSandboxBinding {
+    /// Reasoning engine the credential lease authorizes sessions under.
+    pub engine: String,
+    /// Environment template every session is created from; it carries the image and the ceilings.
+    pub template: String,
+    /// Region selecting the regional aiplatform endpoint.
+    pub region: String,
+    /// Seconds a session may live, where the declaration asked for one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_ttl_seconds: Option<u32>,
 }
 
 #[derive(Serialize)]
@@ -420,6 +448,7 @@ enum RemoteAiBinding {
 enum RemoteSandboxBinding {
     Aws(RemoteAwsSandboxBinding),
     Azure(RemoteAzureSandboxBinding),
+    Gcp(RemoteGcpSandboxBinding),
 }
 
 enum ResolvedRemoteBinding {
@@ -445,6 +474,7 @@ impl RemoteSandboxBinding {
         match self {
             Self::Aws(_) => RemoteBindingCredentialScope::AwsSandbox,
             Self::Azure(_) => RemoteBindingCredentialScope::AzureSandbox,
+            Self::Gcp(_) => RemoteBindingCredentialScope::GcpSandbox,
         }
     }
 }
@@ -696,6 +726,13 @@ impl ResolveBindingResponse {
             }
             (RemoteSandboxBinding::Azure(binding), ClientConfig::Azure(client_config)) => {
                 Ok(Self::SandboxAzure {
+                    binding,
+                    client_config: (*client_config).try_into()?,
+                    expires_at,
+                })
+            }
+            (RemoteSandboxBinding::Gcp(binding), ClientConfig::Gcp(client_config)) => {
+                Ok(Self::SandboxGcpAgentPlatform {
                     binding,
                     client_config: (*client_config).try_into()?,
                     expires_at,
@@ -1411,6 +1448,17 @@ fn remote_sandbox_binding(
                 cpu: optional(binding.cpu, "Azure sandbox cpu")?,
                 memory: optional(binding.memory, "Azure sandbox memory")?,
                 disk: optional(binding.disk, "Azure sandbox disk")?,
+            }))
+        }
+        (Platform::Gcp, SandboxBinding::GcpAgentPlatform(binding)) => {
+            // No egress check here, unlike the two arms above: the binding carries no policy to
+            // re-check, because Agent Platform holds it on the environment template and
+            // `sandbox/remote-execute` grants no template verb to create or replace one.
+            Ok(RemoteSandboxBinding::Gcp(RemoteGcpSandboxBinding {
+                engine: concrete_binding_value(&binding.engine, "GCP sandbox engine")?,
+                template: concrete_binding_value(&binding.template, "GCP sandbox template")?,
+                region: concrete_binding_value(&binding.region, "GCP sandbox region")?,
+                session_ttl_seconds: binding.session_ttl_seconds,
             }))
         }
         _ => Err(ErrorData::bad_request(format!(

--- a/crates/alien-manager/src/routes/bindings/tests.rs
+++ b/crates/alien-manager/src/routes/bindings/tests.rs
@@ -248,9 +248,19 @@ fn open_sandbox_binding_for(platform: Platform) -> SandboxBinding {
             alien_core::SandboxEgress::Allow,
             None,
         ),
+        Platform::Gcp => SandboxBinding::gcp_agent_platform(
+            GCP_ENGINE,
+            format!("{GCP_ENGINE}/sandboxEnvironmentTemplates/7"),
+            "us-central1",
+            Some(1800),
+        ),
         _ => open_sandbox_binding(),
     }
 }
+
+/// A reasoning engine's name as Vertex assigns it: the id is server-side, so a test that spelled
+/// it after the sandbox would assert a path no deployment ever carries.
+const GCP_ENGINE: &str = "projects/acme/locations/us-central1/reasoningEngines/4242";
 
 #[test]
 fn remote_sandbox_validation_returns_the_topology_a_session_is_started_from() {
@@ -350,7 +360,7 @@ fn remote_sandbox_resolve_agrees_with_the_permission_set_platform_coverage() {
 /// carries one but is handed a binding belonging to another cloud.
 #[test]
 fn remote_sandbox_validation_refuses_platforms_without_a_durable_parent() {
-    for platform in [Platform::Gcp, Platform::Local] {
+    for platform in [Platform::Local] {
         let deployment = deployment_on_platform(
             sandbox_stack_state(open_sandbox_binding(), platform),
             platform,
@@ -425,6 +435,47 @@ fn remote_sandbox_response_carries_the_service_tag_and_no_extra_credentials() {
         format!("{response:?}"),
         "ResolveBindingResponse { lease: \"<redacted>\" }"
     );
+}
+
+/// The GCP arm of the same wire contract. Both names a session is addressed by have to reach the
+/// caller: a session created without the template runs an unpinned image with none of the declared
+/// ceilings or egress applied.
+#[test]
+fn a_gcp_remote_sandbox_response_carries_the_agent_platform_tag_and_both_names() {
+    let response = ResolveBindingResponse::from_sandbox_parts(
+        match remote_sandbox_binding(
+            &deployment_on_platform(
+                sandbox_stack_state(open_sandbox_binding_for(Platform::Gcp), Platform::Gcp),
+                Platform::Gcp,
+            ),
+            "agents",
+        ) {
+            Ok(binding) => binding,
+            Err(error) => panic!("fixture must resolve: {error}"),
+        },
+        lease(ClientConfig::Gcp(Box::new(alien_core::GcpClientConfig {
+            project_id: "acme".to_string(),
+            region: "us-central1".to_string(),
+            credentials: alien_core::GcpCredentials::AccessToken {
+                token: "token".to_string(),
+            },
+            service_overrides: None,
+            project_number: None,
+        }))),
+        "2026-01-01T00:00:00Z".to_string(),
+    )
+    .expect("a GCP binding pairs with a GCP lease");
+
+    let json = serde_json::to_value(&response).expect("response serializes");
+    assert_eq!(json["service"], "sandbox-gcp-agent-platform");
+    assert_eq!(json["binding"]["engine"], GCP_ENGINE);
+    assert_eq!(
+        json["binding"]["template"],
+        format!("{GCP_ENGINE}/sandboxEnvironmentTemplates/7")
+    );
+    assert_eq!(json["binding"]["region"], "us-central1");
+    assert_eq!(json["binding"]["sessionTtlSeconds"], 1800);
+    assert_eq!(json["clientConfig"]["credentials"]["type"], "accessToken");
 }
 
 #[test]

--- a/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/heartbeat.jsonc
@@ -50,10 +50,11 @@
     ],
     "gcp": [
       {
-        // Existence and state of the session, nothing inside it. get returns no payload, and the
-        // content-reaching execute verb stays in sandbox/execute alone.
+        // The parent template's lifecycle state, which is what the controller reads and the only
+        // health signal Agent Platform offers. No `sandboxEnvironments` verb at all: a session is
+        // not the parent, and heartbeat must address the parent alone.
         "grant": {
-          "permissions": ["aiplatform.sandboxEnvironments.get"]
+          "permissions": ["aiplatform.sandboxEnvironmentTemplates.get"]
         },
         "binding": {
           "stack": {

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -2,14 +2,9 @@
   "id": "sandbox/remote-execute",
   "description": "Allows a remote caller to create sandbox sessions and run arbitrary code inside them",
   "platforms": {
-    // AWS and Azure: the two clouds whose sandbox parent setup creates, and can therefore scope a
-    // grant to. Both refuse an assignment naming a resource that doesn't exist yet, so parent and
+    // Every cloud here creates the sandbox's parent in setup, and can therefore scope a grant to
+    // it. All three refuse an assignment naming a resource that doesn't exist yet, so parent and
     // grant must come from the same template.
-    //
-    // GCP is absent for two reasons: `sandbox/execute` binds it at `projects/${projectName}` for
-    // both stack and resource, so a grant here would reach every sandbox in the project, not just
-    // the one published; and the engine a narrower grant would scope to is created by a Live
-    // controller after apply, not by setup, so there is nothing to name it against.
     "aws": [
       {
         "label": "session-lifecycle",
@@ -99,6 +94,37 @@
           "resource": {
             // `${resourceName}` already resolves to the prefixed name, so no `${stackPrefix}`.
             "scope": "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/sandboxGroups/${resourceName}"
+          }
+        }
+      }
+    ],
+    "gcp": [
+      {
+        "label": "session-lifecycle-and-exec",
+        "description": "Create, drive and tear down sessions under the selected sandbox's reasoning engine.",
+        "grant": {
+          // The verbs the Agent Platform provider calls, `execute` included — this set and
+          // `sandbox/execute` are the only two that reach session content. A custom role rather
+          // than a predefined one because none isolates them: `roles/aiplatform.user`,
+          // `roles/aiplatform.admin`, `roles/editor` and `roles/owner` all carry `execute`
+          // alongside the rest of Vertex AI.
+          "permissions": [
+            "aiplatform.sandboxEnvironments.create",
+            "aiplatform.sandboxEnvironments.get",
+            "aiplatform.sandboxEnvironments.list",
+            "aiplatform.sandboxEnvironments.delete",
+            "aiplatform.sandboxEnvironments.execute",
+            "aiplatform.sandboxEnvironments.pause",
+            "aiplatform.sandboxEnvironments.resume"
+          ]
+        },
+        // The engine, and nothing wider — the same boundary the AWS and Azure blocks draw. IAM on
+        // a reasoning engine is enforced on the sessions hanging under it, while a project scope
+        // would hand a remote caller every sibling sandbox in the deployment. No `stack` binding
+        // for that reason: `projects/${projectName}` is the only stack-level scope GCP can express.
+        "binding": {
+          "resource": {
+            "scope": "projects/${projectName}/locations/${region}/reasoningEngines/${resourceName}"
           }
         }
       }

--- a/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
+++ b/crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc
@@ -104,10 +104,9 @@
         "description": "Create, drive and tear down sessions under the selected sandbox's reasoning engine.",
         "grant": {
           // The verbs the Agent Platform provider calls, `execute` included — this set and
-          // `sandbox/execute` are the only two that reach session content. A custom role rather
-          // than a predefined one because none isolates them: `roles/aiplatform.user`,
-          // `roles/aiplatform.admin`, `roles/editor` and `roles/owner` all carry `execute`
-          // alongside the rest of Vertex AI.
+          // `sandbox/execute` are the only two that reach session content. Custom role: no
+          // predefined one isolates `execute` from the rest of Vertex AI, and ten carry it,
+          // `roles/owner` and `roles/editor` included.
           "permissions": [
             "aiplatform.sandboxEnvironments.create",
             "aiplatform.sandboxEnvironments.get",
@@ -118,10 +117,10 @@
             "aiplatform.sandboxEnvironments.resume"
           ]
         },
-        // The engine, and nothing wider — the same boundary the AWS and Azure blocks draw. IAM on
-        // a reasoning engine is enforced on the sessions hanging under it, while a project scope
-        // would hand a remote caller every sibling sandbox in the deployment. No `stack` binding
-        // for that reason: `projects/${projectName}` is the only stack-level scope GCP can express.
+        // The engine, and nothing wider — same boundary the AWS and Azure blocks draw. Reasoning-
+        // engine IAM is enforced on the sessions under it; project scope would hand a remote caller
+        // every sibling sandbox. No `stack` binding: `projects/${projectName}` is the only GCP
+        // stack-level scope.
         "binding": {
           "resource": {
             "scope": "projects/${projectName}/locations/${region}/reasoningEngines/${resourceName}"

--- a/crates/alien-permissions/src/generators/gcp_runtime.rs
+++ b/crates/alien-permissions/src/generators/gcp_runtime.rs
@@ -62,6 +62,8 @@ pub enum GcpBindingResourceKind {
     PubsubSubscription,
     /// Artifact Registry repository IAM policy.
     ArtifactRegistryRepository,
+    /// Vertex AI reasoning engine IAM policy.
+    VertexAiReasoningEngine,
 }
 
 /// GCP IAM policy binding.
@@ -720,6 +722,9 @@ fn binding_resource_kind(binding_spec: &GcpBindingSpec) -> Option<GcpBindingReso
     }
     if scope.contains("/repositories/") {
         return Some(GcpBindingResourceKind::ArtifactRegistryRepository);
+    }
+    if scope.contains("/reasoningEngines/") {
+        return Some(GcpBindingResourceKind::VertexAiReasoningEngine);
     }
     None
 }

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -192,13 +192,9 @@ const GCP_SESSION_REACHING_ROLES: &[&str] = &[
 /// exist yet and this answer decides whether the single-tenancy gate refuses a stack.
 const GCP_AIPLATFORM_ROLES_WITHOUT_SESSION_REACH: &[&str] = &["roles/aiplatform.viewer"];
 
-/// Whether a GCP role can run code in a sandbox session.
-///
-/// Three ways to say yes, because guessing wrong here certifies a stack whose second identity
-/// holds `execute` as single-tenant. A custom role is unbounded by name, a role Vertex AI adds
-/// after this list was written is not on it, and the rest are enumerated above. Roles outside
-/// those cases answer no, so a `roles/datastore.viewer` on a neighbouring resource does not refuse
-/// a deployment that has nothing to do with sandboxes.
+/// Three ways to say yes — a custom role (unbounded by name), an `aiplatform.*` role added after
+/// this list was written, or one of the roles enumerated above — because guessing wrong here lets
+/// a second identity hold `execute` as though single-tenant. Everything else answers no.
 fn gcp_role_reaches_a_sandbox_session(role: &str) -> bool {
     if GCP_AIPLATFORM_ROLES_WITHOUT_SESSION_REACH
         .iter()
@@ -745,7 +741,7 @@ mod tests {
         }
     }
 
-    /// The four predefined roles were read off their definitions, where each carries
+    /// Predefined roles read off their live definitions, each carrying
     /// `aiplatform.sandboxEnvironments.execute`. A management profile naming one holds the reach
     /// the remote caller was published, so the reach scan has to see it through the role name.
     #[test]
@@ -767,8 +763,8 @@ mod tests {
             },
         };
 
-        // Six of these are the ones a list of reaching roles missed. Verified against the live
-        // role definitions, along with `roles/aiplatform.viewer` carrying no session verb.
+        // Verified against the live role definitions, along with `roles/aiplatform.viewer`
+        // carrying no session verb.
         for role in [
             "roles/owner",
             "roles/editor",

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -157,7 +157,78 @@ pub fn permission_set_reaches_a_sandbox_session(
         .flatten()
         .any(azure_entry_reaches_a_sandbox_session);
 
-    reaches_on_aws || reaches_on_azure
+    let reaches_on_gcp = permission_set
+        .platforms
+        .gcp
+        .iter()
+        .flatten()
+        .any(gcp_entry_reaches_a_sandbox_session);
+
+    reaches_on_aws || reaches_on_azure || reaches_on_gcp
+}
+
+/// Predefined GCP roles that carry a session-reaching Agent Platform verb.
+///
+/// Read off the role definitions rather than inferred from the names: every one of these includes
+/// `aiplatform.sandboxEnvironments.execute` beside the rest of Vertex AI, which is also why
+/// `sandbox/remote-execute` renders a custom role instead of naming one of them.
+const GCP_SESSION_REACHING_ROLES: &[&str] = &[
+    "roles/owner",
+    "roles/editor",
+    "roles/aiplatform.user",
+    "roles/aiplatform.admin",
+];
+
+/// Whether one GCP permission entry reaches a sandbox session, by role or by permission.
+fn gcp_entry_reaches_a_sandbox_session(
+    entry: &alien_core::permissions::GcpPlatformPermission,
+) -> bool {
+    entry
+        .grant
+        .predefined_roles
+        .iter()
+        .flatten()
+        .any(|role| {
+            GCP_SESSION_REACHING_ROLES
+                .iter()
+                .any(|known| known.eq_ignore_ascii_case(role))
+        })
+        // Both lists, unconditionally: an entry setting `permissions` and `residualPermissions`
+        // together would otherwise hide the grant in the unscanned one.
+        || entry
+            .grant
+            .permissions
+            .iter()
+            .flatten()
+            .chain(entry.grant.residual_permissions.iter().flatten())
+            .any(|permission| permission_reaches_a_sandbox_session(permission))
+}
+
+/// Whether one GCP permission, possibly carrying a `*`, addresses a sandbox session.
+///
+/// **Lifecycle.** Counts as reach for the same reason `RunMicrovm` does on AWS: whoever creates a
+/// session can put whatever it likes inside it.
+///
+/// **`get` and `list` do not.** They report a session's existence and state and confer nothing
+/// over it or inside it, so a status-only grant stays with the deployment's own identity rather
+/// than being claimed by the remote caller.
+///
+/// **Wildcard, both directions.** `*` and `aiplatform.*` sit above the sandbox namespace and still
+/// reach into it; `aiplatform.sandboxEnvironments.*` sits below. Either way a wildcard covers a
+/// verb past `get`/`list`, so it is answered yes — over-approximating withholds a grant, while
+/// under-approximating leaves reach on an identity a second tenant holds.
+///
+/// Compared lowercased throughout, as the Azure helper is.
+fn permission_reaches_a_sandbox_session(permission: &str) -> bool {
+    const SANDBOX_NAMESPACE: &str = "aiplatform.sandboxenvironments.";
+    let permission = permission.to_ascii_lowercase();
+    if permission.contains('*') {
+        let literal = permission.split('*').next().unwrap_or_default();
+        return SANDBOX_NAMESPACE.starts_with(literal) || literal.starts_with(SANDBOX_NAMESPACE);
+    }
+    permission
+        .strip_prefix(SANDBOX_NAMESPACE)
+        .is_some_and(|verb| !matches!(verb, "get" | "list"))
 }
 
 /// The predefined role carrying Azure's whole sandbox data plane, session contents included.
@@ -288,6 +359,10 @@ fn names_one_resource(scope: &str) -> bool {
 /// wildcard runs past the name, reaches siblings whatever key it is filed under. Entries that reach
 /// no session are not consulted — `sandbox/remote-execute` binds AWS's own network connector by a
 /// fixed ARN, which names no sandbox and grants nothing inside one.
+///
+/// Answered for AWS and Azure only. `sandbox/execute` and `sandbox/management` bind GCP at
+/// `projects/${projectName}`, so the key-scoping assumption does not hold there at all and the
+/// gate reads a named GCP set as inline instead.
 #[cfg(test)]
 fn permission_set_is_resource_scoped_on(
     permission_set: &alien_core::permissions::PermissionSet,
@@ -327,9 +402,9 @@ fn permission_set_is_resource_scoped_on(
                     .as_ref()
                     .is_some_and(|spec| names_one_resource(&spec.scope))
             }),
-        // The reach scan behind this predicate reads only the AWS and Azure blocks, so on any
-        // other platform there is no session-reaching entry to judge and nothing to answer.
-        _ => unreachable!("only AWS and Azure carry a session-reaching entry to judge"),
+        // GCP reaches a session through a project-scoped binding, which this predicate has no
+        // verdict for; every other platform declares no sandbox block at all.
+        _ => unreachable!("only AWS and Azure carry a resource-scoped session-reaching entry"),
     }
 }
 
@@ -488,6 +563,10 @@ mod tests {
     /// under, which only holds while every such set's resource binding names `${resourceName}`.
     /// A set that reaches a session through a project- or subscription-wide resource binding has
     /// to fall through to the inline treatment instead, so this pins the assumption at the source.
+    ///
+    /// GCP is not in the loop because it is the platform that fell through: its session-reaching
+    /// sets bind at `projects/${projectName}`, and `reaches_this_sandbox` reads a named GCP set as
+    /// inline for exactly that reason.
     #[test]
     fn every_session_reaching_set_is_resource_scoped_by_resource_name() {
         for id in list_permission_set_ids() {
@@ -526,16 +605,16 @@ mod tests {
             }
         }
 
-        // Both clouds whose sandbox parent setup can create and then scope a grant to: an AWS
-        // MicroVM image, and an Azure sandbox group.
-        for platform in [Platform::Aws, Platform::Azure] {
+        // Every cloud whose sandbox parent setup can create and then scope a grant to: an AWS
+        // MicroVM image, an Azure sandbox group, a GCP reasoning engine.
+        for platform in [Platform::Aws, Platform::Azure, Platform::Gcp] {
             assert!(permission_set_covers_platform(
                 "sandbox/remote-execute",
                 platform
             ));
         }
 
-        for platform in [Platform::Gcp, Platform::Local] {
+        for platform in [Platform::Local] {
             assert!(
                 !permission_set_covers_platform("sandbox/remote-execute", platform),
                 "widening sandbox/remote-execute to {platform} must be done together with \
@@ -593,6 +672,80 @@ mod tests {
                 "{action} does not reach a session"
             );
         }
+    }
+
+    /// The same question the AWS wildcard test asks, on the cloud where the namespace is a
+    /// permission prefix rather than an action name. A pattern this misses leaves session reach on
+    /// the deployment's management identity beside a remote caller that also holds it.
+    #[test]
+    fn a_gcp_permission_naming_the_sandbox_namespace_reaches_a_session() {
+        for permission in [
+            "aiplatform.sandboxEnvironments.create",
+            "aiplatform.sandboxEnvironments.delete",
+            "aiplatform.sandboxEnvironments.execute",
+            "aiplatform.sandboxEnvironments.pause",
+            "aiplatform.sandboxEnvironments.resume",
+            "aiplatform.sandboxEnvironments.snapshot",
+            "aiplatform.sandboxenvironments.execute",
+            // Below the namespace, and above it: both cover a verb past get/list.
+            "aiplatform.sandboxEnvironments.*",
+            "aiplatform.*",
+            "*",
+        ] {
+            assert!(
+                permission_reaches_a_sandbox_session(permission),
+                "{permission} authorizes a sandbox session verb"
+            );
+        }
+
+        // Existence and state, conferring nothing over the session or inside it. The parent's own
+        // resources are not the session at all.
+        for permission in [
+            "aiplatform.sandboxEnvironments.get",
+            "aiplatform.sandboxEnvironments.list",
+            "aiplatform.sandboxEnvironmentTemplates.get",
+            "aiplatform.sandboxEnvironmentTemplates.create",
+            "aiplatform.reasoningEngines.create",
+            "storage.objects.get",
+        ] {
+            assert!(
+                !permission_reaches_a_sandbox_session(permission),
+                "{permission} does not reach a session"
+            );
+        }
+    }
+
+    /// The four predefined roles were read off their definitions, where each carries
+    /// `aiplatform.sandboxEnvironments.execute`. A management profile naming one holds the reach
+    /// the remote caller was published, so the reach scan has to see it through the role name.
+    #[test]
+    fn a_gcp_predefined_role_carrying_the_execute_verb_reaches_a_session() {
+        use alien_core::permissions::{
+            BindingConfiguration, GcpBindingSpec, GcpPlatformPermission, PermissionGrant,
+        };
+
+        let entry = |roles: &[&str]| GcpPlatformPermission {
+            label: None,
+            description: None,
+            grant: PermissionGrant {
+                predefined_roles: Some(roles.iter().map(|role| (*role).to_string()).collect()),
+                ..PermissionGrant::default()
+            },
+            binding: BindingConfiguration::<GcpBindingSpec> {
+                stack: None,
+                resource: None,
+            },
+        };
+
+        for role in GCP_SESSION_REACHING_ROLES {
+            assert!(
+                gcp_entry_reaches_a_sandbox_session(&entry(&[role])),
+                "{role} includes aiplatform.sandboxEnvironments.execute"
+            );
+        }
+        assert!(!gcp_entry_reaches_a_sandbox_session(&entry(&[
+            "roles/aiplatform.viewer"
+        ])));
     }
 
     #[test]

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -386,9 +386,9 @@ fn names_one_resource(scope: &str) -> bool {
 /// no session are not consulted — `sandbox/remote-execute` binds AWS's own network connector by a
 /// fixed ARN, which names no sandbox and grants nothing inside one.
 ///
-/// Answered for AWS and Azure only. `sandbox/execute` and `sandbox/management` bind GCP at
-/// `projects/${projectName}`, so the key-scoping assumption does not hold there at all and the
-/// gate reads a named GCP set as inline instead.
+/// Consulted for AWS and Azure, the platforms whose named sets the gate scopes by key. GCP has no
+/// counterpart invariant — its session-reaching sets are not all pinned to one resource — so
+/// `reaches_this_sandbox` reads a named GCP set as inline.
 #[cfg(test)]
 fn permission_set_is_resource_scoped_on(
     permission_set: &alien_core::permissions::PermissionSet,
@@ -428,9 +428,23 @@ fn permission_set_is_resource_scoped_on(
                     .as_ref()
                     .is_some_and(|spec| names_one_resource(&spec.scope))
             }),
-        // GCP reaches a session through a project-scoped binding, which this predicate has no
-        // verdict for; every other platform declares no sandbox block at all.
-        _ => unreachable!("only AWS and Azure carry a resource-scoped session-reaching entry"),
+        alien_core::Platform::Gcp => platforms
+            .gcp
+            .iter()
+            .flatten()
+            .filter(|entry| gcp_entry_reaches_a_sandbox_session(entry))
+            .all(|entry| {
+                entry
+                    .binding
+                    .resource
+                    .as_ref()
+                    .is_some_and(|spec| names_one_resource(&spec.scope))
+            }),
+        // A permission set declares no block for these, so it carries no entry to scope.
+        alien_core::Platform::Kubernetes
+        | alien_core::Platform::Machines
+        | alien_core::Platform::Local
+        | alien_core::Platform::Test => true,
     }
 }
 
@@ -590,9 +604,8 @@ mod tests {
     /// A set that reaches a session through a project- or subscription-wide resource binding has
     /// to fall through to the inline treatment instead, so this pins the assumption at the source.
     ///
-    /// GCP is not in the loop because it is the platform that fell through: its session-reaching
-    /// sets bind at `projects/${projectName}`, and `reaches_this_sandbox` reads a named GCP set as
-    /// inline for exactly that reason.
+    /// GCP is out of the loop: its session-reaching sets are not all pinned to one resource, so
+    /// `reaches_this_sandbox` reads a named GCP set as inline rather than scoping it by key.
     #[test]
     fn every_session_reaching_set_is_resource_scoped_by_resource_name() {
         for id in list_permission_set_ids() {

--- a/crates/alien-permissions/src/registry.rs
+++ b/crates/alien-permissions/src/registry.rs
@@ -167,17 +167,51 @@ pub fn permission_set_reaches_a_sandbox_session(
     reaches_on_aws || reaches_on_azure || reaches_on_gcp
 }
 
-/// Predefined GCP roles that carry a session-reaching Agent Platform verb.
+/// Predefined GCP roles that carry `aiplatform.sandboxEnvironments.execute`, read off the live
+/// role definitions rather than inferred from the names. It is also why `sandbox/remote-execute`
+/// renders a custom role instead of naming one of them.
 ///
-/// Read off the role definitions rather than inferred from the names: every one of these includes
-/// `aiplatform.sandboxEnvironments.execute` beside the rest of Vertex AI, which is also why
-/// `sandbox/remote-execute` renders a custom role instead of naming one of them.
+/// Re-derive with: describe every `roles/aiplatform.*`, `roles/ml*`, `roles/notebooks*`,
+/// `roles/discoveryengine*` and `roles/geminienterprise*` role plus the basic roles, and keep the
+/// ones whose `includedPermissions` contain that verb.
 const GCP_SESSION_REACHING_ROLES: &[&str] = &[
     "roles/owner",
     "roles/editor",
     "roles/aiplatform.user",
     "roles/aiplatform.admin",
+    "roles/aiplatform.editor",
+    "roles/aiplatform.expressAdmin",
+    "roles/aiplatform.expressUser",
+    "roles/aiplatform.customCodeServiceAgent",
+    "roles/aiplatform.serviceAgent",
+    "roles/discoveryengine.serviceAgent",
 ];
+
+/// The one `roles/aiplatform.*` role proven to carry no session verb. Everything else under that
+/// prefix is treated as reaching, because a list of names cannot answer for a role that does not
+/// exist yet and this answer decides whether the single-tenancy gate refuses a stack.
+const GCP_AIPLATFORM_ROLES_WITHOUT_SESSION_REACH: &[&str] = &["roles/aiplatform.viewer"];
+
+/// Whether a GCP role can run code in a sandbox session.
+///
+/// Three ways to say yes, because guessing wrong here certifies a stack whose second identity
+/// holds `execute` as single-tenant. A custom role is unbounded by name, a role Vertex AI adds
+/// after this list was written is not on it, and the rest are enumerated above. Roles outside
+/// those cases answer no, so a `roles/datastore.viewer` on a neighbouring resource does not refuse
+/// a deployment that has nothing to do with sandboxes.
+fn gcp_role_reaches_a_sandbox_session(role: &str) -> bool {
+    if GCP_AIPLATFORM_ROLES_WITHOUT_SESSION_REACH
+        .iter()
+        .any(|safe| safe.eq_ignore_ascii_case(role))
+    {
+        return false;
+    }
+    !role.starts_with("roles/")
+        || role.starts_with("roles/aiplatform.")
+        || GCP_SESSION_REACHING_ROLES
+            .iter()
+            .any(|known| known.eq_ignore_ascii_case(role))
+}
 
 /// Whether one GCP permission entry reaches a sandbox session, by role or by permission.
 fn gcp_entry_reaches_a_sandbox_session(
@@ -188,11 +222,7 @@ fn gcp_entry_reaches_a_sandbox_session(
         .predefined_roles
         .iter()
         .flatten()
-        .any(|role| {
-            GCP_SESSION_REACHING_ROLES
-                .iter()
-                .any(|known| known.eq_ignore_ascii_case(role))
-        })
+        .any(|role| gcp_role_reaches_a_sandbox_session(role))
         // Both lists, unconditionally: an entry setting `permissions` and `residualPermissions`
         // together would otherwise hide the grant in the unscanned one.
         || entry
@@ -586,7 +616,7 @@ mod tests {
     }
 
     /// The Remote Bindings platform gate refuses a kind whose set does not cover the deployment's
-    /// platform. `sandbox/remote-execute` covers AWS and Azure; `alien-manager`'s resolve route
+    /// platform. `sandbox/remote-execute` covers AWS, Azure and GCP; `alien-manager`'s resolve route
     /// carries the matching pair of arms.
     #[test]
     fn remote_binding_permission_sets_cover_the_platforms_that_support_them() {
@@ -737,15 +767,45 @@ mod tests {
             },
         };
 
-        for role in GCP_SESSION_REACHING_ROLES {
+        // Six of these are the ones a list of reaching roles missed. Verified against the live
+        // role definitions, along with `roles/aiplatform.viewer` carrying no session verb.
+        for role in [
+            "roles/owner",
+            "roles/editor",
+            "roles/aiplatform.user",
+            "roles/aiplatform.admin",
+            "roles/aiplatform.editor",
+            "roles/aiplatform.expressAdmin",
+            "roles/aiplatform.expressUser",
+            "roles/aiplatform.customCodeServiceAgent",
+            "roles/aiplatform.serviceAgent",
+            "roles/discoveryengine.serviceAgent",
+            // Neither enumerable: a role Vertex AI adds later, and a custom role of any name.
+            "roles/aiplatform.someRoleAddedLater",
+            "projects/example/roles/aCustomRole",
+        ] {
             assert!(
                 gcp_entry_reaches_a_sandbox_session(&entry(&[role])),
-                "{role} includes aiplatform.sandboxEnvironments.execute"
+                "{role} must be treated as reaching a sandbox session"
             );
         }
-        assert!(!gcp_entry_reaches_a_sandbox_session(&entry(&[
-            "roles/aiplatform.viewer"
-        ])));
+        // A neighbouring resource's grant must not refuse a deployment: these are the GCP roles
+        // shipped permission sets actually name, and none of them reaches a sandbox session.
+        for role in [
+            "roles/aiplatform.viewer",
+            "roles/datastore.viewer",
+            "roles/datastore.user",
+            "roles/storage.objectAdmin",
+            "roles/storage.bucketViewer",
+            "roles/cloudkms.viewer",
+            "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+            "roles/artifactregistry.reader",
+        ] {
+            assert!(
+                !gcp_entry_reaches_a_sandbox_session(&entry(&[role])),
+                "{role} carries no session verb"
+            );
+        }
     }
 
     #[test]

--- a/crates/alien-permissions/tests/gcp_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/gcp_sensitive_invariant.rs
@@ -121,13 +121,10 @@ fn gcp_sandbox_execute_permission_is_confined_to_the_session_reaching_sets() {
     );
 }
 
-/// A heartbeat addresses the sandbox's parent and never a session of it.
-///
-/// Stricter than the reach predicate on purpose, and heartbeat-only: `sandbox/management` names
-/// `aiplatform.sandboxEnvironments.create` and the rest of the session lifecycle because that is
-/// what it is for, while a heartbeat that reads a session has crossed into a resource whose
-/// contents it has no business near. Agent Platform's own health signal is the parent template's
-/// lifecycle state, which is what the controller reads.
+/// A heartbeat addresses the sandbox's parent, never a session of it — stricter than the general
+/// reach predicate on purpose. `sandbox/management` legitimately names the session lifecycle verbs;
+/// a heartbeat reading a session has crossed into content it has no business near, since Agent
+/// Platform's own health signal is the parent template's lifecycle state.
 #[test]
 fn a_gcp_heartbeat_reads_the_parent_and_never_a_session() {
     const SESSION_NAMESPACE: &str = "aiplatform.sandboxEnvironments.";

--- a/crates/alien-permissions/tests/gcp_sensitive_invariant.rs
+++ b/crates/alien-permissions/tests/gcp_sensitive_invariant.rs
@@ -76,10 +76,16 @@ fn gcp_implicit_management_sets_do_not_grant_sensitive_content() {
     }
 }
 
-/// The execute verb reaches session content, so it must appear in `sandbox/execute` and nowhere
-/// else. Positive and negative in one: the collected set is asserted to equal exactly that id.
+/// The two permission sets that may reach inside a sandbox session on GCP.
+///
+/// `execute` serves a workload in the customer's own cloud; `remote-execute` serves a hosted
+/// caller across the Remote Bindings boundary, and is engine-scoped for that reason.
+const SESSION_REACHING_SANDBOX_SETS: &[&str] = &["sandbox/execute", "sandbox/remote-execute"];
+
+/// The execute verb reaches session content, so it must appear in those two sets and nowhere
+/// else. Positive and negative in one: the collected set is asserted to equal exactly that list.
 #[test]
-fn gcp_sandbox_execute_permission_is_confined_to_the_execute_set() {
+fn gcp_sandbox_execute_permission_is_confined_to_the_session_reaching_sets() {
     const EXECUTE_PERMISSION: &str = "aiplatform.sandboxEnvironments.execute";
 
     let mut sets_granting_execute: Vec<&str> = Vec::new();
@@ -105,11 +111,53 @@ fn gcp_sandbox_execute_permission_is_confined_to_the_execute_set() {
         }
     }
 
+    sets_granting_execute.sort_unstable();
+    let mut expected = SESSION_REACHING_SANDBOX_SETS.to_vec();
+    expected.sort_unstable();
     assert_eq!(
-        sets_granting_execute,
-        vec!["sandbox/execute"],
-        "{EXECUTE_PERMISSION} reaches session content and must appear in sandbox/execute alone"
+        sets_granting_execute, expected,
+        "{EXECUTE_PERMISSION} reaches session content; a new set granting it reaches inside a \
+         session"
     );
+}
+
+/// A heartbeat addresses the sandbox's parent and never a session of it.
+///
+/// Stricter than the reach predicate on purpose, and heartbeat-only: `sandbox/management` names
+/// `aiplatform.sandboxEnvironments.create` and the rest of the session lifecycle because that is
+/// what it is for, while a heartbeat that reads a session has crossed into a resource whose
+/// contents it has no business near. Agent Platform's own health signal is the parent template's
+/// lifecycle state, which is what the controller reads.
+#[test]
+fn a_gcp_heartbeat_reads_the_parent_and_never_a_session() {
+    const SESSION_NAMESPACE: &str = "aiplatform.sandboxEnvironments.";
+
+    for permission_set_id in list_permission_set_ids() {
+        if !permission_set_id.ends_with("/heartbeat") {
+            continue;
+        }
+        let permission_set = alien_permissions::get_permission_set(permission_set_id)
+            .expect("permission set exists");
+        let Some(gcp_entries) = &permission_set.platforms.gcp else {
+            continue;
+        };
+
+        for (index, entry) in gcp_entries.iter().enumerate() {
+            let permissions = entry
+                .grant
+                .permissions
+                .iter()
+                .flatten()
+                .chain(entry.grant.residual_permissions.iter().flatten());
+            for permission in permissions {
+                assert!(
+                    !permission.starts_with(SESSION_NAMESPACE),
+                    "{permission_set_id} GCP entry {index} reads a sandbox session through \
+                     {permission}; a heartbeat reads the parent's state"
+                );
+            }
+        }
+    }
 }
 
 fn is_implicit_management_set(permission_set_id: &str) -> bool {

--- a/crates/alien-permissions/tests/permission_set_validation.rs
+++ b/crates/alien-permissions/tests/permission_set_validation.rs
@@ -446,6 +446,11 @@ fn validate_gcp_permissions(
 /// fetched at test time and lags a preview service. Exact-match, not a prefix: a sandbox
 /// permission not on this list still fails, and `aiplatform.reasoningEngines.*` is published so a
 /// typo there is caught against the dataset.
+///
+/// Every name here was accepted by live IAM in a throwaway custom role, against a fabricated
+/// control IAM rejected. `gcloud iam list-testable-permissions` and the public permissions
+/// reference both omit them, so neither is evidence a name is wrong — delete one from a grant only
+/// after IAM refuses to create a role naming it.
 const GCP_UNPUBLISHED_PERMISSIONS: &[&str] = &[
     // Agent-platform sandbox environments and their templates, in preview.
     "aiplatform.sandboxEnvironmentTemplates.create",

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -307,9 +307,8 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str, platform: Platform) -> Opt
 /// by its key, so it can't touch this sandbox from another worker's entry; an **inline** set
 /// carries its own scope and can name this sandbox's group from under any key.
 ///
-/// On GCP a named set is read as inline too: `sandbox/execute` and `sandbox/management` bind there
-/// at `projects/${projectName}`, so the key a set is filed under scopes nothing and a grant on one
-/// sandbox reaches every session in the project.
+/// On GCP a named set is read as inline too: the reach scan reads no binding scope, and GCP has no
+/// counterpart to the `${resourceName}` invariant that lets a key scope an AWS or Azure set.
 fn reaches_this_sandbox(
     reference: &PermissionSetReference,
     target: &str,

--- a/crates/alien-preflights/src/mutations/remote_bindings.rs
+++ b/crates/alien-preflights/src/mutations/remote_bindings.rs
@@ -50,7 +50,7 @@ impl StackMutation for RemoteBindingsMutation {
         validate_remote_bindings_cover_the_platform(&stack, platform, self.description())?;
         validate_isolated_remote_resource(&stack, self.description())?;
         validate_remote_sandboxes_are_deliverable(&stack, self.description())?;
-        validate_remote_sandboxes_are_single_tenant(&stack, self.description())?;
+        validate_remote_sandboxes_are_single_tenant(&stack, self.description(), platform)?;
 
         if let Some(existing) = stack.resources.get(REMOTE_BINDINGS_ID) {
             return Err(AlienError::new(ErrorData::StackMutationFailed {
@@ -198,16 +198,21 @@ fn validate_remote_sandboxes_are_deliverable(stack: &Stack, mutation_name: &str)
 
 /// Refuses a remotely published sandbox that the deployment's own workloads can also reach.
 ///
-/// Neither cloud that publishes a sandbox remotely can scope the grant to a subset of its
-/// sessions: one AWS MicroVM image serves them all, and Azure's `SandboxGroup Data Owner` role
-/// covers every sandbox in the group. So a remote caller can reach sessions the customer's own
-/// compute started; single tenancy is the only containment available.
-fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &str) -> Result<()> {
+/// No cloud that publishes a sandbox remotely can scope the grant to a subset of its sessions: one
+/// AWS MicroVM image serves them all, Azure's `SandboxGroup Data Owner` role covers every sandbox
+/// in the group, and a GCP grant on the reasoning engine covers every session under it. So a remote
+/// caller can reach sessions the customer's own compute started; single tenancy is the only
+/// containment available.
+fn validate_remote_sandboxes_are_single_tenant(
+    stack: &Stack,
+    mutation_name: &str,
+    platform: Platform,
+) -> Result<()> {
     for (resource_id, entry) in &stack.resources {
         if !entry.has_remote_bindings() || entry.config.resource_type() != Sandbox::RESOURCE_TYPE {
             continue;
         }
-        let Some(reach) = in_cloud_reach_to(stack, resource_id) else {
+        let Some(reach) = in_cloud_reach_to(stack, resource_id, platform) else {
             continue;
         };
         return Err(AlienError::new(ErrorData::StackMutationFailed {
@@ -234,7 +239,7 @@ fn validate_remote_sandboxes_are_single_tenant(stack: &Stack, mutation_name: &st
 /// entry is stripped by neither. This runs before `ManagementPermissionProfileMutation`, so the
 /// profile here is what the author wrote, not the auto-derived baseline —
 /// `remote_bindings_is_gated_before_the_management_profile_is_derived` pins that order.
-fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
+fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str, platform: Platform) -> Option<String> {
     let linked_by = stack.resources().find(|(_, entry)| {
         links_of(&entry.config)
             .iter()
@@ -253,9 +258,9 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
                 .0
                 .iter()
                 .any(|(target, permission_sets)| {
-                    permission_sets
-                        .iter()
-                        .any(|reference| reaches_this_sandbox(reference, target, sandbox_id))
+                    permission_sets.iter().any(|reference| {
+                        reaches_this_sandbox(reference, target, sandbox_id, platform)
+                    })
                 })
                 .then(|| format!("permission profile '{profile_name}' grants access to it"))
         });
@@ -287,7 +292,7 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
             .find_map(|(target, permission_sets)| {
                 permission_sets
                     .iter()
-                    .find(|reference| reaches_this_sandbox(reference, target, sandbox_id))
+                    .find(|reference| reaches_this_sandbox(reference, target, sandbox_id, platform))
                     .map(|reference| {
                         format!(
                             "the management profile grants '{}' on '{target}', which reaches it",
@@ -301,18 +306,23 @@ fn in_cloud_reach_to(stack: &Stack, sandbox_id: &str) -> Option<String> {
 /// Whether a profile entry filed under `target` reaches `sandbox_id`. A **named** set is scoped
 /// by its key, so it can't touch this sandbox from another worker's entry; an **inline** set
 /// carries its own scope and can name this sandbox's group from under any key.
+///
+/// On GCP a named set is read as inline too: `sandbox/execute` and `sandbox/management` bind there
+/// at `projects/${projectName}`, so the key a set is filed under scopes nothing and a grant on one
+/// sandbox reaches every session in the project.
 fn reaches_this_sandbox(
     reference: &PermissionSetReference,
     target: &str,
     sandbox_id: &str,
+    platform: Platform,
 ) -> bool {
     match reference {
         // An unresolvable name is no reach: the manager rejects an unknown set before it grants
         // anything. The key scopes a named set because every session-reaching set interpolates
         // `${resourceName}`, which `every_session_reaching_set_is_resource_scoped_by_resource_name`
-        // pins in the registry.
+        // pins in the registry — for the two platforms it covers.
         PermissionSetReference::Name(name) => {
-            (target == sandbox_id || target == "*")
+            (platform == Platform::Gcp || target == sandbox_id || target == "*")
                 && get_permission_set(name).is_some_and(permission_set_reaches_a_sandbox_session)
         }
         PermissionSetReference::Inline(set) => permission_set_reaches_a_sandbox_session(set),
@@ -470,21 +480,26 @@ mod tests {
         assert_eq!(bindings.grants[0].permission_set, "sandbox/remote-execute");
     }
 
-    /// `sandbox/remote-execute` grants on AWS and Azure, nothing on GCP. Without this gate, a GCP
-    /// deployment's security review approves a PERMISSIONS.md heading promising arbitrary code
-    /// execution while listing nothing. Checked both directions: a covered platform must pass
-    /// too, or a set gaining a cloud silently stops deploying there.
+    /// `sandbox/remote-execute` grants on the three clouds whose setup creates the sandbox's
+    /// parent, and nowhere else. Without this gate a deployment's security review approves a
+    /// PERMISSIONS.md heading promising arbitrary code execution while listing nothing. Checked
+    /// both directions: a covered platform must pass too, or a set gaining a cloud silently stops
+    /// deploying there.
     #[tokio::test]
     async fn a_remote_sandbox_is_refused_where_its_permission_set_grants_nothing() {
-        let covered = Stack::new("byo-sandbox".to_string())
-            .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
-            .build();
-        RemoteBindingsMutation
-            .mutate(covered, &StackState::new(Platform::Azure), &config())
-            .await
-            .expect("Azure carries a remote-execute grant, so the gate must let it through");
+        for platform in [Platform::Azure, Platform::Gcp] {
+            let covered = Stack::new("byo-sandbox".to_string())
+                .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
+                .build();
+            RemoteBindingsMutation
+                .mutate(covered, &StackState::new(platform), &config())
+                .await
+                .unwrap_or_else(|error| {
+                    panic!("{platform} carries a remote-execute grant: {error}")
+                });
+        }
 
-        for platform in [Platform::Gcp] {
+        for platform in [Platform::Kubernetes, Platform::Local] {
             let stack = Stack::new("byo-sandbox".to_string())
                 .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
                 .build();
@@ -514,45 +529,43 @@ mod tests {
             .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
             .build();
         let mut config = config();
-        config.base_platform = Some(Platform::Gcp);
+        config.base_platform = Some(Platform::Kubernetes);
 
         let error = RemoteBindingsMutation
-            .mutate(stack, &StackState::new(Platform::Kubernetes), &config)
+            .mutate(stack, &StackState::new(Platform::Gcp), &config)
             .await
             .expect_err("the base platform is the one the grants are emitted for");
 
         assert_eq!(error.code, "STACK_MUTATION_FAILED");
-        assert!(error.to_string().contains("is not supported on gcp"));
+        assert!(error.to_string().contains("is not supported on kubernetes"));
     }
 
-    /// A GCP remote sandbox's in-cloud reach is not something `in_cloud_reach_to` can see, so
-    /// single tenancy would certify this stack. The platform gate runs first and is what keeps
-    /// that unreachable.
+    /// The same stack `a_named_session_set_targeted_at_another_resource_is_allowed` accepts on
+    /// Azure, refused on GCP.
+    ///
+    /// GCP binds `sandbox/execute` at `projects/${projectName}`, so the key a set is filed under
+    /// scopes nothing: the worker granted it on `some-worker` can run code in the published
+    /// sandbox's sessions too, and that is the second tenant this gate exists to refuse.
     #[tokio::test]
-    async fn a_gcp_remote_sandbox_is_refused_before_single_tenancy_can_certify_it() {
-        let worker = Worker::new("processor".to_string())
-            .permissions("execution".to_string())
-            .code(WorkerCode::Image {
-                image: "example.com/processor:latest".to_string(),
-            })
-            .build();
+    async fn a_named_session_set_under_another_key_still_reaches_the_sandbox_on_gcp() {
         let stack = Stack::new("application".to_string())
             .add_with_remote_access(sandbox(SandboxEgress::Allow), ResourceLifecycle::Frozen)
-            .add(worker, ResourceLifecycle::Live)
+            .permission(
+                "execution",
+                PermissionProfile::new().resource("some-worker", ["sandbox/execute"]),
+            )
             .build();
-
-        assert!(
-            in_cloud_reach_to(&stack, "agents").is_none(),
-            "no link and no profile grant, so the single-tenancy scan finds nobody"
-        );
 
         let error = RemoteBindingsMutation
             .mutate(stack, &StackState::new(Platform::Gcp), &config())
             .await
-            .expect_err("a GCP remote sandbox must be refused whatever the reach scan says");
+            .expect_err("a project-scoped grant reaches the published sandbox from any key");
 
-        assert_eq!(error.code, "STACK_MUTATION_FAILED");
-        assert!(error.to_string().contains("is not supported on gcp"));
+        assert_eq!(error.code, "STACK_MUTATION_FAILED", "{error}");
+        assert!(
+            error.to_string().contains("permission profile 'execution'"),
+            "the refusal must come from the reach scan, got: {error}"
+        );
     }
 
     /// The gate is the permission set's own coverage, so the kinds that carry all three blocks

--- a/crates/alien-terraform/src/emitters/gcp/queue.rs
+++ b/crates/alien-terraform/src/emitters/gcp/queue.rs
@@ -187,7 +187,8 @@ fn emit_queue_iam(ctx: &EmitContext<'_>, fragment: &mut TfFragment, label: &str)
                         );
                         fragment.resource_blocks.push(member_block);
                     }
-                    GcpBindingResourceKind::ArtifactRegistryRepository => {}
+                    GcpBindingResourceKind::ArtifactRegistryRepository
+                    | GcpBindingResourceKind::VertexAiReasoningEngine => {}
                 }
             }
         }

--- a/crates/alien-terraform/src/emitters/gcp/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/gcp/sandbox.rs
@@ -140,11 +140,9 @@ impl TfEmitter for GcpAgentPlatformSandboxEmitter {
     }
 }
 
-/// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
-///
-/// Scoped to the engine and nothing wider: IAM on a reasoning engine is enforced on the sessions
-/// hanging under it, while the only scope above it GCP can express is the whole project — which
-/// would hand a remote caller every sibling sandbox in the deployment.
+/// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity, scoped to
+/// the engine and nothing wider: engine IAM covers only the sessions under it, while GCP's only
+/// wider scope is the whole project — every sibling sandbox in the deployment.
 fn emit_remote_access(ctx: &EmitContext<'_>, fragment: &mut TfFragment) -> Result<()> {
     let (Some(definition), Some(access_label)) = (
         alien_core::remote_bindings::remote_binding_is_deliverable(ctx.resource)
@@ -328,11 +326,9 @@ mod tests {
                 .unwrap_or_else(|| panic!("the block carries no '{key}': {block:?}"))
         }
 
-        /// The grant names the engine by reading the created block's server-assigned `name`.
-        ///
-        /// A name derived from the setup label would be a scope no engine answers to, so the
-        /// binding would apply to nothing and the remote caller would hold no session access at
-        /// all — while `PERMISSIONS.md` still advertised the grant.
+        /// The grant names the engine by reading the created block's server-assigned `name` — a
+        /// name derived from the setup label would be a scope no engine answers to, so the caller
+        /// would hold no session access at all while `PERMISSIONS.md` still advertised the grant.
         #[test]
         fn the_engine_grant_references_the_created_engine() {
             let stack = stack_with(SandboxEgress::Allow, None, ResourceLifecycle::Frozen, true);

--- a/crates/alien-terraform/src/emitters/gcp/sandbox.rs
+++ b/crates/alien-terraform/src/emitters/gcp/sandbox.rs
@@ -1,16 +1,31 @@
 //! GCP Agent Platform sandbox emitter.
 //!
 //! The sandbox is the release-owned environment template, which the runtime controller creates
-//! under its engine, so setup emits no resource for it. It refuses domain-scoped egress here
-//! rather than at apply, because the single internet-access switch cannot express a hostname list.
+//! under its engine, so setup emits no resource for it — only the remote grant, which is scoped to
+//! the engine its own emitter creates. It refuses domain-scoped egress here rather than at apply,
+//! because the single internet-access switch cannot express a hostname list.
 
 use crate::{
+    block::{attr, resource_block},
     emitter::{TfEmitter, TfFragment},
-    emitters::gcp::helpers::{downcast, required_label},
+    emitters::gcp::{
+        agent_platform_engine::ENGINE_RESOURCE,
+        helpers::{
+            binding_label_for_role, downcast, emit_custom_roles_for_bindings, permission_context,
+            required_label, role_expression_for_binding, service_account_member_for_label,
+        },
+    },
     expr,
 };
-use alien_core::{import::EmitContext, ErrorData, Result, Sandbox};
-use alien_error::AlienError;
+use alien_core::{
+    import::EmitContext, ErrorData, GcpAgentPlatformEngine, RemoteBindings, ResourceLifecycle,
+    Result, Sandbox,
+};
+use alien_error::{AlienError, Context};
+use alien_permissions::{
+    generators::{GcpBindingResourceKind, GcpBindingTargetScope, GcpRuntimePermissionsGenerator},
+    BindingTarget,
+};
 use hcl::expr::Expression;
 
 /// Serde `service` tag of the `GcpAgentPlatformSandboxBinding`, and the resource-name shapes
@@ -35,25 +50,50 @@ fn refuse_domain_egress(sandbox: &Sandbox) -> Result<()> {
     }))
 }
 
+/// Terraform label of the engine this sandbox's sessions hang under.
+fn engine_label<'a>(ctx: &'a EmitContext<'_>) -> Result<&'a str> {
+    let engine_id = GcpAgentPlatformEngine::id_for_sandbox(ctx.resource_id);
+    ctx.name_for(&engine_id).ok_or_else(|| {
+        AlienError::new(ErrorData::GenericError {
+            message: format!("sandbox '{}' has no engine '{engine_id}'", ctx.resource_id),
+        })
+    })
+}
+
+/// The engine name a session is created under.
+///
+/// Vertex assigns the id, so for a Frozen engine this reads the server-assigned name off the block
+/// that created it. A Live engine is made by its controller after apply, where setup has no address
+/// to reference and the controller republishes the binding with the name it was given.
+fn engine_name(ctx: &EmitContext<'_>, label: &str) -> Result<String> {
+    if ctx.resource.lifecycle != ResourceLifecycle::Frozen {
+        return Ok(format!(
+            "projects/${{var.gcp_project}}/locations/${{var.gcp_region}}/reasoningEngines/{label}"
+        ));
+    }
+    Ok(format!(
+        "${{{ENGINE_RESOURCE}.{}.name}}",
+        engine_label(ctx)?
+    ))
+}
+
 /// The engine, template, region and ttl fields a linked worker's environment reads.
 ///
-/// `engine` and `template` are derived from the setup label rather than read off a resource: the
-/// template is created by the controller after apply and has no Terraform address to reference.
+/// The template id is assigned when the controller creates it, after apply, so the path below is
+/// what setup can name and the controller replaces it in the binding it publishes.
 /// `sessionTtlSeconds` is present only when the declaration set a lifetime, matching the binding's
 /// `skip_serializing_if`.
-fn agent_platform_fields(sandbox: &Sandbox, label: &str) -> Vec<(&'static str, Expression)> {
+fn agent_platform_fields(
+    ctx: &EmitContext<'_>,
+    sandbox: &Sandbox,
+    label: &str,
+) -> Result<Vec<(&'static str, Expression)>> {
+    let engine = engine_name(ctx, label)?;
     let mut fields = vec![
-        (
-            "engine",
-            expr::template(format!(
-                "projects/${{var.gcp_project}}/locations/${{var.gcp_region}}/reasoningEngines/{label}"
-            )),
-        ),
+        ("engine", expr::template(engine.clone())),
         (
             "template",
-            expr::template(format!(
-                "projects/${{var.gcp_project}}/locations/${{var.gcp_region}}/reasoningEngines/{label}/sandboxEnvironmentTemplates/{label}"
-            )),
+            expr::template(format!("{engine}/sandboxEnvironmentTemplates/{label}")),
         ),
         ("region", expr::raw("var.gcp_region")),
     ];
@@ -63,7 +103,7 @@ fn agent_platform_fields(sandbox: &Sandbox, label: &str) -> Vec<(&'static str, E
             Expression::Number(hcl::Number::from(seconds as i64)),
         ));
     }
-    fields
+    Ok(fields)
 }
 
 /// Emits the GCP Agent Platform sandbox: nothing of its own, plus the region its registration
@@ -72,10 +112,12 @@ fn agent_platform_fields(sandbox: &Sandbox, label: &str) -> Vec<(&'static str, E
 pub struct GcpAgentPlatformSandboxEmitter;
 
 impl TfEmitter for GcpAgentPlatformSandboxEmitter {
-    fn emit(&self, _ctx: &EmitContext<'_>) -> Result<TfFragment> {
+    fn emit(&self, ctx: &EmitContext<'_>) -> Result<TfFragment> {
         // The environment template is release-owned: a new image replaces it, so it belongs to the
         // controller under either lifecycle. Only its engine is ever a setup resource.
-        Ok(TfFragment::default())
+        let mut fragment = TfFragment::default();
+        emit_remote_access(ctx, &mut fragment)?;
+        Ok(fragment)
     }
 
     fn emit_import_ref(&self, ctx: &EmitContext<'_>) -> Result<Expression> {
@@ -89,13 +131,95 @@ impl TfEmitter for GcpAgentPlatformSandboxEmitter {
         let label = required_label(ctx)?;
         let sandbox = downcast::<Sandbox>(ctx, Sandbox::RESOURCE_TYPE)?;
         refuse_domain_egress(sandbox)?;
-        let mut fields = agent_platform_fields(sandbox, label);
+        let mut fields = agent_platform_fields(ctx, sandbox, label)?;
         fields.push((
             "service",
             Expression::String(AGENT_PLATFORM_SERVICE.to_string()),
         ));
         Ok(Some(expr::object(fields)))
     }
+}
+
+/// Attaches this sandbox's remote grant to the stack's shared Remote Bindings identity.
+///
+/// Scoped to the engine and nothing wider: IAM on a reasoning engine is enforced on the sessions
+/// hanging under it, while the only scope above it GCP can express is the whole project — which
+/// would hand a remote caller every sibling sandbox in the deployment.
+fn emit_remote_access(ctx: &EmitContext<'_>, fragment: &mut TfFragment) -> Result<()> {
+    let (Some(definition), Some(access_label)) = (
+        alien_core::remote_bindings::remote_binding_is_deliverable(ctx.resource)
+            .then(|| alien_core::remote_bindings::remote_binding_for_entry(ctx.resource))
+            .flatten(),
+        remote_bindings_label(ctx),
+    ) else {
+        return Ok(());
+    };
+    if ctx.resource.lifecycle != ResourceLifecycle::Frozen {
+        return Err(AlienError::new(ErrorData::OperationNotSupported {
+            operation: format!("terraform publish sandbox '{}' remotely", ctx.resource_id),
+            reason: "GCP refuses an IAM binding on a reasoning engine that does not exist yet, \
+                     and a Live engine is created by its controller after apply. Declare the \
+                     sandbox as frozen"
+                .to_string(),
+        }));
+    }
+    let engine_label = engine_label(ctx)?;
+    let permission_set = alien_permissions::get_permission_set(definition.permission_set)
+        .ok_or_else(|| {
+            AlienError::new(ErrorData::GenericError {
+                message: format!(
+                    "{} permission set is not registered",
+                    definition.permission_set
+                ),
+            })
+        })?;
+
+    let context = permission_context(access_label, ctx.stack.id())
+        .with_resource_name(format!("${{{ENGINE_RESOURCE}.{engine_label}.name}}"));
+    let plan = GcpRuntimePermissionsGenerator::new()
+        .generate_grant_plan(permission_set, BindingTarget::Resource, &context)
+        .context(ErrorData::GenericError {
+            message: "failed to generate GCP remote Sandbox permissions".to_string(),
+        })?;
+
+    let bindings = plan.bindings_for_target(GcpBindingTargetScope::CurrentResource);
+    let custom_roles = emit_custom_roles_for_bindings(fragment, &plan, &bindings)?;
+    let member = service_account_member_for_label(access_label);
+    for (index, binding) in bindings.iter().enumerate() {
+        if binding.resource_kind != Some(GcpBindingResourceKind::VertexAiReasoningEngine) {
+            continue;
+        }
+        let role_label = binding_label_for_role(&binding.role, &custom_roles)?;
+        fragment.resource_blocks.push(resource_block(
+            "google_vertex_ai_reasoning_engine_iam_member",
+            &format!("{role_label}_{engine_label}_access_{index}"),
+            [
+                // The engine type lives only in google-beta, and so does its IAM member.
+                attr("provider", expr::raw("google-beta")),
+                // The created engine rather than a name derived from the label: Vertex assigns the
+                // id, and referencing the block is also what orders the grant after it.
+                attr(
+                    "reasoning_engine",
+                    expr::traversal([ENGINE_RESOURCE, engine_label, "name"]),
+                ),
+                attr(
+                    "role",
+                    role_expression_for_binding(&binding.role, &custom_roles)?,
+                ),
+                attr("member", member.clone()),
+            ],
+        ));
+    }
+
+    Ok(())
+}
+
+fn remote_bindings_label<'a>(ctx: &'a EmitContext<'_>) -> Option<&'a str> {
+    ctx.stack.resources().find_map(|(id, entry)| {
+        (entry.config.resource_type() == RemoteBindings::RESOURCE_TYPE)
+            .then(|| ctx.name_for(id))
+            .flatten()
+    })
 }
 
 #[cfg(test)]
@@ -107,33 +231,59 @@ mod tests {
             ResourceLifecycle, SandboxCode, SandboxEgress, SandboxSessionPolicy, Stack,
             StackSettings,
         };
+        use hcl::structure::Structure;
         use indexmap::IndexMap;
         use std::collections::BTreeSet;
 
-        fn emit_binding(egress: SandboxEgress, ttl: Option<u32>) -> Result<Option<Expression>> {
-            let stack = Stack::new("acme".to_string())
-                .add(
-                    Sandbox::new("agents".to_string())
-                        .code(SandboxCode::Image {
-                            image: "ubuntu".to_string(),
-                        })
-                        .egress(egress)
-                        .session(SandboxSessionPolicy {
-                            max_lifetime_seconds: ttl,
-                            idle_suspend_seconds: None,
-                        })
-                        .build(),
-                    ResourceLifecycle::Frozen,
-                )
+        /// The stack `GcpAgentPlatformEngineMutation` produces: the sandbox and the engine it
+        /// hangs under, sharing a lifecycle.
+        fn stack_with(
+            egress: SandboxEgress,
+            ttl: Option<u32>,
+            lifecycle: ResourceLifecycle,
+            remote_access: bool,
+        ) -> Stack {
+            let sandbox = Sandbox::new("agents".to_string())
+                .code(SandboxCode::Image {
+                    image: "ubuntu".to_string(),
+                })
+                .egress(egress)
+                .session(SandboxSessionPolicy {
+                    max_lifetime_seconds: ttl,
+                    idle_suspend_seconds: None,
+                })
                 .build();
+            let builder = Stack::new("acme".to_string()).add(
+                GcpAgentPlatformEngine::new("agents-engine".to_string()).build(),
+                lifecycle,
+            );
+            if remote_access {
+                builder
+                    .add(RemoteBindings::new("access".to_string()).build(), lifecycle)
+                    .add_with_remote_access(sandbox, lifecycle)
+                    .build()
+            } else {
+                builder.add(sandbox, lifecycle).build()
+            }
+        }
+
+        fn names() -> IndexMap<String, String> {
+            IndexMap::from([
+                ("agents".to_string(), "agents".to_string()),
+                ("agents-engine".to_string(), "agents_engine".to_string()),
+                ("access".to_string(), "access".to_string()),
+            ])
+        }
+
+        fn with_context<T>(stack: &Stack, run: impl FnOnce(&EmitContext<'_>) -> T) -> T {
             let resource = stack
                 .resources
                 .get("agents")
                 .expect("the sandbox is in the stack");
-            let names = IndexMap::from([("agents".to_string(), "agents".to_string())]);
+            let names = names();
             let settings = StackSettings::default();
             let ctx = EmitContext {
-                stack: &stack,
+                stack,
                 resource,
                 resource_id: "agents",
                 platform: alien_core::Platform::Gcp,
@@ -141,7 +291,14 @@ mod tests {
                 stack_settings: &settings,
                 names: &names,
             };
-            GcpAgentPlatformSandboxEmitter.emit_binding_ref(&ctx)
+            run(&ctx)
+        }
+
+        fn emit_binding(egress: SandboxEgress, ttl: Option<u32>) -> Result<Option<Expression>> {
+            let stack = stack_with(egress, ttl, ResourceLifecycle::Frozen, false);
+            with_context(&stack, |ctx| {
+                GcpAgentPlatformSandboxEmitter.emit_binding_ref(ctx)
+            })
         }
 
         fn object_keys(expr: &Expression) -> BTreeSet<String> {
@@ -156,6 +313,84 @@ mod tests {
                     .collect(),
                 other => panic!("expected an object, got {other:?}"),
             }
+        }
+
+        fn attribute(block: &hcl::structure::Block, key: &str) -> String {
+            block
+                .body
+                .iter()
+                .find_map(|structure| match structure {
+                    Structure::Attribute(attribute) if attribute.key.as_str() == key => {
+                        Some(attribute.expr.to_string())
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("the block carries no '{key}': {block:?}"))
+        }
+
+        /// The grant names the engine by reading the created block's server-assigned `name`.
+        ///
+        /// A name derived from the setup label would be a scope no engine answers to, so the
+        /// binding would apply to nothing and the remote caller would hold no session access at
+        /// all — while `PERMISSIONS.md` still advertised the grant.
+        #[test]
+        fn the_engine_grant_references_the_created_engine() {
+            let stack = stack_with(SandboxEgress::Allow, None, ResourceLifecycle::Frozen, true);
+            let fragment = with_context(&stack, |ctx| {
+                GcpAgentPlatformSandboxEmitter
+                    .emit(ctx)
+                    .expect("a frozen remote sandbox renders its grant")
+            });
+
+            let member = fragment
+                .resource_blocks
+                .iter()
+                .find(|block| {
+                    block.labels.first().map(|label| label.as_str())
+                        == Some("google_vertex_ai_reasoning_engine_iam_member")
+                })
+                .expect("the remote grant renders an engine-scoped IAM member");
+            assert_eq!(
+                attribute(member, "reasoning_engine"),
+                format!("{ENGINE_RESOURCE}.agents_engine.name")
+            );
+            assert_eq!(attribute(member, "provider"), "google-beta");
+            assert_eq!(
+                attribute(member, "member"),
+                "\"serviceAccount:${google_service_account.access.email}\""
+            );
+            // The role is the generated custom one, not a predefined role: every predefined role
+            // carrying the execute verb carries the rest of Vertex AI with it.
+            assert!(
+                attribute(member, "role").contains("google_project_iam_custom_role"),
+                "{member:?}"
+            );
+
+            // A sandbox nobody published gets no grant, whatever else the stack declares.
+            let unpublished =
+                stack_with(SandboxEgress::Allow, None, ResourceLifecycle::Frozen, false);
+            let fragment = with_context(&unpublished, |ctx| {
+                GcpAgentPlatformSandboxEmitter.emit(ctx).expect("renders")
+            });
+            assert!(fragment.resource_blocks.is_empty(), "{fragment:?}");
+        }
+
+        /// GCP refuses an IAM binding whose engine does not exist yet, and a Live engine is created
+        /// by its controller after apply. Emitting the member anyway would reference a block this
+        /// template never renders.
+        #[test]
+        fn a_live_remote_sandbox_is_refused_naming_the_lifecycle() {
+            let stack = stack_with(SandboxEgress::Allow, None, ResourceLifecycle::Live, true);
+            let error = with_context(&stack, |ctx| {
+                GcpAgentPlatformSandboxEmitter
+                    .emit(ctx)
+                    .expect_err("a Live engine has no scope a grant can name")
+            });
+
+            assert_eq!(error.code, "OPERATION_NOT_SUPPORTED", "{error}");
+            let rendered = error.to_string();
+            assert!(rendered.contains("agents"), "names the sandbox: {rendered}");
+            assert!(rendered.contains("frozen"), "names the fix: {rendered}");
         }
 
         /// The emitted keys are read against the binding type, not a second hand-typed list, so

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -700,6 +700,15 @@ fn permission_doc_scope(scope: &str, target: TerraformTarget, resource_id: &str)
         ),
         _ => format!("${{local.resource_prefix}}-{resource_id}"),
     };
+    // Vertex AI assigns a reasoning engine's id at apply, so no scope can name it. The engine's
+    // display name is what an approver can find in the module, and the path still shows the
+    // boundary: this engine's sessions, not the project's.
+    let scope = match scope.strip_suffix("/reasoningEngines/${resourceName}") {
+        Some(parent) => format!(
+            "{parent}/reasoningEngines/(the id assigned at apply to {resource_name}-engine)"
+        ),
+        None => scope.to_string(),
+    };
     scope
         // Sandbox templates carry the prefix separately; storage templates include it in
         // resourceName. Resolve the pair first so the document matches the installed grant.
@@ -1083,7 +1092,11 @@ fn gcp_iam_resource_addresses(per_resource: &IndexMap<String, TfFragment>) -> Ve
             };
             matches!(
                 provider_type,
-                "google_project_iam_member" | "google_service_account_iam_member"
+                "google_project_iam_member"
+                    | "google_service_account_iam_member"
+                    // The grant that admits a remote caller: registration must not report success
+                    // while it is still propagating, or the caller's first call is a 403.
+                    | "google_vertex_ai_reasoning_engine_iam_member"
             )
         })
         .filter_map(resource_address)

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -712,6 +712,7 @@ fn permission_doc_scope(scope: &str, target: TerraformTarget, resource_id: &str)
             "${data.aws_caller_identity.current.account_id}",
         )
         .replace("${projectName}", "${var.gcp_project}")
+        .replace("${region}", "${var.gcp_region}")
         .replace("${subscriptionId}", "${var.azure_subscription_id}")
         .replace("${resourceGroup}", "${var.azure_resource_group_name}")
         .replace(

--- a/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
+++ b/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
@@ -378,6 +378,22 @@ fn a_gcp_remote_sandbox_grants_the_access_identity_its_own_engine_and_nothing_wi
         permissions_md.contains("/reasoningEngines/"),
         "the documented scope must be the engine, not the project:\n{permissions_md}"
     );
+    // Whatever the document names, an approver has to be able to find it in the module. Vertex
+    // assigns the engine's id at apply, so the display name is the only identifier that is both
+    // written down here and greppable there.
+    let engine_display_name = module
+        .files
+        .get("agents_engine.tf")
+        .expect("setup declares the engine")
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("display_name = "))
+        .expect("the engine declares a display name")
+        .trim_matches('"')
+        .to_string();
+    assert!(
+        permissions_md.contains(&engine_display_name),
+        "the documented scope names {engine_display_name} nowhere:\n{permissions_md}"
+    );
     for token in [
         "${projectName}",
         "${region}",

--- a/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
+++ b/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
@@ -279,12 +279,10 @@ fn a_live_gcp_sandbox_gets_no_engine_and_no_google_beta_provider() {
     assert_terraform_valid(&module, "gcp live sandbox engine");
 }
 
-/// The remote grant reaches one reasoning engine and nothing wider.
-///
-/// The engine is referenced rather than named: a derived path would render a scope no engine
-/// answers to, and referencing the block is also what orders the binding after the engine GCP
-/// refuses to grant on before it exists. `projects/<project>` is the only scope above the engine
-/// GCP can express, and it would hand a remote caller every sibling sandbox in the deployment.
+/// The remote grant reaches one reasoning engine and nothing wider. The engine is referenced
+/// rather than named — a derived path would render a scope no engine answers to, and referencing
+/// the block also orders the binding after the engine exists. `projects/<project>` is the only
+/// wider scope GCP can express, and it would hand a remote caller every sibling sandbox.
 #[test]
 fn a_gcp_remote_sandbox_grants_the_access_identity_its_own_engine_and_nothing_wider() {
     let stack = Stack::new("byo-sandbox".to_string())
@@ -414,11 +412,9 @@ fn a_gcp_remote_sandbox_grants_the_access_identity_its_own_engine_and_nothing_wi
 }
 
 /// The management identity reports on a remotely published sandbox without reaching its sessions.
-///
-/// GCP is where this is load-bearing: `sandbox/management` binds at `projects/${projectName}`, so
-/// a grant left on the management identity would reach the published engine's sessions from
-/// anywhere in the project — the second tenant the single-tenancy gate exists to refuse. The
-/// remote binding claims it instead, and this asserts the artifact agrees.
+/// GCP is where this is load-bearing: `sandbox/management` binds at `projects/${projectName}`, so a
+/// grant left there would reach the published engine's sessions from anywhere in the project — the
+/// second tenant the single-tenancy gate exists to refuse.
 #[test]
 fn a_gcp_remote_sandbox_management_role_heartbeats_without_reaching_a_session() {
     let stack = Stack::new("byo-sandbox".to_string())

--- a/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
+++ b/crates/alien-terraform/tests/generator/gcp_compute_tests.rs
@@ -8,9 +8,9 @@
 use super::helpers::{assert_terraform_valid, render, snapshot_module};
 use alien_core::{
     ArtifactRegistry, Build, CapacityGroup, ComputeCluster, ErrorData, GcpAgentPlatformEngine,
-    Platform, Queue, ResourceLifecycle, ResourceRef, Sandbox, SandboxCode, SandboxEgress,
-    SandboxSessionPolicy, ServiceAccount, Stack, StackSettings, Storage, Worker, WorkerCode,
-    WorkerTrigger,
+    Platform, Queue, RemoteBindings, ResourceLifecycle, ResourceRef, Sandbox, SandboxCode,
+    SandboxEgress, SandboxSessionPolicy, ServiceAccount, Stack, StackSettings, Storage, Worker,
+    WorkerCode, WorkerTrigger,
 };
 use alien_terraform::{generate_terraform_module, TerraformOptions, TerraformTarget, TfRegistry};
 
@@ -277,4 +277,187 @@ fn a_live_gcp_sandbox_gets_no_engine_and_no_google_beta_provider() {
     );
 
     assert_terraform_valid(&module, "gcp live sandbox engine");
+}
+
+/// The remote grant reaches one reasoning engine and nothing wider.
+///
+/// The engine is referenced rather than named: a derived path would render a scope no engine
+/// answers to, and referencing the block is also what orders the binding after the engine GCP
+/// refuses to grant on before it exists. `projects/<project>` is the only scope above the engine
+/// GCP can express, and it would hand a remote caller every sibling sandbox in the deployment.
+#[test]
+fn a_gcp_remote_sandbox_grants_the_access_identity_its_own_engine_and_nothing_wider() {
+    let stack = Stack::new("byo-sandbox".to_string())
+        .add(
+            GcpAgentPlatformEngine::new("agents-engine".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add_with_remote_access(
+            Sandbox::new("agents".to_string())
+                .code(SandboxCode::Image {
+                    image: "python:3.12".to_string(),
+                })
+                .egress(SandboxEgress::Allow)
+                .session(SandboxSessionPolicy {
+                    max_lifetime_seconds: None,
+                    idle_suspend_seconds: None,
+                })
+                .build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Gcp, StackSettings::default());
+    let rendered = module
+        .files
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let member = rendered
+        .split(r#"resource "google_vertex_ai_reasoning_engine_iam_member""#)
+        .nth(1)
+        .expect("the remote grant attaches to the Remote Bindings identity")
+        .split("\nresource ")
+        .next()
+        .expect("block ends");
+    // HCL pads `=` to align an attribute with its siblings, so the column an assertion would match
+    // on moves whenever a neighbouring attribute is added or renamed.
+    let member = member.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    let attribute = |key: &str| {
+        member
+            .split(&format!("{key} = "))
+            .nth(1)
+            .unwrap_or_else(|| panic!("the member carries no '{key}': {member}"))
+            .split(' ')
+            .next()
+            .expect("the attribute is one token")
+            .to_string()
+    };
+    assert_eq!(
+        attribute("reasoning_engine"),
+        "google_vertex_ai_reasoning_engine.agents_engine.name",
+        "the grant must name the created engine by reference, and nothing wider"
+    );
+    assert_eq!(
+        attribute("member"),
+        "\"serviceAccount:${google_service_account.access.email}\"",
+        "the grant belongs to the Remote Bindings identity, not the deployment's own"
+    );
+
+    // The role is generated from the `gcp` block rather than a predefined one: every predefined
+    // role carrying the session verbs carries the rest of Vertex AI with it.
+    let role = rendered
+        .split(r#"resource "google_project_iam_custom_role""#)
+        .nth(1)
+        .expect("the remote grant renders its custom role")
+        .split("\nresource ")
+        .next()
+        .expect("block ends");
+    for permission in [
+        "aiplatform.sandboxEnvironments.create",
+        "aiplatform.sandboxEnvironments.execute",
+        "aiplatform.sandboxEnvironments.delete",
+    ] {
+        assert!(role.contains(permission), "{role}");
+    }
+
+    // The document a security team approves the grant from. A permission-set token left behind
+    // renders a scope that resolves to nothing, and this is the only place a reader sees it.
+    let permissions_md = module
+        .files
+        .get("PERMISSIONS.md")
+        .expect("a remote binding publishes a permissions document");
+    assert!(
+        permissions_md.contains("/reasoningEngines/"),
+        "the documented scope must be the engine, not the project:\n{permissions_md}"
+    );
+    for token in [
+        "${projectName}",
+        "${region}",
+        "${resourceName}",
+        "${stackPrefix}",
+    ] {
+        assert!(
+            !permissions_md.contains(token),
+            "{token} reached the approver's document unsubstituted:\n{permissions_md}"
+        );
+    }
+
+    // `terraform init` is what proves the google-beta provider block was emitted: the IAM member
+    // type resolves nowhere else, and a `required_providers` entry without a `provider` block
+    // fails at plan rather than at emit.
+    assert_terraform_valid(&module, "gcp remote sandbox");
+    snapshot_module("gcp_remote_sandbox", &module);
+}
+
+/// The management identity reports on a remotely published sandbox without reaching its sessions.
+///
+/// GCP is where this is load-bearing: `sandbox/management` binds at `projects/${projectName}`, so
+/// a grant left on the management identity would reach the published engine's sessions from
+/// anywhere in the project — the second tenant the single-tenancy gate exists to refuse. The
+/// remote binding claims it instead, and this asserts the artifact agrees.
+#[test]
+fn a_gcp_remote_sandbox_management_role_heartbeats_without_reaching_a_session() {
+    let stack = Stack::new("byo-sandbox".to_string())
+        .management(alien_core::permissions::ManagementPermissions::extend(
+            alien_core::PermissionProfile::new()
+                .global(["sandbox/heartbeat", "sandbox/management"]),
+        ))
+        .add(
+            GcpAgentPlatformEngine::new("agents-engine".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            RemoteBindings::new("access".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add(
+            alien_core::RemoteStackManagement::new("management".to_string()).build(),
+            ResourceLifecycle::Frozen,
+        )
+        .add_with_remote_access(
+            Sandbox::new("agents".to_string())
+                .code(SandboxCode::Image {
+                    image: "python:3.12".to_string(),
+                })
+                .egress(SandboxEgress::Allow)
+                .session(SandboxSessionPolicy {
+                    max_lifetime_seconds: None,
+                    idle_suspend_seconds: None,
+                })
+                .build(),
+            ResourceLifecycle::Frozen,
+        )
+        .build();
+
+    let module = render(&stack, TerraformTarget::Gcp, StackSettings::default());
+    // Only the management identity's own files: the access role legitimately carries the session
+    // verbs, so a whole-module grep would assert the opposite of what this pins.
+    let rendered = module
+        .files
+        .iter()
+        .filter(|(name, _)| name.contains("management"))
+        .map(|(_, body)| body.clone())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        rendered.contains("aiplatform.sandboxEnvironmentTemplates.get"),
+        "the management identity must be able to read the parent it reports on:\n{rendered}"
+    );
+    // The whole namespace, not a verb list: `sandbox/management` is claimed by the remote binding
+    // and `sandbox/heartbeat` addresses the parent, so nothing the management identity holds may
+    // name a session at all.
+    assert!(
+        !rendered.contains("aiplatform.sandboxEnvironments."),
+        "the management identity names a sandbox session, which belongs to the remote caller \
+         alone:\n{rendered}"
+    );
 }

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_remote_sandbox.snap
@@ -207,7 +207,8 @@ resource "time_sleep" "gcp_iam_propagation" {
   create_duration = "120s"
   depends_on = [
     google_service_account_iam_member.access_manager_token_creator,
-    google_service_account_iam_member.access_manager_user
+    google_service_account_iam_member.access_manager_user,
+    google_vertex_ai_reasoning_engine_iam_member.gcp_role_session_lifecycle_and_exec_agents_engine_access_0
   ]
 }
 
@@ -308,7 +309,7 @@ Create and terminate sessions in this sandbox, and run arbitrary code inside the
 Permission set: `sandbox/remote-execute` (revision 1).
 
 - Create, drive and tear down sessions under the selected sandbox's reasoning engine.
-  Scope: `projects/${var.gcp_project}/locations/${var.gcp_region}/reasoningEngines/${local.resource_prefix}-agents`
+  Scope: `projects/${var.gcp_project}/locations/${var.gcp_region}/reasoningEngines/(the id assigned at apply to ${local.resource_prefix}-agents-engine)`
   - `aiplatform.sandboxEnvironments.create`
   - `aiplatform.sandboxEnvironments.get`
   - `aiplatform.sandboxEnvironments.list`

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_remote_sandbox.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__gcp_remote_sandbox.snap
@@ -1,0 +1,370 @@
+---
+source: crates/alien-terraform/tests/generator/helpers.rs
+expression: buf
+---
+=== versions.tf ===
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+=== variables.tf ===
+variable "resource_prefix" {
+  type        = string
+  description = "Optional stable physical resource prefix. Leave empty to generate one."
+  default     = ""
+
+  validation {
+    condition     = var.resource_prefix == "" || (can(regex("^[a-z][a-z0-9-]{1,38}[a-z0-9]$", var.resource_prefix)) && length(regexall("--", var.resource_prefix)) == 0)
+    error_message = "resource_prefix must be 3-40 characters: lowercase letters, numbers, and hyphens; start with a letter; end with a letter or number; and not contain consecutive hyphens."
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "Human-readable application name shown in setup and cloud IAM review metadata."
+}
+
+variable "token" {
+  type        = string
+  description = "Install token from the application setup page. This is the same token used by the deploy CLI --token flag."
+  sensitive   = true
+}
+
+variable "management_url" {
+  type        = string
+  description = "Management endpoint used to register this deployment."
+  default     = ""
+}
+
+variable "gcp_project" {
+  type        = string
+  description = "GCP project ID."
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "GCP region."
+  default     = "us-central1"
+}
+
+variable "managing_service_account_email" {
+  type        = string
+  description = "Email of the management service account allowed to impersonate setup-created identities."
+}
+
+variable "gcp_manage_custom_roles" {
+  type        = bool
+  description = "Whether this module creates the GCP project custom roles it binds. Set to false when those roles are managed outside this stack."
+  default     = true
+}
+
+variable "gcp_custom_role_prefix" {
+  type        = string
+  description = "Prefix used for GCP project custom role IDs when gcp_manage_custom_roles is false. Empty uses resource_prefix."
+  default     = ""
+}
+
+=== providers.tf ===
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+provider "google-beta" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+=== resource_prefix.tf ===
+resource "random_id" "resource_prefix" {
+  byte_length = 4
+}
+
+=== locals.tf ===
+locals {
+  resource_prefix              = var.resource_prefix == "" ? format("a%s", random_id.resource_prefix.hex) : var.resource_prefix
+  deployment_name              = var.name
+  gcp_custom_role_prefix       = var.gcp_custom_role_prefix != "" ? substr(replace(lower(var.gcp_custom_role_prefix), "-", "_"), 0, 18) : length(replace(lower(local.resource_prefix), "-", "_")) <= 18 ? replace(lower(local.resource_prefix), "-", "_") : format("%s_%s", substr(replace(lower(local.resource_prefix), "-", "_"), 0, 9), substr(sha256(local.resource_prefix), 0, 8))
+  deployment_platform          = "gcp"
+  deployment_target            = "gcp"
+  deployment_region            = var.gcp_region
+  deployment_management_config = null
+  deployment_settings = {
+    deploymentModel = "push"
+    updates         = "approval-required"
+    telemetry       = "off"
+    heartbeats      = "on"
+  }
+  deployment_resources = [
+    {
+      id   = "agents-engine"
+      type = "gcp_agent_platform_engine"
+      importData = {
+        engineId = google_vertex_ai_reasoning_engine.agents_engine.name
+      }
+    },
+    {
+      id   = "access"
+      type = "resource-access"
+      importData = {
+        projectId              = var.gcp_project
+        serviceAccountEmail    = google_service_account.access.email
+        serviceAccountUniqueId = google_service_account.access.unique_id
+      }
+    },
+    {
+      id   = "agents"
+      type = "sandbox"
+      importData = {
+        region = var.gcp_region
+      }
+    }
+  ]
+}
+
+=== agents_engine.tf ===
+resource "google_vertex_ai_reasoning_engine" "agents_engine" {
+  provider     = google-beta
+  region       = var.gcp_region
+  display_name = "${local.resource_prefix}-agents-engine"
+  labels = {
+    "managed-by"    = "setup"
+    deployment      = local.resource_prefix
+    resource        = "agents-engine"
+    "resource-type" = "sandbox-engine"
+  }
+}
+
+=== access.tf ===
+resource "google_service_account" "access" {
+  project      = var.gcp_project
+  account_id   = format("%s-%s", trim(substr(replace(lower(format("a-%s-access", local.resource_prefix)), "_", "-"), 0, 21), "-"), substr(sha1(replace(lower(format("%s-access", local.resource_prefix)), "_", "-")), 0, 8))
+  display_name = "${local.deployment_name}: application access"
+  description  = "Data-plane identity for explicitly published resources in ${local.deployment_name}."
+}
+
+resource "google_service_account_iam_member" "access_manager_token_creator" {
+  for_each           = toset(compact([var.managing_service_account_email]))
+  service_account_id = google_service_account.access.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${each.value}"
+}
+
+resource "google_service_account_iam_member" "access_manager_user" {
+  for_each           = toset(compact([var.managing_service_account_email]))
+  service_account_id = google_service_account.access.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${each.value}"
+}
+
+=== agents.tf ===
+resource "google_project_iam_custom_role" "gcp_role_session_lifecycle_and_exec" {
+  count       = var.gcp_manage_custom_roles ? 1 : 0
+  project     = var.gcp_project
+  role_id     = format("role_%s_session_lifecycle_and_exec", local.gcp_custom_role_prefix)
+  title       = "${local.deployment_name}: Session Lifecycle And Exec"
+  description = "Used by ${local.deployment_name}. Create, drive and tear down sessions under the selected sandbox's reasoning engine. Resource prefix: ${local.resource_prefix}."
+  stage       = "GA"
+  permissions = [
+    "aiplatform.sandboxEnvironments.create",
+    "aiplatform.sandboxEnvironments.delete",
+    "aiplatform.sandboxEnvironments.execute",
+    "aiplatform.sandboxEnvironments.get",
+    "aiplatform.sandboxEnvironments.list",
+    "aiplatform.sandboxEnvironments.pause",
+    "aiplatform.sandboxEnvironments.resume"
+  ]
+}
+
+resource "google_vertex_ai_reasoning_engine_iam_member" "gcp_role_session_lifecycle_and_exec_agents_engine_access_0" {
+  provider         = google-beta
+  reasoning_engine = google_vertex_ai_reasoning_engine.agents_engine.name
+  role             = var.gcp_manage_custom_roles ? google_project_iam_custom_role.gcp_role_session_lifecycle_and_exec[0].name : format("projects/%s/roles/role_%s_session_lifecycle_and_exec", var.gcp_project, local.gcp_custom_role_prefix)
+  member           = "serviceAccount:${google_service_account.access.email}"
+}
+
+=== iam_propagation.tf ===
+resource "time_sleep" "gcp_iam_propagation" {
+  create_duration = "120s"
+  depends_on = [
+    google_service_account_iam_member.access_manager_token_creator,
+    google_service_account_iam_member.access_manager_user
+  ]
+}
+
+=== registration.tf ===
+resource "terraform_data" "deployment_registration" {
+  input = {
+    platform                    = local.deployment_platform
+    token                       = var.token
+    name                        = var.name
+    resource_prefix             = local.resource_prefix
+    setup_target                = ""
+    setup_import_format_version = 1
+    setup_fingerprint           = ""
+    setup_fingerprint_version   = 0
+    management_url              = var.management_url
+    management_config           = local.deployment_management_config
+    stack_settings              = local.deployment_settings
+    resources                   = local.deployment_resources
+    inputValues                 = {}
+  }
+  depends_on = [
+    google_vertex_ai_reasoning_engine.agents_engine,
+    google_service_account.access,
+    google_service_account_iam_member.access_manager_token_creator,
+    google_service_account_iam_member.access_manager_user,
+    google_project_iam_custom_role.gcp_role_session_lifecycle_and_exec,
+    google_vertex_ai_reasoning_engine_iam_member.gcp_role_session_lifecycle_and_exec_agents_engine_access_0,
+    time_sleep.gcp_iam_propagation
+  ]
+}
+
+=== outputs.tf ===
+output "deployment_target" {
+  value       = "gcp"
+  description = "Terraform module target."
+}
+
+output "deployment_resource_prefix" {
+  value       = local.resource_prefix
+  description = "Physical resource prefix."
+}
+
+output "deployment_platform" {
+  value       = local.deployment_platform
+  description = "Target platform."
+}
+
+output "deployment_region" {
+  value       = local.deployment_region
+  description = "Target cloud region or location."
+}
+
+output "deployment_setup_target" {
+  value       = ""
+  description = "Setup target."
+}
+
+output "deployment_setup_import_format_version" {
+  value       = 1
+  description = "Setup registration payload format version."
+}
+
+output "deployment_setup_fingerprint" {
+  value       = ""
+  description = "Setup compatibility fingerprint."
+}
+
+output "deployment_setup_fingerprint_version" {
+  value       = 0
+  description = "Setup fingerprint algorithm version."
+}
+
+output "deployment_management_config" {
+  value       = jsonencode(local.deployment_management_config)
+  description = "Deployment registration management configuration JSON."
+}
+
+output "deployment_stack_settings" {
+  value       = jsonencode(local.deployment_settings)
+  description = "Deployment registration settings JSON."
+  sensitive   = true
+}
+
+output "deployment_resources" {
+  value       = jsonencode(local.deployment_resources)
+  description = "Deployment registration resource metadata JSON."
+}
+
+=== PERMISSIONS.md ===
+# Application access permissions
+
+The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.
+
+## `agents` (sandbox)
+
+Create and terminate sessions in this sandbox, and run arbitrary code inside them.
+
+Permission set: `sandbox/remote-execute` (revision 1).
+
+- Create, drive and tear down sessions under the selected sandbox's reasoning engine.
+  Scope: `projects/${var.gcp_project}/locations/${var.gcp_region}/reasoningEngines/${local.resource_prefix}-agents`
+  - `aiplatform.sandboxEnvironments.create`
+  - `aiplatform.sandboxEnvironments.get`
+  - `aiplatform.sandboxEnvironments.list`
+  - `aiplatform.sandboxEnvironments.delete`
+  - `aiplatform.sandboxEnvironments.execute`
+  - `aiplatform.sandboxEnvironments.pause`
+  - `aiplatform.sandboxEnvironments.resume`
+
+=== README.md ===
+# Deployment setup - byo-sandbox
+
+Target: `gcp`.
+
+This module creates setup-owned infrastructure, grants the management access needed after setup, and prepares deployment registration metadata. Review the generated `.tf` files before applying; each resource file maps to one setup resource.
+
+## Inputs
+
+Required:
+
+- `token`: install token from the setup page.
+- `name`: deployment name to include in the registration metadata.
+
+Common optional settings:
+
+- `resource_prefix`: stable physical-name prefix. Leave empty to generate one.
+- `management_url`: management endpoint used to register this deployment. The generated installation snippet supplies the endpoint selected for the deployment target.
+
+GCP settings:
+
+- `gcp_project`: target GCP project ID.
+- `gcp_region`: target GCP region.
+- `managing_service_account_email`: management service account allowed to impersonate setup-created identities.
+- `gcp_manage_custom_roles`: whether this module creates project custom roles.
+- `gcp_custom_role_prefix`: custom role ID prefix when roles are managed outside this module.
+
+## Run
+
+Use your organization's normal backend and approval workflow. A typical local review looks like:
+
+```bash
+export TF_VAR_name="byo-sandbox"
+export TF_VAR_token="..."
+terraform init
+terraform validate
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+## Registration
+
+This module exposes `deployment_management_config`, `deployment_stack_settings`, `deployment_resources`, and (when the stack declares deployer inputs) `deployment_input_values` outputs for registration flows managed outside Terraform.
+
+## Outputs
+
+- `deployment_management_config`: management endpoint and credential-boundary metadata.
+- `deployment_stack_settings`: deployment settings JSON assembled from typed variables, package defaults, and advanced-setting overlays.
+- `deployment_resources`: setup-owned resource metadata handed to the deployment runtime.
+- `deployment_input_values`: deployer input values JSON, emitted only when the stack declares deployer inputs.
+- `deployment_id` and `deployment_token`: emitted only when Terraform performs registration.


### PR DESCRIPTION
## Summary

Brings GCP to parity with AWS and Azure for remotely published sandboxes. `sandbox/remote-execute` gains a GCP block, the Manager resolves a `sandbox-gcp-agent-platform` binding, and the bindings decoder round-trips it.

Stacked on #589. What happens when a deployment publishes a GCP sandbox to a remote caller:

1. Setup creates the reasoning engine (#589), so a grant has something to name, and attaches a custom role at the engine rather than at the project.
2. **The single-tenancy gate decides whether any other role in the deployment reaches that sandbox's sessions** — it used to answer by naming the four roles it knew, so any role nobody had enumerated read as safe.
3. The Manager resolves the `sandbox-gcp-agent-platform` binding and leases a session to the remote caller.

This PR changes GCP remote sandbox publication from refused to allowed, with the grant bounded to a single reasoning engine.

## What was broken

The set was absent on GCP for two stated reasons and both have stopped holding. The engine is created by setup now, so a grant has something to name; and naming it is what keeps the grant off the project, where a remote caller would reach every sibling sandbox in the deployment. Separately, the single-tenancy gate certified a profile granting `roles/aiplatform.editor` to a second identity as single-tenant, while that identity could run code in the published sandbox.

## What I did

- Added the GCP block to `sandbox/remote-execute`, scoped to the engine. `GcpAgentPlatformEngine::id_for_sandbox` is 1:1, so engine scope is sandbox scope and a sibling's sessions are out of reach.
- Used a custom role rather than a predefined one, because **ten** predefined roles carry `execute` beside the rest of Vertex AI. Read off the live role definitions, not the names. `roles/aiplatform.viewer` is the one that does not.
- Rewrote the reach predicate to say yes on three grounds instead of an enumeration: a custom role (a name bounds nothing), anything under `roles/aiplatform.` bar the proven-safe one (where a role added later appears), and the ten enumerated. A blanket refusal was the alternative and is wrong here — this predicate runs over every set a service account or profile names, and shipped sets name `roles/datastore.viewer` and `roles/storage.objectAdmin`.
- Fixed two review findings on top. The approver's document named an identifier that exists nowhere in the module: it rendered `<prefix>-agents`, while the engine's declared display name is `<prefix>-agents-engine` and the real id is assigned by Vertex at apply. The boundary was right, but a document whose only job is verifiability has to name something the reader can find; the assertion guarding it was a string-existence check and now ties the documented scope to the display name the engine file declares. And the engine's IAM member sat outside the propagation barrier, which named only project and service-account members — so registration could report success while the grant admitting the remote caller was still propagating, and the caller's first call would be a 403 in the customer's own cloud.

## Files touched

- `crates/alien-permissions/permission-sets/sandbox/remote-execute.jsonc`, `heartbeat.jsonc` — the GCP block.
- `crates/alien-permissions/src/registry.rs`, `crates/alien-permissions/src/generators/gcp_runtime.rs` — the rewritten reach predicate.
- `crates/alien-terraform/src/emitters/gcp/sandbox.rs` — the custom role, the engine-scoped IAM member, and the propagation barrier.
- `crates/alien-manager/src/routes/bindings.rs`, `crates/alien-bindings/src/remote/manager_conversion.rs`, `crates/alien-bindings/src/remote.rs` — resolving and decoding the `sandbox-gcp-agent-platform` binding.
- `crates/alien-preflights/src/mutations/remote_bindings.rs` — GCP no longer refused before the gate can answer.
- Plus tests, one new Terraform snapshot, and the regenerated OpenAPI copies.

## How I tested

- **Manually:** `gcloud beta iam list-testable-permissions` against a reasoning engine returns `aiplatform.sandboxEnvironments.{create,delete,execute,get,list}` plus the engine's own IAM-policy verbs — so those permissions are grantable **at** the engine, and the engine accepts an allow policy. For the two permission names a review called fictional, `sandboxEnvironments.{pause,resume}` and `sandboxEnvironmentTemplates.*` are absent from `gcloud iam list-testable-permissions` and from the published permissions reference because they are preview-gated; creating one throwaway custom role per name settles it — all nine accepted, `aiplatform.notARealThing.frobnicate` rejected as the control. The method is now recorded beside the suppression list so a listing API's silence is not read as evidence again.
- **Unit tests:** six mutations, each with its failing assertion recorded; a seventh reported as non-discriminating rather than hidden. `cargo test -p alien-terraform` — 226 pass, with `terraform validate` running inside the generator tests. `cargo test -p alien-permissions -p alien-preflights` — 488 pass. `cargo nextest run --workspace` — green apart from live-cloud e2e suites needing credentials this machine lacks.
- **Anything I couldn't test:** the live staging proof — `testIamPermissions` returning the session set on engine A and `{}` on engine B, and a session round-trip through the Manager — needs a staging project and a narrow service account. That verification stays open.

I also ran a security review on the diff. What it checked:

- The grant landing on the project, where a remote caller would reach every sibling sandbox in the deployment — it is attached at the engine, and `GcpAgentPlatformEngine::id_for_sandbox` is 1:1, so engine scope is sandbox scope.
- A predefined role quietly carrying `execute` — ten of them do, read off the live role definitions rather than the names, which is why the set uses a custom role.
- A second identity in the deployment reaching the published sandbox through a role nobody enumerated — the reach predicate now answers on three grounds including "anything under `roles/aiplatform.` bar the proven-safe one", so a role added later reads as reach instead of as safe.
- Registration reporting success while the grant is still propagating, so the remote caller's first call 403s in the customer's own cloud — the engine's IAM member is inside the propagation barrier now.
- The generated permissions document naming a scope the reader cannot verify — the assertion ties the documented scope to the display name the engine file declares, rather than checking a string exists.

Nothing turned up.

## Out of scope

Follow-ups filed: the AWS permissions document renders unsubstituted tokens and a doubled prefix, and GCP `execute` is bound at the project when the engine is expressible.
