### PR TITLE
fix: resolve AWS scopes in generated permission documents

### DIFF
--- a/crates/alien-terraform/src/generator.rs
+++ b/crates/alien-terraform/src/generator.rs
@@ -693,7 +693,16 @@ fn permission_doc_scope(scope: &str, target: TerraformTarget, resource_id: &str)
         _ => format!("${{local.resource_prefix}}-{resource_id}"),
     };
     scope
+        // Sandbox templates carry the prefix separately; storage templates include it in
+        // resourceName. Resolve the pair first so the document matches the installed grant.
+        .replace("${stackPrefix}-${resourceName}", &resource_name)
         .replace("${resourceName}", &resource_name)
+        .replace("${stackPrefix}", "${local.resource_prefix}")
+        .replace("${awsRegion}", "${data.aws_region.current.region}")
+        .replace(
+            "${awsAccountId}",
+            "${data.aws_caller_identity.current.account_id}",
+        )
         .replace("${projectName}", "${var.gcp_project}")
         .replace("${subscriptionId}", "${var.azure_subscription_id}")
         .replace("${resourceGroup}", "${var.azure_resource_group_name}")

--- a/crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
+++ b/crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
@@ -460,6 +460,13 @@ fn aws_remote_sandbox_grants_the_access_identity_its_own_image_and_nothing_wider
         );
     }
 
+    insta::assert_snapshot!(
+        "aws_remote_sandbox_permissions",
+        module
+            .files
+            .get("PERMISSIONS.md")
+            .expect("permission document")
+    );
     assert_terraform_valid(&module, "aws_remote_sandbox");
 }
 

--- a/crates/alien-terraform/tests/generator/snapshots/generator__generator__aws_data_layer_tests__aws_remote_sandbox_permissions.snap
+++ b/crates/alien-terraform/tests/generator/snapshots/generator__generator__aws_data_layer_tests__aws_remote_sandbox_permissions.snap
@@ -1,0 +1,29 @@
+---
+source: crates/alien-terraform/tests/generator/aws_data_layer_tests.rs
+expression: "module.files.get(\"PERMISSIONS.md\").expect(\"permission document\")"
+---
+# Application access permissions
+
+The setup creates one narrow application access identity. It can access only the resources listed below; it does not receive the setup's management permissions.
+
+## `agents` (sandbox)
+
+Create and terminate sessions in this sandbox, and run arbitrary code inside them.
+
+Permission set: `sandbox/remote-execute` (revision 1).
+
+- Start, suspend, resume, and terminate sessions of the selected sandbox.
+  Scope: `arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:microvm-image:${local.resource_prefix}-agents`
+  - `lambda:RunMicrovm`
+  - `lambda:SuspendMicrovm`
+  - `lambda:ResumeMicrovm`
+  - `lambda:TerminateMicrovm`
+
+- Start a session on the AWS-managed internet egress and HTTP ingress connectors.
+  Scope: `arn:aws:lambda:${data.aws_region.current.region}:aws:network-connector:aws-network-connector:*`
+  - `lambda:PassNetworkConnector`
+
+- Read a session's state and mint the token the sandbox agent protocol travels on.
+  Scope: `arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:microvm-image:${local.resource_prefix}-agents`
+  - `lambda:CreateMicrovmAuthToken`
+  - `lambda:GetMicrovm`


### PR DESCRIPTION
## Summary
Resolve AWS region/account placeholders in generated PERMISSIONS.md and apply the resource prefix exactly once for sandbox image scopes. No IAM policies or provisioning behavior change.

## Validation
Ran the existing AWS remote-sandbox generator test twice, including terraform fmt and terraform validate. Reviewed the complete generated permissions document and added its snapshot to the existing scenario.

Command: cargo test -p alien-terraform --test generator aws_remote_sandbox_grants_the_access_identity_its_own_image_and_nothing_wider -- --nocapture

Scope: fixes the known AWS substitutions in ALIEN-708; does not introduce a new general-purpose template validator.