### PR TITLE
chore: release v3.3.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "alien-ai-gateway"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "alien-aws-clients"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-client-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "alien-azure-clients"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "alien-bindings-node"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "alien-build"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-build",
  "alien-core",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cli-common"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-deployment",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-config"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "alien-client-core"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error",
  "anyhow",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "alien-cloudformation"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "alien-commands-client"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "base64 0.23.1",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "alien-core"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error",
  "alien-macros",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deploy-cli"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-cli-common",
  "alien-core",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "alien-deployment"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error-derive",
  "anyhow",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "alien-error-derive"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "alien-gcp-clients"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "alien-helm"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "alien-infra"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "alien-k8s-clients"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-client-core",
  "alien-core",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "alien-local"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-bindings",
  "alien-build",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "alien-macros"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "aegis",
  "alien-aws-clients",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "alien-manager-api"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "alien-observer"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-aws-clients",
  "alien-azure-clients",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operations-sdk"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "alien-operator"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "aegis",
  "alien-client-config",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "alien-permissions"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "alien-platform-api"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error",
  "chrono",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "alien-preflights"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sandbox-agent"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "alien-sdk"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-bindings",
  "alien-core",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "alien-terraform"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-core",
  "alien-error",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-ai-gateway",
  "alien-aws-clients",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "alien-test-app"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error",
  "alien-sdk",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-protocol"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-error",
  "async-stream",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "alien-worker-runtime"
-version = "3.3.20"
+version = "3.3.21"
 dependencies = [
  "alien-bindings",
  "alien-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.3.20"
+version = "3.3.21"
 edition = "2021"
 authors = ["Alien Software, Inc. <hi@alien.dev>"]
 description = "Deploy software into your customers' cloud accounts and keep it fully managed"
@@ -66,40 +66,40 @@ repository = "https://github.com/alienplatform/alien"
 license-file = "LICENSE.md"
 
 [workspace.dependencies]
-alien-commands = { path = "crates/alien-commands", version = "3.3.20", default-features = false }
+alien-commands = { path = "crates/alien-commands", version = "3.3.21", default-features = false }
 alien-commands-client = { path = "crates/alien-commands-client" }
-alien-bindings = { path = "crates/alien-bindings", version = "3.3.20", default-features = false }
-alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.20" }
-alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.20" }
-alien-sdk = { path = "crates/alien-sdk", version = "3.3.20", default-features = false }
-alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.20" }
+alien-bindings = { path = "crates/alien-bindings", version = "3.3.21", default-features = false }
+alien-ai-gateway = { path = "crates/alien-ai-gateway", version = "3.3.21" }
+alien-worker-protocol = { path = "crates/alien-worker-protocol", version = "3.3.21" }
+alien-sdk = { path = "crates/alien-sdk", version = "3.3.21", default-features = false }
+alien-worker-runtime = { path = "crates/alien-worker-runtime", version = "3.3.21" }
 dockdash = "0.2.0"
-alien-core = { path = "crates/alien-core", version = "3.3.20" }
-alien-infra = { path = "crates/alien-infra", version = "3.3.20" }
-alien-build = { path = "crates/alien-build", version = "3.3.20" }
-alien-macros = { path = "crates/alien-macros", version = "3.3.20" }
-alien-client-core = { path = "crates/alien-client-core", version = "3.3.20" }
-alien-client-config = { path = "crates/alien-client-config", version = "3.3.20" }
-alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.20" }
-alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.20" }
-alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.20" }
-alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.20" }
-alien-error = { path = "crates/alien-error", version = "3.3.20", features = ["anyhow"] }
-alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.20" }
-alien-permissions = { path = "crates/alien-permissions", version = "3.3.20" }
-alien-operations-sdk = { path = "crates/alien-operations-sdk", version = "3.3.20" }
-alien-preflights = { path = "crates/alien-preflights", version = "3.3.20" }
-alien-deployment = { path = "crates/alien-deployment", version = "3.3.20" }
-alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.20" }
-alien-local = { path = "crates/alien-local", version = "3.3.20" }
-alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.20" }
-alien-terraform = { path = "crates/alien-terraform", version = "3.3.20" }
-alien-helm = { path = "crates/alien-helm", version = "3.3.20" }
-alien-manager = { path = "crates/alien-manager", version = "3.3.20" }
-alien-observer = { path = "crates/alien-observer", version = "3.3.20" }
+alien-core = { path = "crates/alien-core", version = "3.3.21" }
+alien-infra = { path = "crates/alien-infra", version = "3.3.21" }
+alien-build = { path = "crates/alien-build", version = "3.3.21" }
+alien-macros = { path = "crates/alien-macros", version = "3.3.21" }
+alien-client-core = { path = "crates/alien-client-core", version = "3.3.21" }
+alien-client-config = { path = "crates/alien-client-config", version = "3.3.21" }
+alien-aws-clients = { path = "crates/alien-aws-clients", version = "3.3.21" }
+alien-gcp-clients = { path = "crates/alien-gcp-clients", version = "3.3.21" }
+alien-azure-clients = { path = "crates/alien-azure-clients", version = "3.3.21" }
+alien-k8s-clients = { path = "crates/alien-k8s-clients", version = "3.3.21" }
+alien-error = { path = "crates/alien-error", version = "3.3.21", features = ["anyhow"] }
+alien-error-derive = { path = "crates/alien-error-derive", version = "3.3.21" }
+alien-permissions = { path = "crates/alien-permissions", version = "3.3.21" }
+alien-operations-sdk = { path = "crates/alien-operations-sdk", version = "3.3.21" }
+alien-preflights = { path = "crates/alien-preflights", version = "3.3.21" }
+alien-deployment = { path = "crates/alien-deployment", version = "3.3.21" }
+alien-cli-common = { path = "crates/alien-cli-common", version = "3.3.21" }
+alien-local = { path = "crates/alien-local", version = "3.3.21" }
+alien-cloudformation = { path = "crates/alien-cloudformation", version = "3.3.21" }
+alien-terraform = { path = "crates/alien-terraform", version = "3.3.21" }
+alien-helm = { path = "crates/alien-helm", version = "3.3.21" }
+alien-manager = { path = "crates/alien-manager", version = "3.3.21" }
+alien-observer = { path = "crates/alien-observer", version = "3.3.21" }
 alien-deploy-cli = { path = "crates/alien-deploy-cli" }
-alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.20", default-features = false, features = ["rustls"] }
-alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.20", default-features = false, features = ["rustls"] }
+alien-manager-api = { path = "client-sdks/manager/rust", version = "3.3.21", default-features = false, features = ["rustls"] }
+alien-platform-api = { path = "client-sdks/platform/rust", version = "3.3.21", default-features = false, features = ["rustls"] }
 
 # External dependencies
 anyhow = "1.0"

--- a/client-sdks/manager/typescript/.speakeasy/gen.lock
+++ b/client-sdks/manager/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.20
+  releaseVersion: 3.3.21
   configChecksum: e4b2d88985ffb955cd697b9adc28ca69
   repoURL: https://github.com/alienplatform/alien.git
   repoSubDirectory: client-sdks/manager/typescript

--- a/client-sdks/manager/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/manager/typescript/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.20
+  version: 3.3.21
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/manager/typescript/jsr.json
+++ b/client-sdks/manager/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/manager/typescript/package.json
+++ b/client-sdks/manager/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/manager-api",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/manager/typescript/src/lib/config.ts
+++ b/client-sdks/manager/typescript/src/lib/config.ts
@@ -58,8 +58,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "3.3.20",
+  sdkVersion: "3.3.21",
   genVersion: "2.788.15",
   userAgent:
-    "speakeasy-sdk/typescript 3.3.20 2.788.15 1.0.0 @alienplatform/manager-api",
+    "speakeasy-sdk/typescript 3.3.21 2.788.15 1.0.0 @alienplatform/manager-api",
 } as const;

--- a/client-sdks/platform/typescript/.speakeasy/gen.lock
+++ b/client-sdks/platform/typescript/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.680.11
   generationVersion: 2.788.15
-  releaseVersion: 3.3.20
+  releaseVersion: 3.3.21
   configChecksum: 7fe9bf3bb7ed81118308e996cc6f2024
 persistentEdits:
   generation_id: db6ac3e5-6bcc-4de5-a81f-eb659048385d

--- a/client-sdks/platform/typescript/.speakeasy/gen.yaml
+++ b/client-sdks/platform/typescript/.speakeasy/gen.yaml
@@ -33,7 +33,7 @@ generation:
     skipResponseBodyAssertions: false
   versioningStrategy: manual
 typescript:
-  version: 3.3.20
+  version: 3.3.21
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client-sdks/platform/typescript/jsr.json
+++ b/client-sdks/platform/typescript/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client-sdks/platform/typescript/package-lock.json
+++ b/client-sdks/platform/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alienplatform/platform-api",
-      "version": "3.3.20",
+      "version": "3.3.21",
       "license": "FSL-1.1-Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/client-sdks/platform/typescript/package.json
+++ b/client-sdks/platform/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/platform-api",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "homepage": "https://alien.dev",
   "license": "FSL-1.1-Apache-2.0",

--- a/client-sdks/platform/typescript/src/lib/config.ts
+++ b/client-sdks/platform/typescript/src/lib/config.ts
@@ -66,8 +66,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "3.3.20",
+  sdkVersion: "3.3.21",
   genVersion: "2.788.15",
   userAgent:
-    "speakeasy-sdk/typescript 3.3.20 2.788.15 1.0.0 @alienplatform/platform-api",
+    "speakeasy-sdk/typescript 3.3.21 2.788.15 1.0.0 @alienplatform/platform-api",
 } as const;

--- a/crates/alien-bindings-node/package.json
+++ b/crates/alien-bindings-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-node",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "private": true,
   "description": "napi-rs addon exposing alien-bindings storage/kv/queue/vault to JavaScript",
   "napi": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/ai-gateway",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/bindings/npm/darwin-arm64/package.json
+++ b/packages/bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-arm64",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/darwin-x64/package.json
+++ b/packages/bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-darwin-x64",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/npm/linux-arm64-gnu/package.json
+++ b/packages/bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-arm64-gnu",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "cpu": [
     "arm64"
   ],

--- a/packages/bindings/npm/linux-x64-gnu/package.json
+++ b/packages/bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings-linux-x64-gnu",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "cpu": [
     "x64"
   ],

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/bindings",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/commands",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/core",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "type": "module",
   "files": [
     "dist"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/sdk",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "type": "module",
   "files": [
     "dist"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alienplatform/testing",
-  "version": "3.3.20",
+  "version": "3.3.21",
   "description": "Testing framework for Alien applications",
   "author": "Alien Software, Inc. <hi@alien.dev>",
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
Version-only release PR generated by the stable release workflow. The **Release qualification** check builds and records the exact artifact set. After every required check passes and this merges, run the stable **publish** action from `main` to promote those qualified artifacts.