### PR TITLE
fix: isolate the Azure Terraform test resource group

### DIFF
--- a/crates/alien-test/src/distribution.rs
+++ b/crates/alien-test/src/distribution.rs
@@ -3325,13 +3325,14 @@ fn terraform_tfvars(
     kubernetes_namespace: Option<&str>,
 ) -> anyhow::Result<Value> {
     let mut vars = serde_json::Map::new();
+    let resource_prefix = crate::config::e2e_resource_prefix()?;
     vars.insert(
         "name".to_string(),
         Value::String(format!("e2e-{}", &uuid::Uuid::new_v4().to_string()[..8])),
     );
     vars.insert(
         "resource_prefix".to_string(),
-        Value::String(crate::config::e2e_resource_prefix()?),
+        Value::String(resource_prefix.clone()),
     );
     vars.insert(
         "token".to_string(),
@@ -3407,12 +3408,15 @@ fn terraform_tfvars(
                 .azure_target
                 .as_ref()
                 .context("Azure target missing")?;
+            // Terraform owns this group. AZURE_TARGET_RESOURCE_GROUP identifies
+            // pre-provisioned shared infrastructure and must not be created or
+            // destroyed by a distribution test. Shared environment bindings keep
+            // their own resource-group reference.
             insert_azure_tfvars(
                 &mut vars,
                 azure_target,
                 prepared.config.azure_mgmt.as_ref(),
-                &std::env::var("AZURE_TARGET_RESOURCE_GROUP")
-                    .context("AZURE_TARGET_RESOURCE_GROUP is required")?,
+                &format!("{resource_prefix}-terraform-rg"),
                 target,
             );
         }


### PR DESCRIPTION
## Root cause
The E2E environment generator assigns AZURE_TARGET_RESOURCE_GROUP from the existing shared Container Apps environment resource group. The Terraform harness feeds that value to azure_resource_group_name, whose emitter creates azurerm_resource_group. That deterministically conflicts with the pre-provisioned group (ALIEN-717, reproduced on main in run 34157676192).

## Fix
Give the Terraform-owned group the validated E2E job prefix plus -terraform-rg. Keep the shared Container Apps environment binding and its own resource-group reference unchanged. No shared-resource import, deletion, permission widening, or cleanup sweep.

## Validation
- Traced env generation, tfvars input, resource-group emitter, external environment binding, and slot cleanup selection.
- Existing azure_function_reuses_external_container_apps_environment generator scenario passes locally, including Terraform validation.
- rustfmt and git diff --check pass.
- No live Azure apply/destroy was run; this PR does not claim full Azure E2E acceptance. To validate that, run terraform_azure_push_comprehensive_rust in a reserved test slot and confirm its Terraform group is deleted while the shared environment remains.