### PR TITLE
fix: prevent verbose local builds from blocking on output

### DIFF
--- a/crates/alien-bindings/src/providers/build/local.rs
+++ b/crates/alien-bindings/src/providers/build/local.rs
@@ -6,6 +6,8 @@ use alien_core::{bindings::BuildBinding, BuildConfig, BuildExecution, BuildStatu
 use alien_error::{AlienError, Context, IntoAlienError};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::{
     process::Stdio,
     time::{SystemTime, UNIX_EPOCH},
@@ -264,13 +266,31 @@ impl Build for LocalBuild {
                 })?;
         }
 
+        // A detached build has no pipe reader. Write to files so verbose commands cannot
+        // block on a full stdout/stderr pipe, and keep their output available for debugging.
+        let log_file = |name: &str| {
+            let mut options = std::fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            options
+                .open(build_dir.join(name))
+                .into_alien_error()
+                .context(ErrorData::BuildOperationFailed {
+                    binding_name: self.binding_name.clone(),
+                    operation: format!("create build log {name}"),
+                })
+        };
+        let stdout = log_file("stdout.log")?;
+        let stderr = log_file("stderr.log")?;
+
         // Prepare environment variables
         let mut cmd = Command::new("bash");
         cmd.arg(&script_path)
             .current_dir(&build_dir)
             .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
 
         // Merge build config environment with binding environment variables
         // Build config environment takes precedence over binding environment
@@ -432,6 +452,38 @@ mod tests {
         let status = settled_status(&local_build, &execution.id).await;
         assert_eq!(status.status, BuildStatus::Succeeded);
         assert!(status.end_time.is_some());
+    }
+
+    #[tokio::test]
+    async fn verbose_build_completes_and_preserves_both_output_streams() {
+        let temp_dir = TempDir::new().unwrap();
+        let local_build =
+            LocalBuild::new_from_path("test-build".to_string(), temp_dir.path().to_path_buf());
+        let config = BuildConfig {
+            image: "unused".to_string(),
+            // Each stream exceeds pipe capacity. The marker proves the script ran past both
+            // writes, rather than relying on the backend's current PID-based success check.
+            script: "printf '%1048576s' x; printf '%1048576s' y >&2; printf done > completed"
+                .to_string(),
+            environment: HashMap::new(),
+            timeout_seconds: 30,
+            compute_type: alien_core::ComputeType::Small,
+            monitoring: None,
+        };
+
+        let execution = local_build.start_build(config).await.unwrap();
+        settled_status(&local_build, &execution.id).await;
+        let (uuid, _, _) = LocalBuild::decode_build_id(&execution.id).unwrap();
+        let build_dir = temp_dir.path().join("builds").join(uuid);
+        assert_eq!(std::fs::read(build_dir.join("completed")).unwrap(), b"done");
+        for (name, final_byte) in [("stdout.log", b'x'), ("stderr.log", b'y')] {
+            let output = std::fs::read(build_dir.join(name)).unwrap();
+            // Bash may emit startup diagnostics before the script's output.
+            assert!(output.len() >= 1_048_576);
+            let output = &output[output.len() - 1_048_576..];
+            assert_eq!(output.last(), Some(&final_byte));
+            assert!(output[..output.len() - 1].iter().all(|byte| *byte == b' '));
+        }
     }
 
     #[tokio::test]

--- a/crates/alien-bindings/src/providers/build/local.rs
+++ b/crates/alien-bindings/src/providers/build/local.rs
@@ -6,8 +6,6 @@ use alien_core::{bindings::BuildBinding, BuildConfig, BuildExecution, BuildStatu
 use alien_error::{AlienError, Context, IntoAlienError};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
 use std::{
     process::Stdio,
     time::{SystemTime, UNIX_EPOCH},
@@ -266,31 +264,15 @@ impl Build for LocalBuild {
                 })?;
         }
 
-        // A detached build has no pipe reader. Write to files so verbose commands cannot
-        // block on a full stdout/stderr pipe, and keep their output available for debugging.
-        let log_file = |name: &str| {
-            let mut options = std::fs::OpenOptions::new();
-            options.write(true).create_new(true);
-            #[cfg(unix)]
-            options.mode(0o600);
-            options
-                .open(build_dir.join(name))
-                .into_alien_error()
-                .context(ErrorData::BuildOperationFailed {
-                    binding_name: self.binding_name.clone(),
-                    operation: format!("create build log {name}"),
-                })
-        };
-        let stdout = log_file("stdout.log")?;
-        let stderr = log_file("stderr.log")?;
-
         // Prepare environment variables
         let mut cmd = Command::new("bash");
         cmd.arg(&script_path)
             .current_dir(&build_dir)
             .stdin(Stdio::null())
-            .stdout(Stdio::from(stdout))
-            .stderr(Stdio::from(stderr));
+            // This detached backend has no output consumer or log retrieval API. Discard
+            // output instead of filling unread pipes or accumulating unbounded log files.
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
 
         // Merge build config environment with binding environment variables
         // Build config environment takes precedence over binding environment
@@ -455,7 +437,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verbose_build_completes_and_preserves_both_output_streams() {
+    async fn verbose_build_completes_without_blocking_on_output() {
         let temp_dir = TempDir::new().unwrap();
         let local_build =
             LocalBuild::new_from_path("test-build".to_string(), temp_dir.path().to_path_buf());
@@ -476,14 +458,6 @@ mod tests {
         let (uuid, _, _) = LocalBuild::decode_build_id(&execution.id).unwrap();
         let build_dir = temp_dir.path().join("builds").join(uuid);
         assert_eq!(std::fs::read(build_dir.join("completed")).unwrap(), b"done");
-        for (name, final_byte) in [("stdout.log", b'x'), ("stderr.log", b'y')] {
-            let output = std::fs::read(build_dir.join(name)).unwrap();
-            // Bash may emit startup diagnostics before the script's output.
-            assert!(output.len() >= 1_048_576);
-            let output = &output[output.len() - 1_048_576..];
-            assert_eq!(output.last(), Some(&final_byte));
-            assert!(output[..output.len() - 1].iter().all(|byte| *byte == b' '));
-        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Root cause
Local builds pipe stdout and stderr, but the detached child task only waits for exit. Once either pipe fills, the build blocks forever.

## Fix
Discard stdout and stderr for this detached backend, which has no output consumer or log retrieval API. This prevents unread-pipe hangs without introducing unbounded disk logs or memory buffering. This replaces the initial file-backed approach after review identified its unbounded growth risk.

## Validation
Executed the real local provider and its unit tests through a small external validation harness (actual provider/error source and core types, equivalent Build/Binding trait declarations), avoiding unrelated cloud SDK dev-dependencies. Five tests pass. The new regression runs a real Bash script writing 1 MiB to each stream and checks a completion marker after both writes. The original pipe wiring fails after 30 seconds; the final null-output fix completes in under one second. rustfmt and diff checks pass.

Full crate/CI integration remains separate from this lightweight local harness.

Part of ALIEN-684 only: exit-status reporting, timeout enforcement, and process-tree cancellation are not changed here.