### PR TITLE
feat: scoped Kubernetes operation declarations (ALIEN-726)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
+ "alien-operations-sdk",
  "indexmap 2.14.1",
  "insta",
  "serde",

--- a/crates/alien-helm/Cargo.toml
+++ b/crates/alien-helm/Cargo.toml
@@ -13,6 +13,7 @@ test-utils = ["dep:tempfile"]
 [dependencies]
 alien-core = { workspace = true, features = ["sandbox-process"] }
 alien-error = { workspace = true }
+alien-operations-sdk = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/alien-helm/src/generator.rs
+++ b/crates/alien-helm/src/generator.rs
@@ -17,6 +17,7 @@ use alien_core::{
     Stack, StackSettings, Worker, WorkerCode,
 };
 use alien_error::{AlienError, Context, IntoAlienError};
+use alien_operations_sdk::KubernetesOperationPermissions;
 use indexmap::IndexMap;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -58,7 +59,7 @@ pub struct ManagerFetchHelmValuesOptions<'a> {
 ///
 /// Renderers expose this value so callers can reject manifests produced by a
 /// generator that predates policy-aware Kubernetes operation permissions.
-pub const OPERATOR_RBAC_POLICY_VERSION: u32 = 1;
+pub const OPERATOR_RBAC_POLICY_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OperatorPermission {
@@ -147,6 +148,9 @@ pub struct OperatorManifestOptions<'a> {
     /// plugin. This gates operation-specific RBAC independently of the
     /// requested permission tier.
     pub kubernetes_operations_enabled: bool,
+    /// Declared requirements from enabled custom operations only. The
+    /// generator validates these before applying the permission ceiling.
+    pub custom_operation_permissions: &'a [KubernetesOperationPermissions],
     pub permission: OperatorPermission,
     pub format: OperatorOutputFormat,
 }
@@ -336,6 +340,7 @@ pub fn generate_operator_manifest(options: OperatorManifestOptions<'_>) -> Resul
             &crd_names,
             options.kubernetes_operations_enabled,
             options.permission,
+            options.custom_operation_permissions,
         ));
         docs.push(operator_clusterrolebinding_doc(
             namespace,
@@ -350,6 +355,7 @@ pub fn generate_operator_manifest(options: OperatorManifestOptions<'_>) -> Resul
             &crd_names,
             options.kubernetes_operations_enabled,
             options.permission,
+            options.custom_operation_permissions,
         ));
         docs.push(operator_rolebinding_doc(namespace, &operator_name, &labels));
     }
@@ -545,6 +551,14 @@ fn validate_runtime_encryption_key(key: &str) -> Result<()> {
 }
 
 fn validate_operator_options(options: &OperatorManifestOptions<'_>) -> Result<()> {
+    for operation in options.custom_operation_permissions {
+        operation.validate().context(ErrorData::GenericError {
+            message: format!(
+                "invalid Kubernetes permissions for {}/{}",
+                operation.plugin, operation.operation
+            ),
+        })?;
+    }
     let invalid = |message: &str| {
         Err(AlienError::new(ErrorData::GenericError {
             message: message.to_string(),
@@ -622,6 +636,7 @@ fn operator_role_doc(
     crd_names: &AccessRequestCrdNames,
     kubernetes_operations_enabled: bool,
     permission: OperatorPermission,
+    custom_operations: &[KubernetesOperationPermissions],
 ) -> String {
     let mut yaml = operator_metadata_doc(
         "rbac.authorization.k8s.io/v1",
@@ -634,6 +649,7 @@ fn operator_role_doc(
         crd_names,
         kubernetes_operations_enabled,
         permission,
+        custom_operations,
     ));
     yaml
 }
@@ -667,6 +683,19 @@ roleRef:
     yaml
 }
 
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct OperatorRuleScope {
+    api_group: String,
+    resource: String,
+    resource_names: BTreeSet<String>,
+}
+
+#[derive(Default)]
+struct OperatorRuleGrant {
+    verbs: BTreeSet<String>,
+    reasons: BTreeSet<String>,
+}
+
 /// Kubernetes operation rules shared by the namespaced `Role` and cluster-wide
 /// `ClusterRole`.
 ///
@@ -692,54 +721,167 @@ fn operator_rules(
     names: &AccessRequestCrdNames,
     kubernetes_operations_enabled: bool,
     permission: OperatorPermission,
+    custom_operations: &[KubernetesOperationPermissions],
 ) -> String {
-    let mut rules = format!(
-        r#"rules:
-  - apiGroups: [""]
-    resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "events", "endpoints"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["metrics.k8s.io"]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["{group}"]
-    resources: ["{plural}"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  - apiGroups: ["{group}"]
-    resources: ["{plural}/status"]
-    verbs: ["get", "update", "patch"]
-"#,
-        group = names.group,
-        plural = names.plural,
-    );
+    // Normalize builtin and custom grants together. Names are part of the key:
+    // sharing a grant never widens a named requirement to all resources.
+    let mut rules = BTreeMap::<OperatorRuleScope, OperatorRuleGrant>::new();
+    let mut add_rule = |group: &str, resource: &str, resource_names, verbs, reason| {
+        let grant = rules
+            .entry(OperatorRuleScope {
+                api_group: group.to_owned(),
+                resource: resource.to_owned(),
+                resource_names,
+            })
+            .or_default();
+        grant.verbs.extend(verbs);
+        grant.reasons.insert(reason);
+    };
+    let status_resource = format!("{}/status", names.plural);
+    let baseline: &[(&str, &[&str], &[&str], &str)] = &[
+        (
+            "",
+            &[
+                "pods",
+                "services",
+                "configmaps",
+                "persistentvolumeclaims",
+                "events",
+                "endpoints",
+            ],
+            &["get", "list", "watch"],
+            "baseline resource inventory.",
+        ),
+        (
+            "apps",
+            &["deployments", "statefulsets", "daemonsets", "replicasets"],
+            &["get", "list", "watch"],
+            "baseline workload inventory.",
+        ),
+        (
+            "batch",
+            &["jobs", "cronjobs"],
+            &["get", "list", "watch"],
+            "baseline job inventory.",
+        ),
+        (
+            "metrics.k8s.io",
+            &["pods"],
+            &["get", "list", "watch"],
+            "baseline pod metrics.",
+        ),
+        (
+            &names.group,
+            &[&names.plural],
+            &["get", "list", "watch", "create", "update", "patch"],
+            "access-request materialization and approval observation.",
+        ),
+        (
+            &names.group,
+            &[&status_resource],
+            &["get", "update", "patch"],
+            "access-request status reporting.",
+        ),
+    ];
+    for (group, resources, verbs, reason) in baseline {
+        for resource in *resources {
+            add_rule(
+                group,
+                resource,
+                BTreeSet::new(),
+                verbs
+                    .iter()
+                    .map(|verb| (*verb).to_owned())
+                    .collect::<BTreeSet<_>>(),
+                (*reason).to_owned(),
+            );
+        }
+    }
     if kubernetes_operations_enabled {
-        rules.push_str(
-            r#"  # Required by the kubernetes/logs operation.
-  - apiGroups: [""]
-    resources: ["pods/log"]
-    verbs: ["get"]
-"#,
+        add_rule(
+            "",
+            "pods/log",
+            BTreeSet::new(),
+            BTreeSet::from(["get".to_owned()]),
+            "the kubernetes/logs operation.".to_owned(),
         );
     }
     if kubernetes_operations_enabled && permission == OperatorPermission::Remediation {
-        rules.push_str(
-            r#"  # Required by the kubernetes/restart-pod operation.
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["delete"]
-  # Required by the kubernetes/scale operation.
-  - apiGroups: ["apps"]
-    resources: ["deployments/scale", "statefulsets/scale", "replicasets/scale"]
-    verbs: ["patch"]
-"#,
+        add_rule(
+            "",
+            "pods",
+            BTreeSet::new(),
+            BTreeSet::from(["delete".to_owned()]),
+            "the kubernetes/restart-pod operation.".to_owned(),
         );
+        for resource in [
+            "deployments/scale",
+            "statefulsets/scale",
+            "replicasets/scale",
+        ] {
+            add_rule(
+                "apps",
+                resource,
+                BTreeSet::new(),
+                BTreeSet::from(["patch".to_owned()]),
+                "the kubernetes/scale operation.".to_owned(),
+            );
+        }
     }
-    rules
+    for operation in custom_operations {
+        for rule in &operation.permissions.rules {
+            let verbs: BTreeSet<_> = rule
+                .verbs
+                .iter()
+                .filter(|verb| {
+                    permission == OperatorPermission::Remediation
+                        || matches!(verb.as_str(), "get" | "list" | "watch")
+                })
+                .cloned()
+                .collect();
+            if !verbs.is_empty() {
+                add_rule(
+                    &rule.api_group,
+                    &rule.resource,
+                    rule.resource_names.iter().cloned().collect(),
+                    verbs,
+                    format!(
+                        "{}/{}: {}",
+                        operation.plugin, operation.operation, rule.reason
+                    ),
+                );
+            }
+        }
+    }
+    let mut yaml = "rules:\n".to_owned();
+    for (scope, grant) in rules {
+        for reason in grant.reasons {
+            yaml.push_str(&format!("  # Required by {reason}\n"));
+        }
+        yaml.push_str(&format!(
+            "  - apiGroups: [{}]\n    resources: [{}]\n    verbs: [{}]\n",
+            yaml_string(&scope.api_group),
+            yaml_string(&scope.resource),
+            grant
+                .verbs
+                .iter()
+                .map(|verb| yaml_string(verb))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        if !scope.resource_names.is_empty() {
+            yaml.push_str(&format!(
+                "    resourceNames: [{}]\n",
+                scope
+                    .resource_names
+                    .iter()
+                    .map(|name| yaml_string(name))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+    yaml
 }
 
 /// The access-request `CustomResourceDefinition`, white-labeled from `names`.
@@ -882,12 +1024,14 @@ fn operator_clusterrole_doc(
     crd_names: &AccessRequestCrdNames,
     kubernetes_operations_enabled: bool,
     permission: OperatorPermission,
+    custom_operations: &[KubernetesOperationPermissions],
 ) -> String {
     let mut yaml = operator_cluster_metadata_doc("ClusterRole", operator_name, labels);
     yaml.push_str(&operator_rules(
         crd_names,
         kubernetes_operations_enabled,
         permission,
+        custom_operations,
     ));
     yaml
 }
@@ -4123,6 +4267,7 @@ mod tests {
 
     fn operator_test_manifest() -> String {
         generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -4144,6 +4289,7 @@ mod tests {
 
     fn operator_test_manifest_with_log_collector() -> String {
         generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -4172,6 +4318,7 @@ mod tests {
             ..Default::default()
         };
         generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -4349,6 +4496,7 @@ mod tests {
     #[test]
     fn operator_remediation_adds_only_restart_and_scale_writes() {
         let manifest = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -4372,33 +4520,45 @@ mod tests {
             .as_sequence()
             .expect("Role should include rules");
 
-        let writes = rules
-            .iter()
-            .filter_map(|rule| {
-                let verbs = rule["verbs"].as_sequence()?;
-                verbs
-                    .iter()
-                    .any(|verb| verb == "delete" || verb == "patch")
-                    .then(|| (rule["resources"].clone(), rule["verbs"].clone()))
-            })
-            .collect::<Vec<_>>();
-
+        let mut writes = BTreeSet::new();
+        for rule in rules {
+            for group in rule["apiGroups"].as_sequence().unwrap() {
+                for resource in rule["resources"].as_sequence().unwrap() {
+                    for verb in rule["verbs"].as_sequence().unwrap() {
+                        let verb = verb.as_str().unwrap();
+                        if !matches!(verb, "get" | "list" | "watch") {
+                            writes.insert((
+                                group.as_str().unwrap(),
+                                resource.as_str().unwrap(),
+                                verb,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
         assert_eq!(
-            writes.len(),
-            4,
-            "two access-request rules plus restart and scale"
+            writes,
+            BTreeSet::from([
+                ("", "pods", "delete"),
+                ("apps", "deployments/scale", "patch"),
+                ("apps", "statefulsets/scale", "patch"),
+                ("apps", "replicasets/scale", "patch"),
+                ("accessrequests.alien", "alienaccessrequests", "create"),
+                ("accessrequests.alien", "alienaccessrequests", "update"),
+                ("accessrequests.alien", "alienaccessrequests", "patch"),
+                (
+                    "accessrequests.alien",
+                    "alienaccessrequests/status",
+                    "update"
+                ),
+                (
+                    "accessrequests.alien",
+                    "alienaccessrequests/status",
+                    "patch"
+                ),
+            ])
         );
-        assert!(writes
-            .iter()
-            .any(|(resources, verbs)| { resources[0] == "pods" && verbs[0] == "delete" }));
-        assert!(writes.iter().any(|(resources, verbs)| {
-            resources.as_sequence().is_some_and(|items| {
-                items.iter().all(|item| {
-                    item.as_str()
-                        .is_some_and(|resource| resource.ends_with("/scale"))
-                })
-            }) && verbs[0] == "patch"
-        }));
     }
 
     #[test]
@@ -4409,6 +4569,7 @@ mod tests {
         // is never required — it's slugified into the CRD group, never
         // resolved.
         let manifest = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -4668,6 +4829,7 @@ mod tests {
         // Label scope is cluster-wide: emits the selector env and ClusterRole/
         // ClusterRoleBinding instead of a namespaced Role.
         let manifest = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
@@ -4726,6 +4888,7 @@ mod tests {
     #[test]
     fn operator_helm_template_sources_namespace_and_identity_from_helm() {
         let manifest = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
@@ -4761,6 +4924,7 @@ mod tests {
     #[test]
     fn raw_manifest_requires_install_namespace_and_environment_name() {
         let missing_namespace = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
@@ -4783,6 +4947,7 @@ mod tests {
         );
 
         let missing_env = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,
@@ -4803,6 +4968,7 @@ mod tests {
 
         // Label scope must carry a non-empty selector.
         let empty_label = generate_operator_manifest(OperatorManifestOptions {
+            custom_operation_permissions: &[],
             manager_url: "https://manager.example.com",
             group_token: "ax_dg_test",
             encryption_key: TEST_RUNTIME_ENCRYPTION_KEY,

--- a/crates/alien-helm/tests/generator/operator_manifest_tests.rs
+++ b/crates/alien-helm/tests/generator/operator_manifest_tests.rs
@@ -2,6 +2,7 @@ use alien_helm::{
     generate_operator_manifest, HelmChart, OperatorManifestOptions, OperatorOutputFormat,
     OperatorPermission, OperatorScope,
 };
+use alien_operations_sdk::{KubernetesOperationPermissions, PluginManifest};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_yaml::Value as YamlValue;
@@ -16,7 +17,25 @@ fn rendered_manifest(
     permission: OperatorPermission,
     kubernetes_operations_enabled: bool,
 ) -> String {
+    rendered_with_custom(
+        scope,
+        permission,
+        kubernetes_operations_enabled,
+        &[],
+        OperatorOutputFormat::RawManifest,
+    )
+    .expect("operator manifest should render")
+}
+
+fn rendered_with_custom(
+    scope: OperatorScope,
+    permission: OperatorPermission,
+    kubernetes_operations_enabled: bool,
+    custom_operation_permissions: &[KubernetesOperationPermissions],
+    format: OperatorOutputFormat,
+) -> alien_core::Result<String> {
     generate_operator_manifest(OperatorManifestOptions {
+        custom_operation_permissions,
         manager_url: "https://manager.example.com",
         group_token: "ax_dg_test",
         encryption_key: TEST_ENCRYPTION_KEY,
@@ -31,9 +50,193 @@ fn rendered_manifest(
         label_selector: None,
         kubernetes_operations_enabled,
         permission,
-        format: OperatorOutputFormat::RawManifest,
+        format,
     })
-    .expect("operator manifest should render")
+}
+
+fn custom_operation(plugin_name: &str) -> KubernetesOperationPermissions {
+    // Exercise the author-facing metadata contract, not a hand-built rule.
+    let manifest = serde_json::json!({
+        "name": plugin_name, "version": "1", "tier": "read-only",
+        "binaries": {"amd64": "inspector"},
+        "operations": [{"name": "inspect", "kubernetesPermissions": {
+            "schemaVersion": 1, "rules": [{
+                "apiGroup": "example.com", "resource": "widgets",
+                "verbs": ["watch", "get", "list", "get"],
+                "resourceNames": ["sample", "sample"], "reason": "Inspect selected widgets"
+            }]
+        }}]
+    });
+    let parsed = PluginManifest::parse_and_validate(manifest.to_string().as_bytes()).unwrap();
+    let operation = &parsed.operations[0];
+    KubernetesOperationPermissions {
+        plugin: parsed.name.clone(),
+        operation: operation.name.clone(),
+        tier: operation.effective_tier(parsed.tier),
+        permissions: operation.kubernetes_permissions.clone().unwrap(),
+    }
+}
+
+#[test]
+fn custom_permissions_follow_enabled_consumers_with_stable_scoped_rbac() {
+    let first = custom_operation("first");
+    let second = custom_operation("second");
+    for scope in [OperatorScope::Namespace, OperatorScope::Cluster] {
+        for enabled in [
+            vec![],
+            vec![first.clone()],
+            vec![first.clone(), second.clone()],
+            vec![second.clone()],
+            vec![],
+        ] {
+            let rendered = rendered_with_custom(
+                scope,
+                OperatorPermission::Diagnostics,
+                false,
+                &enabled,
+                OperatorOutputFormat::RawManifest,
+            )
+            .unwrap();
+            let docs = parse_manifest(&rendered);
+            let role = docs
+                .iter()
+                .find(|doc| doc["kind"] == "Role" || doc["kind"] == "ClusterRole")
+                .unwrap();
+            let rules: Vec<_> = role["rules"]
+                .as_sequence()
+                .unwrap()
+                .iter()
+                .filter(|rule| rule["resources"][0] == "widgets")
+                .collect();
+            assert_eq!(rules.len(), usize::from(!enabled.is_empty()));
+            if let Some(rule) = rules.first() {
+                assert_eq!(
+                    rule["apiGroups"],
+                    serde_yaml::to_value(["example.com"]).unwrap()
+                );
+                assert_eq!(
+                    rule["verbs"],
+                    serde_yaml::to_value(["get", "list", "watch"]).unwrap()
+                );
+                assert_eq!(
+                    rule["resourceNames"],
+                    serde_yaml::to_value(["sample"]).unwrap()
+                );
+            }
+            for operation in &enabled {
+                assert!(rendered.contains(&format!(
+                    "{}/inspect: Inspect selected widgets",
+                    operation.plugin
+                )));
+            }
+            let mut reordered = enabled.clone();
+            reordered.reverse();
+            for operation in &mut reordered {
+                operation.permissions.rules[0].verbs.reverse();
+            }
+            assert_eq!(
+                rendered,
+                rendered_with_custom(
+                    scope,
+                    OperatorPermission::Diagnostics,
+                    false,
+                    &reordered,
+                    OperatorOutputFormat::RawManifest
+                )
+                .unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn custom_rules_obey_ceiling_and_validate_before_filtering() {
+    let mut operation = custom_operation("restarter");
+    operation.tier = alien_operations_sdk::RiskTier::Mutating;
+    let rule = &mut operation.permissions.rules[0];
+    rule.api_group.clear();
+    rule.resource = "pods".into();
+    rule.verbs = vec!["delete".into()];
+    for (permission, expected) in [
+        (OperatorPermission::Diagnostics, false),
+        (OperatorPermission::Remediation, true),
+    ] {
+        let manifest = rendered_with_custom(
+            OperatorScope::Namespace,
+            permission,
+            false,
+            &[operation.clone()],
+            OperatorOutputFormat::RawManifest,
+        )
+        .unwrap();
+        let docs = parse_manifest(&manifest);
+        let role = docs.iter().find(|doc| doc["kind"] == "Role").unwrap();
+        assert_eq!(rule_allows(role, "pods", "delete"), expected);
+    }
+    for invalid_resource in ["secrets", "pods/exec", "*"] {
+        operation.permissions.rules[0].resource = invalid_resource.into();
+        assert!(rendered_with_custom(
+            OperatorScope::Namespace,
+            OperatorPermission::Diagnostics,
+            false,
+            &[operation.clone()],
+            OperatorOutputFormat::RawManifest
+        )
+        .is_err());
+    }
+    operation.permissions.schema_version = 999;
+    assert!(rendered_with_custom(
+        OperatorScope::Namespace,
+        OperatorPermission::Diagnostics,
+        false,
+        &[operation],
+        OperatorOutputFormat::RawManifest
+    )
+    .is_err());
+}
+
+#[test]
+fn shared_builtin_and_custom_grants_are_deduplicated_and_keep_both_reasons() {
+    let mut operation = custom_operation("inspector");
+    let rule = &mut operation.permissions.rules[0];
+    rule.api_group.clear();
+    rule.resource = "pods/log".to_owned();
+    rule.verbs = vec!["get".to_owned()];
+    rule.resource_names.clear();
+    for (builtin, custom, expected) in [
+        (true, true, 1),
+        (true, false, 1),
+        (false, true, 1),
+        (false, false, 0),
+    ] {
+        let enabled = if custom {
+            vec![operation.clone()]
+        } else {
+            vec![]
+        };
+        let manifest = rendered_with_custom(
+            OperatorScope::Namespace,
+            OperatorPermission::Diagnostics,
+            builtin,
+            &enabled,
+            OperatorOutputFormat::RawManifest,
+        )
+        .unwrap();
+        let docs = parse_manifest(&manifest);
+        let role = docs.iter().find(|doc| doc["kind"] == "Role").unwrap();
+        let rules: Vec<_> = role["rules"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .filter(|rule| rule["resources"][0] == "pods/log")
+            .collect();
+        assert_eq!(rules.len(), expected);
+        assert_eq!(manifest.contains("the kubernetes/logs operation."), builtin);
+        assert_eq!(
+            manifest.contains("inspector/inspect: Inspect selected widgets"),
+            custom
+        );
+    }
 }
 
 fn parse_manifest(manifest: &str) -> Vec<YamlValue> {
@@ -140,7 +343,9 @@ fn complete_operator_manifests_intersect_operation_enablement_with_permission_ce
 
 #[test]
 fn operator_template_accepts_cloud_identity_values() {
+    let custom = custom_operation("inspector");
     let template = generate_operator_manifest(OperatorManifestOptions {
+        custom_operation_permissions: &[custom],
         manager_url: "https://manager.example.com",
         group_token:
             "{{ required \"remoteOperator.registrationToken is required\" .Values.remoteOperator.registrationToken }}",
@@ -189,6 +394,23 @@ alien:
     test_utils::helm_lint(&chart.files).assert_ok("remote operator cloud identity helm lint");
     let rendered = test_utils::helm_template(&chart.files, None);
     rendered.assert_ok("remote operator cloud identity helm template");
+    let documents = parse_manifest(&rendered.stdout);
+    let role = documents.iter().find(|doc| doc["kind"] == "Role").unwrap();
+    let rule = role["rules"]
+        .as_sequence()
+        .unwrap()
+        .iter()
+        .find(|rule| rule["resources"][0] == "widgets")
+        .unwrap();
+    assert_eq!(rule["apiGroups"][0], "example.com");
+    assert_eq!(
+        rule["resourceNames"],
+        serde_yaml::to_value(["sample"]).unwrap()
+    );
+    assert_eq!(
+        rule["verbs"],
+        serde_yaml::to_value(["get", "list", "watch"]).unwrap()
+    );
     assert!(
         rendered
             .stdout

--- a/crates/alien-helm/tests/generator/operator_manifest_tests.rs
+++ b/crates/alien-helm/tests/generator/operator_manifest_tests.rs
@@ -197,6 +197,35 @@ fn custom_rules_obey_ceiling_and_validate_before_filtering() {
 }
 
 #[test]
+fn custom_rules_reject_malformed_identifiers_before_rendering() {
+    for (group, resource) in [
+        ("example..com", "widgets"),
+        ("example.-com", "widgets"),
+        ("example.com", "1widgets"),
+        ("example.com", "custom.widgets"),
+    ] {
+        let mut operation = custom_operation("inspector");
+        operation.permissions.rules[0].api_group = group.to_owned();
+        operation.permissions.rules[0].resource = resource.to_owned();
+        for scope in [OperatorScope::Namespace, OperatorScope::Cluster] {
+            for format in [
+                OperatorOutputFormat::RawManifest,
+                OperatorOutputFormat::HelmTemplate,
+            ] {
+                assert!(rendered_with_custom(
+                    scope,
+                    OperatorPermission::Diagnostics,
+                    false,
+                    &[operation.clone()],
+                    format,
+                )
+                .is_err());
+            }
+        }
+    }
+}
+
+#[test]
 fn shared_builtin_and_custom_grants_are_deduplicated_and_keep_both_reasons() {
     let mut operation = custom_operation("inspector");
     let rule = &mut operation.permissions.rules[0];

--- a/crates/alien-helm/tests/generator/operator_manifest_tests.rs
+++ b/crates/alien-helm/tests/generator/operator_manifest_tests.rs
@@ -6,6 +6,7 @@ use alien_operations_sdk::{KubernetesOperationPermissions, PluginManifest};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_yaml::Value as YamlValue;
+use std::collections::BTreeSet;
 
 use super::test_utils;
 
@@ -244,6 +245,103 @@ fn parse_manifest(manifest: &str) -> Vec<YamlValue> {
         .map(|doc| YamlValue::deserialize(doc).expect("manifest document should be valid YAML"))
         .filter(|doc| !doc.is_null())
         .collect()
+}
+
+fn permission_grants(manifest: &str) -> BTreeSet<(String, String, String, Vec<String>)> {
+    let mut grants = BTreeSet::new();
+    for doc in parse_manifest(manifest) {
+        if doc["kind"] != "Role" && doc["kind"] != "ClusterRole" {
+            continue;
+        }
+        for rule in doc["rules"].as_sequence().unwrap() {
+            let mut names: Vec<_> = rule["resourceNames"]
+                .as_sequence()
+                .into_iter()
+                .flatten()
+                .map(|name| name.as_str().unwrap().to_owned())
+                .collect();
+            names.sort();
+            for group in rule["apiGroups"].as_sequence().unwrap() {
+                for resource in rule["resources"].as_sequence().unwrap() {
+                    for verb in rule["verbs"].as_sequence().unwrap() {
+                        grants.insert((
+                            group.as_str().unwrap().to_owned(),
+                            resource.as_str().unwrap().to_owned(),
+                            verb.as_str().unwrap().to_owned(),
+                            names.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    grants
+}
+
+#[test]
+fn attribution_cannot_inject_grants_into_rendered_yaml() {
+    for scope in [OperatorScope::Namespace, OperatorScope::Cluster] {
+        let mut operation = custom_operation("inspector");
+        operation.permissions.rules[0].reason = "Inspect widgets — 状態".to_owned();
+        let mut expected = permission_grants(&rendered_manifest(
+            scope,
+            OperatorPermission::Diagnostics,
+            false,
+        ));
+        for verb in ["get", "list", "watch"] {
+            expected.insert((
+                "example.com".to_owned(),
+                "widgets".to_owned(),
+                verb.to_owned(),
+                vec!["sample".to_owned()],
+            ));
+        }
+        let valid = rendered_with_custom(
+            scope,
+            OperatorPermission::Diagnostics,
+            false,
+            &[operation.clone()],
+            OperatorOutputFormat::RawManifest,
+        )
+        .unwrap();
+        assert_eq!(permission_grants(&valid), expected);
+
+        for line_break in ['\n', '\r', '\u{85}', '\u{2028}', '\u{2029}'] {
+            let attribution = format!("Inspect{line_break}  - apiGroups: [\"\"]{line_break}    resources: [\"secrets\"]{line_break}    verbs: [\"get\"]{line_break}  #");
+            for field in ["plugin", "operation", "reason"] {
+                let mut malicious = operation.clone();
+                match field {
+                    "plugin" => malicious.plugin = attribution.clone(),
+                    "operation" => malicious.operation = attribution.clone(),
+                    _ => malicious.permissions.rules[0].reason = attribution.clone(),
+                }
+                for format in [
+                    OperatorOutputFormat::RawManifest,
+                    OperatorOutputFormat::HelmTemplate,
+                ] {
+                    let rendered = rendered_with_custom(
+                        scope,
+                        OperatorPermission::Diagnostics,
+                        false,
+                        &[malicious.clone()],
+                        format,
+                    );
+                    if format == OperatorOutputFormat::RawManifest {
+                        if let Ok(manifest) = &rendered {
+                            // Inspect actual YAML semantics, not just the string:
+                            // an accepted comment must never add another grant.
+                            assert_eq!(
+                                permission_grants(manifest),
+                                expected,
+                                "attribution changed the emitted grants"
+                            );
+                        }
+                    }
+                    assert!(rendered.is_err(), "accepted {line_break:?} in {field}");
+                }
+            }
+        }
+    }
 }
 
 fn rule_allows(role: &YamlValue, resource: &str, verb: &str) -> bool {

--- a/crates/alien-operations-sdk/src/kubernetes.rs
+++ b/crates/alien-operations-sdk/src/kubernetes.rs
@@ -1,0 +1,248 @@
+//! Explicit Kubernetes requirements for an operation. Installers apply these
+//! rules only for enabled plugins and within the selected installation scope.
+//!
+//! Version 1 supports reads, pod deletion, and workload scale patches. It does
+//! not support Secrets, impersonation, RBAC changes, remote execution, or
+//! workload creation (which could mount Secrets or assume a service account).
+//!
+//! Add this field to an operation in `metadata.json`:
+//! ```json
+//! "kubernetesPermissions": {
+//!   "schemaVersion": 1,
+//!   "rules": [{
+//!     "apiGroup": "networking.k8s.io",
+//!     "resource": "ingresses",
+//!     "verbs": ["get"],
+//!     "resourceNames": ["customer-ingress"],
+//!     "reason": "Inspect the selected ingress routing configuration"
+//!   }]
+//! }
+//! ```
+//! No namespace, label selector, non-resource URL, wildcard, or role binding
+//! can be declared here. The installation's chosen namespace/cluster scope
+//! and diagnostics/remediation ceiling remain authoritative. Re-render and
+//! reapply the setup-owned Role/ClusterRole when enabled plugins change.
+
+use alien_error::AlienError;
+use serde::{Deserialize, Serialize};
+
+use crate::{ErrorData, Result, RiskTier};
+
+/// Versioned requirements declared in an operation's `kubernetesPermissions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct KubernetesPermissions {
+    /// Must be 1. Unknown versions are rejected, never silently ignored.
+    pub schema_version: u32,
+    /// Explicit rules; each rule addresses one API group and resource.
+    pub rules: Vec<KubernetesPermissionRule>,
+}
+
+/// One Kubernetes API requirement, inherited by the installation's Role or
+/// ClusterRole. An empty API group denotes the Kubernetes core API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct KubernetesPermissionRule {
+    pub api_group: String,
+    /// Plural resource, optionally including a supported subresource.
+    pub resource: String,
+    /// Concrete verbs; no wildcards or privilege-management verbs.
+    pub verbs: Vec<String>,
+    /// Empty means all names within the installation scope. Kubernetes requires
+    /// a matching metadata.name field selector for list/watch with named access.
+    #[serde(default)]
+    pub resource_names: Vec<String>,
+    /// Human-readable explanation emitted alongside the generated RBAC rule.
+    pub reason: String,
+}
+
+/// An enabled operation's requirements and their attribution, supplied by the
+/// installer after resolving the operation's effective risk tier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct KubernetesOperationPermissions {
+    pub plugin: String,
+    pub operation: String,
+    pub tier: RiskTier,
+    pub permissions: KubernetesPermissions,
+}
+
+impl KubernetesOperationPermissions {
+    pub fn validate(&self) -> Result<()> {
+        validate_label(&self.plugin, "plugin")?;
+        validate_label(&self.operation, "operation")?;
+        self.permissions.validate(self.tier)
+    }
+}
+
+impl KubernetesPermissions {
+    /// Validate before emitting permissions, even when constructed directly in
+    /// Rust rather than loaded through `PluginManifest::parse_and_validate`.
+    pub fn validate(&self, tier: RiskTier) -> Result<()> {
+        if self.schema_version != 1 {
+            return invalid("unsupported Kubernetes permission schemaVersion; expected 1");
+        }
+        if self.rules.is_empty() {
+            return invalid("Kubernetes permission rules must not be empty");
+        }
+        for rule in &self.rules {
+            if (!rule.api_group.is_empty() && !valid_token(&rule.api_group, false))
+                || !valid_token(&rule.resource, true)
+            {
+                return invalid("Kubernetes API groups and resources must be concrete tokens");
+            }
+            let mut parts = rule.resource.split('/');
+            let resource = parts.next().unwrap_or_default();
+            let subresource = parts.next();
+            if resource == "secrets"
+                || parts.next().is_some()
+                || subresource.is_some_and(|sub| !matches!(sub, "log" | "scale" | "status"))
+            {
+                return invalid("Kubernetes Secrets and privileged subresources are not supported");
+            }
+            if rule.verbs.is_empty() {
+                return invalid("Kubernetes permission verbs must not be empty");
+            }
+            for verb in &rule.verbs {
+                let read = matches!(verb.as_str(), "get" | "list" | "watch");
+                let remediation =
+                    (rule.api_group.is_empty() && rule.resource == "pods" && verb == "delete")
+                        || (rule.api_group == "apps"
+                            && matches!(
+                                rule.resource.as_str(),
+                                "deployments/scale" | "statefulsets/scale" | "replicasets/scale"
+                            )
+                            && verb == "patch");
+                if !read && (!remediation || tier == RiskTier::ReadOnly) {
+                    return invalid(
+                        "unsupported Kubernetes verb/resource or write in read-only operation",
+                    );
+                }
+            }
+            for name in &rule.resource_names {
+                // Concrete path-segment names only; reject Helm expressions too.
+                if !valid_token(name, false) {
+                    return invalid("Kubernetes resourceNames must be concrete names");
+                }
+            }
+            validate_label(&rule.reason, "reason")?;
+        }
+        Ok(())
+    }
+}
+
+fn valid_token(value: &str, allow_slash: bool) -> bool {
+    !value.is_empty()
+        && value.len() <= 253
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'.')
+                || (allow_slash && byte == b'/')
+        })
+        && value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && value
+            .bytes()
+            .last()
+            .is_some_and(|byte| byte.is_ascii_alphanumeric())
+}
+
+fn validate_label(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty()
+        || value.len() > 1024
+        || value.chars().any(char::is_control)
+        || value.contains("{{")
+        || value.contains("}}")
+    {
+        return invalid(&format!("Kubernetes permission {field} must be nonempty single-line text without template expressions"));
+    }
+    Ok(())
+}
+
+fn invalid<T>(reason: &str) -> Result<T> {
+    Err(AlienError::new(ErrorData::ManifestInvalid {
+        reason: reason.to_owned(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use crate::PluginManifest;
+
+    fn manifest() -> Value {
+        json!({
+            "name": "inspector", "version": "1", "tier": "read-only",
+            "binaries": {"amd64": "inspector"},
+            "operations": [{"name": "inspect", "kubernetesPermissions": {
+                "schemaVersion": 1,
+                "rules": [{"apiGroup": "example.com", "resource": "widgets",
+                    "verbs": ["get", "list", "watch"], "resourceNames": ["sample"],
+                    "reason": "Inspect the selected widget"}]
+            }}]
+        })
+    }
+
+    #[test]
+    fn declaration_round_trips_through_the_public_manifest() {
+        let value = manifest();
+        let parsed = PluginManifest::parse_and_validate(value.to_string().as_bytes()).unwrap();
+        let actual = serde_json::to_value(parsed).unwrap();
+        assert_eq!(
+            actual["operations"][0]["kubernetesPermissions"],
+            value["operations"][0]["kubernetesPermissions"]
+        );
+    }
+
+    #[test]
+    fn unsafe_or_unknown_declarations_fail_closed() {
+        for (field, value) in [
+            ("verbs", json!(["*"])),
+            ("verbs", json!(["escalate"])),
+            ("verbs", json!(["impersonate"])),
+            ("verbs", json!(["create"])),
+            ("verbs", json!(["deletecollection"])),
+            ("verbs", json!([])),
+            ("resource", json!("secrets")),
+            ("resource", json!("secrets/status")),
+            ("resource", json!("pods/exec")),
+            ("resource", json!("pods/attach")),
+            ("resource", json!("serviceaccounts/token")),
+            ("resource", json!("*")),
+            ("apiGroup", json!("*")),
+            ("resourceNames", json!(["*"])),
+            ("reason", json!("{{ lookup }}")),
+            ("reason", json!("line\n- injected")),
+            ("namespace", json!("another-namespace")),
+        ] {
+            let mut input = manifest();
+            input["operations"][0]["kubernetesPermissions"]["rules"][0][field] = value;
+            assert!(
+                PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err(),
+                "accepted invalid {field}: {input}"
+            );
+        }
+        let mut input = manifest();
+        input["operations"][0]["kubernetesPermissions"]["schemaVersion"] = json!(2);
+        assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err());
+        input["operations"][0]["kubernetesPermissions"] = Value::Null;
+        assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err());
+    }
+
+    #[test]
+    fn write_requirements_cannot_hide_in_a_read_only_operation() {
+        let mut input = manifest();
+        input["operations"][0]["kubernetesPermissions"]["rules"][0] = json!({
+            "apiGroup": "", "resource": "pods", "verbs": ["delete"], "reason": "Restart a pod"
+        });
+        assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err());
+        input["operations"][0]["tier"] = json!("mutating");
+        assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_ok());
+        input["operations"][0]["kubernetesPermissions"]["rules"][0]["verbs"] = json!(["create"]);
+        assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err());
+    }
+}

--- a/crates/alien-operations-sdk/src/kubernetes.rs
+++ b/crates/alien-operations-sdk/src/kubernetes.rs
@@ -86,14 +86,15 @@ impl KubernetesPermissions {
             return invalid("Kubernetes permission rules must not be empty");
         }
         for rule in &self.rules {
-            if (!rule.api_group.is_empty() && !valid_token(&rule.api_group, false))
-                || !valid_token(&rule.resource, true)
-            {
-                return invalid("Kubernetes API groups and resources must be concrete tokens");
+            if !rule.api_group.is_empty() && !valid_api_group(&rule.api_group) {
+                return invalid("Kubernetes API groups must be DNS subdomains");
             }
             let mut parts = rule.resource.split('/');
             let resource = parts.next().unwrap_or_default();
             let subresource = parts.next();
+            if !valid_resource(resource) {
+                return invalid("Kubernetes resources must be DNS-1035 labels");
+            }
             if resource == "secrets"
                 || parts.next().is_some()
                 || subresource.is_some_and(|sub| !matches!(sub, "log" | "scale" | "status"))
@@ -121,7 +122,7 @@ impl KubernetesPermissions {
             }
             for name in &rule.resource_names {
                 // Concrete path-segment names only; reject Helm expressions too.
-                if !valid_token(name, false) {
+                if !valid_token(name) {
                     return invalid("Kubernetes resourceNames must be concrete names");
                 }
             }
@@ -131,14 +132,27 @@ impl KubernetesPermissions {
     }
 }
 
-fn valid_token(value: &str, allow_slash: bool) -> bool {
+fn valid_api_group(value: &str) -> bool {
+    // Kubernetes DNS-1123 subdomain validation limits the whole name to 253
+    // bytes and checks each label's syntax. Single-label builtins are valid.
+    value.len() <= 253 && value.split('.').all(valid_token)
+}
+
+fn valid_resource(value: &str) -> bool {
+    value.len() <= 63
+        && valid_token(value)
+        && !value.contains('.')
+        && value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase())
+}
+
+fn valid_token(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 253
         && value.bytes().all(|byte| {
-            byte.is_ascii_lowercase()
-                || byte.is_ascii_digit()
-                || matches!(byte, b'-' | b'.')
-                || (allow_slash && byte == b'/')
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'.')
         })
         && value
             .bytes()
@@ -200,6 +214,94 @@ mod tests {
             actual["operations"][0]["kubernetesPermissions"],
             value["operations"][0]["kubernetesPermissions"]
         );
+    }
+
+    #[test]
+    fn api_groups_use_dns_subdomain_syntax() {
+        for group in [
+            "".to_owned(),
+            "apps".to_owned(),
+            "batch".to_owned(),
+            "networking.k8s.io".to_owned(),
+            "v2.custom-api.example.com".to_owned(),
+            "1.example.com".to_owned(),
+            "a".repeat(253),
+        ] {
+            let mut input = manifest();
+            input["operations"][0]["kubernetesPermissions"]["rules"][0]["apiGroup"] = json!(group);
+            assert!(
+                PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_ok(),
+                "rejected valid API group: {group}"
+            );
+        }
+        for group in [
+            "example..com".to_owned(),
+            "example.-com".to_owned(),
+            "example-.com".to_owned(),
+            ".example.com".to_owned(),
+            "example.com.".to_owned(),
+            "example_com".to_owned(),
+            "Example.com".to_owned(),
+            "example/com".to_owned(),
+            "a".repeat(254),
+        ] {
+            let mut input = manifest();
+            input["operations"][0]["kubernetesPermissions"]["rules"][0]["apiGroup"] = json!(group);
+            assert!(
+                PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err(),
+                "accepted invalid API group: {group}"
+            );
+        }
+    }
+
+    #[test]
+    fn resources_use_dns1035_labels_with_only_supported_subresources() {
+        for resource in [
+            "widgets".to_owned(),
+            "widget-v2s".to_owned(),
+            "pods/log".to_owned(),
+            "deployments/scale".to_owned(),
+            "widgets/status".to_owned(),
+            "a".repeat(63),
+        ] {
+            let mut input = manifest();
+            input["operations"][0]["kubernetesPermissions"]["rules"][0]["resource"] =
+                json!(resource);
+            assert!(
+                PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_ok(),
+                "rejected valid resource: {resource}"
+            );
+        }
+        for resource in [
+            "".to_owned(),
+            "1widgets".to_owned(),
+            "custom.widgets".to_owned(),
+            "Widgets".to_owned(),
+            "-widgets".to_owned(),
+            "widgets-".to_owned(),
+            "widgets_v2".to_owned(),
+            "pods/".to_owned(),
+            "/status".to_owned(),
+            "pods//log".to_owned(),
+            "pods/status/scale".to_owned(),
+            "a".repeat(64),
+        ] {
+            let mut input = manifest();
+            input["operations"][0]["kubernetesPermissions"]["rules"][0]["resource"] =
+                json!(resource);
+            assert!(
+                PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err(),
+                "accepted invalid resource: {resource}"
+            );
+        }
+    }
+
+    #[test]
+    fn resource_names_keep_the_existing_concrete_path_token_contract() {
+        let mut input = manifest();
+        input["operations"][0]["kubernetesPermissions"]["rules"][0]["resourceNames"] =
+            json!(["1.widget-v2", "widget..name"]);
+        assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_ok());
     }
 
     #[test]

--- a/crates/alien-operations-sdk/src/kubernetes.rs
+++ b/crates/alien-operations-sdk/src/kubernetes.rs
@@ -153,7 +153,11 @@ fn valid_token(value: &str, allow_slash: bool) -> bool {
 fn validate_label(value: &str, field: &str) -> Result<()> {
     if value.trim().is_empty()
         || value.len() > 1024
-        || value.chars().any(char::is_control)
+        // YAML parsers recognize Unicode line/paragraph separators as line
+        // breaks too, although Rust does not classify them as control characters.
+        || value.chars().any(|character| {
+            character.is_control() || matches!(character, '\u{2028}' | '\u{2029}')
+        })
         || value.contains("{{")
         || value.contains("}}")
     {
@@ -172,7 +176,7 @@ fn invalid<T>(reason: &str) -> Result<T> {
 mod tests {
     use serde_json::{json, Value};
 
-    use crate::PluginManifest;
+    use crate::{KubernetesOperationPermissions, PluginManifest, RiskTier};
 
     fn manifest() -> Value {
         json!({
@@ -196,6 +200,35 @@ mod tests {
             actual["operations"][0]["kubernetesPermissions"],
             value["operations"][0]["kubernetesPermissions"]
         );
+    }
+
+    #[test]
+    fn attribution_rejects_all_yaml_line_breaks() {
+        for line_break in ['\n', '\r', '\u{85}', '\u{2028}', '\u{2029}'] {
+            let text = format!("Inspect{line_break}another line");
+            for field in ["plugin", "operation", "reason"] {
+                let parsed =
+                    PluginManifest::parse_and_validate(manifest().to_string().as_bytes()).unwrap();
+                let mut declaration = KubernetesOperationPermissions {
+                    plugin: parsed.name,
+                    operation: parsed.operations[0].name.clone(),
+                    tier: RiskTier::ReadOnly,
+                    permissions: parsed.operations[0].kubernetes_permissions.clone().unwrap(),
+                };
+                match field {
+                    "plugin" => declaration.plugin = text.clone(),
+                    "operation" => declaration.operation = text.clone(),
+                    _ => declaration.permissions.rules[0].reason = text.clone(),
+                }
+                assert!(
+                    declaration.validate().is_err(),
+                    "accepted {line_break:?} in {field}"
+                );
+            }
+            let mut input = manifest();
+            input["operations"][0]["kubernetesPermissions"]["rules"][0]["reason"] = json!(text);
+            assert!(PluginManifest::parse_and_validate(input.to_string().as_bytes()).is_err());
+        }
     }
 
     #[test]

--- a/crates/alien-operations-sdk/src/lib.rs
+++ b/crates/alien-operations-sdk/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod docs;
 pub mod error;
+pub mod kubernetes;
 pub mod manifest;
 pub mod mcp;
 pub mod plugin;
@@ -26,6 +27,9 @@ pub mod verification;
 
 pub use docs::generate_docs;
 pub use error::{ErrorData, Result};
+pub use kubernetes::{
+    KubernetesOperationPermissions, KubernetesPermissionRule, KubernetesPermissions,
+};
 pub use manifest::{
     Arch, OperationManifest, PluginManifest, RetryPolicy, RiskTier, SensitiveOutputPolicy,
 };

--- a/crates/alien-operations-sdk/src/manifest.rs
+++ b/crates/alien-operations-sdk/src/manifest.rs
@@ -37,6 +37,7 @@ use schemars::schema::RootSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{ErrorData, Result};
+use crate::kubernetes::KubernetesPermissions;
 use crate::verification::Verification;
 
 /// The `metadata.json` filename conventionally used inside a plugin bundle.
@@ -148,6 +149,14 @@ pub struct RetryPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OperationManifest {
+    /// Explicit Kubernetes API requirements, compiled by the installer for
+    /// enabled plugins within the chosen scope and permission ceiling.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_kubernetes_permissions"
+    )]
+    pub kubernetes_permissions: Option<KubernetesPermissions>,
     /// Operation name, unique within the plugin (e.g. `vacuum`).
     pub name: String,
     /// Risk tier for this specific operation. Falls back to the plugin's
@@ -195,6 +204,17 @@ impl OperationManifest {
     pub fn effective_tier(&self, plugin_default: RiskTier) -> RiskTier {
         self.tier.unwrap_or(plugin_default)
     }
+}
+
+fn deserialize_kubernetes_permissions<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<KubernetesPermissions>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // Missing declarations remain backwards compatible; explicit null is not
+    // a valid versioned declaration and must not silently suppress permissions.
+    KubernetesPermissions::deserialize(deserializer).map(Some)
 }
 
 /// The parsed, validated contents of a plugin manifest.
@@ -262,6 +282,9 @@ impl PluginManifest {
         let mut seen = BTreeSet::new();
         for (index, operation) in self.operations.iter().enumerate() {
             require_non_empty(&operation.name, &format!("operations[{index}].name"))?;
+            if let Some(permissions) = &operation.kubernetes_permissions {
+                permissions.validate(operation.effective_tier(self.tier))?;
+            }
             if !seen.insert(operation.name.as_str()) {
                 return Err(AlienError::new(ErrorData::OperationDuplicate {
                     plugin: self.name.clone(),
@@ -377,6 +400,7 @@ mod tests {
     #[test]
     fn operation_tier_falls_back_to_plugin_default() {
         let op = OperationManifest {
+            kubernetes_permissions: None,
             name: "vacuum".into(),
             tier: None,
             description: None,


### PR DESCRIPTION
## Summary

Implements ALIEN-726 on `main`.

- Adds optional, versioned `kubernetesPermissions` declarations to public operation manifests.
- Allows reads plus pod deletion and workload `scale` patches; rejects wildcards, Secrets, privilege-bearing subresources, and broader writes.
- Compiles enabled custom requirements with baseline/builtin RBAC using stable scope keys while preserving attribution and `resourceNames`.
- Keeps RBAC setup-owned: plugin changes require re-rendering and reapplying the Role/ClusterRole.

## Review repairs

Validation now rejects YAML line breaks in attribution and malformed Kubernetes API groups/resources, including subresource identifiers. Built-in groups, supported subresources, ordinary Unicode text, and named-resource behavior remain supported.

## Verification

- `cargo test -p alien-operations-sdk -p alien-helm --quiet`: 82 unit/integration tests plus 1 doctest.
- Real Helm lint/template and disposable Kind positive, negative, and revocation checks passed.
- `cargo fmt --check`, focused Clippy, docs, and `git diff --check` passed.
- Independent `$pr-review` passed at exact head `596e6ef8c038aa07185a8ac27939c82a5d8e2597` with no material findings.

No live EKS/GKE/AKS claim is made.