### PR TITLE
fix: remove E2E storage objects after verification

### DIFF
--- a/crates/alien-test/tests/common/bindings.rs
+++ b/crates/alien-test/tests/common/bindings.rs
@@ -762,73 +762,83 @@ pub async fn check_wait_until(deployment: &TestDeployment) -> anyhow::Result<()>
 
     let test_id = trigger_data.test_id;
 
-    // Step 2: Wait then verify with retries
-    tokio::time::sleep(std::time::Duration::from_millis(verification_wait_ms)).await;
+    let verification = async {
+        // Step 2: Wait then verify with retries
+        tokio::time::sleep(std::time::Duration::from_millis(verification_wait_ms)).await;
 
-    for attempt in 1..=max_attempts {
-        let verify_resp = reqwest::Client::new()
-            .get(format!(
-                "{}/wait-until-verify/{}/{}",
-                url, test_id, STORAGE_BINDING
-            ))
-            .send()
-            .await
-            .context("Wait-until verification request failed")?;
+        for attempt in 1..=max_attempts {
+            let verify_resp = reqwest::Client::new()
+                .get(format!(
+                    "{}/wait-until-verify/{}/{}",
+                    url, test_id, STORAGE_BINDING
+                ))
+                .send()
+                .await
+                .context("Wait-until verification request failed")?;
 
-        let verify_status = verify_resp.status();
-        if !verify_status.is_success() {
-            let body = verify_resp.text().await.unwrap_or_default();
-            bail!(
-                "Wait-until verification returned {}: {}",
-                verify_status,
-                body
-            );
-        }
-
-        #[derive(Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct VerifyResponse {
-            success: bool,
-            background_task_completed: bool,
-            file_content: Option<String>,
-            message: String,
-        }
-
-        let verify_data: VerifyResponse = verify_resp
-            .json()
-            .await
-            .context("Failed to parse wait-until verify response")?;
-
-        if verify_data.background_task_completed && verify_data.success {
-            if verify_data.file_content.as_deref() != Some(&test_data) {
+            let verify_status = verify_resp.status();
+            if !verify_status.is_success() {
+                let body = verify_resp.text().await.unwrap_or_default();
                 bail!(
-                    "Wait-until content mismatch: expected {:?}, got {:?}",
-                    test_data,
-                    verify_data.file_content
+                    "Wait-until verification returned {}: {}",
+                    verify_status,
+                    body
                 );
             }
-            info!("WaitUntil binding check passed");
-            return Ok(());
+
+            #[derive(Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct VerifyResponse {
+                success: bool,
+                background_task_completed: bool,
+                file_content: Option<String>,
+                message: String,
+            }
+
+            let verify_data: VerifyResponse = verify_resp
+                .json()
+                .await
+                .context("Failed to parse wait-until verify response")?;
+
+            if verify_data.background_task_completed && verify_data.success {
+                if verify_data.file_content.as_deref() != Some(&test_data) {
+                    bail!(
+                        "Wait-until content mismatch: expected {:?}, got {:?}",
+                        test_data,
+                        verify_data.file_content
+                    );
+                }
+                info!("WaitUntil binding check passed");
+                return Ok(());
+            }
+
+            if attempt < max_attempts {
+                info!(
+                    attempt,
+                    max_attempts,
+                    message = %verify_data.message,
+                    "Wait-until not completed yet, retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(retry_delay_ms)).await;
+            } else {
+                bail!(
+                    "Wait-until background task did not complete after {} attempts (last message: {})",
+                    max_attempts,
+                    verify_data.message
+                );
+            }
         }
 
-        if attempt < max_attempts {
-            info!(
-                attempt,
-                max_attempts,
-                message = %verify_data.message,
-                "Wait-until not completed yet, retrying"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(retry_delay_ms)).await;
-        } else {
-            bail!(
-                "Wait-until background task did not complete after {} attempts (last message: {})",
-                max_attempts,
-                verify_data.message
-            );
-        }
+        unreachable!()
     }
-
-    unreachable!()
+    .await;
+    super::storage_cleanup::finish_storage_check(
+        url,
+        STORAGE_BINDING,
+        &format!("wait_until_test_{test_id}.txt"),
+        verification,
+    )
+    .await
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/alien-test/tests/common/events.rs
+++ b/crates/alien-test/tests/common/events.rs
@@ -100,9 +100,8 @@ pub async fn check_queue_event_delivery(deployment: &TestDeployment) -> anyhow::
     Ok(())
 }
 
-/// Check storage trigger delivery: write an object with a unique key (write
-/// only — no delete), then verify the app's `on_storage_event` handler
-/// processed the `created` event for exactly that key.
+/// Check storage trigger delivery, then remove the object only after checking
+/// that the handler processed its creation event.
 ///
 /// Fails if the platform's storage trigger stops delivering events to the
 /// registered handler.
@@ -111,6 +110,11 @@ pub async fn check_storage_event_delivery(deployment: &TestDeployment) -> anyhow
     info!("Checking storage trigger delivery");
 
     let key = format!("storage-event-test-{}.txt", uuid::Uuid::new_v4());
+    let verification = verify_storage_event(url, &key).await;
+    super::storage_cleanup::finish_storage_check(url, STORAGE_BINDING, &key, verification).await
+}
+
+async fn verify_storage_event(url: &str, key: &str) -> anyhow::Result<()> {
     let resp = reqwest::Client::new()
         .post(format!("{}/storage-write/{}", url, STORAGE_BINDING))
         .json(&serde_json::json!({

--- a/crates/alien-test/tests/common/mod.rs
+++ b/crates/alien-test/tests/common/mod.rs
@@ -7,6 +7,7 @@ pub mod remote_bindings;
 pub mod routing;
 pub mod runner;
 pub mod runtime_less;
+pub mod storage_cleanup;
 
 use std::future::Future;
 use std::time::Duration;

--- a/crates/alien-test/tests/common/storage_cleanup.rs
+++ b/crates/alien-test/tests/common/storage_cleanup.rs
@@ -1,0 +1,108 @@
+use anyhow::{bail, Context};
+
+/// Await cleanup even when verification failed, preserving both errors if necessary.
+/// Only the current test's exact object key is deleted; bucket protection stays enabled.
+pub async fn finish_storage_check(
+    url: &str,
+    binding: &str,
+    key: &str,
+    verification: anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let cleanup = async {
+        reqwest::Client::new()
+            .delete(format!("{url}/storage-object/{binding}/{key}"))
+            .send()
+            .await
+            .context("Test object cleanup request failed")?
+            .error_for_status()
+            .context("Test object cleanup returned an error")?;
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    match (verification, cleanup) {
+        (Ok(()), cleanup) => cleanup,
+        (Err(verification), Ok(())) => Err(verification),
+        (Err(verification), Err(cleanup)) => {
+            bail!("Storage verification failed: {verification:#}; cleanup of {key} also failed: {cleanup:#}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        extract::{Path, State},
+        http::StatusCode,
+        routing::delete,
+        Router,
+    };
+
+    #[tokio::test]
+    async fn removes_only_the_test_object_even_when_verification_failed() {
+        let directory = tempfile::tempdir().unwrap();
+        let sentinel = directory.path().join("unrelated.txt");
+        std::fs::write(&sentinel, "keep").unwrap();
+        let app = Router::new()
+            .route(
+                "/storage-object/files/{key}",
+                delete(
+                    |State(root): State<std::path::PathBuf>, Path(key): Path<String>| async move {
+                        tokio::fs::remove_file(root.join(key)).await.unwrap();
+                        StatusCode::NO_CONTENT
+                    },
+                ),
+            )
+            .with_state(directory.path().to_path_buf());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        for failed in [false, true] {
+            let key = format!("storage-event-test-{}.txt", uuid::Uuid::new_v4());
+            let object = directory.path().join(&key);
+            std::fs::write(&object, "test").unwrap();
+            let verification = if failed {
+                Err(anyhow::anyhow!("event delivery failed"))
+            } else {
+                Ok(())
+            };
+            let result = finish_storage_check(&url, "files", &key, verification).await;
+            if failed {
+                assert_eq!(result.unwrap_err().to_string(), "event delivery failed");
+            } else {
+                result.unwrap();
+            }
+            assert!(!object.exists());
+            assert_eq!(std::fs::read_to_string(&sentinel).unwrap(), "keep");
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn reports_cleanup_failure_without_losing_verification_failure() {
+        let app = Router::new().route(
+            "/storage-object/files/{key}",
+            delete(|| async { StatusCode::SERVICE_UNAVAILABLE }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let error = finish_storage_check(
+            &url,
+            "files",
+            "test.txt",
+            Err(anyhow::anyhow!("content mismatch")),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("content mismatch"), "{error}");
+        assert!(error.contains("cleanup of test.txt also failed"), "{error}");
+        assert!(error.contains("503"), "{error}");
+        assert!(finish_storage_check(&url, "files", "test.txt", Ok(()))
+            .await
+            .is_err());
+        server.abort();
+    }
+}

--- a/crates/alien-test/tests/common/storage_cleanup.rs
+++ b/crates/alien-test/tests/common/storage_cleanup.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{bail, Context};
 
 /// Await cleanup even when verification failed, preserving both errors if necessary.
@@ -11,6 +13,8 @@ pub async fn finish_storage_check(
     let cleanup = async {
         reqwest::Client::new()
             .delete(format!("{url}/storage-object/{binding}/{key}"))
+            // A stalled test app must not prevent the runner from reaching teardown.
+            .timeout(Duration::from_secs(10))
             .send()
             .await
             .context("Test object cleanup request failed")?
@@ -37,6 +41,40 @@ mod tests {
         routing::delete,
         Router,
     };
+
+    #[tokio::test]
+    async fn stalled_cleanup_times_out_and_preserves_verification_failure() {
+        let app = Router::new().route(
+            "/storage-object/files/{key}",
+            delete(|| std::future::pending::<StatusCode>()),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let results = tokio::time::timeout(Duration::from_secs(15), async {
+            tokio::join!(
+                finish_storage_check(&url, "files", "test.txt", Ok(())),
+                finish_storage_check(
+                    &url,
+                    "files",
+                    "test.txt",
+                    Err(anyhow::anyhow!("content mismatch")),
+                ),
+            )
+        })
+        .await;
+        server.abort();
+
+        let (successful_verification, failed_verification) =
+            results.expect("cleanup must finish before the test watchdog");
+        let error = successful_verification.unwrap_err();
+        assert!(error.downcast_ref::<reqwest::Error>().unwrap().is_timeout());
+        let error = format!("{:#}", failed_verification.unwrap_err());
+        assert!(error.contains("content mismatch"), "{error}");
+        assert!(error.contains("cleanup of test.txt also failed"), "{error}");
+        assert!(error.contains("timed out"), "{error}");
+    }
 
     #[tokio::test]
     async fn removes_only_the_test_object_even_when_verification_failed() {

--- a/crates/alien-test/tests/common/storage_cleanup.rs
+++ b/crates/alien-test/tests/common/storage_cleanup.rs
@@ -13,8 +13,8 @@ pub async fn finish_storage_check(
     let cleanup = async {
         reqwest::Client::new()
             .delete(format!("{url}/storage-object/{binding}/{key}"))
-            // A stalled test app must not prevent the runner from reaching teardown.
-            .timeout(Duration::from_secs(10))
+            // Allow cold starts beyond 10s, but bound stalls so teardown can proceed.
+            .timeout(Duration::from_secs(30))
             .send()
             .await
             .context("Test object cleanup request failed")?
@@ -52,7 +52,7 @@ mod tests {
         let url = format!("http://{}", listener.local_addr().unwrap());
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-        let results = tokio::time::timeout(Duration::from_secs(15), async {
+        let results = tokio::time::timeout(Duration::from_secs(40), async {
             tokio::join!(
                 finish_storage_check(&url, "files", "test.txt", Ok(())),
                 finish_storage_check(
@@ -74,6 +74,24 @@ mod tests {
         assert!(error.contains("content mismatch"), "{error}");
         assert!(error.contains("cleanup of test.txt also failed"), "{error}");
         assert!(error.contains("timed out"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn cleanup_allows_a_slow_successful_response() {
+        let app = Router::new().route(
+            "/storage-object/files/{key}",
+            delete(|| async {
+                // A valid cold start can exceed the old 10-second deadline.
+                tokio::time::sleep(Duration::from_secs(12)).await;
+                StatusCode::NO_CONTENT
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let result = finish_storage_check(&url, "files", "test.txt", Ok(())).await;
+        server.abort();
+        result.expect("slow successful cleanup must not fail verification");
     }
 
     #[tokio::test]

--- a/tests/e2e/test-apps/comprehensive-rust/src/bin/main.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/bin/main.rs
@@ -398,6 +398,10 @@ fn build_router(app_state: AppState) -> Router {
             post(handlers::storage::write_storage_object),
         )
         .route(
+            "/storage-object/{binding_name}/{key}",
+            axum::routing::delete(handlers::storage_cleanup::delete_storage_object),
+        )
+        .route(
             "/build-test/{binding_name}",
             post(handlers::build::test_build),
         )

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/mod.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/mod.rs
@@ -12,5 +12,6 @@ pub mod sandbox;
 pub mod service_account;
 pub mod sse;
 pub mod storage;
+pub mod storage_cleanup;
 pub mod vault;
 pub mod wait_until;

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/storage_cleanup.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/storage_cleanup.rs
@@ -1,0 +1,29 @@
+use alien_error::{Context, IntoAlienError};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+};
+
+use crate::{models::AppState, ErrorData, Result};
+
+/// Remove one test object after its content or creation event has been verified.
+pub async fn delete_storage_object(
+    State(state): State<AppState>,
+    Path((binding_name, key)): Path<(String, String)>,
+) -> Result<StatusCode> {
+    let storage = state
+        .ctx
+        .bindings()
+        .storage(&binding_name)
+        .await
+        .context(ErrorData::BindingNotFound { binding_name })?;
+    let path = object_store::path::Path::from(key);
+    match storage.delete(&path).await {
+        Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(StatusCode::NO_CONTENT),
+        Err(error) => Err(error)
+            .into_alien_error()
+            .context(ErrorData::StorageOperationFailed {
+                operation: "delete test object".to_string(),
+            }),
+    }
+}

--- a/tests/e2e/test-apps/comprehensive-rust/src/handlers/storage_cleanup.rs
+++ b/tests/e2e/test-apps/comprehensive-rust/src/handlers/storage_cleanup.rs
@@ -1,4 +1,4 @@
-use alien_error::{Context, IntoAlienError};
+use alien_error::{AlienError, Context, IntoAlienError};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -11,6 +11,18 @@ pub async fn delete_storage_object(
     State(state): State<AppState>,
     Path((binding_name, key)): Path<(String, String)>,
 ) -> Result<StatusCode> {
+    // This test app is public. Cleanup must not expose arbitrary binding/object deletion.
+    let id = key
+        .strip_prefix("storage-event-test-")
+        .or_else(|| key.strip_prefix("wait_until_test_"))
+        .and_then(|key| key.strip_suffix(".txt"));
+    let valid_key =
+        id.is_some_and(|id| uuid::Uuid::parse_str(id).is_ok_and(|uuid| uuid.to_string() == id));
+    if binding_name != "alien-storage" || !valid_key {
+        return Err(AlienError::new(ErrorData::TestValidationFailed {
+            reason: "Cleanup only accepts generated storage test keys in alien-storage".to_string(),
+        }));
+    }
     let storage = state
         .ctx
         .bindings()

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
@@ -61,8 +61,19 @@ app.post("/storage-write/:bindingName", async c => {
 })
 
 app.delete("/storage-object/:bindingName/:key", async c => {
+  const bindingName = c.req.param("bindingName")
+  const key = c.req.param("key")
+  // Only the generated test namespaces are eligible on this public test app.
+  const testKey =
+    /^(?:storage-event-test-|wait_until_test_)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.txt$/
+  if (bindingName !== "alien-storage" || !testKey.test(key)) {
+    return c.json(
+      { success: false, error: "Cleanup only accepts generated storage test keys in alien-storage" },
+      400,
+    )
+  }
   try {
-    await storage(c.req.param("bindingName")).delete(c.req.param("key"))
+    await storage(bindingName).delete(key)
     return c.body(null, 204)
   } catch (error: unknown) {
     if ((await AlienError.from(error)).httpStatusCode === 404) return c.body(null, 204)

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
@@ -1,3 +1,4 @@
+import { AlienError } from "@alienplatform/core"
 import { storage } from "@alienplatform/sdk"
 import { Hono } from "hono"
 import { toExternalOperationError } from "../helpers.js"
@@ -55,6 +56,17 @@ app.post("/storage-write/:bindingName", async c => {
     return c.json({ success: true, bindingName, key })
   } catch (error: unknown) {
     const alienError = await toExternalOperationError(error, "storage-write")
+    return c.json({ success: false, error: alienError.message, code: alienError.code }, 500)
+  }
+})
+
+app.delete("/storage-object/:bindingName/:key", async c => {
+  try {
+    await storage(c.req.param("bindingName")).delete(c.req.param("key"))
+    return c.body(null, 204)
+  } catch (error: unknown) {
+    if ((await AlienError.from(error)).httpStatusCode === 404) return c.body(null, 204)
+    const alienError = await toExternalOperationError(error, "storage-delete")
     return c.json({ success: false, error: alienError.message, code: alienError.code }, 500)
   }
 })

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/storage.ts
@@ -68,7 +68,10 @@ app.delete("/storage-object/:bindingName/:key", async c => {
     /^(?:storage-event-test-|wait_until_test_)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.txt$/
   if (bindingName !== "alien-storage" || !testKey.test(key)) {
     return c.json(
-      { success: false, error: "Cleanup only accepts generated storage test keys in alien-storage" },
+      {
+        success: false,
+        error: "Cleanup only accepts generated storage test keys in alien-storage",
+      },
       400,
     )
   }

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/wait-until.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/wait-until.ts
@@ -13,7 +13,7 @@ app.post("/wait-until-test", async c => {
       await new Promise(resolve => setTimeout(resolve, delayMs || 1000))
       const s = storage(storageBindingName || "alien-storage")
       await s.put(
-        `wait-until-${testId}.txt`,
+        `wait_until_test_${testId}.txt`,
         new TextEncoder().encode(testData || "background-task-done"),
       )
     })(),
@@ -29,7 +29,7 @@ app.get("/wait-until-verify/:testId/:storageBindingName", async c => {
     const s = storage(storageBindingName)
     // Storage has no `exists`; a missing object surfaces as a thrown NotFound
     // from `get`, which the catch below maps to "not completed yet".
-    const result = await s.get(`wait-until-${testId}.txt`)
+    const result = await s.get(`wait_until_test_${testId}.txt`)
     const fileContent = new TextDecoder().decode(result.data)
     return c.json({
       success: true,

--- a/tests/e2e/test-apps/comprehensive-typescript/src/handlers/wait-until.ts
+++ b/tests/e2e/test-apps/comprehensive-typescript/src/handlers/wait-until.ts
@@ -6,7 +6,7 @@ const app = new Hono()
 
 app.post("/wait-until-test", async c => {
   const { storageBindingName, testData, delayMs } = await c.req.json()
-  const testId = `test-${Date.now()}`
+  const testId = crypto.randomUUID()
 
   waitUntil(
     (async () => {


### PR DESCRIPTION
## Root cause
Storage-event and waitUntil checks leave their test objects behind. Successful checks can therefore prevent protected test buckets from being destroyed.

## Change
Delete only each check’s exact object key, after verifying its result. Attempt cleanup on verification failures too, preserving both errors if cleanup also fails. Add the endpoint to both test apps and align their waitUntil object keys. No bucket-wide deletion or force-destroy change.

## Validation
- Three local HTTP tests passed in a lightweight harness importing the actual cleanup client and Rust handler, including a real filesystem ObjectStore. Verified exact-key deletion, unrelated-object preservation, idempotence, and combined failure reporting.
- `pnpm --filter comprehensive-typescript test:ts` passed.
- Rust formatting and diff checks passed.
- Full cloud E2E/app builds were not run locally. This fixes known completed-check leaks, not arbitrary late background writes or every teardown failure.

ALIEN-715