### PR TITLE
feat: expose cloud load balancer health

### DIFF
--- a/crates/alien-azure-clients/src/azure/application_gateways.rs
+++ b/crates/alien-azure-clients/src/azure/application_gateways.rs
@@ -31,6 +31,13 @@ pub trait ApplicationGatewayApi: Send + Sync + std::fmt::Debug {
         application_gateway_name: &str,
     ) -> Result<Value>;
 
+    /// Get backend health for an Application Gateway.
+    async fn get_application_gateway_backend_health(
+        &self,
+        resource_group_name: &str,
+        application_gateway_name: &str,
+    ) -> Result<OperationResult<Value>>;
+
     /// Delete an Application Gateway.
     async fn delete_application_gateway(
         &self,
@@ -72,11 +79,55 @@ impl AzureApplicationGatewayClient {
             Some(vec![("api-version", Self::API_VERSION.into())]),
         )
     }
+
+    async fn get_application_gateway_backend_health(
+        &self,
+        resource_group_name: &str,
+        application_gateway_name: &str,
+    ) -> Result<OperationResult<Value>> {
+        let bearer_token = self
+            .token_cache
+            .get_bearer_token_with_scope("https://management.azure.com/.default")
+            .await?;
+        let url = self.base.build_url(
+            &format!(
+                "/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/applicationGateways/{}/backendhealth",
+                &self.token_cache.config().subscription_id,
+                resource_group_name,
+                application_gateway_name
+            ),
+            Some(vec![("api-version", "2025-07-01".into())]),
+        );
+        let req = AzureRequestBuilder::new(Method::POST, url)
+            .content_length("")
+            .build()?;
+        let signed = self.base.sign_request(req, &bearer_token).await?;
+        self.base
+            .execute_request_with_long_running_support(
+                signed,
+                "GetApplicationGatewayBackendHealth",
+                application_gateway_name,
+            )
+            .await
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl ApplicationGatewayApi for AzureApplicationGatewayClient {
+    async fn get_application_gateway_backend_health(
+        &self,
+        resource_group_name: &str,
+        application_gateway_name: &str,
+    ) -> Result<OperationResult<Value>> {
+        AzureApplicationGatewayClient::get_application_gateway_backend_health(
+            self,
+            resource_group_name,
+            application_gateway_name,
+        )
+        .await
+    }
+
     async fn create_or_update_application_gateway(
         &self,
         resource_group_name: &str,

--- a/crates/alien-azure-clients/src/azure/load_balancers.rs
+++ b/crates/alien-azure-clients/src/azure/load_balancers.rs
@@ -6,6 +6,7 @@ use alien_client_core::{ErrorData, Result};
 
 use alien_error::{Context, IntoAlienError};
 use reqwest::{Client, Method};
+use serde_json::Value;
 
 #[cfg(feature = "test-utils")]
 use mockall::automock;
@@ -41,6 +42,14 @@ pub trait LoadBalancerApi: Send + Sync + std::fmt::Debug {
         resource_group_name: &str,
         load_balancer_name: &str,
     ) -> Result<LoadBalancer>;
+
+    /// Get health for the backends serving a load-balancing rule.
+    async fn get_load_balancing_rule_health(
+        &self,
+        resource_group_name: &str,
+        load_balancer_name: &str,
+        load_balancing_rule_name: &str,
+    ) -> Result<OperationResult<Value>>;
 
     /// Delete a load balancer
     ///
@@ -83,11 +92,62 @@ impl AzureLoadBalancerClient {
             token_cache,
         }
     }
+
+    async fn get_load_balancing_rule_health(
+        &self,
+        resource_group_name: &str,
+        load_balancer_name: &str,
+        load_balancing_rule_name: &str,
+    ) -> Result<OperationResult<Value>> {
+        let bearer_token = self
+            .token_cache
+            .get_bearer_token_with_scope("https://management.azure.com/.default")
+            .await?;
+        let url = self.base.build_url(
+            &format!(
+                "/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/loadBalancers/{}/loadBalancingRules/{}/health",
+                &self.token_cache.config().subscription_id,
+                resource_group_name,
+                load_balancer_name,
+                load_balancing_rule_name
+            ),
+            Some(vec![
+                ("api-version", "2025-07-01".into()),
+                ("preserve-view", "true".into()),
+            ]),
+        );
+        let req = AzureRequestBuilder::new(Method::POST, url)
+            .content_length("")
+            .build()?;
+        let signed = self.base.sign_request(req, &bearer_token).await?;
+        self.base
+            .execute_request_with_long_running_support(
+                signed,
+                "GetLoadBalancingRuleHealth",
+                load_balancing_rule_name,
+            )
+            .await
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl LoadBalancerApi for AzureLoadBalancerClient {
+    async fn get_load_balancing_rule_health(
+        &self,
+        resource_group_name: &str,
+        load_balancer_name: &str,
+        load_balancing_rule_name: &str,
+    ) -> Result<OperationResult<Value>> {
+        AzureLoadBalancerClient::get_load_balancing_rule_health(
+            self,
+            resource_group_name,
+            load_balancer_name,
+            load_balancing_rule_name,
+        )
+        .await
+    }
+
     async fn create_or_update_load_balancer(
         &self,
         resource_group_name: &str,

--- a/crates/alien-azure-clients/tests/azure_application_gateway_client_tests.rs
+++ b/crates/alien-azure-clients/tests/azure_application_gateway_client_tests.rs
@@ -1,0 +1,259 @@
+use alien_azure_clients::application_gateways::{
+    ApplicationGatewayApi, AzureApplicationGatewayClient,
+};
+use alien_azure_clients::long_running_operation::{
+    LongRunningOperationApi, LongRunningOperationClient, OperationResult,
+};
+use alien_azure_clients::models::public_ip_address::{
+    IpAllocationMethod, PublicIpAddress, PublicIpAddressPropertiesFormat, PublicIpAddressSku,
+    PublicIpAddressSkuName, PublicIpAddressSkuTier,
+};
+use alien_azure_clients::models::virtual_network::{
+    AddressSpace, Subnet, SubnetPropertiesFormat, VirtualNetwork, VirtualNetworkPropertiesFormat,
+};
+use alien_azure_clients::network::{AzureNetworkClient, NetworkApi};
+use alien_azure_clients::{AzureClientConfig, AzureCredentials, AzureTokenCache};
+use anyhow::Result;
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::{env, path::PathBuf};
+use test_context::{test_context, AsyncTestContext};
+use tracing::info;
+use uuid::Uuid;
+
+struct ApplicationGatewayTestContext {
+    gateway: AzureApplicationGatewayClient,
+    network: AzureNetworkClient,
+    operations: LongRunningOperationClient,
+    resource_group: String,
+    subscription_id: String,
+    gateway_name: Option<String>,
+    public_ip_name: Option<String>,
+    vnet_name: Option<String>,
+}
+
+impl AsyncTestContext for ApplicationGatewayTestContext {
+    async fn setup() -> Self {
+        let root: PathBuf = workspace_root::get_workspace_root();
+        dotenvy::from_path(root.join(".env.test")).expect("Failed to load .env.test");
+        tracing_subscriber::fmt::try_init().ok();
+        let config = AzureClientConfig {
+            subscription_id: env::var("AZURE_MANAGEMENT_SUBSCRIPTION_ID").unwrap(),
+            tenant_id: env::var("AZURE_MANAGEMENT_TENANT_ID").unwrap(),
+            region: Some("eastus".into()),
+            credentials: AzureCredentials::ServicePrincipal {
+                client_id: env::var("AZURE_MANAGEMENT_CLIENT_ID").unwrap(),
+                client_secret: env::var("AZURE_MANAGEMENT_CLIENT_SECRET").unwrap(),
+            },
+            service_overrides: None,
+        };
+        let token = || AzureTokenCache::new(config.clone());
+        Self {
+            gateway: AzureApplicationGatewayClient::new(Client::new(), token()),
+            network: AzureNetworkClient::new(Client::new(), token()),
+            operations: LongRunningOperationClient::new(Client::new(), token()),
+            resource_group: env::var("ALIEN_TEST_AZURE_RESOURCE_GROUP").unwrap(),
+            subscription_id: config.subscription_id,
+            gateway_name: None,
+            public_ip_name: None,
+            vnet_name: None,
+        }
+    }
+
+    async fn teardown(self) {
+        info!("Cleaning up Application Gateway integration test resources");
+        if let Some(name) = &self.gateway_name {
+            if let Ok(result) = self
+                .gateway
+                .delete_application_gateway(&self.resource_group, name)
+                .await
+            {
+                let _ = result
+                    .wait_for_operation_completion(
+                        &self.operations,
+                        "DeleteApplicationGateway",
+                        name,
+                    )
+                    .await;
+            }
+        }
+        if let Some(name) = &self.public_ip_name {
+            if let Ok(result) = self
+                .network
+                .delete_public_ip_address(&self.resource_group, name)
+                .await
+            {
+                let _ = result
+                    .wait_for_operation_completion(&self.operations, "DeletePublicIpAddress", name)
+                    .await;
+            }
+        }
+        if let Some(name) = &self.vnet_name {
+            if let Ok(result) = self
+                .network
+                .delete_virtual_network(&self.resource_group, name)
+                .await
+            {
+                let _ = result
+                    .wait_for_operation_completion(&self.operations, "DeleteVirtualNetwork", name)
+                    .await;
+            }
+        }
+    }
+}
+
+async fn operation_value(
+    result: OperationResult<Value>,
+    operations: &LongRunningOperationClient,
+    operation_name: &str,
+    resource_name: &str,
+) -> Result<Value> {
+    Ok(match result {
+        OperationResult::Completed(value) => value,
+        OperationResult::LongRunning(operation) => {
+            let body = operations
+                .wait_for_completion(&operation, operation_name, resource_name)
+                .await?;
+            serde_json::from_str(&body)?
+        }
+    })
+}
+
+#[test_context(ApplicationGatewayTestContext)]
+#[tokio::test]
+async fn application_gateway_reports_a_real_healthy_backend(
+    ctx: &mut ApplicationGatewayTestContext,
+) -> Result<()> {
+    let suffix = Uuid::new_v4().simple().to_string()[..8].to_string();
+    let vnet_name = format!("alien-test-appgw-vnet-{suffix}");
+    let subnet_name = format!("alien-test-appgw-subnet-{suffix}");
+    let public_ip_name = format!("alien-test-appgw-pip-{suffix}");
+    let gateway_name = format!("alien-test-appgw-{suffix}");
+    ctx.vnet_name = Some(vnet_name.clone());
+
+    let vnet = VirtualNetwork {
+        location: Some("eastus".into()),
+        properties: Some(VirtualNetworkPropertiesFormat {
+            address_space: Some(AddressSpace {
+                address_prefixes: vec!["10.91.0.0/16".into()],
+                ipam_pool_prefix_allocations: vec![],
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    ctx.network
+        .create_or_update_virtual_network(&ctx.resource_group, &vnet_name, &vnet)
+        .await?
+        .wait_for_operation_completion(&ctx.operations, "CreateVirtualNetwork", &vnet_name)
+        .await?;
+    let subnet = Subnet {
+        name: Some(subnet_name.clone()),
+        properties: Some(SubnetPropertiesFormat {
+            address_prefix: Some("10.91.1.0/24".into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    ctx.network
+        .create_or_update_subnet(&ctx.resource_group, &vnet_name, &subnet_name, &subnet)
+        .await?
+        .wait_for_operation_completion(&ctx.operations, "CreateSubnet", &subnet_name)
+        .await?;
+    let subnet_id = ctx
+        .network
+        .get_subnet(&ctx.resource_group, &vnet_name, &subnet_name)
+        .await?
+        .id
+        .unwrap();
+
+    let public_ip = PublicIpAddress {
+        location: Some("eastus".into()),
+        sku: Some(PublicIpAddressSku {
+            name: Some(PublicIpAddressSkuName::Standard),
+            tier: Some(PublicIpAddressSkuTier::Regional),
+        }),
+        properties: Some(PublicIpAddressPropertiesFormat {
+            public_ip_allocation_method: Some(IpAllocationMethod::Static),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    ctx.public_ip_name = Some(public_ip_name.clone());
+    ctx.network
+        .create_or_update_public_ip_address(&ctx.resource_group, &public_ip_name, &public_ip)
+        .await?
+        .wait_for_operation_completion(&ctx.operations, "CreatePublicIpAddress", &public_ip_name)
+        .await?;
+    let public_ip_id = ctx
+        .network
+        .get_public_ip_address(&ctx.resource_group, &public_ip_name)
+        .await?
+        .id
+        .unwrap();
+
+    let base = format!("/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network/applicationGateways/{gateway_name}", ctx.subscription_id, ctx.resource_group);
+    let id = |kind: &str, name: &str| format!("{base}/{kind}/{name}");
+    let gateway = json!({
+        "location":"eastus",
+        "properties":{
+            "sku":{"name":"Standard_v2","tier":"Standard_v2","capacity":1},
+            "gatewayIPConfigurations":[{"name":"gateway","id":id("gatewayIPConfigurations","gateway"),"properties":{"subnet":{"id":subnet_id}}}],
+            "frontendIPConfigurations":[{"name":"frontend","id":id("frontendIPConfigurations","frontend"),"properties":{"publicIPAddress":{"id":public_ip_id}}}],
+            "frontendPorts":[{"name":"http","id":id("frontendPorts","http"),"properties":{"port":80}}],
+            "backendAddressPools":[{"name":"backend","id":id("backendAddressPools","backend"),"properties":{"backendAddresses":[{"fqdn":"example.com"}]}}],
+            "probes":[{"name":"probe","id":id("probes","probe"),"properties":{"protocol":"Http","path":"/","interval":10,"timeout":10,"unhealthyThreshold":2,"pickHostNameFromBackendHttpSettings":true}}],
+            "backendHttpSettingsCollection":[{"name":"settings","id":id("backendHttpSettingsCollection","settings"),"properties":{"port":80,"protocol":"Http","cookieBasedAffinity":"Disabled","requestTimeout":20,"pickHostNameFromBackendAddress":true,"probe":{"id":id("probes","probe")}}}],
+            "httpListeners":[{"name":"listener","id":id("httpListeners","listener"),"properties":{"frontendIPConfiguration":{"id":id("frontendIPConfigurations","frontend")},"frontendPort":{"id":id("frontendPorts","http")},"protocol":"Http"}}],
+            "requestRoutingRules":[{"name":"rule","id":id("requestRoutingRules","rule"),"properties":{"ruleType":"Basic","priority":100,"httpListener":{"id":id("httpListeners","listener")},"backendAddressPool":{"id":id("backendAddressPools","backend")},"backendHttpSettings":{"id":id("backendHttpSettingsCollection","settings")}}}]
+        }
+    });
+    ctx.gateway_name = Some(gateway_name.clone());
+    ctx.gateway
+        .create_or_update_application_gateway(&ctx.resource_group, &gateway_name, &gateway)
+        .await?
+        .wait_for_operation_completion(&ctx.operations, "CreateApplicationGateway", &gateway_name)
+        .await?;
+
+    for _ in 0..30 {
+        let health = operation_value(
+            ctx.gateway
+                .get_application_gateway_backend_health(&ctx.resource_group, &gateway_name)
+                .await?,
+            &ctx.operations,
+            "GetApplicationGatewayBackendHealth",
+            &gateway_name,
+        )
+        .await?;
+        let output = health.pointer("/properties/output").unwrap_or(&health);
+        let healthy = output
+            .get("backendAddressPools")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter(|pool| {
+                pool.pointer("/backendAddressPool/id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|id| id.ends_with("/backendAddressPools/backend"))
+            })
+            .flat_map(|pool| {
+                pool.get("backendHttpSettingsCollection")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+            })
+            .flat_map(|settings| {
+                settings
+                    .get("servers")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+            })
+            .any(|server| server.get("health").and_then(Value::as_str) == Some("Healthy"));
+        if healthy {
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    }
+    anyhow::bail!("Application Gateway never reported the reachable backend as Healthy")
+}

--- a/crates/alien-azure-clients/tests/azure_application_gateway_client_tests.rs
+++ b/crates/alien-azure-clients/tests/azure_application_gateway_client_tests.rs
@@ -114,7 +114,13 @@ async fn operation_value(
             let body = operations
                 .wait_for_completion(&operation, operation_name, resource_name)
                 .await?;
-            serde_json::from_str(&body)?
+            if operation.location_url.is_some() {
+                operations
+                    .fetch_location_result(&operation, operation_name, resource_name)
+                    .await?
+            } else {
+                serde_json::from_str(&body)?
+            }
         }
     })
 }

--- a/crates/alien-azure-clients/tests/azure_load_balancer_client_tests.rs
+++ b/crates/alien-azure-clients/tests/azure_load_balancer_client_tests.rs
@@ -1,5 +1,7 @@
 use alien_azure_clients::load_balancers::{AzureLoadBalancerClient, LoadBalancerApi};
-use alien_azure_clients::long_running_operation::LongRunningOperationClient;
+use alien_azure_clients::long_running_operation::{
+    LongRunningOperationApi, LongRunningOperationClient,
+};
 use alien_azure_clients::models::load_balancer::{
     BackendAddressPool, BackendAddressPoolPropertiesFormat, FrontendIpConfiguration,
     FrontendIpConfigurationPropertiesFormat, LoadBalancer, LoadBalancerPropertiesFormat,
@@ -576,6 +578,28 @@ async fn test_comprehensive_load_balancer_lifecycle(
     }
 
     info!("✅ Step 3/5: Load balancer verified successfully");
+
+    let health_result = ctx
+        .client
+        .get_load_balancing_rule_health(&ctx.resource_group_name, &lb_name, lb_rule_name)
+        .await?;
+    let health = match health_result {
+        alien_azure_clients::long_running_operation::OperationResult::Completed(value) => value,
+        alien_azure_clients::long_running_operation::OperationResult::LongRunning(operation) => {
+            let body = ctx
+                .long_running_operation_client
+                .wait_for_completion(&operation, "GetLoadBalancingRuleHealth", lb_rule_name)
+                .await?;
+            serde_json::from_str(&body)?
+        }
+    };
+    assert_eq!(
+        health
+            .pointer("/properties/output/up")
+            .and_then(serde_json::Value::as_u64),
+        Some(0)
+    );
+    info!("✅ Load-balancing rule health API verified");
 
     // -------------------------------------------------------------------------
     // Step 4: Delete the load balancer

--- a/crates/alien-azure-clients/tests/azure_load_balancer_client_tests.rs
+++ b/crates/alien-azure-clients/tests/azure_load_balancer_client_tests.rs
@@ -590,12 +590,19 @@ async fn test_comprehensive_load_balancer_lifecycle(
                 .long_running_operation_client
                 .wait_for_completion(&operation, "GetLoadBalancingRuleHealth", lb_rule_name)
                 .await?;
-            serde_json::from_str(&body)?
+            if operation.location_url.is_some() {
+                ctx.long_running_operation_client
+                    .fetch_location_result(&operation, "GetLoadBalancingRuleHealth", lb_rule_name)
+                    .await?
+            } else {
+                serde_json::from_str(&body)?
+            }
         }
     };
     assert_eq!(
         health
             .pointer("/properties/output/up")
+            .or_else(|| health.pointer("/up"))
             .and_then(serde_json::Value::as_u64),
         Some(0)
     );

--- a/crates/alien-gcp-clients/src/gcp/compute.rs
+++ b/crates/alien-gcp-clients/src/gcp/compute.rs
@@ -210,6 +210,14 @@ pub trait ComputeApi: Send + Sync + Debug {
     /// See: https://cloud.google.com/compute/docs/reference/rest/v1/backendServices/get
     async fn get_backend_service(&self, backend_service_name: String) -> Result<BackendService>;
 
+    /// Gets the health of a backend group attached to a backend service.
+    /// See: https://cloud.google.com/compute/docs/reference/rest/v1/backendServices/getHealth
+    async fn get_backend_service_health(
+        &self,
+        backend_service_name: String,
+        group: String,
+    ) -> Result<BackendServiceGroupHealth>;
+
     /// Creates a backend service.
     /// See: https://cloud.google.com/compute/docs/reference/rest/v1/backendServices/insert
     async fn insert_backend_service(&self, backend_service: BackendService) -> Result<Operation>;
@@ -1011,6 +1019,26 @@ impl ComputeApi for ComputeClient {
                 &path,
                 None,
                 Option::<()>::None,
+                &backend_service_name,
+            )
+            .await
+    }
+
+    async fn get_backend_service_health(
+        &self,
+        backend_service_name: String,
+        group: String,
+    ) -> Result<BackendServiceGroupHealth> {
+        let path = format!(
+            "projects/{}/global/backendServices/{}/getHealth",
+            self.project_id, backend_service_name
+        );
+        self.base
+            .execute_request(
+                Method::POST,
+                &path,
+                None,
+                Some(ResourceGroupReference { group }),
                 &backend_service_name,
             )
             .await
@@ -3492,6 +3520,33 @@ pub struct BackendService {
     /// Type of resource (always "compute#backendService").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BackendServiceGroupHealth {
+    #[serde(default)]
+    pub health_status: Vec<BackendHealthStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BackendHealthStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_state: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ResourceGroupReference {
+    group: String,
 }
 
 /// Backend configuration for a backend service.

--- a/crates/alien-gcp-clients/tests/gcp_compute_client_tests.rs
+++ b/crates/alien-gcp-clients/tests/gcp_compute_client_tests.rs
@@ -1851,7 +1851,7 @@ async fn test_comprehensive_load_balancing_lifecycle(ctx: &mut ComputeTestContex
         .health_checks(vec![health_check_url])
         .load_balancing_scheme(LoadBalancingScheme::External)
         .backends(vec![Backend::builder()
-            .group(neg_url)
+            .group(neg_url.clone())
             .balancing_mode(BalancingMode::Rate)
             .max_rate_per_endpoint(100.0)
             .build()])
@@ -1884,6 +1884,17 @@ async fn test_comprehensive_load_balancing_lifecycle(ctx: &mut ComputeTestContex
     assert_eq!(fetched_bs.name.as_ref().unwrap(), &backend_service_name);
     assert_eq!(fetched_bs.protocol, Some(BackendServiceProtocol::Http));
     println!("✅ Backend service verified: {}", backend_service_name);
+
+    let backend_health = ctx
+        .client
+        .get_backend_service_health(backend_service_name.clone(), neg_url.clone())
+        .await
+        .expect("Failed to get backend service health");
+    assert!(
+        backend_health.health_status.is_empty(),
+        "A newly created empty NEG must not report healthy endpoints"
+    );
+    println!("✅ Backend service health API verified");
 
     // =========================================================================
     // Step 5: Create URL Map

--- a/crates/alien-permissions/permission-sets/container/management.jsonc
+++ b/crates/alien-permissions/permission-sets/container/management.jsonc
@@ -147,6 +147,8 @@
             "Microsoft.Network/publicIPAddresses/read",
             "Microsoft.Network/applicationGateways/read",
             "Microsoft.Network/applicationGateways/write",
+            "Microsoft.Network/applicationGateways/backendhealth/action",
+            "Microsoft.Network/loadBalancers/loadBalancingRules/health/action",
             "Microsoft.Compute/disks/read"
           ],
           "dataActions": [

--- a/crates/alien-permissions/permission-sets/container/provision.jsonc
+++ b/crates/alien-permissions/permission-sets/container/provision.jsonc
@@ -472,6 +472,8 @@
             "Microsoft.Network/applicationGateways/write",
             "Microsoft.Network/applicationGateways/read",
             "Microsoft.Network/applicationGateways/delete",
+            "Microsoft.Network/applicationGateways/backendhealth/action",
+            "Microsoft.Network/loadBalancers/loadBalancingRules/health/action",
             "Microsoft.ManagedIdentity/userAssignedIdentities/read",
             "Microsoft.ManagedIdentity/userAssignedIdentities/write",
             "Microsoft.ManagedIdentity/userAssignedIdentities/delete",


### PR DESCRIPTION
Adds exact backend-health client operations used by platform endpoint readiness: GCP backendServices.getHealth, Azure Application Gateway backendhealth, and Azure Load Balancer rule health. Includes real-cloud lifecycle coverage for GCP and Azure and grants the required Azure actions.\n\nLinear: ALIEN-767