### PR TITLE
fix: re-register setup with deployment-scoped credentials

### DIFF
--- a/crates/alien-manager/src/routes/stack.rs
+++ b/crates/alien-manager/src/routes/stack.rs
@@ -98,20 +98,36 @@ pub async fn stack_import(
         Err(e) => return e.into_response(),
     };
 
-    // The import endpoint is intentionally narrow: a deployment-group token is
-    // the only credential class that has a meaningful "import into this group"
-    // semantic. Workspace/admin tokens could be allowed here too, but every
-    // existing call-site (CloudFormation custom resource, Terraform provider,
-    // Helm bootstrap) mints a DG token at setup time, so widening would only weaken
-    // the audit trail without adding new flows.
+    // Bootstrap may create in a group. A deployment credential may only
+    // re-register its own existing setup; it must never fall through to create.
     let deployment_group_id = match &subject.scope {
         Scope::DeploymentGroup {
             deployment_group_id,
             ..
         } => deployment_group_id.clone(),
+        Scope::Deployment { deployment_id, .. } => {
+            let existing = match state
+                .deployment_store
+                .get_deployment(&subject, deployment_id)
+                .await
+            {
+                Ok(Some(deployment)) => deployment,
+                Ok(None) => return ErrorData::not_found_deployment(deployment_id).into_response(),
+                Err(error) => return error.into_response(),
+            };
+            if existing.name != req.deployment_name.trim()
+                || !state.authz.can_update_deployment(&subject, &existing)
+            {
+                return ErrorData::forbidden("Cannot register setup for another deployment")
+                    .into_response();
+            }
+            existing.deployment_group_id.clone()
+        }
         _ => {
-            return ErrorData::forbidden("Stack import requires a deployment-group-scoped token")
-                .into_response();
+            return ErrorData::forbidden(
+                "Stack import requires a deployment-group or deployment token",
+            )
+            .into_response();
         }
     };
 
@@ -139,16 +155,6 @@ pub async fn stack_import(
     let setup_metadata = match setup_metadata_for_persistence(&req) {
         Ok(metadata) => metadata,
         Err(error) => return error.into_response(),
-    };
-
-    let dg = match state
-        .deployment_store
-        .get_deployment_group(&subject, &deployment_group_id)
-        .await
-    {
-        Ok(Some(dg)) => dg,
-        Ok(None) => return ErrorData::not_found_group(&deployment_group_id).into_response(),
-        Err(e) => return e.into_response(),
     };
 
     let release = match req.release_id.as_deref() {
@@ -419,6 +425,21 @@ pub async fn stack_import(
         Err(e) => return e.into_response(),
     }
 
+    // The deployment could have been deleted during preparation. Do not turn
+    // a re-registration into a new deployment or issue a replacement credential.
+    if matches!(subject.scope, Scope::Deployment { .. }) {
+        return ErrorData::forbidden("A deployment token cannot create a deployment")
+            .into_response();
+    }
+    let dg = match state
+        .deployment_store
+        .get_deployment_group(&subject, &deployment_group_id)
+        .await
+    {
+        Ok(Some(dg)) => dg,
+        Ok(None) => return ErrorData::not_found_group(&deployment_group_id).into_response(),
+        Err(error) => return error.into_response(),
+    };
     let runtime_metadata = import_runtime_metadata(&prepared_stack, imported_gate_answers);
 
     let create_ctx = crate::auth::DeploymentCreateCtx {

--- a/crates/alien-manager/src/routes/stack.rs
+++ b/crates/alien-manager/src/routes/stack.rs
@@ -421,6 +421,7 @@ pub async fn stack_import(
                     &subject,
                     &existing.id,
                     UpdateImportedDeploymentParams {
+                        stack_settings: req.stack_settings.clone(),
                         stack_state: stack_state.clone(),
                         environment_info: environment_info.clone(),
                         runtime_metadata: runtime_metadata.clone(),

--- a/crates/alien-manager/src/routes/stack.rs
+++ b/crates/alien-manager/src/routes/stack.rs
@@ -962,7 +962,11 @@ fn is_idempotent_import(
         .as_deref()
         .or(existing.current_release_id.as_deref())
         == Some(release_id)
+        && existing.setup_target.as_deref() == Some(req.setup_target.as_str())
         && existing.setup_fingerprint.as_deref() == Some(req.setup_fingerprint.as_str())
+        && existing.setup_fingerprint_version == Some(req.setup_fingerprint_version)
+        && existing.stack_settings.as_ref() == Some(&req.stack_settings)
+        && existing.environment_info.as_ref() == infer_import_environment_info(req).as_ref()
         && existing.input_values == req.input_values
         && imported_resources_are_unchanged(existing, imported_stack_state)
 }
@@ -1694,6 +1698,62 @@ mod setup_update_authorization_tests {
             &imported_state,
             &None,
             &runtime_metadata,
+            "release",
+            &req,
+        ));
+    }
+
+    #[test]
+    fn idempotent_import_requires_every_persisted_setup_field_to_match() {
+        let prepared = stack("live-worker", "frozen-storage");
+        let existing = record(prepared);
+        let mut req = request();
+        req.stack_settings = existing.stack_settings.clone().unwrap();
+        let imported_state = existing.stack_state.clone().unwrap();
+
+        assert!(is_idempotent_import(
+            &existing,
+            &imported_state,
+            "release",
+            &req,
+        ));
+
+        req.setup_target = "different-target".to_string();
+        assert!(!is_idempotent_import(
+            &existing,
+            &imported_state,
+            "release",
+            &req,
+        ));
+        req.setup_target = "target".to_string();
+
+        req.setup_fingerprint_version = 2;
+        assert!(!is_idempotent_import(
+            &existing,
+            &imported_state,
+            "release",
+            &req,
+        ));
+        req.setup_fingerprint_version = 1;
+
+        req.stack_settings.telemetry = alien_core::TelemetryMode::Off;
+        assert!(!is_idempotent_import(
+            &existing,
+            &imported_state,
+            "release",
+            &req,
+        ));
+
+        req.stack_settings = existing.stack_settings.clone().unwrap();
+        let mut existing_with_environment = existing;
+        existing_with_environment.environment_info =
+            Some(EnvironmentInfo::Aws(AwsEnvironmentInfo {
+                account_id: "123456789012".to_string(),
+                region: "region".to_string(),
+            }));
+        assert!(!is_idempotent_import(
+            &existing_with_environment,
+            &imported_state,
             "release",
             &req,
         ));

--- a/crates/alien-manager/src/routes/stack.rs
+++ b/crates/alien-manager/src/routes/stack.rs
@@ -275,6 +275,7 @@ pub async fn stack_import(
                 })
                 .into_response();
             }
+            let activates_setup_reservation = is_pending_setup_reservation(&existing, &release.id);
             match setup_registration_replay(&existing.setup_metadata, &setup_metadata) {
                 SetupRegistrationReplay::Exact => {
                     let Some(stack_settings) = existing.stack_settings else {
@@ -305,19 +306,47 @@ pub async fn stack_import(
                 }
                 SetupRegistrationReplay::None => {}
             }
-            if let Some(existing_stack_state) = existing.stack_state.as_ref() {
-                stack_state = match merge_reimported_stack_state(
-                    &state,
-                    &req,
-                    &prepared_stack,
-                    existing_stack_state,
-                    stack_state,
-                ) {
-                    Ok(state) => state,
-                    Err(error) => return error.into_response(),
+            let has_registration_operation = setup_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get(SETUP_REGISTRATION_OPERATION_ID))
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|operation_id| !operation_id.is_empty());
+            if !has_registration_operation
+                && is_idempotent_import(&existing, &stack_state, &release.id, &req)
+            {
+                let Some(stack_settings) = existing.stack_settings else {
+                    return ErrorData::internal("imported deployment is missing stack_settings")
+                        .into_response();
                 };
+                let stack_state = existing.stack_state.unwrap_or(stack_state);
+                return (
+                    StatusCode::OK,
+                    Json(StackImportResponse {
+                        deployment_id: existing.id,
+                        deployment_token: existing.deployment_token,
+                        stack_settings,
+                        stack_state,
+                    }),
+                )
+                    .into_response();
             }
-            if !can_accept_reimport(&existing, &stack_state, &release.id, &req) {
+            if !activates_setup_reservation {
+                if let Some(existing_stack_state) = existing.stack_state.as_ref() {
+                    stack_state = match merge_reimported_stack_state(
+                        &state,
+                        &req,
+                        &prepared_stack,
+                        existing_stack_state,
+                        stack_state,
+                    ) {
+                        Ok(state) => state,
+                        Err(error) => return error.into_response(),
+                    };
+                }
+            }
+            if !activates_setup_reservation
+                && !can_accept_reimport(&existing, &stack_state, &release.id, &req)
+            {
                 return AlienError::new(ErrorData::ImportedDeploymentConflict {
                     reason: format!(
                         "Imported deployment '{}' is not in a re-importable state and the payload is not idempotent",
@@ -326,7 +355,7 @@ pub async fn stack_import(
                 })
                 .into_response();
             }
-            if !can_reconcile_after_import(&existing) {
+            if !activates_setup_reservation && !can_reconcile_after_import(&existing) {
                 return AlienError::new(ErrorData::ImportedDeploymentConflict {
                     reason: format!(
                         "Imported deployment '{}' is currently reconciling; retry setup after it reaches a stable state",
@@ -360,24 +389,31 @@ pub async fn stack_import(
                     }
                 }
             }
-            let runtime_metadata = match reimport_runtime_metadata(
-                &existing,
-                &prepared_stack,
-                &release.id,
-                &req,
-                imported_gate_answers,
-            ) {
-                Ok(metadata) => metadata,
-                Err(error) => return error.into_response(),
+            let runtime_metadata = if activates_setup_reservation {
+                import_runtime_metadata(&prepared_stack, imported_gate_answers)
+            } else {
+                match reimport_runtime_metadata(
+                    &existing,
+                    &prepared_stack,
+                    &release.id,
+                    &req,
+                    imported_gate_answers,
+                ) {
+                    Ok(metadata) => metadata,
+                    Err(error) => return error.into_response(),
+                }
             };
-            let should_reconcile = import_changes_deployment(
-                &existing,
-                &stack_state,
-                &environment_info,
-                &runtime_metadata,
-                &release.id,
-                &req,
-            );
+            let should_reconcile = !activates_setup_reservation
+                && import_changes_deployment(
+                    &existing,
+                    &stack_state,
+                    &environment_info,
+                    &runtime_metadata,
+                    &release.id,
+                    &req,
+                );
+            let activation_status = activates_setup_reservation
+                .then(|| initial_import_status(&prepared_stack, &stack_state));
             let setup_metadata = merge_setup_metadata(&existing.setup_metadata, setup_metadata);
             let updated = match state
                 .deployment_store
@@ -393,6 +429,7 @@ pub async fn stack_import(
                         setup_target: req.setup_target.clone(),
                         setup_fingerprint: req.setup_fingerprint.clone(),
                         setup_fingerprint_version: req.setup_fingerprint_version,
+                        activation_status,
                         schedule_reconciliation: should_reconcile,
                         input_values: req.input_values.clone(),
                     },
@@ -909,14 +946,38 @@ fn can_accept_reimport(
     release_id: &str,
     req: &StackImportRequest,
 ) -> bool {
-    let idempotent = existing.current_release_id.as_deref() == Some(release_id)
-        && existing.setup_fingerprint.as_deref() == Some(req.setup_fingerprint.as_str())
-        && imported_resources_are_unchanged(existing, imported_stack_state);
-
     matches!(
         existing.status.as_str(),
         "running" | "update-failed" | "refresh-failed"
-    ) || idempotent
+    ) || is_idempotent_import(existing, imported_stack_state, release_id, req)
+}
+
+fn is_idempotent_import(
+    existing: &DeploymentRecord,
+    imported_stack_state: &StackState,
+    release_id: &str,
+    req: &StackImportRequest,
+) -> bool {
+    existing
+        .desired_release_id
+        .as_deref()
+        .or(existing.current_release_id.as_deref())
+        == Some(release_id)
+        && existing.setup_fingerprint.as_deref() == Some(req.setup_fingerprint.as_str())
+        && existing.input_values == req.input_values
+        && imported_resources_are_unchanged(existing, imported_stack_state)
+}
+
+fn is_pending_setup_reservation(existing: &DeploymentRecord, release_id: &str) -> bool {
+    existing.status == "pending"
+        && existing.current_release_id.is_none()
+        && existing
+            .setup_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("setupReservation"))
+            .and_then(|reservation| reservation.get("releaseId"))
+            .and_then(serde_json::Value::as_str)
+            == Some(release_id)
 }
 
 fn can_reconcile_after_import(existing: &DeploymentRecord) -> bool {
@@ -998,6 +1059,22 @@ fn imported_resources_are_unchanged(
     let Some(existing_stack_state) = existing.stack_state.as_ref() else {
         return false;
     };
+
+    let existing_resource_ids = existing_stack_state
+        .resources
+        .iter()
+        .filter(|(_, resource)| resource.lifecycle == Some(ResourceLifecycle::Frozen))
+        .map(|(id, _)| id)
+        .collect::<std::collections::HashSet<_>>();
+    let imported_resource_ids = imported_stack_state
+        .resources
+        .iter()
+        .filter(|(_, resource)| resource.lifecycle == Some(ResourceLifecycle::Frozen))
+        .map(|(id, _)| id)
+        .collect::<std::collections::HashSet<_>>();
+    if existing_resource_ids != imported_resource_ids {
+        return false;
+    }
 
     imported_stack_state.resources.iter().all(|(id, imported)| {
         existing_stack_state

--- a/crates/alien-manager/src/routes/stack.rs
+++ b/crates/alien-manager/src/routes/stack.rs
@@ -947,10 +947,8 @@ fn can_accept_reimport(
     release_id: &str,
     req: &StackImportRequest,
 ) -> bool {
-    matches!(
-        existing.status.as_str(),
-        "running" | "update-failed" | "refresh-failed"
-    ) || is_idempotent_import(existing, imported_stack_state, release_id, req)
+    is_stable_setup_repair_state(&existing.status)
+        || is_idempotent_import(existing, imported_stack_state, release_id, req)
 }
 
 fn is_idempotent_import(
@@ -982,9 +980,24 @@ fn is_pending_setup_reservation(existing: &DeploymentRecord, release_id: &str) -
 }
 
 fn can_reconcile_after_import(existing: &DeploymentRecord) -> bool {
+    is_stable_setup_repair_state(&existing.status)
+}
+
+/// Setup may be rerun after a completed deployment or a terminal failure.
+///
+/// These states have no active execution to race. In particular, the initial
+/// failure states must remain repairable: setup owns the frozen resources and
+/// is the only actor that can correct them before provisioning resumes. Active
+/// and deletion states deliberately remain excluded.
+fn is_stable_setup_repair_state(status: &str) -> bool {
     matches!(
-        existing.status.as_str(),
-        "running" | "update-failed" | "refresh-failed"
+        status,
+        "preflights-failed"
+            | "initial-setup-failed"
+            | "provisioning-failed"
+            | "running"
+            | "update-failed"
+            | "refresh-failed"
     )
 }
 
@@ -1599,6 +1612,44 @@ mod setup_update_authorization_tests {
                 ResourceLifecycle::Live,
             )
             .build()
+    }
+
+    #[test]
+    fn setup_repair_accepts_only_terminal_non_deletion_states() {
+        for status in [
+            "preflights-failed",
+            "initial-setup-failed",
+            "provisioning-failed",
+            "running",
+            "refresh-failed",
+            "update-failed",
+        ] {
+            assert!(
+                is_stable_setup_repair_state(status),
+                "{status} must remain repairable by its owning setup tool"
+            );
+        }
+
+        for status in [
+            "pending",
+            "initial-setup",
+            "provisioning",
+            "waiting-for-machines",
+            "update-pending",
+            "updating",
+            "delete-pending",
+            "deleting",
+            "delete-failed",
+            "teardown-required",
+            "teardown-failed",
+            "deleted",
+            "error",
+        ] {
+            assert!(
+                !is_stable_setup_repair_state(status),
+                "{status} must not accept a concurrent setup repair"
+            );
+        }
     }
 
     #[test]

--- a/crates/alien-manager/src/stores/sqlite/deployment.rs
+++ b/crates/alien-manager/src/stores/sqlite/deployment.rs
@@ -715,6 +715,7 @@ impl DeploymentStore for SqliteDeploymentStore {
             setup_target,
             setup_fingerprint,
             setup_fingerprint_version,
+            activation_status,
             schedule_reconciliation,
             input_values,
         } = params;
@@ -774,6 +775,9 @@ impl DeploymentStore for SqliteDeploymentStore {
 
             if let Some(release_id) = current_release_id {
                 update.value(Deployments::CurrentReleaseId, release_id);
+            }
+            if let Some(status) = activation_status {
+                update.value(Deployments::Status, status);
             }
             if schedule_reconciliation {
                 update

--- a/crates/alien-manager/src/stores/sqlite/deployment.rs
+++ b/crates/alien-manager/src/stores/sqlite/deployment.rs
@@ -707,6 +707,7 @@ impl DeploymentStore for SqliteDeploymentStore {
         params: UpdateImportedDeploymentParams,
     ) -> Result<DeploymentRecord, AlienError> {
         let UpdateImportedDeploymentParams {
+            stack_settings,
             stack_state,
             environment_info,
             runtime_metadata,
@@ -727,6 +728,11 @@ impl DeploymentStore for SqliteDeploymentStore {
             .into_alien_error()
             .context(GenericError {
                 message: "Failed to serialize imported stack_state".to_string(),
+            })?;
+        let stack_settings_json = serde_json::to_string(&stack_settings)
+            .into_alien_error()
+            .context(GenericError {
+                message: "Failed to serialize imported stack_settings".to_string(),
             })?;
         let runtime_metadata_json = serde_json::to_string(&runtime_metadata)
             .into_alien_error()
@@ -756,6 +762,7 @@ impl DeploymentStore for SqliteDeploymentStore {
             let mut update = Query::update();
             update
                 .table(Deployments::Table)
+                .value(Deployments::StackSettings, stack_settings_json)
                 .value(Deployments::StackState, stack_state_json)
                 .value(Deployments::EnvironmentInfo, environment_info_json)
                 .value(Deployments::RuntimeMetadata, runtime_metadata_json)

--- a/crates/alien-manager/src/traits/deployment_store.rs
+++ b/crates/alien-manager/src/traits/deployment_store.rs
@@ -194,6 +194,9 @@ pub struct UpdateImportedDeploymentParams {
     pub setup_target: String,
     pub setup_fingerprint: String,
     pub setup_fingerprint_version: u32,
+    /// Initial status when this import activates a launch-time reservation.
+    /// Ordinary re-imports leave this unset and preserve their current status.
+    pub activation_status: Option<String>,
     /// Move the deployment to `update-pending` in the same write as the import data.
     pub schedule_reconciliation: bool,
     /// Deployer stack input values carried by the re-import; they overwrite

--- a/crates/alien-manager/src/traits/deployment_store.rs
+++ b/crates/alien-manager/src/traits/deployment_store.rs
@@ -186,6 +186,13 @@ pub struct CreateImportedDeploymentParams {
 /// Import-owned fields replaced when setup re-registers a deployment.
 #[derive(Debug, Clone)]
 pub struct UpdateImportedDeploymentParams {
+    /// Complete deployment settings resolved by the setup artifact.
+    ///
+    /// A launch-time reservation contains only the choices known before the
+    /// customer runs setup. Registration must replace those placeholders with
+    /// the concrete network and compute selections that created the imported
+    /// infrastructure.
+    pub stack_settings: StackSettings,
     pub stack_state: StackState,
     pub environment_info: Option<EnvironmentInfo>,
     pub runtime_metadata: RuntimeMetadata,

--- a/crates/alien-manager/tests/credentials_mint/bindings_resolve.rs
+++ b/crates/alien-manager/tests/credentials_mint/bindings_resolve.rs
@@ -61,6 +61,7 @@ async fn persist_remote_storage_state(fixture: &Fixture) {
                 setup_target: "test".to_string(),
                 setup_fingerprint: "test".to_string(),
                 setup_fingerprint_version: 1,
+                activation_status: None,
                 schedule_reconciliation: false,
                 input_values: Default::default(),
             },

--- a/crates/alien-manager/tests/credentials_mint/bindings_resolve.rs
+++ b/crates/alien-manager/tests/credentials_mint/bindings_resolve.rs
@@ -53,6 +53,7 @@ async fn persist_remote_storage_state(fixture: &Fixture) {
             &Subject::system(),
             &fixture.deployment_a,
             UpdateImportedDeploymentParams {
+                stack_settings: StackSettings::default(),
                 stack_state,
                 environment_info: None,
                 runtime_metadata: RuntimeMetadata::default(),

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -309,6 +309,7 @@ async fn input_values_survive_create_import_and_reimport() {
             &test_subject(),
             &imported.id,
             UpdateImportedDeploymentParams {
+                stack_settings: StackSettings::default(),
                 stack_state: StackState::new(Platform::Aws),
                 environment_info: None,
                 runtime_metadata: RuntimeMetadata::default(),

--- a/crates/alien-manager/tests/sqlite_store_tests.rs
+++ b/crates/alien-manager/tests/sqlite_store_tests.rs
@@ -317,6 +317,7 @@ async fn input_values_survive_create_import_and_reimport() {
                 setup_target: "test".to_string(),
                 setup_fingerprint: "test".to_string(),
                 setup_fingerprint_version: 1,
+                activation_status: None,
                 schedule_reconciliation: false,
                 input_values: edited.clone(),
             },

--- a/crates/alien-manager/tests/stack_import.rs
+++ b/crates/alien-manager/tests/stack_import.rs
@@ -33,8 +33,8 @@ use alien_core::{
     AzureRemoteStackManagementImportData, DeploymentState, DeploymentStatus, EnvironmentInfo,
     GcpEnvironmentInfo, GcpManagementConfig, GcpRemoteStackManagementImportData, KubernetesCluster,
     KubernetesClusterOwnership, KubernetesClusterProvider, ManagementConfig, Platform, ReleaseInfo,
-    RemoteStackManagement, ResourceLifecycle, ResourceStatus, ServiceAccount, Stack, StackSettings,
-    Storage, Worker, WorkerCode,
+    RemoteStackManagement, ResourceLifecycle, ResourceStatus, RuntimeMetadata, ServiceAccount,
+    Stack, StackSettings, StackState, Storage, Worker, WorkerCode,
 };
 use alien_manager::auth::Authz;
 use alien_manager::config::ManagerConfig;
@@ -47,9 +47,9 @@ use alien_manager::stores::sqlite::{
     SqliteDatabase, SqliteDeploymentStore, SqliteReleaseStore, SqliteTokenStore,
 };
 use alien_manager::traits::{
-    AuthValidator, CreateDeploymentGroupParams, CreateDeploymentParams, CreateReleaseParams,
-    CreateTokenParams, CredentialResolver, DeploymentStore, ReconcileData, ReleaseStore,
-    TelemetryBackend, TokenStore, TokenType,
+    AuthValidator, CreateDeploymentGroupParams, CreateDeploymentParams,
+    CreateImportedDeploymentParams, CreateReleaseParams, CreateTokenParams, CredentialResolver,
+    DeploymentStore, ReconcileData, ReleaseStore, TelemetryBackend, TokenStore, TokenType,
 };
 
 // ---------------------------------------------------------------------------
@@ -715,6 +715,68 @@ async fn deployment_token_reimports_only_its_own_setup_without_bootstrap_token()
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn deployment_token_activates_its_pending_setup_reservation() {
+    let fixture = make_fixture(Some(stack_with_storage("assets"))).await;
+    let release_id = fixture.release_id.clone().expect("fixture has a release");
+    let reserved = fixture
+        .deployment_store
+        .create_with_state(
+            &alien_manager::auth::Subject::system(),
+            CreateImportedDeploymentParams {
+                name: "acme-reserved".to_string(),
+                deployment_group_id: fixture.deployment_group_id.clone(),
+                platform: Platform::Aws,
+                deployment_protocol_version: alien_core::CURRENT_DEPLOYMENT_PROTOCOL_VERSION,
+                base_platform: None,
+                stack_settings: StackSettings::default(),
+                stack_state: StackState::new(Platform::Aws),
+                environment_info: None,
+                runtime_metadata: RuntimeMetadata::default(),
+                status: "pending".to_string(),
+                current_release_id: None,
+                desired_release_id: None,
+                import_source: Some(ImportSourceKind::CloudFormation),
+                setup_metadata: Some(serde_json::json!({
+                    "setupReservation": { "releaseId": release_id.clone() }
+                })),
+                setup_target: "aws".to_string(),
+                setup_fingerprint: "test".to_string(),
+                setup_fingerprint_version: 1,
+                deployment_token: None,
+                management_config: None,
+                input_values: Default::default(),
+            },
+        )
+        .await
+        .unwrap();
+    let deployment_token = mint_token(
+        &fixture.token_store,
+        TokenType::Deployment,
+        "ax_dep_",
+        None,
+        Some(reserved.id.clone()),
+    )
+    .await;
+
+    let body = aws_s3_import_request("acme-reserved", "us-east-1", "assets", "acme-imports");
+    let (status, json) = post_import(&fixture, Some(&deployment_token), &body).await;
+    assert_eq!(status, StatusCode::OK, "{json:#}");
+
+    let activated = fixture
+        .deployment_store
+        .get_deployment(&alien_manager::auth::Subject::system(), &reserved.id)
+        .await
+        .unwrap()
+        .expect("reservation remains the same deployment");
+    assert_eq!(activated.status, "provisioning");
+    assert_eq!(
+        activated.current_release_id.as_deref(),
+        Some(release_id.as_str())
+    );
+    assert!(activated.stack_state.is_some());
 }
 
 #[tokio::test]

--- a/crates/alien-manager/tests/stack_import.rs
+++ b/crates/alien-manager/tests/stack_import.rs
@@ -30,11 +30,12 @@ use alien_core::permissions::PermissionProfile;
 use alien_core::{
     AwsEnvironmentInfo, AwsManagementConfig, AwsRemoteStackManagementImportData,
     AwsServiceAccountImportData, AwsStorageImportData, AzureEnvironmentInfo, AzureManagementConfig,
-    AzureRemoteStackManagementImportData, DeploymentState, DeploymentStatus, EnvironmentInfo,
-    GcpEnvironmentInfo, GcpManagementConfig, GcpRemoteStackManagementImportData, KubernetesCluster,
-    KubernetesClusterOwnership, KubernetesClusterProvider, ManagementConfig, Platform, ReleaseInfo,
-    RemoteStackManagement, ResourceLifecycle, ResourceStatus, RuntimeMetadata, ServiceAccount,
-    Stack, StackSettings, StackState, Storage, Worker, WorkerCode,
+    AzureRemoteStackManagementImportData, ComputePoolSelection, ComputeSettings, DeploymentState,
+    DeploymentStatus, EnvironmentInfo, GcpEnvironmentInfo, GcpManagementConfig,
+    GcpRemoteStackManagementImportData, KubernetesCluster, KubernetesClusterOwnership,
+    KubernetesClusterProvider, ManagementConfig, Platform, ReleaseInfo, RemoteStackManagement,
+    ResourceLifecycle, ResourceStatus, RuntimeMetadata, ServiceAccount, Stack, StackSettings,
+    StackState, Storage, Worker, WorkerCode,
 };
 use alien_manager::auth::Authz;
 use alien_manager::config::ManagerConfig;
@@ -761,7 +762,18 @@ async fn deployment_token_activates_its_pending_setup_reservation() {
     )
     .await;
 
-    let body = aws_s3_import_request("acme-reserved", "us-east-1", "assets", "acme-imports");
+    let mut body = aws_s3_import_request("acme-reserved", "us-east-1", "assets", "acme-imports");
+    let selected_compute = ComputeSettings {
+        pools: HashMap::from([(
+            "general".to_string(),
+            ComputePoolSelection::Fixed {
+                machines: 1,
+                machine: Some("t4g.medium".to_string()),
+                failure_domains: None,
+            },
+        )]),
+    };
+    body.stack_settings.compute = Some(selected_compute.clone());
     let (status, json) = post_import(&fixture, Some(&deployment_token), &body).await;
     assert_eq!(status, StatusCode::OK, "{json:#}");
 
@@ -777,6 +789,14 @@ async fn deployment_token_activates_its_pending_setup_reservation() {
         Some(release_id.as_str())
     );
     assert!(activated.stack_state.is_some());
+    assert_eq!(
+        activated
+            .stack_settings
+            .expect("activated reservation has stack settings")
+            .compute,
+        Some(selected_compute),
+        "registration must replace reservation placeholders with setup selections"
+    );
 }
 
 #[tokio::test]

--- a/crates/alien-manager/tests/stack_import.rs
+++ b/crates/alien-manager/tests/stack_import.rs
@@ -669,6 +669,55 @@ async fn happy_path_creates_imported_deployment() {
 }
 
 #[tokio::test]
+async fn deployment_token_reimports_only_its_own_setup_without_bootstrap_token() {
+    let fixture = make_fixture(Some(stack_with_storage("assets"))).await;
+    let body = aws_s3_import_request("acme-prod", "us-east-1", "assets", "acme-imports");
+    let (status, json) = post_import(&fixture, Some(&fixture.dg_token), &body).await;
+    assert_eq!(status, StatusCode::CREATED, "{json:#}");
+    let first: StackImportResponse = serde_json::from_value(json).unwrap();
+    let token = first
+        .deployment_token
+        .as_deref()
+        .expect("deployment credential");
+
+    let hash = format!("{:x}", Sha256::digest(fixture.dg_token.as_bytes()));
+    let bootstrap = fixture
+        .token_store
+        .validate_token(&hash)
+        .await
+        .unwrap()
+        .unwrap();
+    fixture
+        .token_store
+        .delete_token(&bootstrap.id)
+        .await
+        .unwrap();
+    let (status, _) = post_import(&fixture, Some(&fixture.dg_token), &body).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    let (status, json) = post_import(&fixture, Some(token), &body).await;
+    assert_eq!(status, StatusCode::OK, "{json:#}");
+    let replay: StackImportResponse = serde_json::from_value(json).unwrap();
+    assert_eq!(replay.deployment_id, first.deployment_id);
+    assert_eq!(replay.deployment_token, first.deployment_token);
+
+    let mut other = body;
+    other.deployment_name = "another-deployment".to_string();
+    let (status, json) = post_import(&fixture, Some(token), &other).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{json:#}");
+    assert!(fixture
+        .deployment_store
+        .get_deployment_by_name(
+            &alien_manager::auth::Subject::system(),
+            &fixture.deployment_group_id,
+            "another-deployment"
+        )
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
 async fn incomplete_setup_handoff_is_rejected_before_deployment_creation() {
     let fixture = make_fixture(Some(stack_with_storage("assets"))).await;
     let mut body = aws_s3_import_request("acme-prod", "us-east-1", "assets", "acme-imports");

--- a/crates/alien-manager/tests/stack_import.rs
+++ b/crates/alien-manager/tests/stack_import.rs
@@ -1064,6 +1064,100 @@ async fn re_import_replaces_stack_state() {
 }
 
 #[tokio::test]
+async fn re_import_repairs_terminal_initial_failures() {
+    for failed_status in [
+        DeploymentStatus::PreflightsFailed,
+        DeploymentStatus::InitialSetupFailed,
+        DeploymentStatus::ProvisioningFailed,
+    ] {
+        let fixture = make_fixture(Some(stack_with_storage("assets"))).await;
+        let mut body = aws_s3_import_request("acme-prod", "us-east-1", "assets", "acme-imports");
+
+        let (status, json) = post_import(&fixture, Some(&fixture.dg_token), &body).await;
+        assert_eq!(status, StatusCode::CREATED, "body = {json:#}");
+        let imported: StackImportResponse = serde_json::from_value(json).unwrap();
+
+        let deployment = fixture
+            .deployment_store
+            .get_deployment(
+                &alien_manager::auth::Subject::system(),
+                &imported.deployment_id,
+            )
+            .await
+            .unwrap()
+            .expect("deployment must persist");
+        fixture
+            .deployment_store
+            .reconcile(
+                &alien_manager::auth::Subject::system(),
+                ReconcileData {
+                    deployment_id: deployment.id,
+                    session: "failed-initial-deployment".to_string(),
+                    execution_claim: None,
+                    state: DeploymentState {
+                        status: failed_status,
+                        platform: deployment.platform,
+                        current_release: Some(ReleaseInfo {
+                            release_id: fixture.release_id.clone(),
+                            version: None,
+                            description: None,
+                            stack: stack_with_storage("assets"),
+                        }),
+                        target_release: None,
+                        stack_state: deployment.stack_state,
+                        error: None,
+                        environment_info: deployment.environment_info,
+                        runtime_metadata: deployment.runtime_metadata,
+                        retry_requested: false,
+                        protocol_version: deployment.deployment_protocol_version,
+                    },
+                    update_heartbeat: false,
+                    suggested_delay_ms: None,
+                    heartbeats: vec![],
+                    observed_inventory_batches: vec![],
+                    capabilities: vec![],
+                    operator_version: None,
+                },
+            )
+            .await
+            .expect("fixture should enter a stable failure state");
+
+        body.resources[0].import_data = serde_json::to_value(AwsStorageImportData {
+            bucket_name: "acme-imports-repaired".to_string(),
+            bucket_arn: "arn:aws:s3:::acme-imports-repaired".to_string(),
+        })
+        .unwrap();
+        let (status, json) = post_import(&fixture, Some(&fixture.dg_token), &body).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "stable failure {failed_status:?} must be repairable: {json:#}"
+        );
+
+        let persisted = fixture
+            .deployment_store
+            .get_deployment(
+                &alien_manager::auth::Subject::system(),
+                &imported.deployment_id,
+            )
+            .await
+            .unwrap()
+            .expect("deployment must persist");
+        assert_eq!(persisted.status, "update-pending");
+        let outputs = persisted
+            .stack_state
+            .as_ref()
+            .and_then(|state| state.resources.get("assets"))
+            .and_then(|resource| resource.outputs.as_ref())
+            .expect("repaired setup outputs must persist");
+        assert!(serde_json::to_value(outputs)
+            .unwrap()
+            .to_string()
+            .contains("acme-imports-repaired"));
+    }
+}
+
+#[tokio::test]
 async fn re_import_advances_setup_registration_replay_baseline() {
     let fixture = make_fixture(Some(stack_with_storage("assets"))).await;
     let mut first_request =


### PR DESCRIPTION
## Scope
Foundation for ALIEN-768. Keep draft pending lifecycle integration and validation.

Allow stack re-registration with a deployment credential after the bootstrap credential is no longer valid. Derive the group from the authenticated deployment, check update permission and the requested name, and prohibit falling through to deployment creation. Group credentials retain the initial registration path.

## Validation
Added an HTTP-handler integration test that creates a setup, deletes its bootstrap token, reimports with the returned deployment credential, checks stable deployment identity and credential, and rejects another deployment name.

Rustfmt passed. Local test compilation was stopped to protect low disk space; the new test has not executed yet. Do not treat this as end-to-end validated.