### PR TITLE
fix: require explicit subnets for postgres setup

### DIFF
--- a/crates/alien-cloudformation/src/generator.rs
+++ b/crates/alien-cloudformation/src/generator.rs
@@ -1089,9 +1089,9 @@ fn add_network_parameters(
     // parameter is checked before the transform runs, where a template Rule is not yet reached.
     let restricted = restricts_network_mode(stack, target);
     let description = if restricted {
-        "Choose create-new for a managed VPC, or use-existing for your VPC. A sandbox in this \
-         application routes session egress through a VPC connector when enabled, and that connector \
-         must name subnets."
+        "Choose create-new for a managed VPC, or use-existing for your VPC. This application's \
+         private resources require explicit subnet IDs, which setup cannot discover from the \
+         account default VPC."
     } else {
         modes.push(CfExpression::from("use-default"));
         "Choose create-new for a managed VPC, use-existing for your VPC, or use-default for the account default VPC."

--- a/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_restricted_aws.snap
+++ b/crates/alien-cloudformation/tests/generator/snapshots/generator__generator__aws_sandbox_tests__sandbox_restricted_aws.snap
@@ -73,7 +73,7 @@ Parameters:
     Default: ''
   NetworkMode:
     Type: String
-    Description: Choose create-new for a managed VPC, or use-existing for your VPC. A sandbox in this application routes session egress through a VPC connector when enabled, and that connector must name subnets.
+    Description: Choose create-new for a managed VPC, or use-existing for your VPC. This application's private resources require explicit subnet IDs, which setup cannot discover from the account default VPC.
     Default: create-new
     AllowedValues:
     - create-new

--- a/crates/alien-core/src/resources/sandbox.rs
+++ b/crates/alien-core/src/resources/sandbox.rs
@@ -486,22 +486,25 @@ pub struct Sandbox {
 
 /// Whether the artifact being rendered restricts which network modes it accepts.
 ///
-/// A sandbox is not emitted on a Kubernetes target, so nothing there routes egress through a
-/// connector and the default network stays a working answer. Every site that withholds the mode,
-/// explains the restriction, or renders a branch for it has to ask this one question — asking the
-/// stack directly is how they came to disagree.
+/// Cloud setup needs explicit subnets for private databases and restricted sandbox connectors.
+/// Kubernetes targets do not emit these cloud backends.
 pub fn restricts_network_mode(stack: &crate::Stack, targets_kubernetes: bool) -> bool {
     !targets_kubernetes && stack_needs_named_subnets_at_setup(stack)
 }
 
-/// Whether any sandbox in the stack forces setup to name subnets.
+/// Whether any setup-owned resource forces setup to name subnets.
 ///
-/// A restricted sandbox routes session egress through a VPC connector, and neither generator can
-/// enumerate the account default VPC's subnets, so that mode leaves the connector without any and
-/// it fails at create. Callers that render an artifact want [`restricts_network_mode`] instead:
+/// Private databases and restricted sandbox connectors require subnet IDs. Neither generator can
+/// enumerate the account default VPC's subnets. Callers rendering an artifact want
+/// [`restricts_network_mode`] instead:
 /// this one answers for the declaration, which on a Kubernetes target is not what gets emitted.
 pub fn stack_needs_named_subnets_at_setup(stack: &crate::Stack) -> bool {
     stack.resources().any(|(_resource_id, resource)| {
+        if resource.lifecycle == crate::ResourceLifecycle::Frozen
+            && resource.config.downcast_ref::<crate::Postgres>().is_some()
+        {
+            return true;
+        }
         resource
             .config
             .downcast_ref::<Sandbox>()
@@ -1041,6 +1044,30 @@ pub fn parse_bundle_uri(uri: &str) -> std::result::Result<BundleUri<'_>, String>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn private_database_setup_requires_named_subnets() {
+        for lifecycle in [
+            crate::ResourceLifecycle::Frozen,
+            crate::ResourceLifecycle::Live,
+        ] {
+            let stack = crate::Stack::new("database".to_string())
+                .add(
+                    crate::Postgres::new("metadata".to_string()).build(),
+                    lifecycle,
+                )
+                .build();
+            assert_eq!(
+                restricts_network_mode(&stack, false),
+                lifecycle == crate::ResourceLifecycle::Frozen,
+            );
+            assert!(!restricts_network_mode(&stack, true));
+        }
+        assert!(!restricts_network_mode(
+            &crate::Stack::new("empty".to_string()).build(),
+            false,
+        ));
+    }
 
     /// A wildcard reaching the grant would widen it past the bundle, and it widens the Frozen
     /// object grant as readily as the Live prefix — both interpolate the path into the ARN.

--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -2004,7 +2004,7 @@ fn string_enum_variable_block(
 /// the account default VPC's cannot be enumerated at setup.
 fn network_mode_description(needs_named_subnets: bool) -> &'static str {
     if needs_named_subnets {
-        "Choose whether this setup creates a new network or uses an existing one. Values: create-new, use-existing. A sandbox in this application routes session egress through a VPC connector when enabled, and that connector must name subnets, so the default network is not offered."
+        "Choose whether this setup creates a new network or uses an existing one. Values: create-new, use-existing. This application's private resources require explicit subnet IDs, which setup cannot discover from the account default VPC."
     } else {
         "Choose whether this setup creates a new network, uses an existing network, or uses the default network. Values: create-new, use-existing, use-default."
     }
@@ -2040,7 +2040,7 @@ fn network_mode_variable_block(needs_named_subnets: bool) -> Block {
                 attr(
                     "error_message",
                     Expression::String(
-                        "network_mode must be create-new or use-existing: this application's sandbox routes session egress through a VPC connector, which must name subnets."
+                        "network_mode must be create-new or use-existing: this application's private resources must name subnets."
                             .to_string(),
                     ),
                 ),
@@ -3383,7 +3383,7 @@ fn readme_azure_inputs(target: TerraformTarget) -> String {
 /// the package contradict itself.
 fn readme_network_inputs(target: TerraformTarget, needs_named_subnets: bool) -> String {
     match target.cloud_platform() {
-        alien_core::Platform::Aws if needs_named_subnets => "Network settings:\n\n- `network_mode`: `create-new` or `use-existing`. A sandbox in this application routes session egress through a VPC connector when enabled, and that connector must name subnets, so the default network is not offered.\n- `vpc_cidr`, `availability_zones`: used with `create-new`.\n- `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `security_group_ids`: required with `use-existing`.".to_string(),
+        alien_core::Platform::Aws if needs_named_subnets => "Network settings:\n\n- `network_mode`: `create-new` or `use-existing`. Private resources require explicit subnet IDs, so the default network is not offered.\n- `vpc_cidr`, `availability_zones`: used with `create-new`.\n- `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `security_group_ids`: required with `use-existing`.".to_string(),
         alien_core::Platform::Aws => "Network settings:\n\n- `network_mode`: `create-new`, `use-existing`, or `use-default`.\n- `vpc_cidr`, `availability_zones`: used with `create-new`.\n- `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `security_group_ids`: required with `use-existing`.".to_string(),
         alien_core::Platform::Gcp => "Network settings:\n\n- `network_mode`: `create-new`, `use-existing`, or `use-default`.\n- `network_cidr`, `availability_zones`: used with `create-new`.\n- `network_name`, `subnet_name`, `network_region`: required with `use-existing`.".to_string(),
         _ => String::new(),

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_sandbox_restricted.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__helpers__aws_sandbox_restricted.snap
@@ -133,12 +133,12 @@ variable "managing_account_id" {
 
 variable "network_mode" {
   type        = string
-  description = "Choose whether this setup creates a new network or uses an existing one. Values: create-new, use-existing. A sandbox in this application routes session egress through a VPC connector when enabled, and that connector must name subnets, so the default network is not offered."
+  description = "Choose whether this setup creates a new network or uses an existing one. Values: create-new, use-existing. This application's private resources require explicit subnet IDs, which setup cannot discover from the account default VPC."
   default     = "create-new"
 
   validation {
     condition     = contains(["create-new", "use-existing"], var.network_mode)
-    error_message = "network_mode must be create-new or use-existing: this application's sandbox routes session egress through a VPC connector, which must name subnets."
+    error_message = "network_mode must be create-new or use-existing: this application's private resources must name subnets."
   }
 }
 
@@ -647,7 +647,7 @@ AWS settings:
 
 Network settings:
 
-- `network_mode`: `create-new` or `use-existing`. A sandbox in this application routes session egress through a VPC connector when enabled, and that connector must name subnets, so the default network is not offered.
+- `network_mode`: `create-new` or `use-existing`. Private resources require explicit subnet IDs, so the default network is not offered.
 - `vpc_cidr`, `availability_zones`: used with `create-new`.
 - `vpc_id`, `public_subnet_ids`, `private_subnet_ids`, `security_group_ids`: required with `use-existing`.
 


### PR DESCRIPTION
## Problem
Setup offered the account default network for a Frozen Postgres resource, although its private networking needs explicit subnet IDs. Generated expressions could resolve to AWS::NoValue and fail during stack creation.

## Changes
Include setup-owned Postgres in the shared named-subnet requirement. Keep runtime-owned databases and Kubernetes targets unaffected. Describe the restriction in terms of private resources rather than only sandbox connectors.

## Local validation
- New core regression covers Frozen, Live, Kubernetes and empty stacks.
- 48 relevant sandbox generator tests passed across local runs, including cfn-lint and Terraform plan rejection for use-default.
- Two additional existing sandbox tests fail because installed cfn-lint does not recognize MicroVM IAM actions; no suppressions added.
- Updated generated snapshots were reviewed (description text only).
- No cloud resources or installations changed.

ALIEN-735