### PR TITLE
ci: review pull requests once by default

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,9 +1,5 @@
 {
   "triggerOnUpdates": false,
-  "excludeAuthors": [
-    "renovate[bot]",
-    "dependabot[bot]",
-    "posthog[bot]"
-  ],
+  "excludeAuthors": ["renovate[bot]", "dependabot[bot]", "posthog[bot]"],
   "ignorePatterns": "packages/core/openapi.json\npackages/core/src/generated/**\npackages/sdk/src/generated/**\npackages/sdk/src/worker-runtime/generated/**\npackages/sdk/dist/generated/**"
 }

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,4 +1,9 @@
 {
-  "triggerOnUpdates": true,
+  "triggerOnUpdates": false,
+  "excludeAuthors": [
+    "renovate[bot]",
+    "dependabot[bot]",
+    "posthog[bot]"
+  ],
   "ignorePatterns": "packages/core/openapi.json\npackages/core/src/generated/**\npackages/sdk/src/generated/**\npackages/sdk/src/worker-runtime/generated/**\npackages/sdk/dist/generated/**"
 }


### PR DESCRIPTION
Greptile currently reviews every update to every pull request, including known dependency bot PRs.

This keeps the automatic review when a human-authored PR opens, stops automatic re-reviews after every push, and excludes Renovate, Dependabot, and PostHog bot authors. Maintainers can request a fresh review after meaningful follow-up changes by commenting `@greptileai`.

Validation:
- `jq empty .greptile/config.json`
- Confirmed `triggerOnUpdates` and `excludeAuthors` against Greptile's current configuration reference.
