### PR TITLE
fix: avoid claiming convergence without rollout observations

### DIFF
--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -2518,6 +2518,8 @@ mod tests {
             assert_eq!(observed_rollout_state(&resource), "unavailable");
         }
 
+        resource.desired_image = Some("registry.example/api:desired".to_string());
+        resource.observed_image = Some("registry.example/api:previous".to_string());
         resource.stale = true;
         assert_eq!(observed_rollout_state(&resource), "stale");
 

--- a/crates/alien-cli/src/commands/deployments.rs
+++ b/crates/alien-cli/src/commands/deployments.rs
@@ -1308,13 +1308,13 @@ fn observed_rollout_state(resource: &ObservedRolloutResource) -> &'static str {
         "unavailable"
     } else if resource.stale {
         "stale"
-    } else if resource.desired_image.is_some()
-        && resource.observed_image.is_some()
-        && resource.desired_image != resource.observed_image
-    {
-        "rollout pending"
     } else {
-        "converged"
+        // Missing image identity is not evidence that the rollout reached its target.
+        match (&resource.desired_image, &resource.observed_image) {
+            (Some(desired), Some(observed)) if desired == observed => "converged",
+            (Some(_), Some(_)) => "rollout pending",
+            _ => "unavailable",
+        }
     }
 }
 
@@ -2507,6 +2507,16 @@ mod tests {
 
         resource.observed_image = resource.desired_image.clone();
         assert_eq!(observed_rollout_state(&resource), "converged");
+
+        for (desired_image, observed_image) in [
+            (Some("registry.example/api:desired"), None),
+            (None, Some("registry.example/api:desired")),
+            (None, None),
+        ] {
+            resource.desired_image = desired_image.map(str::to_string);
+            resource.observed_image = observed_image.map(str::to_string);
+            assert_eq!(observed_rollout_state(&resource), "unavailable");
+        }
 
         resource.stale = true;
         assert_eq!(observed_rollout_state(&resource), "stale");


### PR DESCRIPTION
## Root cause
The deployment rollout table falls through to converged when either desired or observed image is missing. Resource detail can return no heartbeat/image without an API error, so absence of evidence becomes a success label.

## Fix
Require both image identities before reporting convergence or a mismatch. Missing identities display unavailable. Existing error and stale precedence is unchanged. No mutation, rollout status change, API contract, or new CLI command.

## Validation
Expanded the existing classification test to cover missing desired, missing observed, both missing, matching/mismatched images, and stale/error precedence. Compiled the actual struct, classification function, and test directly with rustc (serialization attributes omitted), without building the full CLI dependency graph. Before the fix it fails with converged vs unavailable; after it passes. rustfmt and diff checks passed. Full CLI integration remains for CI.

ALIEN-759