### PR TITLE
fix: bootstrap autoscaling service role in fresh accounts

### DIFF
--- a/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/management.jsonc
@@ -216,6 +216,35 @@
           }
         }
       },
+      // AWS creates this account-level role on the first ASG. It is shared across
+      // stacks, so scope by its exact ARN and service rather than stack tags.
+      {
+        "grant": {
+          "actions": ["iam:CreateServiceLinkedRole"]
+        },
+        "binding": {
+          "stack": {
+            "resources": [
+              "arn:aws:iam::${awsAccountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ],
+            "condition": {
+              "StringEquals": {
+                "iam:AWSServiceName": "autoscaling.amazonaws.com"
+              }
+            }
+          },
+          "resource": {
+            "resources": [
+              "arn:aws:iam::${awsAccountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ],
+            "condition": {
+              "StringEquals": {
+                "iam:AWSServiceName": "autoscaling.amazonaws.com"
+              }
+            }
+          }
+        }
+      },
       // ASG creation must include boundary tags in the create request.
       {
         "grant": {

--- a/crates/alien-permissions/permission-sets/compute-cluster/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/compute-cluster/provision.jsonc
@@ -194,6 +194,35 @@
           }
         }
       },
+      // AWS creates this account-level role on the first ASG. It is shared across
+      // stacks, so scope by its exact ARN and service rather than stack tags.
+      {
+        "grant": {
+          "actions": ["iam:CreateServiceLinkedRole"]
+        },
+        "binding": {
+          "stack": {
+            "resources": [
+              "arn:aws:iam::${awsAccountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ],
+            "condition": {
+              "StringEquals": {
+                "iam:AWSServiceName": "autoscaling.amazonaws.com"
+              }
+            }
+          },
+          "resource": {
+            "resources": [
+              "arn:aws:iam::${awsAccountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ],
+            "condition": {
+              "StringEquals": {
+                "iam:AWSServiceName": "autoscaling.amazonaws.com"
+              }
+            }
+          }
+        }
+      },
       // ASG creation is name-scoped and must include Alien boundary tags.
       {
         "grant": {

--- a/crates/alien-permissions/tests/aws_runtime.rs
+++ b/crates/alien-permissions/tests/aws_runtime.rs
@@ -90,6 +90,51 @@ fn test_aws_observe_generates_account_wide_read_policy() {
 }
 
 #[test]
+fn compute_cluster_bootstraps_only_the_default_autoscaling_service_role() {
+    // AWS requires this extra authorization when the account has no default
+    // Auto Scaling service role. This grant must not permit arbitrary IAM roles,
+    // other AWS services, custom-suffix roles, or access to workload data.
+    // https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-api-permissions.html
+    for id in ["compute-cluster/provision", "compute-cluster/management"] {
+        for target in [BindingTarget::Stack, BindingTarget::Resource] {
+            let policy = AwsRuntimePermissionsGenerator::new()
+                .generate_policy(
+                    get_permission_set(id).expect("permission set exists"),
+                    target,
+                    &create_test_context(),
+                )
+                .expect("compute permissions should render");
+            let grants = policy
+                .statement
+                .iter()
+                .filter(|statement| {
+                    statement
+                        .action
+                        .iter()
+                        .any(|action| action == "iam:CreateServiceLinkedRole")
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(grants.len(), 1, "{id} / {target}");
+            let grant = grants[0];
+            assert_eq!(grant.effect, "Allow");
+            assert_eq!(grant.action, ["iam:CreateServiceLinkedRole"]);
+            assert_eq!(
+                grant.resource,
+                [
+                    "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+                ]
+            );
+            assert_eq!(
+                serde_json::to_value(&grant.condition).unwrap(),
+                serde_json::json!({
+                    "StringEquals": { "iam:AWSServiceName": "autoscaling.amazonaws.com" }
+                })
+            );
+        }
+    }
+}
+
+#[test]
 fn compute_cluster_execute_does_not_read_workload_secrets() {
     let generator = AwsRuntimePermissionsGenerator::new();
     let permission_set =


### PR DESCRIPTION
## Problem
The first Auto Scaling group in a fresh AWS account fails if AWSServiceRoleForAutoScaling does not exist. Both compute-cluster ownership profiles permit CreateAutoScalingGroup but omit its dependent IAM authorization.

## Fix
Permit only iam:CreateServiceLinkedRole on the account’s exact default Auto Scaling service role, conditioned on iam:AWSServiceName. No custom-suffix roles, other services, broad IAM administration, or secret payload access is added.

AWS documents the dependency: https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-api-permissions.html

## Validation
- Locally ran cargo nextest run -p alien-permissions --test aws_cloudformation --test aws_runtime --test aws_abac_validation: 52 passed.
- New regression checks both ownership profiles and both binding scopes, including the exact action, ARN, and service condition.
- No cloud deployments or existing installations changed. Fresh-account deployment remains cloud acceptance, not claimed by these local tests.

ALIEN-734