### PR TITLE
fix: continue health observations after refresh failure

### DIFF
--- a/crates/alien-deployment/src/lib.rs
+++ b/crates/alien-deployment/src/lib.rs
@@ -296,14 +296,7 @@ pub async fn step(
             }
         }
         DeploymentStatus::RefreshFailed => {
-            running::handle_refresh_failed(
-                current,
-                require_target_stack()?,
-                config,
-                client_config,
-                service_provider,
-            )
-            .await?
+            running::handle_refresh_failed(current, config, client_config, service_provider).await?
         }
         DeploymentStatus::Deleted => {
             debug!("Deployment is deleted, no action");

--- a/crates/alien-deployment/src/runner.rs
+++ b/crates/alien-deployment/src/runner.rs
@@ -138,7 +138,7 @@ pub async fn run_step_loop(
     .await
 }
 
-/// Run one refresh step for a deployment whose initial status is already Running.
+/// Run one observation step for a Running or RefreshFailed deployment.
 ///
 /// Normal deployment loops treat Running as already synced and stop before
 /// calling [`crate::step()`]. Heartbeat loops use this entry point to execute the
@@ -324,7 +324,10 @@ async fn run_step_loop_body(
         if !should_step_retryable_failure(state) {
             let should_run_initial_running_refresh = allow_initial_running_step
                 && step_count == 1
-                && state.status == DeploymentStatus::Running;
+                && matches!(
+                    state.status,
+                    DeploymentStatus::Running | DeploymentStatus::RefreshFailed
+                );
             if let Some(result) = classify_status(&state.status, policy.operation) {
                 if !should_run_initial_running_refresh {
                     return Ok(RunnerResult {
@@ -963,44 +966,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initial_running_runs_one_step_when_policy_allows_running_start() {
-        let transport = FailFirstCheckpointTransport::default();
-        let mut state = test_state();
-        state.status = DeploymentStatus::Running;
-        state.current_release = state.target_release.take();
-        state.stack_state = Some(StackState::new(Platform::Test));
-        let mut config = test_config();
-        let policy = RunnerPolicy {
-            max_steps: 1,
-            operation: LoopOperation::Deploy,
-            delay_strategy: DelayStrategy::Inline,
-        };
+    async fn heartbeat_runs_one_step_from_running_or_refresh_failed() {
+        for initial_status in [DeploymentStatus::Running, DeploymentStatus::RefreshFailed] {
+            let transport = FailFirstCheckpointTransport::default();
+            let mut state = test_state();
+            state.status = initial_status;
+            state.current_release = state.target_release.take();
+            state.stack_state = Some(StackState::new(Platform::Test));
+            let mut config = test_config();
+            let policy = RunnerPolicy {
+                max_steps: 1,
+                operation: LoopOperation::Deploy,
+                delay_strategy: DelayStrategy::Inline,
+            };
 
-        let result = run_running_refresh_step_loop(
-            &mut state,
-            &mut config,
-            &ClientConfig::Test,
-            "dep_test",
-            &policy,
-            &transport,
-            None,
-            None,
-        )
-        .await
-        .expect("runner should run one heartbeat step for an initially running deployment");
+            let result = run_running_refresh_step_loop(
+                &mut state,
+                &mut config,
+                &ClientConfig::Test,
+                "dep_test",
+                &policy,
+                &transport,
+                None,
+                None,
+            )
+            .await
+            .expect("runner should run one heartbeat step even after a health failure");
 
-        assert_eq!(result.steps_executed, 1);
-        assert_eq!(state.status, DeploymentStatus::RefreshFailed);
-        assert_eq!(
-            transport
-                .checkpointed_statuses
-                .lock()
-                .expect("statuses lock poisoned")
-                .as_slice(),
-            &[
-                DeploymentStatus::RefreshFailed,
-                DeploymentStatus::RefreshFailed
-            ],
-        );
+            assert_eq!(result.steps_executed, 1);
+            assert_eq!(state.status, DeploymentStatus::RefreshFailed);
+            assert_eq!(
+                transport
+                    .checkpointed_statuses
+                    .lock()
+                    .expect("statuses lock poisoned")
+                    .as_slice(),
+                &[
+                    DeploymentStatus::RefreshFailed,
+                    DeploymentStatus::RefreshFailed
+                ],
+            );
+        }
     }
 }

--- a/crates/alien-deployment/src/running.rs
+++ b/crates/alien-deployment/src/running.rs
@@ -1,7 +1,6 @@
 use crate::{
     DeploymentConfig, DeploymentState, DeploymentStatus, DeploymentStepResult, ErrorData, Result,
 };
-use alien_core::Stack;
 use alien_error::{AlienError, Context};
 use alien_infra::StackExecutor;
 use tracing::info;
@@ -133,7 +132,6 @@ pub async fn handle_running(
 /// 4. Sets clear_retry_requested flag to clear the retry marker
 pub async fn handle_refresh_failed(
     current: DeploymentState,
-    _target_stack: Stack,
     config: DeploymentConfig,
     client_config: alien_core::ClientConfig,
     service_provider: std::sync::Arc<dyn alien_infra::PlatformServiceProvider>,

--- a/crates/alien-deployment/src/running.rs
+++ b/crates/alien-deployment/src/running.rs
@@ -110,6 +110,7 @@ pub async fn handle_running(
     } else {
         info!("Health check passed for all resources");
 
+        next.status = DeploymentStatus::Running;
         next.stack_state = Some(step_result.next_state);
         next.error = None;
 
@@ -123,19 +124,19 @@ pub async fn handle_running(
     }
 }
 
-/// Handle RefreshFailed status - retry failed resources and transition back to Running
+/// Observe recovery after a health failure, or honor an explicit resource retry.
 ///
 /// This step:
-/// 1. Checks if retry_requested flag is set
+/// 1. Continues observation when no retry is requested, preserving controller state
 /// 2. Calls retry_failed() on stack state to recover failed resources
 /// 3. Transitions back to Running status
 /// 4. Sets clear_retry_requested flag to clear the retry marker
 pub async fn handle_refresh_failed(
     current: DeploymentState,
     _target_stack: Stack,
-    _config: DeploymentConfig,
-    _client_config: alien_core::ClientConfig,
-    _service_provider: std::sync::Arc<dyn alien_infra::PlatformServiceProvider>,
+    config: DeploymentConfig,
+    client_config: alien_core::ClientConfig,
+    service_provider: std::sync::Arc<dyn alien_infra::PlatformServiceProvider>,
 ) -> Result<DeploymentStepResult> {
     info!("Handling RefreshFailed status");
 
@@ -144,14 +145,9 @@ pub async fn handle_refresh_failed(
 
     // Check if retry was requested
     if !current.retry_requested {
-        info!("No retry requested, staying in RefreshFailed status");
-        return Ok(DeploymentStepResult {
-            state: current,
-            suggested_delay_ms: None,
-            update_heartbeat: false,
-            heartbeats: vec![],
-            observed_inventory_batches: vec![],
-        });
+        // Observation must continue after a transient health failure. Do not
+        // reset controller state or enter a create/update retry flow here.
+        return handle_running(current, config, client_config, service_provider).await;
     }
 
     info!("Retrying failed resources");

--- a/crates/alien-deployment/tests/test_platform.rs
+++ b/crates/alien-deployment/tests/test_platform.rs
@@ -609,6 +609,57 @@ async fn test_running_updates_heartbeat_when_healthy() {
 }
 
 #[tokio::test]
+async fn health_failure_recovers_through_observation_without_retry_or_reprovisioning() {
+    let mut stack = create_test_stack("health-stack", "health-worker");
+    let worker = Worker::new("health-worker".to_string())
+        .code(WorkerCode::Image {
+            image: "test:latest".to_string(),
+        })
+        .permissions("default".to_string())
+        .environment(HashMap::from([
+            (
+                "SIMULATE_OBSERVED_URL_REFRESH".to_string(),
+                "true".to_string(),
+            ),
+            (
+                "SIMULATE_OBSERVED_REFRESH_FAIL_ONCE".to_string(),
+                "true".to_string(),
+            ),
+        ]))
+        .build();
+    stack.resources.get_mut("health-worker").unwrap().config = alien_core::Resource::new(worker);
+    let config = create_test_config("health", false);
+    let state = run_to_completion(create_initial_state(stack), config.clone()).await;
+    assert_eq!(state.status, DeploymentStatus::Running);
+    let release = state.current_release.clone();
+    let failed = alien_deployment::step(state, config.clone(), ClientConfig::Test, None)
+        .await
+        .unwrap();
+    assert_eq!(failed.state.status, DeploymentStatus::RefreshFailed);
+    assert!(!failed.state.retry_requested);
+    let recovered = alien_deployment::step(failed.state, config, ClientConfig::Test, None)
+        .await
+        .unwrap();
+    assert_eq!(recovered.state.status, DeploymentStatus::Running);
+    assert!(recovered.update_heartbeat);
+    assert!(!recovered.state.retry_requested);
+    assert_eq!(recovered.state.current_release, release);
+    let worker = &recovered.state.stack_state.as_ref().unwrap().resources["health-worker"];
+    let outputs = worker
+        .outputs
+        .as_ref()
+        .unwrap()
+        .downcast_ref::<alien_core::WorkerOutputs>()
+        .unwrap();
+    // The second observation proves the existing controller survived; recreating
+    // it would reset the observation counter and repeat the first failure.
+    assert_eq!(
+        outputs.public_endpoints["default"].url,
+        "https://observed-2.test"
+    );
+}
+
+#[tokio::test]
 async fn test_running_transitions_to_refresh_failed_on_health_check_failure() {
     let _temp_dir = TempDir::new().expect("Failed to create temp dir");
 

--- a/crates/alien-deployment/tests/test_platform.rs
+++ b/crates/alien-deployment/tests/test_platform.rs
@@ -660,7 +660,7 @@ async fn health_failure_recovers_through_observation_without_retry_or_reprovisio
 }
 
 #[tokio::test]
-async fn test_running_transitions_to_refresh_failed_on_health_check_failure() {
+async fn persistent_worker_failure_surfaces_during_provisioning() {
     let _temp_dir = TempDir::new().expect("Failed to create temp dir");
 
     // Create a function configured to fail persistently

--- a/crates/alien-manager/src/loops/heartbeat.rs
+++ b/crates/alien-manager/src/loops/heartbeat.rs
@@ -66,7 +66,7 @@ impl HeartbeatLoop {
     /// One heartbeat tick: acquire running deployments and run one health-check step.
     async fn tick(&self) {
         let filter = DeploymentFilter {
-            statuses: Some(vec!["running".to_string()]),
+            statuses: Some(vec!["running".to_string(), "refresh-failed".to_string()]),
             platforms: if self.config.targets.is_empty() {
                 None
             } else {
@@ -205,7 +205,7 @@ mod tests {
             move |_, _, filter, limit| {
                 assert_eq!(
                     filter.statuses.as_deref(),
-                    Some(["running".to_string()].as_slice())
+                    Some(["running".to_string(), "refresh-failed".to_string()].as_slice())
                 );
                 assert_eq!(filter.deployment_model, Some(DeploymentModel::Push));
                 assert_eq!(limit, MAX_CONCURRENT_DEPLOYMENTS as u32);

--- a/crates/alien-manager/src/stores/sqlite/deployment.rs
+++ b/crates/alien-manager/src/stores/sqlite/deployment.rs
@@ -90,6 +90,10 @@ impl SqliteDeploymentStore {
                     Self::WORK_STATUSES.contains(status)
                         || Self::SETUP_TEARDOWN_STATUSES.contains(status)
                         || *status == Self::RUNNING_STATUS
+                        // The heartbeat loop requests Running alongside RefreshFailed.
+                        // Work-only acquisition must still require an explicit retry.
+                        || (*status == "refresh-failed"
+                            && statuses.iter().any(|status| status == Self::RUNNING_STATUS))
                 })
                 .collect();
             let requested_failed: Vec<&str> = statuses

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -689,6 +689,47 @@ async fn acquire_and_release() {
 }
 
 #[tokio::test]
+async fn heartbeat_acquires_refresh_failure_without_turning_it_into_a_work_retry() {
+    let db = fresh_db().await;
+    let store = SqliteDeploymentStore::new(db.clone());
+    let group_id = create_test_group(&store).await;
+    let dep = create_test_deployment(&store, &group_id, "health", Platform::Aws).await;
+    db.conn()
+        .lock()
+        .await
+        .execute(
+            "UPDATE deployments SET status = 'refresh-failed', retry_requested = 0 WHERE id = ?",
+            [dep.id.as_str()],
+        )
+        .await
+        .unwrap();
+
+    for (statuses, expected_count) in [
+        (vec!["refresh-failed".to_string()], 0),
+        (vec!["running".to_string(), "refresh-failed".to_string()], 1),
+    ] {
+        let acquired = store
+            .acquire(
+                &test_subject(),
+                "health-session",
+                &DeploymentFilter {
+                    statuses: Some(statuses),
+                    deployment_ids: Some(vec![dep.id.clone()]),
+                    ..Default::default()
+                },
+                1,
+            )
+            .await
+            .unwrap();
+        assert_eq!(acquired.len(), expected_count);
+        if let Some(item) = acquired.first() {
+            assert_eq!(item.deployment.status, "refresh-failed");
+            assert!(!item.deployment.retry_requested);
+        }
+    }
+}
+
+#[tokio::test]
 async fn acquire_does_not_pick_failed_status_without_retry_request() {
     let db = fresh_db().await;
     let store = SqliteDeploymentStore::new(db.clone());


### PR DESCRIPTION
## Summary

Continue observation after a deployment health check fails, without resetting resource controllers or automatically retrying provisioning/update/deletion.

- Heartbeat acquisition includes `refresh-failed`; SQLite only acquires these without retry for a heartbeat filter that also requests `running`.
- The heartbeat runner executes one observation from either status instead of stopping before the failed-state handler.
- A refresh failure with no retry request uses the existing observation path. It returns to Running only after resource health recovers. Explicit resource retry remains a separate path.

## Evidence and validation

A disposable, previously healthy single-host service was subjected to host loss. Automatic replacement restored the endpoint; a fresh Git clone matched its original commit and stored PR/comment data survived. The deployment nevertheless remained refresh-failed for more than eight minutes after failure detection. Source inspection found the running-only heartbeat filter, pre-step failed-status gate, and retry-only refresh-failure handler.

Added regressions for SQLite acquisition isolation, the runner's failed-status entry, and an actual test controller's healthy → failed observation → recovered observation sequence. The latter checks that the existing controller survives (second observation rather than a recreated controller) and no retry or release change occurs.

Formatting and diff checks pass. Rust tests are pending CI; a new local manager build is not feasible with the available disk space. This PR does not claim live acceptance yet.

Release acceptance: repeat host loss, verify failure visibility, autonomous status recovery without retry, unchanged applied release and retained application data. Also verify explicit retry behavior for provisioning/update/delete failures remains unchanged.
